### PR TITLE
chore: clean config and prep release flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -55,7 +55,7 @@ jobs:
         run: bun run test:coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           file: ./coverage/unit/lcov.info,./packages/create/coverage/lcov.info
           flags: unittests
@@ -67,7 +67,7 @@ jobs:
     needs: [lint, test]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -120,10 +120,10 @@ jobs:
             project_name: smoke-advanced-yarn
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -158,7 +158,7 @@ jobs:
     needs: [build]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -200,7 +200,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,13 +24,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout release commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ github.event.release.tag_name || github.ref }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: ${{ env.NPM_REGISTRY }}

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -25,10 +25,10 @@ jobs:
         node: ["20", "22", "24"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node }}
 
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.sampo/changesets/config-release-cleanup.md
+++ b/.sampo/changesets/config-release-cleanup.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/create: patch
+---
+
+Refresh workspace configuration and GitHub Actions release wiring for the scoped `@wp-typia` package flow.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,12 +18,6 @@
     "sourceMap": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"],
-      "@blocks/*": ["src/blocks/*"],
-      "@components/*": ["src/components/*"],
-      "@utils/*": ["src/utils/*"],
-      "@hooks/*": ["src/hooks/*"],
-      "@types/*": ["src/types/*"],
       "@wp-typia/block-types": [
         "packages/wp-typia-block-types/src/index.ts"
       ],
@@ -40,8 +34,7 @@
     "packages/*/src/**/*",
     "packages/*/tests/**/*",
     "test-template/**/src/**/*",
-    "tests/**/*",
-    "templates/**/*"
+    "tests/**/*"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## Summary
- clean up root TypeScript config after the scoped package/workspace refactor
- update GitHub Actions versions in CI/release workflows to reduce stale runtime warnings
- add a Sampo changeset to exercise the release PR flow for `@wp-typia/create`

## What changed
- removed stale root `tsconfig.json` path aliases and the dead `templates/**/*` include
- bumped workflow action versions in CI, release, publish, and test-matrix workflows
- added `.sampo/changesets/config-release-cleanup.md`

## Verification
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `SAMPO_RELEASE_BRANCH=main sampo release --dry-run`

## Release flow check
Dry-run currently plans:
- `@wp-typia/create`: `0.1.0 -> 0.1.1`
- `create-wp-typia`: `1.0.0 -> 1.0.1`

That matches the expected compatibility bump behavior for the scoped create package.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow actions to latest major versions for improved security and performance.
  * Refreshed workspace configuration and GitHub Actions release workflow setup.
  * Updated TypeScript build configuration for better path management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->