### PR TITLE
ci: automate GitHub releases from release merges

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,69 @@
+name: Create GitHub Release
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: create-release-${{ github.sha || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  create-release:
+    name: Create release from merged release PR
+    if: "${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.head_commit.message, 'release: version packages') }}"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout release commit
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Resolve release tag
+        id: release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_SHA: ${{ github.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          existing_tag="$(gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate --jq ".[] | select(.target_commitish == \"${GITHUB_SHA}\") | .tag_name" | head -n1)"
+          if [[ -n "${existing_tag}" ]]; then
+            echo "tag=${existing_tag}" >> "$GITHUB_OUTPUT"
+            echo "name=$(gh release view "${existing_tag}" --json name --jq '.name')" >> "$GITHUB_OUTPUT"
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          date_prefix="$(date -u +%Y-%m-%d)"
+          next_seq=1
+          while IFS= read -r tag; do
+            [[ -z "${tag}" ]] && continue
+            suffix="${tag##*-}"
+            if [[ "${suffix}" =~ ^[0-9]+$ ]] && (( 10#${suffix} >= next_seq )); then
+              next_seq=$((10#${suffix} + 1))
+            fi
+          done < <(gh release list --limit 100 --json tagName --jq '.[].tagName' | grep "^release-${date_prefix}-" || true)
+
+          printf -v seq '%02d' "${next_seq}"
+          tag="release-${date_prefix}-${seq}"
+          name="Release ${date_prefix}-${seq}"
+
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "name=${name}" >> "$GITHUB_OUTPUT"
+          echo "exists=false" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        if: steps.release.outputs.exists != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.release.outputs.tag }}" \
+            --target "${{ github.sha }}" \
+            --title "${{ steps.release.outputs.name }}" \
+            --generate-notes

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -70,7 +70,7 @@ jobs:
             - updates package changelogs
             - consumes pending `.sampo/changesets/*`
 
-            Merge this PR with **Squash and merge**, then create a GitHub Release from the merged commit to trigger npm OIDC publish.
+            Merge this PR with **Squash and merge** to automatically create a GitHub Release and trigger npm OIDC publish from `main`.
           labels: |
             release
           add-paths: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,8 +50,10 @@ GitHub release automation is split into two workflows:
 1. Merge feature PRs into `main` with **Squash and merge**
 2. `.github/workflows/release-pr.yml` updates the `release/sampo` PR from `main`
 3. Review and **Squash and merge** the release PR
-4. Create a GitHub Release from that merged release commit
-5. `.github/workflows/publish.yml` publishes packages with npm OIDC
+4. `.github/workflows/create-release.yml` creates a GitHub Release automatically from the merged release commit
+5. `.github/workflows/publish.yml` publishes packages with npm OIDC from that release event
+
+`workflow_dispatch` remains available as a manual fallback if the publish workflow ever needs to be rerun for the current commit.
 
 ## Pull requests
 

--- a/docs/legacy-sunset.md
+++ b/docs/legacy-sunset.md
@@ -7,8 +7,8 @@ This note captures the post-release cleanup for the old `wp-typia-*` package nam
 1. Merge feature PRs into `main` with squash merge
 2. Let `release-pr.yml` update the `release/sampo` release PR
 3. Squash merge the release PR so version/changelog changes land on `main` as one release commit
-4. Create a GitHub Release from that merged commit
-5. Let `publish.yml` publish `@wp-typia/create`, `@wp-typia/block-types`, and `create-wp-typia` with npm OIDC
+4. Let `create-release.yml` create a GitHub Release automatically from that merged release commit
+5. Let `publish.yml` publish `@wp-typia/create`, `@wp-typia/block-types`, and `create-wp-typia` with npm OIDC from the release event
 6. Confirm `npx @wp-typia/create@latest`, `bunx @wp-typia/create@latest`, and `bun create wp-typia` all work
 7. Apply npm deprecations to the legacy package names
 
@@ -31,4 +31,4 @@ npm deprecate wp-typia-advanced@"*" "wp-typia-advanced is no longer maintained f
 - `@wp-typia/block-types` provides the shared semantic unions used by generated `types.ts`
 - Manifest v2, `typia-validator.php`, and advanced snapshot migrations remain supported
 - `wp-typia-*` packages remain on npm for historical installs but receive no further releases
-- GitHub Release creation is the explicit trigger for npm OIDC publish
+- release PR squash merge triggers automatic GitHub Release creation, which then triggers npm OIDC publish


### PR DESCRIPTION
## Summary
- create GitHub Releases automatically when a release PR is squash-merged into `main`
- keep `publish.yml` on the release event so npm OIDC trusted publishing stays on the existing workflow path
- update contributor docs to match the new release flow

## What changed
- add `.github/workflows/create-release.yml` to watch `main` and create a GitHub Release when the merged commit message starts with `release: version packages`
- keep `.github/workflows/publish.yml` as the release-triggered publish workflow
- update `release-pr.yml` copy so the release PR explains the new automatic release + publish behavior
- update docs so release PR merge is now followed by automatic GitHub Release creation instead of a manual maintainer step

## Notes
- this keeps the trusted publisher path stable by leaving npm OIDC publish on `publish.yml`
- `workflow_dispatch` remains available as a manual fallback for both release creation and publish reruns

## Validation
- YAML parse check for `create-release.yml`, `publish.yml`, and `release-pr.yml`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated GitHub Release creation workflow that triggers upon successful release PR merge to `main`.
  * Updated release process documentation and contributing guidelines to reflect new automated release workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->