### PR TITLE
fix: add pipeline-compatible block type aliases

### DIFF
--- a/.sampo/changesets/block-types-pipeline-compatible.md
+++ b/.sampo/changesets/block-types-pipeline-compatible.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/block-types: patch
+---
+
+Add pipeline-compatible color and min-height aliases alongside richer DX-only template literal block types, and document which aliases are safe to use inside `types.ts` with `sync-types`.

--- a/packages/wp-typia-block-types/README.md
+++ b/packages/wp-typia-block-types/README.md
@@ -29,7 +29,15 @@ Shared WordPress block semantic types derived from Gutenberg source and unoffici
 ## Current v1 areas
 
 - block editor alignment and content-position values
+- color and dimensions helper types
 - layout and flex vocabulary
 - spacing sides and axes
 - typography enums used by core block supports
 - block support keys used by `block.json`
+
+## Typia pipeline notes
+
+- `CssColorValue` and `MinHeightValue` are richer DX aliases that currently rely on template literal types.
+- imported template literal aliases are not yet consumed by the `sync-types` metadata pipeline
+- when a type must round-trip through `types.ts` -> `typia.manifest.json` -> `typia-validator.php`, prefer pipeline-compatible aliases such as `CssNamedColor` and `MinHeightKeyword`
+- for broader CSS-like string shapes in `types.ts`, prefer native Typia constraints on `string`, for example `string & tags.Pattern<"..."> & tags.MaxLength<...>`

--- a/packages/wp-typia-block-types/src/block-editor/color.ts
+++ b/packages/wp-typia-block-types/src/block-editor/color.ts
@@ -1,5 +1,9 @@
 /**
  * Practical CSS color vocabulary used by block editor controls and theme.json values.
+ *
+ * This is primarily a type-level DX helper today. Typia metadata generation does
+ * not yet consume template literal aliases like `#${string}` or `rgb(${string})`
+ * when they are imported into `types.ts`.
  */
 export type CssColorValue =
 	| `#${string}`
@@ -11,6 +15,27 @@ export type CssColorValue =
 	| `color-mix(${string})`
 	| "transparent"
 	| "currentColor";
+
+/**
+ * Pipeline-compatible named-color subset for use in `types.ts`.
+ *
+ * Prefer this alias when the value needs to flow through `sync-types`,
+ * `typia.manifest.json`, and the generated PHP validator unchanged.
+ */
+export type CssNamedColor =
+	| "transparent"
+	| "currentColor"
+	| "inherit"
+	| "initial"
+	| "unset";
+
+export const CSS_NAMED_COLORS = [
+	"transparent",
+	"currentColor",
+	"inherit",
+	"initial",
+	"unset",
+] as const satisfies readonly CssNamedColor[];
 
 /**
  * Derived from Gutenberg duotone preset structures.

--- a/packages/wp-typia-block-types/src/block-editor/dimensions.ts
+++ b/packages/wp-typia-block-types/src/block-editor/dimensions.ts
@@ -28,6 +28,9 @@ export const ASPECT_RATIOS = [
 
 /**
  * Practical min-height value surface for WordPress dimension controls.
+ *
+ * This is primarily a type-level DX helper today. Typia metadata generation does
+ * not yet consume imported template literal aliases such as `${number}px`.
  */
 export type MinHeightValue =
 	| `${number}px`
@@ -40,3 +43,15 @@ export type MinHeightValue =
 	| `clamp(${string})`
 	| `min(${string})`
 	| `max(${string})`;
+
+/**
+ * Pipeline-compatible min-height keyword subset for use in `types.ts`.
+ */
+export type MinHeightKeyword = "auto" | "inherit" | "initial" | "unset";
+
+export const MIN_HEIGHT_KEYWORDS = [
+	"auto",
+	"inherit",
+	"initial",
+	"unset",
+] as const satisfies readonly MinHeightKeyword[];

--- a/tests/type-smoke/block-types-smoke.ts
+++ b/tests/type-smoke/block-types-smoke.ts
@@ -4,8 +4,16 @@ import type {
 	BlockVerticalAlignment,
 	TextAlignment,
 } from "@wp-typia/block-types/block-editor/alignment";
-import type { CssColorValue, DuotonePalette } from "@wp-typia/block-types/block-editor/color";
-import type { AspectRatio, MinHeightValue } from "@wp-typia/block-types/block-editor/dimensions";
+import type {
+	CssColorValue,
+	CssNamedColor,
+	DuotonePalette,
+} from "@wp-typia/block-types/block-editor/color";
+import type {
+	AspectRatio,
+	MinHeightKeyword,
+	MinHeightValue,
+} from "@wp-typia/block-types/block-editor/dimensions";
 import type { LayoutType } from "@wp-typia/block-types/block-editor/layout";
 import type { SpacingDimension } from "@wp-typia/block-types/block-editor/spacing";
 import type { TextTransform } from "@wp-typia/block-types/block-editor/typography";
@@ -15,12 +23,14 @@ const aspectRatio: AspectRatio = "16/9";
 const blockAlignment: BlockAlignment = "wide";
 const contentPosition: BlockContentPosition = "center right";
 const layoutType: LayoutType = "flex";
+const minHeightKeyword: MinHeightKeyword = "auto";
 const minHeight: MinHeightValue = "320px";
 const spacingDimension: SpacingDimension = "bottom";
 const supportKey: TypographySupportKey = "fontStyle";
 const textAlignment: TextAlignment = "justify";
 const textTransform: TextTransform = "capitalize";
 const blockVerticalAlignment: BlockVerticalAlignment = "top";
+const namedColor: CssNamedColor = "transparent";
 const textColor: CssColorValue = "var(--wp--preset--color--primary)";
 const duotonePalette: DuotonePalette = {
 	colors: ["#111111", "rgba(255, 255, 255, 0.95)"],
@@ -33,7 +43,9 @@ void blockAlignment;
 void contentPosition;
 void duotonePalette;
 void layoutType;
+void minHeightKeyword;
 void minHeight;
+void namedColor;
 void spacingDimension;
 void supportKey;
 void textAlignment;

--- a/tests/unit/validators.test.ts
+++ b/tests/unit/validators.test.ts
@@ -146,6 +146,70 @@ export interface BlockAttributes {
     expect(manifest.attributes.alignment.typia.defaultValue).toBe('left');
   });
 
+  test('supports pipeline-compatible aliases from @wp-typia/block-types inside types.ts', async () => {
+    const blockTypesSourceDir = path.resolve(import.meta.dir, '../../packages/wp-typia-block-types/src');
+    const fixtureDir = createFixture({
+      'block.json': JSON.stringify({ attributes: {}, example: { attributes: {} } }, null, 2),
+      'src/types.ts': `import type { CssNamedColor } from "@wp-typia/block-types/block-editor/color";
+import type { MinHeightKeyword } from "@wp-typia/block-types/block-editor/dimensions";
+import { tags } from "typia";
+
+export interface BlockAttributes {
+  textColor?: CssNamedColor & tags.Default<"transparent">;
+  minHeight?: MinHeightKeyword & tags.Default<"auto">;
+}
+`,
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: {
+          baseUrl: '.',
+          module: 'NodeNext',
+          moduleResolution: 'NodeNext',
+          paths: {
+            '@wp-typia/block-types': [`${blockTypesSourceDir}/index.ts`],
+            '@wp-typia/block-types/*': [`${blockTypesSourceDir}/*`],
+          },
+          resolveJsonModule: true,
+          strict: true,
+          target: 'ES2022',
+        },
+        include: ['src/**/*.ts'],
+      }, null, 2),
+    });
+
+    await syncBlockMetadata({
+      blockJsonFile: 'block.json',
+      manifestFile: 'typia.manifest.json',
+      projectRoot: fixtureDir,
+      sourceTypeName: 'BlockAttributes',
+      typesFile: 'src/types.ts',
+    });
+
+    const blockJson = JSON.parse(
+      fs.readFileSync(path.join(fixtureDir, 'block.json'), 'utf8'),
+    );
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(fixtureDir, 'typia.manifest.json'), 'utf8'),
+    );
+
+    expect(blockJson.attributes.textColor.enum).toEqual([
+      'transparent',
+      'currentColor',
+      'inherit',
+      'initial',
+      'unset',
+    ]);
+    expect(blockJson.attributes.textColor.default).toBe('transparent');
+    expect(blockJson.attributes.minHeight.enum).toEqual([
+      'auto',
+      'inherit',
+      'initial',
+      'unset',
+    ]);
+    expect(blockJson.attributes.minHeight.default).toBe('auto');
+    expect(manifest.attributes.textColor.typia.defaultValue).toBe('transparent');
+    expect(manifest.attributes.minHeight.typia.defaultValue).toBe('auto');
+  });
+
   test('generated php validator distinguishes arrays from objects for nested safe-subset attributes', async () => {
     if (!hasPhpBinary()) {
       return;


### PR DESCRIPTION
## Summary
- add `CssNamedColor` and `MinHeightKeyword` as Typia-pipeline-compatible aliases alongside richer template-literal DX helpers
- document which `@wp-typia/block-types` aliases are safe to use in `types.ts` with `sync-types`
- add validator coverage proving imported pipeline-compatible aliases round-trip through block metadata generation

## Validation
- `bun run typecheck`
- `bun test tests/unit/validators.test.ts`
- `bun run --filter @wp-typia/block-types build`
- `SAMPO_RELEASE_BRANCH=main sampo release --dry-run`

## Notes
- `CssColorValue` and `MinHeightValue` remain useful for type-level DX, but they are not yet consumed by the Typia metadata pipeline when imported into `types.ts`
- `sampo release --dry-run` still includes the existing pending `typia-utilization-pass-1` changeset from `main`, so the dry-run output includes package bumps beyond this patch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `CssNamedColor` type alias for CSS named colors (transparent, currentColor, inherit, initial, unset)
  * Added `MinHeightKeyword` type alias for min-height keywords (auto, inherit, initial, unset)
  * Added constants for convenient access to valid color and dimension keyword values

* **Documentation**
  * Added pipeline notes with best practices for using new type aliases in type-to-JSON workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->