### PR TITLE
refactor: generalize persistence rest surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Download CLI artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: wp-typia-create-dist
           path: packages/create/dist
@@ -259,19 +259,19 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Download example build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: my-typia-block-build
           path: examples/my-typia-block/build
 
       - name: Download persistence examples build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: persistence-examples-build
           path: examples/persistence-examples/build
 
       - name: Download compound patterns build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: compound-patterns-build
           path: examples/compound-patterns/build

--- a/.sampo/changesets/silent-umber-lynx.md
+++ b/.sampo/changesets/silent-umber-lynx.md
@@ -1,0 +1,5 @@
+---
+"@wp-typia/create": patch
+---
+
+Generalize generated persistence REST route and contract naming beyond the counter sample, and update CI artifact downloads to the Node 24-compatible action release.

--- a/docs/tutorials/persistence-block-tutorial.md
+++ b/docs/tutorials/persistence-block-tutorial.md
@@ -148,19 +148,19 @@ Open `src/api-types.ts` to define your REST contracts:
 ```typescript
 import { tags } from 'typia';
 
-export interface MyCounterCounterQuery {
+export interface MyCounterStateQuery {
   postId: number & tags.Type<'uint32'>;
   resourceKey: string & tags.MinLength<1> & tags.MaxLength<100>;
 }
 
-export interface MyCounterIncrementRequest {
+export interface MyCounterWriteStateRequest {
   postId: number & tags.Type<'uint32'>;
   publicWriteToken?: string & tags.MinLength<1> & tags.MaxLength<512>;
   resourceKey: string & tags.MinLength<1> & tags.MaxLength<100>;
   delta?: number & tags.Minimum<1> & tags.Type<'uint32'> & tags.Default<1>;
 }
 
-export interface MyCounterCounterResponse {
+export interface MyCounterStateResponse {
   postId: number & tags.Type<'uint32'>;
   resourceKey: string & tags.MinLength<1> & tags.MaxLength<100>;
   count: number & tags.Minimum<0> & tags.Type<'uint32'>;
@@ -180,48 +180,48 @@ import {
 } from '@wp-typia/rest';
 import { apiValidators } from './api-validators';
 import type {
-  MyCounterCounterQuery,
-  MyCounterCounterResponse,
-  MyCounterIncrementRequest,
+  MyCounterStateQuery,
+  MyCounterStateResponse,
+  MyCounterWriteStateRequest,
 } from './api-types';
 
-const COUNTER_PATH = '/create-block/v1/my-counter/counter';
+const STATE_PATH = '/create-block/v1/my-counter/state';
 
-export const counterEndpoint = createEndpoint<
-  MyCounterCounterQuery,
-  MyCounterCounterResponse
+export const stateEndpoint = createEndpoint<
+  MyCounterStateQuery,
+  MyCounterStateResponse
 >({
   buildRequestOptions: () => ({
-    url: resolveRestRouteUrl(COUNTER_PATH),
+    url: resolveRestRouteUrl(STATE_PATH),
   }),
   method: 'GET',
-  path: COUNTER_PATH,
-  validateRequest: apiValidators.counterQuery,
-  validateResponse: apiValidators.counterResponse,
+  path: STATE_PATH,
+  validateRequest: apiValidators.stateQuery,
+  validateResponse: apiValidators.stateResponse,
 });
 
-export const incrementCounterEndpoint = createEndpoint<
-  MyCounterIncrementRequest,
-  MyCounterCounterResponse
+export const writeStateEndpoint = createEndpoint<
+  MyCounterWriteStateRequest,
+  MyCounterStateResponse
 >({
   buildRequestOptions: () => ({
-    url: resolveRestRouteUrl(COUNTER_PATH),
+    url: resolveRestRouteUrl(STATE_PATH),
   }),
   method: 'POST',
-  path: COUNTER_PATH,
-  validateRequest: apiValidators.incrementRequest,
-  validateResponse: apiValidators.counterResponse,
+  path: STATE_PATH,
+  validateRequest: apiValidators.writeStateRequest,
+  validateResponse: apiValidators.stateResponse,
 });
 
-export function fetchCounter(request: MyCounterCounterQuery) {
-  return callEndpoint(counterEndpoint, request);
+export function fetchState(request: MyCounterStateQuery) {
+  return callEndpoint(stateEndpoint, request);
 }
 
-export function incrementCounter(
-  request: MyCounterIncrementRequest,
+export function writeState(
+  request: MyCounterWriteStateRequest,
   restNonce?: string
 ) {
-  return callEndpoint(incrementCounterEndpoint, request, {
+  return callEndpoint(writeStateEndpoint, request, {
     requestOptions: restNonce
       ? {
           headers: {
@@ -233,7 +233,7 @@ export function incrementCounter(
 }
 ```
 
-The default namespace is `create-block`, so the generated route is `/create-block/v1/my-counter/counter` unless you change the namespace during scaffolding.
+The default namespace is `create-block`, so the generated route is `/create-block/v1/my-counter/state` unless you change the namespace during scaffolding.
 
 ## Step 6: Implement Frontend Interactivity
 
@@ -241,7 +241,7 @@ The `src/interactivity.ts` file uses the WordPress Interactivity API:
 
 ```typescript
 import { getContext, store } from '@wordpress/interactivity';
-import { fetchCounter, incrementCounter } from './api';
+import { fetchState, writeState } from './api';
 import type { MyCounterContext, MyCounterState } from './types';
 
 function hasExpiredPublicWriteToken(context: MyCounterContext): boolean {
@@ -281,7 +281,7 @@ const { actions, state } = store('my-counter', {
       state.error = undefined;
 
       try {
-        const result = await fetchCounter({
+        const result = await fetchState({
           postId: context.postId,
           resourceKey: context.resourceKey,
         });
@@ -321,7 +321,7 @@ const { actions, state } = store('my-counter', {
       state.error = undefined;
 
       try {
-        const result = await incrementCounter(
+        const result = await writeState(
           {
             delta: 1,
             postId: context.postId,
@@ -479,14 +479,14 @@ Typical flow:
 
 ```bash
 # Get counter value
-curl "http://localhost:8888/wp-json/create-block/v1/my-counter/counter?postId=1&resourceKey=primary"
+curl "http://localhost:8888/wp-json/create-block/v1/my-counter/state?postId=1&resourceKey=primary"
 
 # Increment counter (default authenticated policy)
 curl -X POST \
   -H "X-WP-Nonce: <wp-rest-nonce>" \
   -H "Content-Type: application/json" \
   -d '{"postId":1,"resourceKey":"primary","delta":1}' \
-  "http://localhost:8888/wp-json/create-block/v1/my-counter/counter"
+  "http://localhost:8888/wp-json/create-block/v1/my-counter/state"
 ```
 
 If you scaffold with `--persistence-policy public`, send the `publicWriteToken` that the block render embeds in its frontend context instead of a REST nonce.

--- a/packages/create/templates/_shared/compound/persistence-auth/{{slugKebabCase}}.php.mustache
+++ b/packages/create/templates/_shared/compound/persistence-auth/{{slugKebabCase}}.php.mustache
@@ -167,7 +167,7 @@ function {{phpPrefix}}_increment_counter( $post_id, $resource_key, $delta ) {
 	);
 }
 
-function {{phpPrefix}}_build_counter_response( $post_id, $resource_key, $count ) {
+function {{phpPrefix}}_build_state_response( $post_id, $resource_key, $count ) {
 	return array(
 		'postId'      => (int) $post_id,
 		'resourceKey' => (string) $resource_key,
@@ -176,14 +176,14 @@ function {{phpPrefix}}_build_counter_response( $post_id, $resource_key, $count )
 	);
 }
 
-function {{phpPrefix}}_handle_get_counter( WP_REST_Request $request ) {
+function {{phpPrefix}}_handle_get_state( WP_REST_Request $request ) {
 	$payload = {{phpPrefix}}_validate_and_sanitize_request(
 		array(
 			'postId'      => $request->get_param( 'postId' ),
 			'resourceKey' => $request->get_param( 'resourceKey' ),
 		),
 		{{phpPrefix}}_get_rest_build_dir(),
-		'counter-query',
+		'state-query',
 		'query'
 	);
 
@@ -193,7 +193,7 @@ function {{phpPrefix}}_handle_get_counter( WP_REST_Request $request ) {
 
 	$count = {{phpPrefix}}_get_counter( (int) $payload['postId'], (string) $payload['resourceKey'] );
 	return rest_ensure_response(
-		{{phpPrefix}}_build_counter_response(
+		{{phpPrefix}}_build_state_response(
 			(int) $payload['postId'],
 			(string) $payload['resourceKey'],
 			$count
@@ -201,11 +201,11 @@ function {{phpPrefix}}_handle_get_counter( WP_REST_Request $request ) {
 	);
 }
 
-function {{phpPrefix}}_handle_increment_counter( WP_REST_Request $request ) {
+function {{phpPrefix}}_handle_write_state( WP_REST_Request $request ) {
 	$payload = {{phpPrefix}}_validate_and_sanitize_request(
 		$request->get_json_params(),
 		{{phpPrefix}}_get_rest_build_dir(),
-		'increment-request',
+		'write-state-request',
 		'body'
 	);
 
@@ -224,7 +224,7 @@ function {{phpPrefix}}_handle_increment_counter( WP_REST_Request $request ) {
 	}
 
 	return rest_ensure_response(
-		{{phpPrefix}}_build_counter_response(
+		{{phpPrefix}}_build_state_response(
 			(int) $payload['postId'],
 			(string) $payload['resourceKey'],
 			$count
@@ -235,16 +235,16 @@ function {{phpPrefix}}_handle_increment_counter( WP_REST_Request $request ) {
 function {{phpPrefix}}_register_routes() {
 	register_rest_route(
 		'{{namespace}}/v1',
-		'/{{slugKebabCase}}/counter',
+		'/{{slugKebabCase}}/state',
 		array(
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => '{{phpPrefix}}_handle_get_counter',
+				'callback'            => '{{phpPrefix}}_handle_get_state',
 				'permission_callback' => '__return_true',
 			),
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => '{{phpPrefix}}_handle_increment_counter',
+				'callback'            => '{{phpPrefix}}_handle_write_state',
 				'permission_callback' => '{{phpPrefix}}_can_write_authenticated',
 			),
 		)

--- a/packages/create/templates/_shared/compound/persistence-public/{{slugKebabCase}}.php.mustache
+++ b/packages/create/templates/_shared/compound/persistence-public/{{slugKebabCase}}.php.mustache
@@ -168,7 +168,7 @@ function {{phpPrefix}}_increment_counter( $post_id, $resource_key, $delta ) {
 	);
 }
 
-function {{phpPrefix}}_build_counter_response( $post_id, $resource_key, $count ) {
+function {{phpPrefix}}_build_state_response( $post_id, $resource_key, $count ) {
 	return array(
 		'postId'      => (int) $post_id,
 		'resourceKey' => (string) $resource_key,
@@ -177,14 +177,14 @@ function {{phpPrefix}}_build_counter_response( $post_id, $resource_key, $count )
 	);
 }
 
-function {{phpPrefix}}_handle_get_counter( WP_REST_Request $request ) {
+function {{phpPrefix}}_handle_get_state( WP_REST_Request $request ) {
 	$payload = {{phpPrefix}}_validate_and_sanitize_request(
 		array(
 			'postId'      => $request->get_param( 'postId' ),
 			'resourceKey' => $request->get_param( 'resourceKey' ),
 		),
 		{{phpPrefix}}_get_rest_build_dir(),
-		'counter-query',
+		'state-query',
 		'query'
 	);
 
@@ -194,7 +194,7 @@ function {{phpPrefix}}_handle_get_counter( WP_REST_Request $request ) {
 
 	$count = {{phpPrefix}}_get_counter( (int) $payload['postId'], (string) $payload['resourceKey'] );
 	return rest_ensure_response(
-		{{phpPrefix}}_build_counter_response(
+		{{phpPrefix}}_build_state_response(
 			(int) $payload['postId'],
 			(string) $payload['resourceKey'],
 			$count
@@ -202,11 +202,11 @@ function {{phpPrefix}}_handle_get_counter( WP_REST_Request $request ) {
 	);
 }
 
-function {{phpPrefix}}_handle_increment_counter( WP_REST_Request $request ) {
+function {{phpPrefix}}_handle_write_state( WP_REST_Request $request ) {
 	$payload = {{phpPrefix}}_validate_and_sanitize_request(
 		$request->get_json_params(),
 		{{phpPrefix}}_get_rest_build_dir(),
-		'increment-request',
+		'write-state-request',
 		'body'
 	);
 
@@ -225,7 +225,7 @@ function {{phpPrefix}}_handle_increment_counter( WP_REST_Request $request ) {
 	}
 
 	return rest_ensure_response(
-		{{phpPrefix}}_build_counter_response(
+		{{phpPrefix}}_build_state_response(
 			(int) $payload['postId'],
 			(string) $payload['resourceKey'],
 			$count
@@ -236,16 +236,16 @@ function {{phpPrefix}}_handle_increment_counter( WP_REST_Request $request ) {
 function {{phpPrefix}}_register_routes() {
 	register_rest_route(
 		'{{namespace}}/v1',
-		'/{{slugKebabCase}}/counter',
+		'/{{slugKebabCase}}/state',
 		array(
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => '{{phpPrefix}}_handle_get_counter',
+				'callback'            => '{{phpPrefix}}_handle_get_state',
 				'permission_callback' => '__return_true',
 			),
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => '{{phpPrefix}}_handle_increment_counter',
+				'callback'            => '{{phpPrefix}}_handle_write_state',
 				'permission_callback' => '{{phpPrefix}}_can_write_publicly',
 			),
 		)

--- a/packages/create/templates/_shared/compound/persistence/scripts/block-config.ts.mustache
+++ b/packages/create/templates/_shared/compound/persistence/scripts/block-config.ts.mustache
@@ -4,16 +4,16 @@ export const BLOCKS = [
 		attributeTypeName: '{{pascalCase}}Attributes',
 		contracts: [
 			{
-				baseName: 'counter-query',
-				sourceTypeName: '{{pascalCase}}CounterQuery',
+				baseName: 'state-query',
+				sourceTypeName: '{{pascalCase}}StateQuery',
 			},
 			{
-				baseName: 'increment-request',
-				sourceTypeName: '{{pascalCase}}IncrementRequest',
+				baseName: 'write-state-request',
+				sourceTypeName: '{{pascalCase}}WriteStateRequest',
 			},
 			{
-				baseName: 'counter-response',
-				sourceTypeName: '{{pascalCase}}CounterResponse',
+				baseName: 'state-response',
+				sourceTypeName: '{{pascalCase}}StateResponse',
 			},
 		],
 		slug: '{{slugKebabCase}}',

--- a/packages/create/templates/_shared/compound/persistence/src/blocks/{{slugKebabCase}}/api-types.ts.mustache
+++ b/packages/create/templates/_shared/compound/persistence/src/blocks/{{slugKebabCase}}/api-types.ts.mustache
@@ -1,18 +1,18 @@
 import { tags } from 'typia';
 
-export interface {{pascalCase}}CounterQuery {
+export interface {{pascalCase}}StateQuery {
 	postId: number & tags.Type< 'uint32' >;
 	resourceKey: string & tags.MinLength< 1 > & tags.MaxLength< 100 >;
 }
 
-export interface {{pascalCase}}IncrementRequest {
+export interface {{pascalCase}}WriteStateRequest {
 	postId: number & tags.Type< 'uint32' >;
 	publicWriteToken?: string & tags.MinLength< 1 > & tags.MaxLength< 512 >;
 	resourceKey: string & tags.MinLength< 1 > & tags.MaxLength< 100 >;
 	delta?: number & tags.Minimum< 1 > & tags.Type< 'uint32' > & tags.Default< 1 >;
 }
 
-export interface {{pascalCase}}CounterResponse {
+export interface {{pascalCase}}StateResponse {
 	postId: number & tags.Type< 'uint32' >;
 	resourceKey: string & tags.MinLength< 1 > & tags.MaxLength< 100 >;
 	count: number & tags.Minimum< 0 > & tags.Type< 'uint32' >;

--- a/packages/create/templates/_shared/compound/persistence/src/blocks/{{slugKebabCase}}/api-validators.ts.mustache
+++ b/packages/create/templates/_shared/compound/persistence/src/blocks/{{slugKebabCase}}/api-validators.ts.mustache
@@ -5,28 +5,28 @@ import {
 	type ValidationResult,
 } from '@wp-typia/rest';
 import type {
-	{{pascalCase}}CounterQuery,
-	{{pascalCase}}CounterResponse,
-	{{pascalCase}}IncrementRequest,
+	{{pascalCase}}StateQuery,
+	{{pascalCase}}StateResponse,
+	{{pascalCase}}WriteStateRequest,
 } from './api-types';
 
-const validateCounterQuery = typia.createValidate< {{pascalCase}}CounterQuery >();
-const validateIncrementRequest =
-	typia.createValidate< {{pascalCase}}IncrementRequest >();
-const validateCounterResponse =
-	typia.createValidate< {{pascalCase}}CounterResponse >();
+const validateStateQuery = typia.createValidate< {{pascalCase}}StateQuery >();
+const validateWriteStateRequest =
+	typia.createValidate< {{pascalCase}}WriteStateRequest >();
+const validateStateResponse =
+	typia.createValidate< {{pascalCase}}StateResponse >();
 
 export const apiValidators = {
-	counterQuery: (
+	stateQuery: (
 		input: unknown
-	): ValidationResult< {{pascalCase}}CounterQuery > =>
-		toValidationResult( validateCounterQuery( input ) ),
-	counterResponse: (
+	): ValidationResult< {{pascalCase}}StateQuery > =>
+		toValidationResult( validateStateQuery( input ) ),
+	stateResponse: (
 		input: unknown
-	): ValidationResult< {{pascalCase}}CounterResponse > =>
-		toValidationResult( validateCounterResponse( input ) ),
-	incrementRequest: (
+	): ValidationResult< {{pascalCase}}StateResponse > =>
+		toValidationResult( validateStateResponse( input ) ),
+	writeStateRequest: (
 		input: unknown
-	): ValidationResult< {{pascalCase}}IncrementRequest > =>
-		toValidationResult( validateIncrementRequest( input ) ),
+	): ValidationResult< {{pascalCase}}WriteStateRequest > =>
+		toValidationResult( validateWriteStateRequest( input ) ),
 };

--- a/packages/create/templates/_shared/compound/persistence/src/blocks/{{slugKebabCase}}/api.ts.mustache
+++ b/packages/create/templates/_shared/compound/persistence/src/blocks/{{slugKebabCase}}/api.ts.mustache
@@ -5,13 +5,13 @@ import {
 } from '@wp-typia/rest';
 
 import {
-	type {{pascalCase}}CounterQuery,
-	type {{pascalCase}}CounterResponse,
-	type {{pascalCase}}IncrementRequest,
+	type {{pascalCase}}StateQuery,
+	type {{pascalCase}}StateResponse,
+	type {{pascalCase}}WriteStateRequest,
 } from './api-types';
 import { apiValidators } from './api-validators';
 
-const COUNTER_PATH = '/{{namespace}}/v1/{{slugKebabCase}}/counter';
+const STATE_PATH = '/{{namespace}}/v1/{{slugKebabCase}}/state';
 
 function resolveRestNonce( fallback?: string ): string | undefined {
 	if ( typeof fallback === 'string' && fallback.length > 0 ) {
@@ -27,45 +27,45 @@ function resolveRestNonce( fallback?: string ): string | undefined {
 		: undefined;
 }
 
-export const counterEndpoint = createEndpoint<
-	{{pascalCase}}CounterQuery,
-	{{pascalCase}}CounterResponse
+export const stateEndpoint = createEndpoint<
+	{{pascalCase}}StateQuery,
+	{{pascalCase}}StateResponse
 >( {
 	buildRequestOptions: () => ( {
-		url: resolveRestRouteUrl( COUNTER_PATH ),
+		url: resolveRestRouteUrl( STATE_PATH ),
 	} ),
 	method: 'GET',
-	path: COUNTER_PATH,
-	validateRequest: apiValidators.counterQuery,
-	validateResponse: apiValidators.counterResponse,
+	path: STATE_PATH,
+	validateRequest: apiValidators.stateQuery,
+	validateResponse: apiValidators.stateResponse,
 } );
 
-export const incrementCounterEndpoint = createEndpoint<
-	{{pascalCase}}IncrementRequest,
-	{{pascalCase}}CounterResponse
+export const writeStateEndpoint = createEndpoint<
+	{{pascalCase}}WriteStateRequest,
+	{{pascalCase}}StateResponse
 >( {
 	buildRequestOptions: () => ( {
-		url: resolveRestRouteUrl( COUNTER_PATH ),
+		url: resolveRestRouteUrl( STATE_PATH ),
 	} ),
 	method: 'POST',
-	path: COUNTER_PATH,
-	validateRequest: apiValidators.incrementRequest,
-	validateResponse: apiValidators.counterResponse,
+	path: STATE_PATH,
+	validateRequest: apiValidators.writeStateRequest,
+	validateResponse: apiValidators.stateResponse,
 } );
 
-export function fetchCounter(
-	request: {{pascalCase}}CounterQuery
+export function fetchState(
+	request: {{pascalCase}}StateQuery
 ) {
-	return callEndpoint( counterEndpoint, request );
+	return callEndpoint( stateEndpoint, request );
 }
 
-export function incrementCounter(
-	request: {{pascalCase}}IncrementRequest,
+export function writeState(
+	request: {{pascalCase}}WriteStateRequest,
 	restNonce?: string
 ) {
 	const nonce = resolveRestNonce( restNonce );
 
-	return callEndpoint( incrementCounterEndpoint, request, {
+	return callEndpoint( writeStateEndpoint, request, {
 		requestOptions: nonce
 			? {
 					headers: {

--- a/packages/create/templates/_shared/compound/persistence/src/blocks/{{slugKebabCase}}/interactivity.ts.mustache
+++ b/packages/create/templates/_shared/compound/persistence/src/blocks/{{slugKebabCase}}/interactivity.ts.mustache
@@ -1,6 +1,6 @@
 import { getContext, store } from '@wordpress/interactivity';
 
-import { fetchCounter, incrementCounter } from './api';
+import { fetchState, writeState } from './api';
 import type { {{pascalCase}}Context, {{pascalCase}}State } from './types';
 
 function hasExpiredPublicWriteToken(
@@ -43,7 +43,7 @@ const { actions, state } = store( '{{slugKebabCase}}', {
 			state.error = undefined;
 
 			try {
-				const result = await fetchCounter( {
+				const result = await fetchState( {
 					postId: context.postId,
 					resourceKey: context.resourceKey,
 				} );
@@ -81,7 +81,7 @@ const { actions, state } = store( '{{slugKebabCase}}', {
 			state.error = undefined;
 
 			try {
-				const result = await incrementCounter( {
+				const result = await writeState( {
 					delta: 1,
 					postId: context.postId,
 					publicWriteToken:

--- a/packages/create/templates/_shared/persistence/auth/{{slugKebabCase}}.php.mustache
+++ b/packages/create/templates/_shared/persistence/auth/{{slugKebabCase}}.php.mustache
@@ -172,7 +172,7 @@ function {{phpPrefix}}_increment_counter( $post_id, $resource_key, $delta ) {
 	);
 }
 
-function {{phpPrefix}}_build_counter_response( $post_id, $resource_key, $count ) {
+function {{phpPrefix}}_build_state_response( $post_id, $resource_key, $count ) {
 	return array(
 		'postId'      => (int) $post_id,
 		'resourceKey' => (string) $resource_key,
@@ -181,14 +181,14 @@ function {{phpPrefix}}_build_counter_response( $post_id, $resource_key, $count )
 	);
 }
 
-function {{phpPrefix}}_handle_get_counter( WP_REST_Request $request ) {
+function {{phpPrefix}}_handle_get_state( WP_REST_Request $request ) {
 	$payload = {{phpPrefix}}_validate_and_sanitize_request(
 		array(
 			'postId'      => $request->get_param( 'postId' ),
 			'resourceKey' => $request->get_param( 'resourceKey' ),
 		),
 		{{phpPrefix}}_get_rest_build_dir(),
-		'counter-query',
+		'state-query',
 		'query'
 	);
 
@@ -198,7 +198,7 @@ function {{phpPrefix}}_handle_get_counter( WP_REST_Request $request ) {
 
 	$count = {{phpPrefix}}_get_counter( (int) $payload['postId'], (string) $payload['resourceKey'] );
 	return rest_ensure_response(
-		{{phpPrefix}}_build_counter_response(
+		{{phpPrefix}}_build_state_response(
 			(int) $payload['postId'],
 			(string) $payload['resourceKey'],
 			$count
@@ -206,11 +206,11 @@ function {{phpPrefix}}_handle_get_counter( WP_REST_Request $request ) {
 	);
 }
 
-function {{phpPrefix}}_handle_increment_counter( WP_REST_Request $request ) {
+function {{phpPrefix}}_handle_write_state( WP_REST_Request $request ) {
 	$payload = {{phpPrefix}}_validate_and_sanitize_request(
 		$request->get_json_params(),
 		{{phpPrefix}}_get_rest_build_dir(),
-		'increment-request',
+		'write-state-request',
 		'body'
 	);
 
@@ -229,7 +229,7 @@ function {{phpPrefix}}_handle_increment_counter( WP_REST_Request $request ) {
 	}
 
 	return rest_ensure_response(
-		{{phpPrefix}}_build_counter_response(
+		{{phpPrefix}}_build_state_response(
 			(int) $payload['postId'],
 			(string) $payload['resourceKey'],
 			$count
@@ -240,16 +240,16 @@ function {{phpPrefix}}_handle_increment_counter( WP_REST_Request $request ) {
 function {{phpPrefix}}_register_routes() {
 	register_rest_route(
 		'{{namespace}}/v1',
-		'/{{slugKebabCase}}/counter',
+		'/{{slugKebabCase}}/state',
 		array(
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => '{{phpPrefix}}_handle_get_counter',
+				'callback'            => '{{phpPrefix}}_handle_get_state',
 				'permission_callback' => '__return_true',
 			),
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => '{{phpPrefix}}_handle_increment_counter',
+				'callback'            => '{{phpPrefix}}_handle_write_state',
 				'permission_callback' => '{{phpPrefix}}_can_write_authenticated',
 			),
 		)

--- a/packages/create/templates/_shared/persistence/core/scripts/sync-rest-contracts.ts.mustache
+++ b/packages/create/templates/_shared/persistence/core/scripts/sync-rest-contracts.ts.mustache
@@ -3,16 +3,16 @@ import { syncTypeSchemas } from '@wp-typia/create/metadata-core';
 
 const CONTRACTS = [
 	{
-		baseName: 'counter-query',
-		sourceTypeName: '{{pascalCase}}CounterQuery',
+		baseName: 'state-query',
+		sourceTypeName: '{{pascalCase}}StateQuery',
 	},
 	{
-		baseName: 'increment-request',
-		sourceTypeName: '{{pascalCase}}IncrementRequest',
+		baseName: 'write-state-request',
+		sourceTypeName: '{{pascalCase}}WriteStateRequest',
 	},
 	{
-		baseName: 'counter-response',
-		sourceTypeName: '{{pascalCase}}CounterResponse',
+		baseName: 'state-response',
+		sourceTypeName: '{{pascalCase}}StateResponse',
 	},
 ] as const;
 

--- a/packages/create/templates/_shared/persistence/core/src/api-types.ts.mustache
+++ b/packages/create/templates/_shared/persistence/core/src/api-types.ts.mustache
@@ -1,18 +1,18 @@
 import { tags } from 'typia';
 
-export interface {{pascalCase}}CounterQuery {
+export interface {{pascalCase}}StateQuery {
 	postId: number & tags.Type< 'uint32' >;
 	resourceKey: string & tags.MinLength< 1 > & tags.MaxLength< 100 >;
 }
 
-export interface {{pascalCase}}IncrementRequest {
+export interface {{pascalCase}}WriteStateRequest {
 	postId: number & tags.Type< 'uint32' >;
 	publicWriteToken?: string & tags.MinLength< 1 > & tags.MaxLength< 512 >;
 	resourceKey: string & tags.MinLength< 1 > & tags.MaxLength< 100 >;
 	delta?: number & tags.Minimum< 1 > & tags.Type< 'uint32' > & tags.Default< 1 >;
 }
 
-export interface {{pascalCase}}CounterResponse {
+export interface {{pascalCase}}StateResponse {
 	postId: number & tags.Type< 'uint32' >;
 	resourceKey: string & tags.MinLength< 1 > & tags.MaxLength< 100 >;
 	count: number & tags.Minimum< 0 > & tags.Type< 'uint32' >;

--- a/packages/create/templates/_shared/persistence/core/src/api-validators.ts.mustache
+++ b/packages/create/templates/_shared/persistence/core/src/api-validators.ts.mustache
@@ -5,28 +5,28 @@ import {
 	type ValidationResult,
 } from '@wp-typia/rest';
 import type {
-	{{pascalCase}}CounterQuery,
-	{{pascalCase}}CounterResponse,
-	{{pascalCase}}IncrementRequest,
+	{{pascalCase}}StateQuery,
+	{{pascalCase}}StateResponse,
+	{{pascalCase}}WriteStateRequest,
 } from './api-types';
 
-const validateCounterQuery = typia.createValidate< {{pascalCase}}CounterQuery >();
-const validateIncrementRequest =
-	typia.createValidate< {{pascalCase}}IncrementRequest >();
-const validateCounterResponse =
-	typia.createValidate< {{pascalCase}}CounterResponse >();
+const validateStateQuery = typia.createValidate< {{pascalCase}}StateQuery >();
+const validateWriteStateRequest =
+	typia.createValidate< {{pascalCase}}WriteStateRequest >();
+const validateStateResponse =
+	typia.createValidate< {{pascalCase}}StateResponse >();
 
 export const apiValidators = {
-	counterQuery: (
+	stateQuery: (
 		input: unknown
-	): ValidationResult< {{pascalCase}}CounterQuery > =>
-		toValidationResult( validateCounterQuery( input ) ),
-	counterResponse: (
+	): ValidationResult< {{pascalCase}}StateQuery > =>
+		toValidationResult( validateStateQuery( input ) ),
+	stateResponse: (
 		input: unknown
-	): ValidationResult< {{pascalCase}}CounterResponse > =>
-		toValidationResult( validateCounterResponse( input ) ),
-	incrementRequest: (
+	): ValidationResult< {{pascalCase}}StateResponse > =>
+		toValidationResult( validateStateResponse( input ) ),
+	writeStateRequest: (
 		input: unknown
-	): ValidationResult< {{pascalCase}}IncrementRequest > =>
-		toValidationResult( validateIncrementRequest( input ) ),
+	): ValidationResult< {{pascalCase}}WriteStateRequest > =>
+		toValidationResult( validateWriteStateRequest( input ) ),
 };

--- a/packages/create/templates/_shared/persistence/core/src/api.ts.mustache
+++ b/packages/create/templates/_shared/persistence/core/src/api.ts.mustache
@@ -5,13 +5,13 @@ import {
 } from '@wp-typia/rest';
 
 import {
-	type {{pascalCase}}CounterQuery,
-	type {{pascalCase}}CounterResponse,
-	type {{pascalCase}}IncrementRequest,
+	type {{pascalCase}}StateQuery,
+	type {{pascalCase}}StateResponse,
+	type {{pascalCase}}WriteStateRequest,
 } from './api-types';
 import { apiValidators } from './api-validators';
 
-const COUNTER_PATH = '/{{namespace}}/v1/{{slugKebabCase}}/counter';
+const STATE_PATH = '/{{namespace}}/v1/{{slugKebabCase}}/state';
 
 function resolveRestNonce( fallback?: string ): string | undefined {
 	if ( typeof fallback === 'string' && fallback.length > 0 ) {
@@ -27,45 +27,45 @@ function resolveRestNonce( fallback?: string ): string | undefined {
 		: undefined;
 }
 
-export const counterEndpoint = createEndpoint<
-	{{pascalCase}}CounterQuery,
-	{{pascalCase}}CounterResponse
+export const stateEndpoint = createEndpoint<
+	{{pascalCase}}StateQuery,
+	{{pascalCase}}StateResponse
 >( {
 	buildRequestOptions: () => ( {
-		url: resolveRestRouteUrl( COUNTER_PATH ),
+		url: resolveRestRouteUrl( STATE_PATH ),
 	} ),
 	method: 'GET',
-	path: COUNTER_PATH,
-	validateRequest: apiValidators.counterQuery,
-	validateResponse: apiValidators.counterResponse,
+	path: STATE_PATH,
+	validateRequest: apiValidators.stateQuery,
+	validateResponse: apiValidators.stateResponse,
 } );
 
-export const incrementCounterEndpoint = createEndpoint<
-	{{pascalCase}}IncrementRequest,
-	{{pascalCase}}CounterResponse
+export const writeStateEndpoint = createEndpoint<
+	{{pascalCase}}WriteStateRequest,
+	{{pascalCase}}StateResponse
 >( {
 	buildRequestOptions: () => ( {
-		url: resolveRestRouteUrl( COUNTER_PATH ),
+		url: resolveRestRouteUrl( STATE_PATH ),
 	} ),
 	method: 'POST',
-	path: COUNTER_PATH,
-	validateRequest: apiValidators.incrementRequest,
-	validateResponse: apiValidators.counterResponse,
+	path: STATE_PATH,
+	validateRequest: apiValidators.writeStateRequest,
+	validateResponse: apiValidators.stateResponse,
 } );
 
-export function fetchCounter(
-	request: {{pascalCase}}CounterQuery
+export function fetchState(
+	request: {{pascalCase}}StateQuery
 ) {
-	return callEndpoint( counterEndpoint, request );
+	return callEndpoint( stateEndpoint, request );
 }
 
-export function incrementCounter(
-	request: {{pascalCase}}IncrementRequest,
+export function writeState(
+	request: {{pascalCase}}WriteStateRequest,
 	restNonce?: string
 ) {
 	const nonce = resolveRestNonce( restNonce );
 
-	return callEndpoint( incrementCounterEndpoint, request, {
+	return callEndpoint( writeStateEndpoint, request, {
 		requestOptions: nonce
 			? {
 					headers: {

--- a/packages/create/templates/_shared/persistence/core/src/interactivity.ts.mustache
+++ b/packages/create/templates/_shared/persistence/core/src/interactivity.ts.mustache
@@ -1,6 +1,6 @@
 import { getContext, store } from '@wordpress/interactivity';
 
-import { fetchCounter, incrementCounter } from './api';
+import { fetchState, writeState } from './api';
 import type { {{pascalCase}}Context, {{pascalCase}}State } from './types';
 
 function hasExpiredPublicWriteToken(
@@ -44,7 +44,7 @@ const { actions, state } = store( '{{slugKebabCase}}', {
 			state.error = undefined;
 
 			try {
-				const result = await fetchCounter( {
+				const result = await fetchState( {
 					postId: context.postId,
 					resourceKey: context.resourceKey,
 				} );
@@ -82,7 +82,7 @@ const { actions, state } = store( '{{slugKebabCase}}', {
 			state.error = undefined;
 
 			try {
-				const result = await incrementCounter( {
+				const result = await writeState( {
 					delta: 1,
 					postId: context.postId,
 					publicWriteToken:

--- a/packages/create/templates/_shared/persistence/core/{{slugKebabCase}}.php.mustache
+++ b/packages/create/templates/_shared/persistence/core/{{slugKebabCase}}.php.mustache
@@ -216,7 +216,7 @@ function {{phpPrefix}}_increment_counter( $post_id, $resource_key, $delta ) {
 	);
 }
 
-function {{phpPrefix}}_build_counter_response( $post_id, $resource_key, $count ) {
+function {{phpPrefix}}_build_state_response( $post_id, $resource_key, $count ) {
 	return array(
 		'postId'      => (int) $post_id,
 		'resourceKey' => (string) $resource_key,
@@ -225,13 +225,13 @@ function {{phpPrefix}}_build_counter_response( $post_id, $resource_key, $count )
 	);
 }
 
-function {{phpPrefix}}_handle_get_counter( WP_REST_Request $request ) {
+function {{phpPrefix}}_handle_get_state( WP_REST_Request $request ) {
 	$payload = {{phpPrefix}}_validate_and_sanitize_request(
 		array(
 			'postId'      => $request->get_param( 'postId' ),
 			'resourceKey' => $request->get_param( 'resourceKey' ),
 		),
-		'counter-query',
+		'state-query',
 		'query'
 	);
 
@@ -241,7 +241,7 @@ function {{phpPrefix}}_handle_get_counter( WP_REST_Request $request ) {
 
 	$count = {{phpPrefix}}_get_counter( (int) $payload['postId'], (string) $payload['resourceKey'] );
 	return rest_ensure_response(
-		{{phpPrefix}}_build_counter_response(
+		{{phpPrefix}}_build_state_response(
 			(int) $payload['postId'],
 			(string) $payload['resourceKey'],
 			$count
@@ -249,10 +249,10 @@ function {{phpPrefix}}_handle_get_counter( WP_REST_Request $request ) {
 	);
 }
 
-function {{phpPrefix}}_handle_increment_counter( WP_REST_Request $request ) {
+function {{phpPrefix}}_handle_write_state( WP_REST_Request $request ) {
 	$payload = {{phpPrefix}}_validate_and_sanitize_request(
 		$request->get_json_params(),
-		'increment-request',
+		'write-state-request',
 		'body'
 	);
 
@@ -271,7 +271,7 @@ function {{phpPrefix}}_handle_increment_counter( WP_REST_Request $request ) {
 	}
 
 	return rest_ensure_response(
-		{{phpPrefix}}_build_counter_response(
+		{{phpPrefix}}_build_state_response(
 			(int) $payload['postId'],
 			(string) $payload['resourceKey'],
 			$count
@@ -282,17 +282,17 @@ function {{phpPrefix}}_handle_increment_counter( WP_REST_Request $request ) {
 function {{phpPrefix}}_register_routes() {
 	register_rest_route(
 		'{{namespace}}/v1',
-		'/{{slugKebabCase}}/counter',
+		'/{{slugKebabCase}}/state',
 		array(
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => '{{phpPrefix}}_handle_get_counter',
+				'callback'            => '{{phpPrefix}}_handle_get_state',
 				'permission_callback' => '__return_true',
 			),
 			array(
 				// Intentional sample behavior: this template demonstrates anonymous/public writes.
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => '{{phpPrefix}}_handle_increment_counter',
+				'callback'            => '{{phpPrefix}}_handle_write_state',
 				'permission_callback' => '__return_true',
 			),
 		)

--- a/packages/create/templates/_shared/persistence/public/{{slugKebabCase}}.php.mustache
+++ b/packages/create/templates/_shared/persistence/public/{{slugKebabCase}}.php.mustache
@@ -173,7 +173,7 @@ function {{phpPrefix}}_increment_counter( $post_id, $resource_key, $delta ) {
 	);
 }
 
-function {{phpPrefix}}_build_counter_response( $post_id, $resource_key, $count ) {
+function {{phpPrefix}}_build_state_response( $post_id, $resource_key, $count ) {
 	return array(
 		'postId'      => (int) $post_id,
 		'resourceKey' => (string) $resource_key,
@@ -182,14 +182,14 @@ function {{phpPrefix}}_build_counter_response( $post_id, $resource_key, $count )
 	);
 }
 
-function {{phpPrefix}}_handle_get_counter( WP_REST_Request $request ) {
+function {{phpPrefix}}_handle_get_state( WP_REST_Request $request ) {
 	$payload = {{phpPrefix}}_validate_and_sanitize_request(
 		array(
 			'postId'      => $request->get_param( 'postId' ),
 			'resourceKey' => $request->get_param( 'resourceKey' ),
 		),
 		{{phpPrefix}}_get_rest_build_dir(),
-		'counter-query',
+		'state-query',
 		'query'
 	);
 
@@ -199,7 +199,7 @@ function {{phpPrefix}}_handle_get_counter( WP_REST_Request $request ) {
 
 	$count = {{phpPrefix}}_get_counter( (int) $payload['postId'], (string) $payload['resourceKey'] );
 	return rest_ensure_response(
-		{{phpPrefix}}_build_counter_response(
+		{{phpPrefix}}_build_state_response(
 			(int) $payload['postId'],
 			(string) $payload['resourceKey'],
 			$count
@@ -207,11 +207,11 @@ function {{phpPrefix}}_handle_get_counter( WP_REST_Request $request ) {
 	);
 }
 
-function {{phpPrefix}}_handle_increment_counter( WP_REST_Request $request ) {
+function {{phpPrefix}}_handle_write_state( WP_REST_Request $request ) {
 	$payload = {{phpPrefix}}_validate_and_sanitize_request(
 		$request->get_json_params(),
 		{{phpPrefix}}_get_rest_build_dir(),
-		'increment-request',
+		'write-state-request',
 		'body'
 	);
 
@@ -230,7 +230,7 @@ function {{phpPrefix}}_handle_increment_counter( WP_REST_Request $request ) {
 	}
 
 	return rest_ensure_response(
-		{{phpPrefix}}_build_counter_response(
+		{{phpPrefix}}_build_state_response(
 			(int) $payload['postId'],
 			(string) $payload['resourceKey'],
 			$count
@@ -241,16 +241,16 @@ function {{phpPrefix}}_handle_increment_counter( WP_REST_Request $request ) {
 function {{phpPrefix}}_register_routes() {
 	register_rest_route(
 		'{{namespace}}/v1',
-		'/{{slugKebabCase}}/counter',
+		'/{{slugKebabCase}}/state',
 		array(
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => '{{phpPrefix}}_handle_get_counter',
+				'callback'            => '{{phpPrefix}}_handle_get_state',
 				'permission_callback' => '__return_true',
 			),
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => '{{phpPrefix}}_handle_increment_counter',
+				'callback'            => '{{phpPrefix}}_handle_write_state',
 				'permission_callback' => '{{phpPrefix}}_can_write_publicly',
 			),
 		)

--- a/packages/create/templates/_shared/rest-helpers/public/inc/rest-public.php.mustache
+++ b/packages/create/templates/_shared/rest-helpers/public/inc/rest-public.php.mustache
@@ -18,7 +18,7 @@ function {{phpPrefix}}_base64url_decode( $value ) {
 }
 
 function {{phpPrefix}}_get_public_write_action() {
-	return '{{namespace}}/{{slugKebabCase}}/counter/increment';
+	return '{{namespace}}/{{slugKebabCase}}/state/write';
 }
 
 function {{phpPrefix}}_create_public_write_token( $post_id, $resource_key ) {

--- a/scripts/run-generated-project-smoke.mjs
+++ b/scripts/run-generated-project-smoke.mjs
@@ -223,9 +223,9 @@ function assertPersistenceTemplateArtifacts(projectDir, projectName) {
 	for (const artifact of [
 		"typia.schema.json",
 		"typia.openapi.json",
-		path.join("api-schemas", "counter-query.schema.json"),
-		path.join("api-schemas", "counter-response.schema.json"),
-		path.join("api-schemas", "increment-request.schema.json"),
+		path.join("api-schemas", "state-query.schema.json"),
+		path.join("api-schemas", "state-response.schema.json"),
+		path.join("api-schemas", "write-state-request.schema.json"),
 	]) {
 		const found = candidateDirs.some((dir) => fs.existsSync(path.join(dir, artifact)));
 		if (!found) {
@@ -253,9 +253,9 @@ function assertCompoundPersistenceArtifacts(projectDir, projectName) {
 	for (const artifact of [
 		"typia.schema.json",
 		"typia.openapi.json",
-		path.join("api-schemas", "counter-query.schema.json"),
-		path.join("api-schemas", "counter-response.schema.json"),
-		path.join("api-schemas", "increment-request.schema.json"),
+		path.join("api-schemas", "state-query.schema.json"),
+		path.join("api-schemas", "state-response.schema.json"),
+		path.join("api-schemas", "write-state-request.schema.json"),
 	]) {
 		if (!fs.existsSync(path.join(parentDir, artifact))) {
 			throw new Error(`Expected ${artifact} in ${parentDir}`);


### PR DESCRIPTION
## Summary
- generalize scaffolded persistence REST naming from counter-specific routes/contracts to a more reusable state/write pattern
- keep the sample UI as a counter while making the generated REST surface easier to adapt
- update CI artifact downloads to the Node 24-compatible action version

## Changes
- rename generated persistence REST contracts to `state-query`, `write-state-request`, and `state-response`
- switch scaffolded REST route paths from `/counter` to `/state`
- rename generated TS REST helpers to `fetchState` / `writeState` and align validators/endpoints
- rename generated PHP route handlers/response builders to state-oriented names while keeping counter storage semantics intact
- update the persistence tutorial and generated smoke expectations
- upgrade `actions/download-artifact@v4` to `actions/download-artifact@v5` in CI
- add a patch changeset for `@wp-typia/create`

## Validation
- `bun run --filter @wp-typia/create test`
- `node scripts/run-generated-project-smoke.mjs --runtime bun --template persistence --package-manager bun --project-name smoke-state-rest-auth --persistence-policy authenticated`
- `node scripts/run-generated-project-smoke.mjs --runtime bun --template persistence --package-manager bun --project-name smoke-state-rest-public --persistence-policy public`
- `node scripts/run-generated-project-smoke.mjs --runtime bun --template compound --package-manager bun --project-name smoke-state-rest-compound --persistence-policy authenticated`

Closes #28


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated persistence block tutorial with new API endpoint and function names.

* **Refactor**
  * Renamed REST API endpoints from counter-specific to state semantics across persistence templates.
  * Updated API helper functions and endpoint exports to reflect new naming conventions.
  * Renamed API types and validators to support generalized state operations.

* **Chores**
  * Updated CI workflow artifact downloads to use a newer GitHub Action version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->