### PR TITLE
fix: restore release changeset package ids

### DIFF
--- a/.sampo/changesets/fuzzy-ember-mica.md
+++ b/.sampo/changesets/fuzzy-ember-mica.md
@@ -1,5 +1,5 @@
 ---
-"@wp-typia/create": patch
+npm/@wp-typia/create: patch
 ---
 
 Extract shared PHP REST helper files for generated persistence-capable scaffolds.

--- a/.sampo/changesets/silent-umber-lynx.md
+++ b/.sampo/changesets/silent-umber-lynx.md
@@ -1,5 +1,5 @@
 ---
-"@wp-typia/create": patch
+npm/@wp-typia/create: patch
 ---
 
 Generalize generated persistence REST route and contract naming beyond the counter sample, and update CI artifact downloads to the Node 24-compatible action release.


### PR DESCRIPTION
## Summary
- restore canonical  package ids in pending Sampo changesets
- fix Release PR workflow failures caused by unsupported scoped package references
- verify  succeeds again

## Validation
- Planned releases:
  @wp-typia/create: 0.4.0 -> 0.5.0
  compound-patterns: 0.1.0 -> 0.1.1
  create-wp-typia: 1.3.0 -> 1.3.1
Dry-run: no files modified, no tags created.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal release tooling configuration metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->