### PR TITLE
docs: clarify php rest extension points

### DIFF
--- a/.sampo/changesets/brisk-pear-sigil.md
+++ b/.sampo/changesets/brisk-pear-sigil.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/create: patch
+---
+
+Document PHP REST extension points in persistence-capable scaffolds, generated README files, and repository guides.

--- a/docs/API.md
+++ b/docs/API.md
@@ -152,6 +152,13 @@ The built-in `persistence` template adds another predictable layer:
 
 For persistence-capable scaffolds, `src/api.openapi.json` is the canonical endpoint-aware REST document. The `src/api-schemas/*.schema.json` files remain the runtime contract artifacts, and `src/api-schemas/*.openapi.json` files remain available as per-contract compatibility fragments.
 
+When you customize the generated PHP:
+
+- edit the plugin bootstrap file for storage helpers, route handlers, response shaping, and route registration
+- edit `inc/rest-auth.php` or `inc/rest-public.php` for permission policy changes
+- keep `src/api-types.ts` as the source of truth for REST contracts, then regenerate `src/api-schemas/*` and `src/api.openapi.json`
+- avoid hand-editing generated schema and OpenAPI artifacts unless you are debugging the generation output itself
+
 `persistence` keeps one minimal aggregate-counter scaffold and lets you choose between:
 
 - `authenticated`: logged-in writes protected by a WordPress REST nonce
@@ -173,6 +180,8 @@ When you opt `compound` into persistence with `--data-storage` or `--persistence
 - `src/blocks/<parent>/api-schemas/`
 - `src/blocks/<parent>/interactivity.ts`
 - generated PHP route/storage wiring in the plugin bootstrap
+
+For persistence-enabled `compound`, the parent block follows the same REST extension pattern as `persistence`. The hidden child block does not own REST routes or storage behavior.
 
 ## 5. Repo-local example app
 

--- a/docs/tutorials/persistence-block-tutorial.md
+++ b/docs/tutorials/persistence-block-tutorial.md
@@ -455,6 +455,12 @@ You only need to run `npm run sync-types` / `npm run sync-rest` manually when yo
 
 For persistence scaffolds, `src/api.openapi.json` is the canonical REST document because it includes the actual route paths, methods, and auth policy metadata. The files in `src/api-schemas/` remain useful per-contract artifacts for validation and compatibility.
 
+For actual customization work:
+
+- edit `my-counter.php` when you need to change storage helpers, route handlers, response shaping, or route registration
+- edit `inc/rest-auth.php` or `inc/rest-public.php` when you need to change the write permission policy
+- keep `src/api-types.ts` as the source of truth for contracts and regenerate `src/api-schemas/*` plus `src/api.openapi.json` instead of hand-maintaining those generated artifacts
+
 These schemas can be used for:
 - API documentation
 - Client SDK generation

--- a/packages/create/README.md
+++ b/packages/create/README.md
@@ -164,7 +164,13 @@ await syncRestOpenApi({
 });
 ```
 
-`src/api-schemas/*.schema.json` remains the runtime-facing artifact for generated PHP validation. `src/api.openapi.json` is the canonical endpoint-aware REST document when a scaffold defines route metadata, while per-contract `src/api-schemas/*.openapi.json` files remain available as compatibility fragments.
+`src/api-types.ts` remains the source of truth for scaffolded REST contracts. `src/api-schemas/*.schema.json` remains the runtime-facing artifact for generated PHP validation, and `src/api.openapi.json` is the canonical endpoint-aware REST document when a scaffold defines route metadata. Per-contract `src/api-schemas/*.openapi.json` files remain available as compatibility fragments.
+
+For persistence-capable scaffolds, generated PHP stays intentionally boring glue:
+
+- edit the plugin bootstrap file when you need to customize storage helpers, route handlers, response shaping, or route registration
+- edit `inc/rest-auth.php` or `inc/rest-public.php` when you need to customize write permission policy
+- regenerate `src/api-schemas/*` and `src/api.openapi.json` from `src/api-types.ts` instead of treating those generated artifacts as hand-maintained sources
 
 The `migrations` commands remain available for projects that include the migration workspace, such as the repo-local reference app in [`examples/my-typia-block`](../../examples/my-typia-block) or compatible remote seeds:
 

--- a/packages/create/src/runtime/scaffold-onboarding.ts
+++ b/packages/create/src/runtime/scaffold-onboarding.ts
@@ -5,6 +5,10 @@ interface SyncOnboardingOptions {
 	compoundPersistenceEnabled?: boolean;
 }
 
+interface PhpRestExtensionOptions extends SyncOnboardingOptions {
+	slug: string;
+}
+
 function templateHasPersistenceSync(
 	templateId: string,
 	{ compoundPersistenceEnabled = false }: SyncOnboardingOptions = {},
@@ -67,4 +71,32 @@ export function getTemplateSourceOfTruthNote(
 	}
 
 	return "`src/types.ts` remains the source of truth for `block.json`, `typia.manifest.json`, and `typia-validator.php`.";
+}
+
+/**
+ * Returns scaffold-local guidance for the main PHP REST customization points.
+ */
+export function getPhpRestExtensionPointsSection(
+	templateId: string,
+	{ compoundPersistenceEnabled = false, slug }: PhpRestExtensionOptions,
+): string | null {
+	if (templateId === "persistence") {
+		return `## PHP REST Extension Points
+
+- Edit \`${slug}.php\` when you need to change storage helpers, route handlers, response shaping, or route registration.
+- Edit \`inc/rest-auth.php\` or \`inc/rest-public.php\` when you need to customize write permissions or token/nonce checks for the selected policy.
+- Keep \`src/api-types.ts\` as the source of truth for request and response contracts, then regenerate \`src/api-schemas/*.schema.json\`, per-contract \`src/api-schemas/*.openapi.json\`, and \`src/api.openapi.json\` with \`sync-rest\`.
+- Avoid hand-editing generated schema and OpenAPI artifacts unless you are debugging generated output; they are meant to be regenerated from TypeScript contracts.`;
+	}
+
+	if (templateId === "compound" && compoundPersistenceEnabled) {
+		return `## PHP REST Extension Points
+
+- Edit \`${slug}.php\` when you need to change parent-block storage helpers, route handlers, response shaping, or route registration.
+- Edit \`inc/rest-auth.php\` or \`inc/rest-public.php\` when you need to customize write permissions or token/nonce checks for the parent block.
+- Keep \`src/blocks/${slug}/api-types.ts\` as the source of truth for parent REST contracts, then regenerate \`src/blocks/${slug}/api-schemas/*.schema.json\`, per-contract \`src/blocks/${slug}/api-schemas/*.openapi.json\`, and \`src/blocks/${slug}/api.openapi.json\` with \`sync-rest\`.
+- The hidden child block does not own REST routes or storage. Avoid hand-editing generated schema and OpenAPI artifacts unless you are debugging generated output.`;
+	}
+
+	return null;
 }

--- a/packages/create/src/runtime/scaffold.ts
+++ b/packages/create/src/runtime/scaffold.ts
@@ -15,6 +15,7 @@ import { getPackageVersions } from "./package-versions.js";
 import {
 	getOptionalOnboardingNote,
 	getOptionalOnboardingSteps,
+	getPhpRestExtensionPointsSection,
 	getTemplateSourceOfTruthNote,
 } from "./scaffold-onboarding.js";
 import { copyInterpolatedDirectory } from "./template-render.js";
@@ -516,6 +517,10 @@ function buildReadme(
 	const sourceOfTruthNote = getTemplateSourceOfTruthNote(templateId, {
 		compoundPersistenceEnabled: variables.compoundPersistenceEnabled === "true",
 	});
+	const phpRestExtensionPointsSection = getPhpRestExtensionPointsSection(templateId, {
+		compoundPersistenceEnabled: variables.compoundPersistenceEnabled === "true",
+		slug: variables.slug,
+	});
 
 	return `# ${variables.title}
 
@@ -546,7 +551,7 @@ ${optionalOnboardingSteps.join("\n")}
 
 ${getOptionalOnboardingNote(packageManager)}
 
-${sourceOfTruthNote}
+${sourceOfTruthNote}${phpRestExtensionPointsSection ? `\n\n${phpRestExtensionPointsSection}` : ""}
 `;
 }
 

--- a/packages/create/templates/_shared/compound/persistence-auth/{{slugKebabCase}}.php.mustache
+++ b/packages/create/templates/_shared/compound/persistence-auth/{{slugKebabCase}}.php.mustache
@@ -16,6 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 define( '{{phpPrefix}}_DATA_STORAGE_MODE', '{{dataStorageMode}}' );
+// These helper files are scaffold-owned plumbing. Customize them only when you are changing auth or request validation behavior.
 require_once __DIR__ . '/inc/rest-shared.php';
 require_once __DIR__ . '/inc/rest-auth.php';
 
@@ -126,6 +127,7 @@ function {{phpPrefix}}_get_counter( $post_id, $resource_key ) {
 	return (int) get_post_meta( $post_id, $meta_key, true );
 }
 
+// Customize storage helpers here when you need a different backend or aggregate behavior for the parent block.
 function {{phpPrefix}}_increment_counter( $post_id, $resource_key, $delta ) {
 	global $wpdb;
 
@@ -176,6 +178,7 @@ function {{phpPrefix}}_build_state_response( $post_id, $resource_key, $count ) {
 	);
 }
 
+// Route handlers are the main product-level extension point for parent-block request/response shaping.
 function {{phpPrefix}}_handle_get_state( WP_REST_Request $request ) {
 	$payload = {{phpPrefix}}_validate_and_sanitize_request(
 		array(
@@ -232,6 +235,7 @@ function {{phpPrefix}}_handle_write_state( WP_REST_Request $request ) {
 	);
 }
 
+// Add or reorganize parent-block endpoints here as the REST surface grows.
 function {{phpPrefix}}_register_routes() {
 	register_rest_route(
 		'{{namespace}}/v1',

--- a/packages/create/templates/_shared/compound/persistence-public/{{slugKebabCase}}.php.mustache
+++ b/packages/create/templates/_shared/compound/persistence-public/{{slugKebabCase}}.php.mustache
@@ -17,6 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( '{{phpPrefix}}_DATA_STORAGE_MODE', '{{dataStorageMode}}' );
 define( '{{phpPrefix}}_PUBLIC_WRITE_TTL', HOUR_IN_SECONDS );
+// These helper files are scaffold-owned plumbing. Customize them only when you are changing auth or request validation behavior.
 require_once __DIR__ . '/inc/rest-shared.php';
 require_once __DIR__ . '/inc/rest-public.php';
 
@@ -127,6 +128,7 @@ function {{phpPrefix}}_get_counter( $post_id, $resource_key ) {
 	return (int) get_post_meta( $post_id, $meta_key, true );
 }
 
+// Customize storage helpers here when you need a different backend or aggregate behavior for the parent block.
 function {{phpPrefix}}_increment_counter( $post_id, $resource_key, $delta ) {
 	global $wpdb;
 
@@ -177,6 +179,7 @@ function {{phpPrefix}}_build_state_response( $post_id, $resource_key, $count ) {
 	);
 }
 
+// Route handlers are the main product-level extension point for parent-block request/response shaping.
 function {{phpPrefix}}_handle_get_state( WP_REST_Request $request ) {
 	$payload = {{phpPrefix}}_validate_and_sanitize_request(
 		array(
@@ -233,6 +236,7 @@ function {{phpPrefix}}_handle_write_state( WP_REST_Request $request ) {
 	);
 }
 
+// Add or reorganize parent-block endpoints here as the REST surface grows.
 function {{phpPrefix}}_register_routes() {
 	register_rest_route(
 		'{{namespace}}/v1',

--- a/packages/create/templates/_shared/persistence/auth/{{slugKebabCase}}.php.mustache
+++ b/packages/create/templates/_shared/persistence/auth/{{slugKebabCase}}.php.mustache
@@ -16,6 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 define( '{{phpPrefix}}_DATA_STORAGE_MODE', '{{dataStorageMode}}' );
+// These helper files are scaffold-owned plumbing. Customize them only when you are changing auth or request validation behavior.
 require_once __DIR__ . '/inc/rest-shared.php';
 require_once __DIR__ . '/inc/rest-auth.php';
 
@@ -131,6 +132,7 @@ function {{phpPrefix}}_get_counter( $post_id, $resource_key ) {
 	return (int) get_post_meta( $post_id, $meta_key, true );
 }
 
+// Customize storage helpers here when you need a different backend or aggregate behavior.
 function {{phpPrefix}}_increment_counter( $post_id, $resource_key, $delta ) {
 	global $wpdb;
 
@@ -181,6 +183,7 @@ function {{phpPrefix}}_build_state_response( $post_id, $resource_key, $count ) {
 	);
 }
 
+// Route handlers are the main product-level extension point for request/response shaping.
 function {{phpPrefix}}_handle_get_state( WP_REST_Request $request ) {
 	$payload = {{phpPrefix}}_validate_and_sanitize_request(
 		array(
@@ -237,6 +240,7 @@ function {{phpPrefix}}_handle_write_state( WP_REST_Request $request ) {
 	);
 }
 
+// Add or reorganize endpoints here as the REST surface grows.
 function {{phpPrefix}}_register_routes() {
 	register_rest_route(
 		'{{namespace}}/v1',

--- a/packages/create/templates/_shared/persistence/public/{{slugKebabCase}}.php.mustache
+++ b/packages/create/templates/_shared/persistence/public/{{slugKebabCase}}.php.mustache
@@ -17,6 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( '{{phpPrefix}}_DATA_STORAGE_MODE', '{{dataStorageMode}}' );
 define( '{{phpPrefix}}_PUBLIC_WRITE_TTL', HOUR_IN_SECONDS );
+// These helper files are scaffold-owned plumbing. Customize them only when you are changing auth or request validation behavior.
 require_once __DIR__ . '/inc/rest-shared.php';
 require_once __DIR__ . '/inc/rest-public.php';
 
@@ -132,6 +133,7 @@ function {{phpPrefix}}_get_counter( $post_id, $resource_key ) {
 	return (int) get_post_meta( $post_id, $meta_key, true );
 }
 
+// Customize storage helpers here when you need a different backend or aggregate behavior.
 function {{phpPrefix}}_increment_counter( $post_id, $resource_key, $delta ) {
 	global $wpdb;
 
@@ -182,6 +184,7 @@ function {{phpPrefix}}_build_state_response( $post_id, $resource_key, $count ) {
 	);
 }
 
+// Route handlers are the main product-level extension point for request/response shaping.
 function {{phpPrefix}}_handle_get_state( WP_REST_Request $request ) {
 	$payload = {{phpPrefix}}_validate_and_sanitize_request(
 		array(
@@ -238,6 +241,7 @@ function {{phpPrefix}}_handle_write_state( WP_REST_Request $request ) {
 	);
 }
 
+// Add or reorganize endpoints here as the REST surface grows.
 function {{phpPrefix}}_register_routes() {
 	register_rest_route(
 		'{{namespace}}/v1',

--- a/packages/create/templates/_shared/rest-helpers/auth/inc/rest-auth.php.mustache
+++ b/packages/create/templates/_shared/rest-helpers/auth/inc/rest-auth.php.mustache
@@ -14,6 +14,7 @@ function {{phpPrefix}}_get_rest_nonce( WP_REST_Request $request ) {
 	return null;
 }
 
+// Customize authenticated write policy here when your project needs stricter capability checks.
 function {{phpPrefix}}_can_write_authenticated( WP_REST_Request $request ) {
 	if ( ! is_user_logged_in() ) {
 		return new WP_Error(

--- a/packages/create/templates/_shared/rest-helpers/public/inc/rest-public.php.mustache
+++ b/packages/create/templates/_shared/rest-helpers/public/inc/rest-public.php.mustache
@@ -21,6 +21,7 @@ function {{phpPrefix}}_get_public_write_action() {
 	return '{{namespace}}/{{slugKebabCase}}/state/write';
 }
 
+// Public write tokens are scaffold-owned by default; customize this flow if you need a different anonymous write policy.
 function {{phpPrefix}}_create_public_write_token( $post_id, $resource_key ) {
 	$expires_at = time() + (int) {{phpPrefix}}_PUBLIC_WRITE_TTL;
 	$payload    = array(
@@ -134,6 +135,7 @@ function {{phpPrefix}}_verify_public_write_token( $token, $post_id, $resource_ke
 	return true;
 }
 
+// Customize the public write gate here when you need different anonymous request checks.
 function {{phpPrefix}}_can_write_publicly( WP_REST_Request $request ) {
 	$payload = $request->get_json_params();
 	if ( ! is_array( $payload ) ) {

--- a/packages/create/templates/_shared/rest-helpers/shared/inc/rest-shared.php.mustache
+++ b/packages/create/templates/_shared/rest-helpers/shared/inc/rest-shared.php.mustache
@@ -1,5 +1,6 @@
 <?php
 
+// Scaffold-owned schema plumbing. Extend request/response behavior in the route handlers instead.
 function {{phpPrefix}}_load_schema_from_build_dir( $build_dir, $schema_name ) {
 	if ( ! is_string( $build_dir ) || '' === $build_dir ) {
 		return null;
@@ -19,6 +20,7 @@ function {{phpPrefix}}_load_schema_from_build_dir( $build_dir, $schema_name ) {
 	return is_array( $decoded ) ? $decoded : null;
 }
 
+// Keep schema sanitation aligned with generated JSON Schema unless you are debugging bridge behavior.
 function {{phpPrefix}}_sanitize_rest_schema( $schema ) {
 	if ( ! is_array( $schema ) ) {
 		return $schema;
@@ -39,6 +41,7 @@ function {{phpPrefix}}_sanitize_rest_schema( $schema ) {
 	return $schema;
 }
 
+// Route handlers call this bridge before product-specific logic runs.
 function {{phpPrefix}}_validate_and_sanitize_request( $value, $build_dir, $schema_name, $param_name ) {
 	$schema = {{phpPrefix}}_load_schema_from_build_dir( $build_dir, $schema_name );
 	if ( ! is_array( $schema ) ) {

--- a/packages/create/tests/create-cli.test.ts
+++ b/packages/create/tests/create-cli.test.ts
@@ -105,6 +105,7 @@ describe("@wp-typia/create scaffolding", () => {
 		expect(readme).not.toContain("npm run sync-rest");
 		expect(readme).toContain("already run the relevant sync scripts");
 		expect(readme).toContain("do not create migration history");
+		expect(readme).not.toContain("## PHP REST Extension Points");
 	});
 
 	test("scaffoldProject creates an interactivity template with typed validation wiring", async () => {
@@ -206,6 +207,12 @@ describe("@wp-typia/create scaffolding", () => {
 		expect(readme).toContain("npm run sync-types");
 		expect(readme).toContain("npm run sync-rest");
 		expect(readme).toContain("src/api-types.ts");
+		expect(readme).toContain("## PHP REST Extension Points");
+		expect(readme).toContain("Edit `demo-persistence-public.php`");
+		expect(readme).toContain("Edit `inc/rest-auth.php` or `inc/rest-public.php`");
+		expect(pluginBootstrap).toContain("Customize storage helpers");
+		expect(pluginBootstrap).toContain("Route handlers are the main product-level extension point");
+		expect(restPublicHelper).toContain("Customize the public write gate here");
 	});
 
 	test("scaffoldProject creates a persistence template with authenticated writes by default", async () => {
@@ -235,6 +242,7 @@ describe("@wp-typia/create scaffolding", () => {
 		const restAuthHelper = fs.readFileSync(path.join(targetDir, "inc", "rest-auth.php"), "utf8");
 		const generatedRender = fs.readFileSync(path.join(targetDir, "src", "render.php"), "utf8");
 		const generatedTypes = fs.readFileSync(path.join(targetDir, "src", "types.ts"), "utf8");
+		const readme = fs.readFileSync(path.join(targetDir, "README.md"), "utf8");
 		const packageJson = JSON.parse(fs.readFileSync(path.join(targetDir, "package.json"), "utf8"));
 		const blockJson = JSON.parse(
 			fs.readFileSync(path.join(targetDir, "src", "block.json"), "utf8"),
@@ -251,6 +259,9 @@ describe("@wp-typia/create scaffolding", () => {
 		expect(restAuthHelper).toContain("function demo_persistence_authenticated_can_write_authenticated");
 		expect(generatedRender).toContain("Sign in to persist this counter.");
 		expect(generatedTypes).toContain("persistencePolicy: 'authenticated' | 'public';");
+		expect(readme).toContain("## PHP REST Extension Points");
+		expect(readme).toContain("Edit `demo-persistence-authenticated.php`");
+		expect(restAuthHelper).toContain("Customize authenticated write policy here");
 	});
 
 	test("scaffoldProject supports explicit text-domain overrides on persistence templates", async () => {
@@ -433,6 +444,7 @@ describe("@wp-typia/create scaffolding", () => {
 		expect(readme).toContain("npm run sync-types");
 		expect(readme).not.toContain("npm run sync-rest");
 		expect(readme).toContain("src/blocks/*/types.ts");
+		expect(readme).not.toContain("## PHP REST Extension Points");
 	});
 
 	test("compound scaffolds enable authenticated persistence when only data storage is provided", async () => {
@@ -487,6 +499,9 @@ describe("@wp-typia/create scaffolding", () => {
 		expect(generatedBlockConfig).toContain("src/blocks/demo-compound-storage/api.openapi.json");
 		expect(readme).toContain("npm run sync-rest");
 		expect(readme).toContain("src/blocks/*/api-types.ts");
+		expect(readme).toContain("## PHP REST Extension Points");
+		expect(readme).toContain("The hidden child block does not own REST routes or storage.");
+		expect(pluginBootstrap).toContain("Customize storage helpers");
 	});
 
 	test("compound scaffolds enable public persistence when only a public policy is provided", async () => {
@@ -523,6 +538,7 @@ describe("@wp-typia/create scaffolding", () => {
 		expect(pluginBootstrap).toContain("HOUR_IN_SECONDS");
 		expect(restPublicHelper).toContain("function demo_compound_public_verify_public_write_token");
 		expect(parentRender).toContain("publicWriteToken");
+		expect(restPublicHelper).toContain("Customize the public write gate here");
 	});
 
 	test("compound scaffolds honor namespace, text-domain, and php-prefix overrides", async () => {


### PR DESCRIPTION
## Summary
- document the ownership boundary between TS REST contracts, generated schema artifacts, and generated PHP glue
- add scaffold-local PHP REST extension-point guidance to persistence-capable README output
- add short inline comments in generated PHP helpers and plugin bootstrap templates to show where customization belongs

## Validation
- `bun run --filter @wp-typia/create test`
- `bun run typecheck`
- `node scripts/run-generated-project-smoke.mjs --runtime bun --template persistence --package-manager bun --project-name smoke-rest-docs-public --persistence-policy public`
- `node scripts/run-generated-project-smoke.mjs --runtime bun --template persistence --package-manager bun --project-name smoke-rest-docs-auth-final --persistence-policy authenticated`
- `node scripts/run-generated-project-smoke.mjs --runtime bun --template compound --package-manager bun --project-name smoke-rest-docs-compound --persistence-policy authenticated`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generated scaffolds now include guidance on customizing PHP REST extension points in README files, with marked customization areas in generated PHP templates for storage helpers and request/response handlers.

* **Documentation**
  * Enhanced documentation providing detailed instructions for customizing REST contracts, authentication policies, and request/response handling in persistence-capable scaffolds, with clarification on source-of-truth files and regeneration workflows.

* **Tests**
  * Added test assertions validating PHP REST extension points guidance in generated scaffolds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->