### PR TITLE
docs: audit create runtime surface

### DIFF
--- a/.sampo/changesets/quick-badgers-cheer.md
+++ b/.sampo/changesets/quick-badgers-cheer.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/create: patch
+---
+
+Document the current runtime surface and classification for `@wp-typia/create`.

--- a/docs/API.md
+++ b/docs/API.md
@@ -102,6 +102,8 @@ Generated projects can also import shared runtime helpers from `@wp-typia/create
 - `@wp-typia/create/runtime/validation`
 - `@wp-typia/create/runtime/editor`
 
+For a repo-backed audit of the current `@wp-typia/create` runtime surface and how it is classified today, see [`docs/runtime-surface.md`](./runtime-surface.md).
+
 The `runtime/editor` helper turns manifest metadata into editor control hints without trying to auto-generate the entire inspector UI.
 
 ```ts

--- a/docs/runtime-surface.md
+++ b/docs/runtime-surface.md
@@ -1,0 +1,111 @@
+# Runtime Surface Audit
+
+This document audits the current public runtime surface around `@wp-typia/create`.
+
+It is intentionally descriptive, not normative. The goal is to capture what the repo currently exposes and relies on so follow-up issues can decide support policy and package boundaries without repeating discovery work.
+
+## Current exported surface
+
+`packages/create/package.json` currently exposes:
+
+- root package: `@wp-typia/create`
+- `@wp-typia/create/cli`
+- `@wp-typia/create/metadata-core`
+- `@wp-typia/create/runtime/defaults`
+- `@wp-typia/create/runtime/editor`
+- `@wp-typia/create/runtime/schema-core`
+- `@wp-typia/create/runtime/validation`
+
+## Classification
+
+### Stable public
+
+These exports already behave like product APIs and are documented or used directly in generated-project-facing material.
+
+- `@wp-typia/create`
+  - root runtime exports are documented in [`packages/create/README.md`](../packages/create/README.md) and used as the main public package surface
+  - recent examples include `projectJsonSchemaDocument()` from the root export
+- `@wp-typia/create/metadata-core`
+  - used by repo examples and scaffold sync scripts for `syncBlockMetadata()`, `syncTypeSchemas()`, `syncRestOpenApi()`, and `defineEndpointManifest()`
+  - this is already the practical authoring surface for schema and manifest generation
+- `@wp-typia/create/runtime/editor`
+  - documented in [`packages/create/README.md`](../packages/create/README.md) and [`docs/API.md`](./API.md)
+  - used by examples and generated templates to build editor models from manifests
+- `@wp-typia/create/runtime/validation`
+  - documented and heavily used by examples and generated templates for nested attribute updates and validation-aware helpers
+
+### Public but create-coupled
+
+These are exported today and used in generated projects, but they still feel closely tied to scaffold internals or generation-era assumptions.
+
+- `@wp-typia/create/runtime/defaults`
+  - used by examples and templates for applying manifest/template defaults
+  - practical and reusable, but closely tied to how `wp-typia` models manifest defaults
+- `@wp-typia/create/runtime/schema-core`
+  - used in example bundler aliasing and now contains reusable schema helpers
+  - however, much of its value still depends on `wp-typia` manifest and schema-generation conventions rather than a clearly separated standalone package contract
+
+### Internal-only
+
+These are effectively internal even when reachable through the root package implementation.
+
+- CLI scaffolding and template-rendering internals under `packages/create/src/runtime/*`
+  - examples: scaffold flow, package manager resolution, template registry, migration command internals
+  - these are not documented as public runtime APIs for generated projects
+- template composition and overlay logic inside `packages/create/templates/*`
+  - widely relied on by scaffold generation, but not a developer-facing runtime surface
+
+### Candidate for package graduation
+
+These are plausible future package candidates because they are already useful outside the CLI/scaffolding story.
+
+- runtime validation helpers
+  - nested patch/update helpers are reused across examples and templates and could eventually live in a narrower runtime package
+- editor model helpers
+  - `createEditorModel()` is runtime-facing and developer-consumable in a way that resembles a standalone support package
+- schema projection and manifest/schema utilities
+  - recent work like `projectJsonSchemaDocument()` increases the amount of schema logic that could eventually outgrow the scaffolding package
+
+## Current repo usage map
+
+### Docs and public examples
+
+- `packages/create/README.md`
+  - documents root exports, `metadata-core`, `runtime/editor`, and `runtime/validation`
+- `docs/API.md`
+  - documents `runtime/defaults`, `runtime/editor`, and `runtime/validation` as generated-project imports
+- repo examples
+  - `examples/my-typia-block` imports `runtime/defaults`, `runtime/editor`, and `runtime/validation`
+  - `examples/persistence-examples` imports `metadata-core`, `runtime/defaults`, `runtime/editor`, and `runtime/validation`
+  - `examples/rest-contract-adapter-poc` imports `metadata-core`
+
+### Generated template usage
+
+- base and compound/persistence sync scripts import `@wp-typia/create/metadata-core`
+- `basic`, `interactivity`, and persistence-capable templates import `runtime/editor`, `runtime/defaults`, and `runtime/validation`
+- generated templates currently do not import `runtime/schema-core` directly, but example webpack configs alias it for repo-local development
+
+## Current mismatch
+
+The repo already treats some `@wp-typia/create` runtime helpers like stable product APIs:
+
+- they are exported from the published package
+- they are documented in public docs
+- they are imported by examples
+- they are baked into generated templates
+
+But the long-term stability level is not stated clearly:
+
+- some helpers feel intentionally public
+- some exports appear public mainly because generated projects need them today
+- package boundaries still reflect the scaffolding origin more than the runtime developer experience
+
+## Policy input for #53
+
+`#53` should decide:
+
+- whether `@wp-typia/create/runtime/*` remains a supported public import surface
+- whether `runtime/editor` and `runtime/validation` should stay on subpaths or move behind narrower root exports
+- whether `runtime/defaults` and `runtime/schema-core` should remain create-coupled or be treated as emerging stable surfaces
+- what semver promises apply to generated-project runtime helpers versus CLI/scaffolding internals
+- whether package extraction should remain optional long term or become part of the product direction

--- a/packages/create/README.md
+++ b/packages/create/README.md
@@ -188,6 +188,8 @@ const aiSafeSchema = projectJsonSchemaDocument(requestSchema, {
 
 `ai-structured-output` is an opt-in derived profile. It does not change the default generated REST/runtime artifacts.
 
+For a repo-backed inventory of the current public runtime surface and how it is used today, see [`docs/runtime-surface.md`](../../docs/runtime-surface.md).
+
 For persistence-capable scaffolds, generated PHP stays intentionally boring glue:
 
 - edit the plugin bootstrap file when you need to customize storage helpers, route handlers, response shaping, or route registration


### PR DESCRIPTION
## Summary
- add a canonical runtime-surface audit doc for `@wp-typia/create`
- classify current exports into stable public, create-coupled, internal-only, and package-graduation candidates
- add lightweight cross-links from the public docs so `#53` can build on the audit without repeating discovery work

## Testing
- bun run typecheck
- bun run changesets:validate

Closes #52

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive runtime surface audit documenting the public API, its classification, and current usage patterns across the package.
  * Updated documentation references to direct users to the new audit document.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->