### PR TITLE
fix: clarify built-in template runtime behavior

### DIFF
--- a/.sampo/changesets/quiet-raven-wrap.md
+++ b/.sampo/changesets/quiet-raven-wrap.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/create: patch
+---
+
+Clarify dynamic-rendered persistence scaffold output and remove dead interactivity callback wiring from generated templates.

--- a/packages/create/src/runtime/scaffold-onboarding.ts
+++ b/packages/create/src/runtime/scaffold-onboarding.ts
@@ -74,7 +74,7 @@ export function getTemplateSourceOfTruthNote(
 	}
 
 	if (templateId === "persistence") {
-		return "`src/types.ts` remains the source of truth for `block.json`, `typia.manifest.json`, and `typia-validator.php`. `src/api-types.ts` remains the source of truth for `src/api-schemas/*` when you run `sync-rest`.";
+		return "`src/types.ts` remains the source of truth for `block.json`, `typia.manifest.json`, and `typia-validator.php`. `src/api-types.ts` remains the source of truth for `src/api-schemas/*` when you run `sync-rest`. This scaffold is intentionally server-rendered: `src/render.php` is the canonical frontend entry, and `src/save.tsx` returns `null` so PHP can inject post context, storage-backed state, and write-policy bootstrap data before hydration.";
 	}
 
 	return "`src/types.ts` remains the source of truth for `block.json`, `typia.manifest.json`, and `typia-validator.php`.";

--- a/packages/create/templates/_shared/persistence/core/src/save.tsx.mustache
+++ b/packages/create/templates/_shared/persistence/core/src/save.tsx.mustache
@@ -1,3 +1,5 @@
 export default function Save() {
+	// This block is intentionally server-rendered. PHP bootstraps post context,
+	// storage-backed state, and write-policy data before the frontend hydrates.
 	return null;
 }

--- a/packages/create/templates/interactivity/src/interactivity.ts.mustache
+++ b/packages/create/templates/interactivity/src/interactivity.ts.mustache
@@ -123,43 +123,6 @@ store('{{slugKebabCase}}', {
         }
       }
     }
-  },
-
-  // Callbacks - lifecycle hooks
-  callbacks: {
-    // Initialize on mount
-    onInit: () => {
-      const context = getContext();
-      const { element } = getElement();
-
-      // Set initial state from attributes
-      context.clicks = parseInt(element.dataset.clicks || '0');
-      context.isAnimating = element.dataset.isAnimating === 'true';
-      context.isVisible = element.dataset.isVisible !== 'false';
-
-      // Set up event listeners
-      element.addEventListener('{{slugKebabCase}}:external-trigger', (event: any) => {
-        context.clicks = event.detail.clicks || context.clicks + 1;
-      });
-    },
-
-    // Log interactions
-    onInteraction: () => {
-      const context = getContext();
-      console.log(`{{slugKebabCase}} interaction:`, {
-        clicks: context.clicks,
-        type: context.lastInteraction,
-        timestamp: new Date().toISOString()
-      });
-    },
-
-    // Cleanup on unmount
-    onDestroy: () => {
-      const context = getContext();
-      if (context.autoPlayTimer) {
-        clearInterval(context.autoPlayTimer);
-      }
-    }
   }
 });
 

--- a/packages/create/templates/interactivity/src/save.tsx.mustache
+++ b/packages/create/templates/interactivity/src/save.tsx.mustache
@@ -14,11 +14,7 @@ export default function Save({ attributes }: { attributes: {{pascalCase}}Attribu
       interactiveMode: attributes.interactiveMode,
       maxClicks: attributes.maxClicks,
       autoPlayInterval: attributes.autoPlayInterval
-    }),
-    'data-clicks': attributes.clickCount,
-    'data-is-animating': attributes.isAnimating,
-    'data-is-visible': attributes.isVisible,
-    'data-unique-id': attributes.uniqueId
+    })
   });
 
   return (

--- a/packages/create/templates/persistence/src/edit.tsx.mustache
+++ b/packages/create/templates/persistence/src/edit.tsx.mustache
@@ -121,7 +121,7 @@ export default function Edit( {
 						label={ __( 'Resource Key', '{{textDomain}}' ) }
 						value={ attributes.resourceKey ?? '' }
 						onChange={ ( value ) => updateAttribute( 'resourceKey', value ) }
-						help={ __( 'Stable key used by the persisted counter endpoint.', '{{textDomain}}' ) }
+						help={ __( 'Stable persisted identifier used by the storage-backed counter endpoint.', '{{textDomain}}' ) }
 					/>
 					<Notice status="info" isDismissible={ false }>
 						{ __( 'Storage mode: {{dataStorageMode}}', '{{textDomain}}' ) }
@@ -130,6 +130,9 @@ export default function Edit( {
 						{ __( 'Persistence policy: {{persistencePolicy}}', '{{textDomain}}' ) }
 						<br />
 						{ persistencePolicyDescription }
+					</Notice>
+					<Notice status="info" isDismissible={ false }>
+						{ __( 'Render mode: dynamic. `render.php` bootstraps post context, storage-backed state, and write-policy data before hydration.', '{{textDomain}}' ) }
 					</Notice>
 				</PanelBody>
 				{ ! isValid && (

--- a/packages/create/tests/create-cli.test.ts
+++ b/packages/create/tests/create-cli.test.ts
@@ -133,6 +133,11 @@ describe("@wp-typia/create scaffolding", () => {
 		const generatedHooks = fs.readFileSync(path.join(targetDir, "src", "hooks.ts"), "utf8");
 		const generatedValidators = fs.readFileSync(path.join(targetDir, "src", "validators.ts"), "utf8");
 		const generatedEdit = fs.readFileSync(path.join(targetDir, "src", "edit.tsx"), "utf8");
+		const generatedInteractivity = fs.readFileSync(
+			path.join(targetDir, "src", "interactivity.ts"),
+			"utf8",
+		);
+		const generatedSave = fs.readFileSync(path.join(targetDir, "src", "save.tsx"), "utf8");
 		const packageJson = JSON.parse(fs.readFileSync(path.join(targetDir, "package.json"), "utf8"));
 		const blockJson = JSON.parse(
 			fs.readFileSync(path.join(targetDir, "src", "block.json"), "utf8"),
@@ -153,6 +158,13 @@ describe("@wp-typia/create scaffolding", () => {
 		expect(generatedEdit).toContain("createAttributeUpdater");
 		expect(generatedValidators).toContain("@wp-typia/create/runtime/defaults");
 		expect(generatedValidators).toContain("@wp-typia/create/runtime/validation");
+		expect(generatedInteractivity).not.toContain("onInit:");
+		expect(generatedInteractivity).not.toContain("onInteraction:");
+		expect(generatedInteractivity).not.toContain("onDestroy:");
+		expect(generatedSave).not.toContain("data-clicks");
+		expect(generatedSave).not.toContain("data-is-animating");
+		expect(generatedSave).not.toContain("data-is-visible");
+		expect(generatedSave).not.toContain("data-unique-id");
 	});
 
 	test("scaffoldProject creates a persistence template with signed public writes and explicit storage mode", async () => {
@@ -189,6 +201,7 @@ describe("@wp-typia/create scaffolding", () => {
 			"utf8",
 		);
 		const generatedTypes = fs.readFileSync(path.join(targetDir, "src", "types.ts"), "utf8");
+		const generatedSave = fs.readFileSync(path.join(targetDir, "src", "save.tsx"), "utf8");
 		const readme = fs.readFileSync(path.join(targetDir, "README.md"), "utf8");
 		const restPublicHelper = fs.readFileSync(path.join(targetDir, "inc", "rest-public.php"), "utf8");
 		const blockJson = JSON.parse(
@@ -235,9 +248,13 @@ describe("@wp-typia/create scaffolding", () => {
 		expect(generatedRender).toContain("publicWriteToken");
 		expect(generatedApiTypes).toContain("publicWriteRequestId: string");
 		expect(generatedTypes).toContain("persistencePolicy: 'authenticated' | 'public';");
+		expect(generatedSave).toContain("intentionally server-rendered");
+		expect(generatedSave).toContain("return null;");
 		expect(readme).toContain("npm run sync-types");
 		expect(readme).toContain("npm run sync-rest");
 		expect(readme).toContain("src/api-types.ts");
+		expect(readme).toContain("`src/render.php` is the canonical frontend entry");
+		expect(readme).toContain("`src/save.tsx` returns `null`");
 		expect(readme).toContain("per-request ids, and coarse rate limiting by default");
 		expect(readme).toContain("## PHP REST Extension Points");
 		expect(readme).toContain("Edit `demo-persistence-public.php`");
@@ -278,6 +295,8 @@ describe("@wp-typia/create scaffolding", () => {
 			"utf8",
 		);
 		const generatedTypes = fs.readFileSync(path.join(targetDir, "src", "types.ts"), "utf8");
+		const generatedEdit = fs.readFileSync(path.join(targetDir, "src", "edit.tsx"), "utf8");
+		const generatedSave = fs.readFileSync(path.join(targetDir, "src", "save.tsx"), "utf8");
 		const readme = fs.readFileSync(path.join(targetDir, "README.md"), "utf8");
 		const packageJson = JSON.parse(fs.readFileSync(path.join(targetDir, "package.json"), "utf8"));
 		const blockJson = JSON.parse(
@@ -301,8 +320,14 @@ describe("@wp-typia/create scaffolding", () => {
 		expect(generatedApiTypes).toContain("publicWriteRequestId?: string");
 		expect(generatedApiTypes).not.toContain("{{#isPublicPersistencePolicy}}");
 		expect(generatedTypes).toContain("persistencePolicy: 'authenticated' | 'public';");
+		expect(generatedEdit).toContain("Stable persisted identifier used by the storage-backed counter endpoint.");
+		expect(generatedEdit).toContain("Render mode: dynamic. `render.php` bootstraps post context, storage-backed state, and write-policy data before hydration.");
+		expect(generatedSave).toContain("intentionally server-rendered");
+		expect(generatedSave).toContain("return null;");
 		expect(readme).toContain("## PHP REST Extension Points");
 		expect(readme).toContain("Edit `demo-persistence-authenticated.php`");
+		expect(readme).toContain("`src/render.php` is the canonical frontend entry");
+		expect(readme).toContain("`src/save.tsx` returns `null`");
 		expect(restAuthHelper).toContain("Customize authenticated write policy here");
 	});
 


### PR DESCRIPTION
## Summary
- remove dead interactivity lifecycle callbacks and unused save-time dataset wiring
- make persistence scaffolds explicitly describe their intentional server-rendered `save() => null` path
- add scaffold regression coverage for both template-correctness fixes

## Testing
- bun run typecheck
- bun run --filter @wp-typia/create test
- bun run changesets:validate

Closes #64