### PR TITLE
Add experimental skip-serialization support typings

### DIFF
--- a/.sampo/changesets/block-types-experimental-skip-serialization.md
+++ b/.sampo/changesets/block-types-experimental-skip-serialization.md
@@ -1,0 +1,8 @@
+---
+npm/@wp-typia/block-types: minor
+---
+
+Add experimental `__experimentalSkipSerialization` typing for selected block
+support sections in `@wp-typia/block-types`, including a reusable
+`SkipSerialization<TFeature>` helper for Gutenberg-tracking server-style
+support metadata.

--- a/packages/wp-typia-block-types/README.md
+++ b/packages/wp-typia-block-types/README.md
@@ -74,6 +74,11 @@ Stable Core coverage now also includes support/style helpers for layout
 `rowGap` / `columnGap`, color `duotone`, per-side border widths, and other
 recently stabilized support keys.
 
+`__experimentalSkipSerialization` is also typed on selected support sections
+for blocks that compute style output on the server. This follows Gutenberg's
+current experimental surface and should not be treated as a long-term
+stability guarantee.
+
 ## Typia pipeline notes
 
 - `CssColorValue` and `MinHeightValue` are richer DX aliases that currently rely on template literal types.

--- a/packages/wp-typia-block-types/src/blocks/supports.ts
+++ b/packages/wp-typia-block-types/src/blocks/supports.ts
@@ -109,11 +109,18 @@ type BlockSupportDefaultControls<TFeature extends string> = Readonly<
   Partial<Record<TFeature, boolean>> & Record<string, boolean | undefined>
 >;
 
+export type SkipSerialization<TFeature extends string> =
+  | boolean
+  | readonly TFeature[];
+
 export interface BlockBorderSupport {
   readonly color?: boolean;
   readonly radius?: boolean;
   readonly style?: boolean;
   readonly width?: boolean;
+  readonly __experimentalSkipSerialization?: SkipSerialization<
+    'color' | 'radius' | 'style' | 'width'
+  >;
   readonly __experimentalDefaultControls?: BlockSupportDefaultControls<
     'color' | 'radius' | 'style' | 'width'
   >;
@@ -141,6 +148,9 @@ export interface BlockColorSupport {
   readonly heading?: boolean;
   readonly link?: boolean;
   readonly text?: boolean;
+  readonly __experimentalSkipSerialization?: SkipSerialization<
+    'background' | 'button' | 'gradients' | 'heading' | 'link' | 'text'
+  >;
   readonly __experimentalDefaultControls?: BlockSupportDefaultControls<
     'background' | 'gradients' | 'link' | 'text'
   >;
@@ -151,6 +161,9 @@ export interface BlockDimensionsSupport {
   readonly height?: boolean;
   readonly minHeight?: boolean;
   readonly width?: boolean;
+  readonly __experimentalSkipSerialization?: SkipSerialization<
+    'aspectRatio' | 'height' | 'minHeight' | 'width'
+  >;
   readonly __experimentalDefaultControls?: BlockSupportDefaultControls<
     'aspectRatio' | 'height' | 'minHeight' | 'width'
   >;
@@ -223,6 +236,7 @@ export interface BlockSpacingSupport {
   readonly padding?: boolean | readonly SpacingDimension[];
   readonly spacingSizes?: readonly SpacingSize[];
   readonly units?: readonly string[];
+  readonly __experimentalSkipSerialization?: SkipSerialization<SpacingSupportKey>;
   readonly __experimentalDefaultControls?: BlockSupportDefaultControls<SpacingSupportKey>;
 }
 
@@ -239,6 +253,7 @@ export interface BlockTypographySupport {
   readonly textDecoration?: boolean;
   readonly textTransform?: boolean;
   readonly writingMode?: boolean;
+  readonly __experimentalSkipSerialization?: SkipSerialization<TypographySupportKey>;
   readonly __experimentalDefaultControls?: BlockSupportDefaultControls<TypographySupportKey>;
 }
 

--- a/tests/type-smoke/block-types-smoke.ts
+++ b/tests/type-smoke/block-types-smoke.ts
@@ -56,6 +56,7 @@ const blockSupports: BlockSupports = {
   border: {
     color: true,
     radius: true,
+    __experimentalSkipSerialization: ['radius', 'width'],
   },
   color: {
     background: true,
@@ -63,6 +64,12 @@ const blockSupports: BlockSupports = {
     gradients: true,
     link: true,
     text: true,
+    __experimentalSkipSerialization: ['background', 'text'],
+  },
+  dimensions: {
+    aspectRatio: true,
+    minHeight: true,
+    __experimentalSkipSerialization: ['minHeight'],
   },
   interactivity: {
     clientNavigation: true,
@@ -88,9 +95,11 @@ const blockSupports: BlockSupports = {
   locking: true,
   spacing: {
     blockGap: ['horizontal', 'vertical'],
+    margin: ['top', 'bottom'],
     padding: ['top', 'bottom', 'left', 'right', 'horizontal'],
     spacingSizes: [spacingSize],
     units: ['px', 'rem', 'em'],
+    __experimentalSkipSerialization: ['margin', 'padding'],
   },
   typography: {
     dropCap: true,
@@ -98,6 +107,7 @@ const blockSupports: BlockSupports = {
     fontSize: true,
     textAlign: ['left', 'justify'],
     textTransform: true,
+    __experimentalSkipSerialization: true,
   },
 };
 const textAlignment: TextAlignment = 'justify';


### PR DESCRIPTION
## Summary
- add a reusable `SkipSerialization<TFeature extends string>` helper in block support typings
- add `__experimentalSkipSerialization` typing to the targeted border, color, dimensions, spacing, and typography support interfaces
- extend the block-types smoke sample, document the experimental surface, and add a Sampo changeset

## Why
Issue #82 adds Gutenberg-tracking experimental typing for blocks that compute style output on the server without changing runtime behavior, scaffolds, or metadata projection.

## Validation
- `bun run --filter @wp-typia/block-types typecheck`
- `bun run typecheck`
- `bun run changesets:validate`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added experimental `__experimentalSkipSerialization` support to block support interfaces, allowing selective server-side style computation for block properties.

* **Documentation**
  * Updated README to document the new experimental serialization skip feature.

* **Tests**
  * Enhanced type smoke tests to cover the new experimental functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->