### PR TITLE
Compose WordPress API helpers from generated api-client artifacts

### DIFF
--- a/.sampo/changesets/create-api-helper-composition.md
+++ b/.sampo/changesets/create-api-helper-composition.md
@@ -1,0 +1,7 @@
+---
+npm/@wp-typia/create: minor
+---
+
+Refactor generated persistence `api.ts` helpers to compose the generated
+portable `api-client.ts` endpoint exports instead of redefining the same
+endpoint metadata locally.

--- a/docs/API.md
+++ b/docs/API.md
@@ -139,7 +139,10 @@ nonce-aware request wiring.
 It does not include WordPress route resolution, `wpApiSettings`, or
 `@wordpress/api-fetch`. Generated persistence contracts can emit a portable
 `src/api-client.ts` module through `syncEndpointClient(...)` in
-`@wp-typia/create/metadata-core`.
+`@wp-typia/create/metadata-core`. In persistence-style scaffolds, that
+generated module is the canonical endpoint-definition artifact, while
+WordPress-facing `src/api.ts` composes those generated endpoint exports to add
+WordPress route resolution and nonce/header behavior.
 
 When a manifest endpoint defines both `queryContract` and `bodyContract`, the
 portable generated client now uses a `{ query, body }` request envelope and

--- a/examples/persistence-examples/src/blocks/counter/api.ts
+++ b/examples/persistence-examples/src/blocks/counter/api.ts
@@ -1,40 +1,29 @@
-import { callEndpoint, createEndpoint } from '@wp-typia/rest';
+import { callEndpoint, resolveRestRouteUrl } from '@wp-typia/rest';
 
-import { buildRestPath, resolveExampleRestRoute } from '../../shared/rest';
 import type {
 	PersistenceCounterIncrementRequest,
 	PersistenceCounterQuery,
-	PersistenceCounterResponse,
 } from './api-types';
-import { apiValidators } from './api-validators';
+import {
+	getPersistenceCounterStateEndpoint,
+	incrementPersistenceCounterStateEndpoint,
+} from './api-client';
 
-const COUNTER_PATH = '/counter';
-
-export const counterEndpoint = createEndpoint<
-	PersistenceCounterQuery,
-	PersistenceCounterResponse
->( {
+export const counterEndpoint = {
+	...getPersistenceCounterStateEndpoint,
 	buildRequestOptions: () => ( {
-		url: resolveExampleRestRoute( COUNTER_PATH ),
+		url: resolveRestRouteUrl( getPersistenceCounterStateEndpoint.path ),
 	} ),
-	method: 'GET',
-	path: buildRestPath( COUNTER_PATH ),
-	validateRequest: apiValidators.counterQuery,
-	validateResponse: apiValidators.counterResponse,
-} );
+};
 
-export const incrementCounterEndpoint = createEndpoint<
-	PersistenceCounterIncrementRequest,
-	PersistenceCounterResponse
->( {
+export const incrementCounterEndpoint = {
+	...incrementPersistenceCounterStateEndpoint,
 	buildRequestOptions: () => ( {
-		url: resolveExampleRestRoute( COUNTER_PATH ),
+		url: resolveRestRouteUrl(
+			incrementPersistenceCounterStateEndpoint.path
+		),
 	} ),
-	method: 'POST',
-	path: buildRestPath( COUNTER_PATH ),
-	validateRequest: apiValidators.incrementRequest,
-	validateResponse: apiValidators.counterResponse,
-} );
+};
 
 export function fetchCounter( request: PersistenceCounterQuery ) {
 	return callEndpoint( counterEndpoint, request );

--- a/examples/persistence-examples/src/blocks/like-button/api.ts
+++ b/examples/persistence-examples/src/blocks/like-button/api.ts
@@ -1,44 +1,28 @@
-import { callEndpoint, createEndpoint } from '@wp-typia/rest';
+import { callEndpoint, resolveRestRouteUrl } from '@wp-typia/rest';
 
-import {
-	buildRestPath,
-	resolveExampleRestRoute,
-	resolveRestNonce,
-} from '../../shared/rest';
+import { resolveRestNonce } from '../../shared/rest';
 import type {
 	PersistenceLikeStatusQuery,
-	PersistenceLikeStatusResponse,
 	PersistenceToggleLikeRequest,
 } from './api-types';
-import { apiValidators } from './api-validators';
+import {
+	getPersistenceLikeStatusEndpoint,
+	togglePersistenceLikeStatusEndpoint,
+} from './api-client';
 
-const LIKE_PATH = '/likes';
-
-export const likeStatusEndpoint = createEndpoint<
-	PersistenceLikeStatusQuery,
-	PersistenceLikeStatusResponse
->( {
+export const likeStatusEndpoint = {
+	...getPersistenceLikeStatusEndpoint,
 	buildRequestOptions: () => ( {
-		url: resolveExampleRestRoute( LIKE_PATH ),
+		url: resolveRestRouteUrl( getPersistenceLikeStatusEndpoint.path ),
 	} ),
-	method: 'GET',
-	path: buildRestPath( LIKE_PATH ),
-	validateRequest: apiValidators.likeStatusQuery,
-	validateResponse: apiValidators.likeStatusResponse,
-} );
+};
 
-export const toggleLikeEndpoint = createEndpoint<
-	PersistenceToggleLikeRequest,
-	PersistenceLikeStatusResponse
->( {
+export const toggleLikeEndpoint = {
+	...togglePersistenceLikeStatusEndpoint,
 	buildRequestOptions: () => ( {
-		url: resolveExampleRestRoute( LIKE_PATH ),
+		url: resolveRestRouteUrl( togglePersistenceLikeStatusEndpoint.path ),
 	} ),
-	method: 'POST',
-	path: buildRestPath( LIKE_PATH ),
-	validateRequest: apiValidators.toggleLikeRequest,
-	validateResponse: apiValidators.likeStatusResponse,
-} );
+};
 
 export function fetchLikeStatus(
 	request: PersistenceLikeStatusQuery,

--- a/packages/create/README.md
+++ b/packages/create/README.md
@@ -232,7 +232,7 @@ await syncEndpointClient({
 });
 ```
 
-`src/api-types.ts` remains the source of truth for scaffolded REST contracts, and the endpoint manifest is the canonical TypeScript description of the scaffolded REST surface. `src/api-client.ts` is the generated portable client artifact for backend-neutral consumers, while `src/api.ts` remains the WordPress-facing helper layer for generated persistence scaffolds. `src/api-schemas/*.schema.json` remains the runtime-facing artifact for generated PHP validation, and `src/api.openapi.json` is the canonical endpoint-aware REST document when a scaffold defines route metadata. Per-contract `src/api-schemas/*.openapi.json` files remain available as compatibility fragments.
+`src/api-types.ts` remains the source of truth for scaffolded REST contracts, and the endpoint manifest is the canonical TypeScript description of the scaffolded REST surface. `src/api-client.ts` is the generated portable client artifact and the canonical home for generated endpoint definitions. `src/api.ts` remains the WordPress-facing helper layer for generated persistence scaffolds, but now composes those generated endpoint exports to add WordPress-specific route resolution and nonce/header behavior. `src/api-schemas/*.schema.json` remains the runtime-facing artifact for generated PHP validation, and `src/api.openapi.json` is the canonical endpoint-aware REST document when a scaffold defines route metadata. Per-contract `src/api-schemas/*.openapi.json` files remain available as compatibility fragments.
 
 When an endpoint manifest defines both `queryContract` and `bodyContract`,
 `syncEndpointClient(...)` now generates a portable request shape of

--- a/packages/create/templates/_shared/compound/persistence/src/blocks/{{slugKebabCase}}/api.ts.mustache
+++ b/packages/create/templates/_shared/compound/persistence/src/blocks/{{slugKebabCase}}/api.ts.mustache
@@ -1,17 +1,16 @@
 import {
 	callEndpoint,
-	createEndpoint,
 	resolveRestRouteUrl,
 } from '@wp-typia/rest';
 
 import {
 	type {{pascalCase}}StateQuery,
-	type {{pascalCase}}StateResponse,
 	type {{pascalCase}}WriteStateRequest,
 } from './api-types';
-import { apiValidators } from './api-validators';
-
-const STATE_PATH = '/{{namespace}}/v1/{{slugKebabCase}}/state';
+import {
+	get{{pascalCase}}StateEndpoint,
+	write{{pascalCase}}StateEndpoint,
+} from './api-client';
 
 function resolveRestNonce( fallback?: string ): string | undefined {
 	if ( typeof fallback === 'string' && fallback.length > 0 ) {
@@ -27,31 +26,19 @@ function resolveRestNonce( fallback?: string ): string | undefined {
 		: undefined;
 }
 
-export const stateEndpoint = createEndpoint<
-	{{pascalCase}}StateQuery,
-	{{pascalCase}}StateResponse
->( {
+export const stateEndpoint = {
+	...get{{pascalCase}}StateEndpoint,
 	buildRequestOptions: () => ( {
-		url: resolveRestRouteUrl( STATE_PATH ),
+		url: resolveRestRouteUrl( get{{pascalCase}}StateEndpoint.path ),
 	} ),
-	method: 'GET',
-	path: STATE_PATH,
-	validateRequest: apiValidators.stateQuery,
-	validateResponse: apiValidators.stateResponse,
-} );
+};
 
-export const writeStateEndpoint = createEndpoint<
-	{{pascalCase}}WriteStateRequest,
-	{{pascalCase}}StateResponse
->( {
+export const writeStateEndpoint = {
+	...write{{pascalCase}}StateEndpoint,
 	buildRequestOptions: () => ( {
-		url: resolveRestRouteUrl( STATE_PATH ),
+		url: resolveRestRouteUrl( write{{pascalCase}}StateEndpoint.path ),
 	} ),
-	method: 'POST',
-	path: STATE_PATH,
-	validateRequest: apiValidators.writeStateRequest,
-	validateResponse: apiValidators.stateResponse,
-} );
+};
 
 export function fetchState(
 	request: {{pascalCase}}StateQuery

--- a/packages/create/templates/_shared/persistence/core/src/api.ts.mustache
+++ b/packages/create/templates/_shared/persistence/core/src/api.ts.mustache
@@ -1,17 +1,16 @@
 import {
 	callEndpoint,
-	createEndpoint,
 	resolveRestRouteUrl,
 } from '@wp-typia/rest';
 
 import {
 	type {{pascalCase}}StateQuery,
-	type {{pascalCase}}StateResponse,
 	type {{pascalCase}}WriteStateRequest,
 } from './api-types';
-import { apiValidators } from './api-validators';
-
-const STATE_PATH = '/{{namespace}}/v1/{{slugKebabCase}}/state';
+import {
+	get{{pascalCase}}StateEndpoint,
+	write{{pascalCase}}StateEndpoint,
+} from './api-client';
 
 function resolveRestNonce( fallback?: string ): string | undefined {
 	if ( typeof fallback === 'string' && fallback.length > 0 ) {
@@ -27,31 +26,19 @@ function resolveRestNonce( fallback?: string ): string | undefined {
 		: undefined;
 }
 
-export const stateEndpoint = createEndpoint<
-	{{pascalCase}}StateQuery,
-	{{pascalCase}}StateResponse
->( {
+export const stateEndpoint = {
+	...get{{pascalCase}}StateEndpoint,
 	buildRequestOptions: () => ( {
-		url: resolveRestRouteUrl( STATE_PATH ),
+		url: resolveRestRouteUrl( get{{pascalCase}}StateEndpoint.path ),
 	} ),
-	method: 'GET',
-	path: STATE_PATH,
-	validateRequest: apiValidators.stateQuery,
-	validateResponse: apiValidators.stateResponse,
-} );
+};
 
-export const writeStateEndpoint = createEndpoint<
-	{{pascalCase}}WriteStateRequest,
-	{{pascalCase}}StateResponse
->( {
+export const writeStateEndpoint = {
+	...write{{pascalCase}}StateEndpoint,
 	buildRequestOptions: () => ( {
-		url: resolveRestRouteUrl( STATE_PATH ),
+		url: resolveRestRouteUrl( write{{pascalCase}}StateEndpoint.path ),
 	} ),
-	method: 'POST',
-	path: STATE_PATH,
-	validateRequest: apiValidators.writeStateRequest,
-	validateResponse: apiValidators.stateResponse,
-} );
+};
 
 export function fetchState(
 	request: {{pascalCase}}StateQuery

--- a/packages/create/tests/create-cli.test.ts
+++ b/packages/create/tests/create-cli.test.ts
@@ -699,6 +699,10 @@ describe("@wp-typia/create scaffolding", () => {
 		expect(restPublicHelper).toContain("SELECT RELEASE_LOCK(%s)");
 		expect(restPublicHelper).toContain("return 'wpt_pwl_' . md5(");
 		expect(generatedApi).toContain("@wp-typia/rest");
+		expect(generatedApi).toContain("from './api-client'");
+		expect(generatedApi).toContain("getDemoPersistencePublicStateEndpoint");
+		expect(generatedApi).toContain("writeDemoPersistencePublicStateEndpoint");
+		expect(generatedApi).not.toContain("createEndpoint(");
 		expect(generatedSyncRest).toContain("syncTypeSchemas");
 		expect(generatedSyncRest).toContain("defineEndpointManifest");
 		expect(generatedSyncRest).toContain("syncEndpointClient");
@@ -1340,8 +1344,22 @@ describe("@wp-typia/create scaffolding", () => {
 			),
 			"utf8",
 		);
+		const generatedParentApi = fs.readFileSync(
+			path.join(
+				targetDir,
+				"src",
+				"blocks",
+				"demo-compound-storage",
+				"api.ts",
+			),
+			"utf8",
+		);
 		expect(generatedApiClient).toContain("from '@wp-typia/api-client'");
 		expect(generatedApiClient).toContain("export const getDemoCompoundStorageStateEndpoint");
+		expect(generatedParentApi).toContain("from './api-client'");
+		expect(generatedParentApi).toContain("getDemoCompoundStorageStateEndpoint");
+		expect(generatedParentApi).toContain("writeDemoCompoundStorageStateEndpoint");
+		expect(generatedParentApi).not.toContain("createEndpoint(");
 			expect(
 				fs.existsSync(
 					path.join(

--- a/packages/wp-typia-rest/tests/rest.test.ts
+++ b/packages/wp-typia-rest/tests/rest.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import type { ApiFetch } from "@wordpress/api-fetch";
+import {
+	createEndpoint as createPortableEndpoint,
+	toValidationResult as toPortableValidationResult,
+} from "../../wp-typia-api-client/src/index";
 
 import {
 	callEndpoint,
@@ -289,6 +293,61 @@ describe("@wp-typia/rest", () => {
 
 		expect(seenUrl).toBe("http://localhost:8889/wp-json/demo/v1/items/");
 		expect(seenPath).toBeUndefined();
+	});
+
+	test("callEndpoint accepts endpoint objects created by @wp-typia/api-client", async () => {
+		let seenUrl = "";
+		let seenMethod = "";
+		const endpoint = {
+			...createPortableEndpoint<{ page: number }, { items: number[] }>({
+				method: "GET",
+				operationId: "getPortableItems",
+				path: "/demo/v1/items",
+				requestLocation: "query",
+				validateRequest: (input: unknown) =>
+					typeof input === "object" &&
+					input !== null &&
+					typeof (input as { page?: unknown }).page === "number"
+						? toPortableValidationResult<{ page: number }>({
+								data: input as { page: number },
+								errors: [],
+								success: true,
+							})
+						: toPortableValidationResult<{ page: number }>({
+								errors: [{ expected: "{ page: number }", path: "$.page", value: undefined }],
+								success: false,
+							}),
+				validateResponse: (input: unknown) =>
+					typeof input === "object" &&
+					input !== null &&
+					Array.isArray((input as { items?: unknown }).items)
+						? toPortableValidationResult<{ items: number[] }>({
+								data: input as { items: number[] },
+								errors: [],
+								success: true,
+							})
+						: toPortableValidationResult<{ items: number[] }>({
+								errors: [{ expected: "{ items: number[] }", path: "$.items", value: undefined }],
+								success: false,
+							}),
+			}),
+			buildRequestOptions: () => ({
+				url: resolveRestRouteUrl("/demo/v1/items", "http://localhost:8889/wp-json/"),
+			}),
+		};
+
+		const result = await callEndpoint(endpoint, { page: 3 }, {
+			fetchFn: asApiFetch(async (options: Record<string, unknown>) => {
+				seenMethod = String(options.method);
+				seenUrl = String(options.url);
+				return { items: [3] } as never;
+			}),
+		});
+
+		expect(seenMethod).toBe("GET");
+		expect(seenUrl).toBe("http://localhost:8889/wp-json/demo/v1/items/?page=3");
+		expect(result.isValid).toBe(true);
+		expect(result.data).toEqual({ items: [3] });
 	});
 
 	test("resolveRestRouteUrl canonicalizes wp-json roots and route slashes", () => {


### PR DESCRIPTION
## Summary
- compose persistence-style WordPress api.ts helpers from generated api-client.ts endpoint exports
- keep WordPress-specific route resolution and nonce/header decoration in api.ts
- add scaffold coverage and a @wp-typia/rest compatibility test for portable endpoint objects

## Verification
- bun run --filter @wp-typia/rest test
- bun run --filter @wp-typia/create test
- bun run examples:typecheck
- bun run typecheck
- bun run changesets:validate
- bun run lint

Closes #99

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * API helper generation refactored to compose generated portable endpoint definitions rather than redefining them locally. This improves code reuse and clarifies separation between portable and WordPress-specific behavior.

* **Documentation**
  * Updated documentation and README to clarify the architectural relationship between generated portable endpoints and WordPress-specific API composition.

* **Tests**
  * Added test coverage verifying the endpoint composition pattern works correctly with generated portable endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->