### PR TITLE
Harden migration CLI diagnostics

### DIFF
--- a/.sampo/changesets/migration-cli-diagnostics.md
+++ b/.sampo/changesets/migration-cli-diagnostics.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/create: patch
+---
+
+Improve migration CLI recovery guidance, same-version edge validation, and interactive safety for fixture overwrites.

--- a/docs/API.md
+++ b/docs/API.md
@@ -353,7 +353,7 @@ Migration-enabled generated projects may also wire:
 - `src/admin/migration-dashboard.tsx`
 - `src/migration-detector.ts`
 
-`migrations doctor` is the read-only workspace health check, `migrations fixtures` refreshes deterministic edge fixtures, and `migrations fuzz` replays those fixtures plus seeded random legacy-shaped inputs derived from the current Typia validator.
+`migrations doctor` is the read-only workspace health check, `migrations fixtures` refreshes deterministic edge fixtures, and `migrations fuzz` replays those fixtures plus seeded random legacy-shaped inputs derived from the current Typia validator. Without `--all`, migration commands target the first legacy version only; `--all` runs across every configured legacy version and every configured block target. In TTY usage, `migrations fixtures --force` asks before overwriting existing fixture files, while non-interactive runs overwrite immediately for script compatibility.
 
 The built-in `persistence` template adds another predictable layer:
 

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -74,6 +74,10 @@ bun run migration:verify
 bun run migration:fuzz -- --all --iterations 25 --seed 1
 ```
 
+When omitted, `verify`, `doctor`, `fixtures`, and `fuzz` target the first legacy
+version only. Add `--all` to run across every configured legacy version and,
+for multi-block projects, every configured block target in the workspace.
+
 The intended authoring flow is:
 
 1. change `src/types.ts`
@@ -151,6 +155,11 @@ Scaffolded rules expose:
 
 `migration:fixtures` is the explicit refresh path for edge fixtures. Without `--force`, existing fixture files are preserved and reported as skipped.
 
+In TTY usage, `migration:fixtures -- --force` asks once before overwriting
+existing fixture files and reports how many files will be replaced. In
+non-interactive usage, `--force` still overwrites immediately so scripted flows
+stay compatible.
+
 `migration:fuzz` is intentionally separate from `migration:verify`. `verify` stays deterministic and fixture-driven, while `fuzz` replays fixture cases and then generates seeded random current samples with `validators.random()`, converts the safe subset back into legacy-shaped inputs, migrates them, and validates the result against the current Typia validator.
 
 High-confidence renames are written into `renameMap` automatically. Ambiguous candidates stay unresolved, and semantic-risk coercions are emitted as suggested transform bodies with unresolved markers left in place. Nested authoring uses the current-path convention:
@@ -160,6 +169,10 @@ High-confidence renames are written into `renameMap` automatically. Ambiguous ca
 - `linkTarget.url.href`
 
 If unresolved `TODO MIGRATION:` markers or unresolved entries remain, `migration:verify` fails on purpose.
+
+If `verify` or `fuzz` report missing generated inputs, rerun
+`migration:scaffold -- --from <semver>` for the missing edge and then
+`migration:doctor -- --all` to confirm the workspace is back in sync.
 
 ## Deprecated Gutenberg entries
 

--- a/packages/create/src/runtime/migration-diff.ts
+++ b/packages/create/src/runtime/migration-diff.ts
@@ -63,8 +63,18 @@ export function createMigrationDiff(
 
 	const snapshotManifestPath = getSnapshotManifestPath(state.projectDir, block, fromVersion);
 	if (!fs.existsSync(snapshotManifestPath)) {
+		const availableSnapshotVersions = state.config.supportedVersions
+			.filter((version) =>
+				fs.existsSync(getSnapshotManifestPath(state.projectDir, block, version)),
+			)
+			.sort((left, right) => left.localeCompare(right, undefined, { numeric: true }));
 		throw new Error(
-			`Snapshot manifest for ${block.blockName} @ ${fromVersion} does not exist. Run \`migrations snapshot --version ${fromVersion}\` first.`,
+			availableSnapshotVersions.length === 0
+				? `Snapshot manifest for ${block.blockName} @ ${fromVersion} does not exist. ` +
+					`No snapshots exist yet for ${block.blockName}. Run \`wp-typia migrations snapshot --version ${fromVersion}\` first.`
+				: `Snapshot manifest for ${block.blockName} @ ${fromVersion} does not exist. ` +
+					`Available snapshot versions for ${block.blockName}: ${availableSnapshotVersions.join(", ")}. ` +
+					`Run \`wp-typia migrations snapshot --version ${fromVersion}\` first if you want to preserve that release.`,
 		);
 	}
 

--- a/packages/create/src/runtime/migrations.ts
+++ b/packages/create/src/runtime/migrations.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
 
+import { formatRunScript } from "./package-managers.js";
 import {
 	ROOT_PHP_MIGRATION_REGISTRY,
 	SNAPSHOT_DIR,
@@ -43,6 +44,7 @@ import {
 	assertSemver,
 	compareSemver,
 	copyFile,
+	detectPackageManagerId,
 	getLocalTsxBinary,
 	readJson,
 	resolveTargetVersion,
@@ -77,8 +79,10 @@ type VerifyOptions = {
 
 type FixturesOptions = {
 	all?: boolean;
+	confirmOverwrite?: ((message: string) => boolean) | undefined;
 	force?: boolean;
 	fromVersion?: string;
+	isInteractive?: boolean;
 	renderLine?: RenderLine;
 	toVersion?: string;
 };
@@ -100,7 +104,12 @@ export function formatMigrationHelpText(): string {
   wp-typia migrations verify [--from <semver>|--all]
   wp-typia migrations doctor [--from <semver>|--all]
   wp-typia migrations fixtures [--from <semver>|--all] [--to current] [--force]
-  wp-typia migrations fuzz [--from <semver>|--all] [--iterations <n>] [--seed <n>]`;
+  wp-typia migrations fuzz [--from <semver>|--all] [--iterations <n>] [--seed <n>]
+
+Notes:
+  --all runs across every configured legacy version and every configured block target.
+  In TTY usage, \`migrations fixtures --force\` asks before overwriting existing fixture files.
+  In non-interactive usage, \`migrations fixtures --force\` overwrites immediately for script compatibility.`;
 }
 
 export function parseMigrationArgs(argv: string[]): ParsedMigrationArgs {
@@ -304,7 +313,18 @@ export function snapshotProjectVersion(
 	ensureAdvancedMigrationProject(projectDir);
 	assertSemver(version, "snapshot version");
 	if (!skipSyncTypes) {
-		runProjectScriptIfPresent(projectDir, "sync-types");
+		try {
+			runProjectScriptIfPresent(projectDir, "sync-types");
+		} catch (error) {
+			const syncTypesCommand = formatRunScript(detectPackageManagerId(projectDir), "sync-types");
+			const reason = error instanceof Error ? error.message : String(error);
+			throw new Error(
+				`Could not capture migration snapshot ${version} because \`${syncTypesCommand}\` failed first. ` +
+					`Install project dependencies if needed, rerun \`${syncTypesCommand}\` in the project root to inspect the underlying error, ` +
+					`then retry \`wp-typia migrations snapshot --version ${version}\`.\n` +
+					`Original error: ${reason}`,
+			);
+		}
 	}
 
 	const state = loadMigrationProject(projectDir, { allowMissingConfig: skipConfigUpdate });
@@ -355,6 +375,7 @@ export function diffProjectMigrations(
 	}
 	const state = loadMigrationProject(projectDir);
 	const targetVersion = resolveTargetVersion(state.config.currentVersion, toVersion);
+	assertDistinctMigrationEdge("diff", fromVersion, targetVersion);
 	const diffs = state.blocks
 		.filter((block) => hasSnapshotForVersion(state, block, fromVersion))
 		.map((block) => ({
@@ -363,7 +384,7 @@ export function diffProjectMigrations(
 		}));
 
 	if (diffs.length === 0) {
-		throw new Error(`No migration block targets have a snapshot for ${fromVersion}.`);
+		throw new Error(createMissingProjectSnapshotMessage(state, fromVersion));
 	}
 
 	for (const { block, diff } of diffs) {
@@ -385,15 +406,18 @@ export function scaffoldProjectMigrations(
 	ensureMigrationDirectories(projectDir);
 	const state = loadMigrationProject(projectDir);
 	const targetVersion = resolveTargetVersion(state.config.currentVersion, toVersion);
+	assertDistinctMigrationEdge("scaffold", fromVersion, targetVersion);
 	const paths = getProjectPaths(projectDir);
 	const scaffolded: Array<{ blockName: string; diff: ReturnType<typeof createMigrationDiff>; rulePath: string }> =
 		[];
+	let eligibleBlocks = 0;
 
 	for (const block of state.blocks) {
 		if (!hasSnapshotForVersion(state, block, fromVersion)) {
 			renderLine(`Skipped ${block.blockName}: no snapshot for ${fromVersion}`);
 			continue;
 		}
+		eligibleBlocks += 1;
 		const diff = createMigrationDiff(state, block, fromVersion, targetVersion);
 		const rulePath = getRuleFilePath(paths, block, fromVersion, targetVersion);
 
@@ -425,6 +449,11 @@ export function scaffoldProjectMigrations(
 		renderLine(formatDiffReport(entry.diff));
 		renderLine(`Scaffolded ${path.relative(projectDir, entry.rulePath)}`);
 	}
+
+	if (eligibleBlocks === 0) {
+		throw new Error(createMissingProjectSnapshotMessage(state, fromVersion));
+	}
+
 	return scaffolded.length === 1 ? scaffolded[0] : { scaffolded };
 }
 
@@ -460,8 +489,10 @@ export function verifyProjectMigrations(
 		}
 		const verifyScriptPath = path.join(getGeneratedDirForBlock(state.paths, block), "verify.ts");
 		if (!fs.existsSync(verifyScriptPath)) {
+			const selectedVersionsForBlock = entries.map((entry) => entry.fromVersion);
 			throw new Error(
-				`Generated verify script is missing for ${block.blockName}. Run \`wp-typia migrations scaffold --from <semver>\` first.`,
+				`Generated verify script is missing for ${block.blockName} (${selectedVersionsForBlock.join(", ")}). ` +
+					`Run \`${formatScaffoldCommand(selectedVersionsForBlock)}\` first, then \`wp-typia migrations doctor --all\` if the workspace should already be scaffolded.`,
 			);
 		}
 
@@ -754,8 +785,10 @@ export function fixturesProjectMigrations(
 	projectDir: string,
 	{
 		all = false,
+		confirmOverwrite,
 		force = false,
 		fromVersion,
+		isInteractive = isInteractiveTerminal(),
 		renderLine = console.log as RenderLine,
 		toVersion = "current",
 	}: FixturesOptions = {},
@@ -772,22 +805,39 @@ export function fixturesProjectMigrations(
 
 	const generatedVersions: string[] = [];
 	const skippedVersions: string[] = [];
+	const fixtureTargets = collectFixtureTargets(state, targetVersions, targetVersion);
 
-	for (const version of targetVersions) {
-		for (const block of state.blocks) {
-			if (!hasSnapshotForVersion(state, block, version)) {
-				continue;
+	if (force) {
+		const overwriteTargets = fixtureTargets.filter(({ fixturePath }) => fs.existsSync(fixturePath));
+		if (isInteractive && overwriteTargets.length > 0) {
+			const confirmed =
+				confirmOverwrite?.(
+					`About to overwrite ${overwriteTargets.length} existing migration fixture file(s). Continue?`,
+				) ?? promptForConfirmation(
+					`About to overwrite ${overwriteTargets.length} existing migration fixture file(s). Continue?`,
+				);
+
+			if (!confirmed) {
+				renderLine(
+					`Cancelled fixture refresh. Kept ${overwriteTargets.length} existing fixture file(s).`,
+				);
+				return {
+					generatedVersions,
+					skippedVersions: overwriteTargets.map(({ scopedLabel }) => scopedLabel),
+				};
 			}
-			const diff = createMigrationDiff(state, block, version, targetVersion);
-			const result = ensureEdgeFixtureFile(projectDir, block, version, targetVersion, diff, { force });
-			const scopedLabel = `${block.key}@${version}`;
-			if (result.written) {
-				generatedVersions.push(scopedLabel);
-				renderLine(`Generated fixture ${path.relative(projectDir, result.fixturePath)}`);
-			} else {
-				skippedVersions.push(scopedLabel);
-				renderLine(`Skipped existing fixture ${path.relative(projectDir, result.fixturePath)}`);
-			}
+		}
+	}
+
+	for (const { block, fixturePath, scopedLabel, version } of fixtureTargets) {
+		const diff = createMigrationDiff(state, block, version, targetVersion);
+		const result = ensureEdgeFixtureFile(projectDir, block, version, targetVersion, diff, { force });
+		if (result.written) {
+			generatedVersions.push(scopedLabel);
+			renderLine(`Generated fixture ${path.relative(projectDir, fixturePath)}`);
+		} else {
+			skippedVersions.push(scopedLabel);
+			renderLine(`Skipped existing fixture ${path.relative(projectDir, fixturePath)}`);
 		}
 	}
 
@@ -834,8 +884,10 @@ export function fuzzProjectMigrations(
 		}
 		const fuzzScriptPath = path.join(getGeneratedDirForBlock(state.paths, block), "fuzz.ts");
 		if (!fs.existsSync(fuzzScriptPath)) {
+			const selectedVersionsForBlock = entries.map((entry) => entry.fromVersion);
 			throw new Error(
-				`Generated fuzz script is missing for ${block.blockName}. Run \`wp-typia migrations scaffold --from <semver>\` first.`,
+				`Generated fuzz script is missing for ${block.blockName} (${selectedVersionsForBlock.join(", ")}). ` +
+					`Run \`${formatScaffoldCommand(selectedVersionsForBlock)}\` first, then \`wp-typia migrations doctor --all\` if the workspace should already be scaffolded.`,
 			);
 		}
 		const selectedVersionsForBlock = entries.map((entry) => entry.fromVersion);
@@ -901,11 +953,16 @@ function resolveLegacyVersions(
 ): string[] {
 	const legacyVersions = state.config.supportedVersions.filter(
 		(version) => version !== state.config.currentVersion,
-	);
+	).sort(compareSemver);
 
 	if (fromVersion) {
 		if (!legacyVersions.includes(fromVersion)) {
-			throw new Error(`Unsupported migration version: ${fromVersion}`);
+			throw new Error(
+				legacyVersions.length === 0
+					? `Unsupported migration version: ${fromVersion}. No legacy versions are configured yet. ` +
+						`Capture an older release with \`wp-typia migrations snapshot --version <semver>\` first.`
+					: `Unsupported migration version: ${fromVersion}. Available legacy versions: ${legacyVersions.join(", ")}.`,
+			);
 		}
 		return [fromVersion];
 	}
@@ -1048,8 +1105,10 @@ function getSelectedEntriesByBlock(
 		const missingLabels = missingEntries
 			.map(({ block, version }) => `${block.blockName} @ ${version}`)
 			.join(", ");
+		const missingVersions = [...new Set(missingEntries.map(({ version }) => version))].sort(compareSemver);
 		throw new Error(
-			`Missing migration ${command} inputs for ${missingLabels}. Run \`wp-typia migrations scaffold --from <semver>\` first.`,
+			`Missing migration ${command} inputs for ${missingLabels}. ` +
+				`Run \`${formatScaffoldCommand(missingVersions)}\` first, then \`wp-typia migrations doctor --all\` if the workspace should already be scaffolded.`,
 		);
 	}
 
@@ -1093,4 +1152,94 @@ function isLegacySingleBlockProject(
 	state: ReturnType<typeof loadMigrationProject>,
 ): boolean {
 	return state.blocks.length === 1 && state.blocks[0]?.layout === "legacy";
+}
+
+function assertDistinctMigrationEdge(
+	command: "diff" | "scaffold",
+	fromVersion: string,
+	toVersion: string,
+): void {
+	if (fromVersion === toVersion) {
+		throw new Error(
+			`\`migrations ${command}\` requires different source and target versions, but both resolved to ${fromVersion}. ` +
+				`Choose an older snapshot with \`--from <semver>\` or capture a newer release with \`wp-typia migrations snapshot --version <semver>\` first.`,
+		);
+	}
+}
+
+function createMissingProjectSnapshotMessage(
+	state: ReturnType<typeof loadMigrationProject>,
+	fromVersion: string,
+): string {
+	const snapshotVersions = [...new Set(
+		state.blocks.flatMap((block) => getAvailableSnapshotVersionsForBlock(state, block)),
+	)].sort(compareSemver);
+
+	return snapshotVersions.length === 0
+		? `No migration block targets have a snapshot for ${fromVersion}. No snapshots exist yet in this project. ` +
+				`Run \`wp-typia migrations snapshot --version ${fromVersion}\` first if you want to preserve that release.`
+		: `No migration block targets have a snapshot for ${fromVersion}. ` +
+				`Available snapshot versions in this project: ${snapshotVersions.join(", ")}. ` +
+				`Run \`wp-typia migrations snapshot --version ${fromVersion}\` first if you want to preserve that release.`;
+}
+
+function getAvailableSnapshotVersionsForBlock(
+	state: ReturnType<typeof loadMigrationProject>,
+	block: ReturnType<typeof loadMigrationProject>["blocks"][number],
+): string[] {
+	return state.config.supportedVersions
+		.filter((version) => hasSnapshotForVersion(state, block, version))
+		.sort(compareSemver);
+}
+
+function formatScaffoldCommand(versions: string[]): string {
+	const uniqueVersions = [...new Set(versions)].sort(compareSemver);
+	return uniqueVersions.length === 1
+		? `wp-typia migrations scaffold --from ${uniqueVersions[0]}`
+		: "wp-typia migrations scaffold --from <semver>";
+}
+
+function isInteractiveTerminal(): boolean {
+	return Boolean(process.stdin.isTTY && process.stdout.isTTY);
+}
+
+function promptForConfirmation(message: string): boolean {
+	process.stdout.write(`${message} [y/N]: `);
+
+	const buffer = Buffer.alloc(1);
+	let answer = "";
+
+	while (true) {
+		const bytesRead = fs.readSync(process.stdin.fd, buffer, 0, 1, null);
+		if (bytesRead === 0) {
+			break;
+		}
+
+		const char = buffer.toString("utf8", 0, bytesRead);
+		if (char === "\n" || char === "\r") {
+			break;
+		}
+
+		answer += char;
+	}
+
+	const normalized = answer.trim().toLowerCase();
+	return normalized === "y" || normalized === "yes";
+}
+
+function collectFixtureTargets(
+	state: ReturnType<typeof loadMigrationProject>,
+	targetVersions: string[],
+	targetVersion: string,
+) {
+	return targetVersions.flatMap((version) =>
+		state.blocks
+			.filter((block) => hasSnapshotForVersion(state, block, version))
+			.map((block) => ({
+				block,
+				fixturePath: getFixtureFilePath(state.paths, block, version, targetVersion),
+				scopedLabel: `${block.key}@${version}`,
+				version,
+			})),
+	);
 }

--- a/packages/create/tests/migrations.test.ts
+++ b/packages/create/tests/migrations.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -7,12 +8,16 @@ import { runUtf8Command } from "../../../tests/helpers/process-utils";
 import { writeJsonFile, writeTextFile } from "../../../tests/helpers/file-fixtures";
 import { createMigrationDiff } from "../src/runtime/migration-diff.js";
 import { parseMigrationArgs } from "../src/runtime/index.js";
+import {
+	fixturesProjectMigrations,
+	snapshotProjectVersion,
+} from "../src/runtime/migrations.js";
 import { loadMigrationProject } from "../src/runtime/migration-project.js";
 import { createMigrationRiskSummary } from "../src/runtime/migration-risk.js";
 
-const packageRoot = process.cwd();
+const packageRoot = resolvePackageRoot();
 const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "wp-typia-migrations-"));
-const entryPath = path.join(packageRoot, "dist", "cli.js");
+const entryPath = resolveCliEntryPath();
 const repoTsxPath = resolveRepoTsxBinary();
 
 function runCli(
@@ -33,6 +38,8 @@ function writeJson(filePath: string, value: unknown) {
 
 function resolveRepoTsxBinary() {
 	const candidates = [
+		path.resolve(packageRoot, "node_modules/.bin/tsx"),
+		path.resolve(packageRoot, "node_modules/.bun/tsx@4.21.0/node_modules/.bin/tsx"),
 		path.resolve(packageRoot, "../../node_modules/.bin/tsx"),
 		path.resolve(packageRoot, "../../node_modules/.bun/tsx@4.21.0/node_modules/.bin/tsx"),
 	];
@@ -43,6 +50,42 @@ function resolveRepoTsxBinary() {
 	}
 
 	return resolved;
+}
+
+function resolvePackageRoot() {
+	const cwd = process.cwd();
+	const directPackageRoot = path.join(cwd, "package.json");
+	if (fs.existsSync(directPackageRoot) && fs.existsSync(path.join(cwd, "src", "cli.ts"))) {
+		return cwd;
+	}
+
+	const nestedPackageRoot = path.join(cwd, "packages", "create");
+	if (
+		fs.existsSync(path.join(nestedPackageRoot, "package.json")) &&
+		fs.existsSync(path.join(nestedPackageRoot, "src", "cli.ts"))
+	) {
+		return nestedPackageRoot;
+	}
+
+	throw new Error("Unable to resolve the @wp-typia/create package root for migration tests.");
+}
+
+function resolveCliEntryPath() {
+	const cliPath = path.join(packageRoot, "dist", "cli.js");
+	if (fs.existsSync(cliPath)) {
+		return cliPath;
+	}
+
+	execFileSync("bun", ["run", "build"], {
+		cwd: packageRoot,
+		stdio: "inherit",
+	});
+
+	if (!fs.existsSync(cliPath)) {
+		throw new Error("Unable to build dist/cli.js for migration tests.");
+	}
+
+	return cliPath;
 }
 
 function createManifestAttribute(
@@ -1491,6 +1534,64 @@ describe("wp-typia migrations", () => {
 		expect(fs.readFileSync(fixturePath, "utf8")).not.toContain('"custom"');
 	});
 
+	test("fixtures --force prompts before overwriting existing fixtures in interactive mode", () => {
+		const projectDir = path.join(tempRoot, "fixtures-force-confirm-project");
+		createVersionedMigrationProject(projectDir);
+
+		runCli("node", [entryPath, "migrations", "scaffold", "--from", "1.0.0"], {
+			cwd: projectDir,
+		});
+
+		const fixturePath = path.join(projectDir, "src", "migrations", "fixtures", "1.0.0-to-2.0.0.json");
+		fs.writeFileSync(
+			fixturePath,
+			`${JSON.stringify({ cases: [{ input: { content: "custom" }, name: "custom" }], fromVersion: "1.0.0", toVersion: "2.0.0" }, null, "\t")}\n`,
+			"utf8",
+		);
+
+		const prompts: string[] = [];
+		const lines: string[] = [];
+		const result = fixturesProjectMigrations(projectDir, {
+			all: true,
+			confirmOverwrite: (message) => {
+				prompts.push(message);
+				return false;
+			},
+			force: true,
+			isInteractive: true,
+			renderLine: (line) => lines.push(line),
+		});
+
+		expect(prompts[0]).toContain("overwrite 1 existing migration fixture file");
+		expect(lines.join("\n")).toContain("Cancelled fixture refresh");
+		expect(result.generatedVersions).toEqual([]);
+		expect(result.skippedVersions.length).toBe(1);
+		expect(fs.readFileSync(fixturePath, "utf8")).toContain('"custom"');
+	});
+
+	test("snapshot surfaces sync-types recovery guidance when the preflight script fails", () => {
+		const projectDir = path.join(tempRoot, "snapshot-sync-types-failure-project");
+		createVersionedMigrationProject(projectDir);
+
+		writeJson(
+			path.join(projectDir, "package.json"),
+			{
+				name: "migration-smoke",
+				packageManager: "bun@1.3.10",
+				private: true,
+				scripts: {
+					"sync-types": `node -e "process.stderr.write('sync-types failed'); process.exit(1)"`,
+				},
+				type: "module",
+				version: "0.1.0",
+			},
+		);
+
+		expect(() => snapshotProjectVersion(projectDir, "3.0.0")).toThrow(
+			/Could not capture migration snapshot 3\.0\.0 because `bun run sync-types` failed first[\s\S]*Install project dependencies[\s\S]*rerun `bun run sync-types`[\s\S]*Original error:/,
+		);
+	});
+
 	test("fuzz command succeeds on a healthy migration edge", () => {
 		const projectDir = path.join(tempRoot, "fuzz-success-project");
 		createVersionedMigrationProject(projectDir);
@@ -1546,7 +1647,24 @@ describe("wp-typia migrations", () => {
 				[entryPath, "migrations", "fuzz", "--from", "9.9.9", "--iterations", "1", "--seed", "0"],
 				{ cwd: projectDir },
 			),
-		).toThrow(/Unsupported migration version: 9.9.9/);
+		).toThrow(/Unsupported migration version: 9.9.9[\s\S]*Available legacy versions: 1\.0\.0/);
+	});
+
+	test("diff and scaffold reject same-version migration edges early", () => {
+		const projectDir = path.join(tempRoot, "same-version-edge-project");
+		createVersionedMigrationProject(projectDir);
+
+		expect(() =>
+			runCli("node", [entryPath, "migrations", "diff", "--from", "2.0.0"], {
+				cwd: projectDir,
+			}),
+		).toThrow(/migrations diff` requires different source and target versions[\s\S]*2\.0\.0/);
+
+		expect(() =>
+			runCli("node", [entryPath, "migrations", "scaffold", "--from", "1.0.0", "--to", "1.0.0"], {
+				cwd: projectDir,
+			}),
+		).toThrow(/migrations scaffold` requires different source and target versions[\s\S]*1\.0\.0/);
 	});
 
 	test("verify defaults to the first legacy version and rejects malformed numeric flags", () => {
@@ -1617,13 +1735,41 @@ describe("wp-typia migrations", () => {
 			runCli("node", [entryPath, "migrations", "verify", "--all"], {
 				cwd: projectDir,
 			}),
-		).toThrow(/Missing migration verify inputs.*1\.5\.0/);
+		).toThrow(/Missing migration verify inputs.*1\.5\.0[\s\S]*migrations scaffold --from 1\.5\.0[\s\S]*migrations doctor --all/);
 		expect(() =>
 			runCli(
 				"node",
 				[entryPath, "migrations", "fuzz", "--all", "--iterations", "1", "--seed", "0"],
 				{ cwd: projectDir },
 			),
-		).toThrow(/Missing migration fuzz inputs.*1\.5\.0/);
+		).toThrow(/Missing migration fuzz inputs.*1\.5\.0[\s\S]*migrations scaffold --from 1\.5\.0[\s\S]*migrations doctor --all/);
+	});
+
+	test("verify and fuzz fail with recovery guidance when generated scripts are missing", () => {
+		const projectDir = path.join(tempRoot, "missing-generated-script-project");
+		createVersionedMigrationProject(projectDir);
+
+		runCli("node", [entryPath, "migrations", "scaffold", "--from", "1.0.0"], {
+			cwd: projectDir,
+		});
+
+		fs.rmSync(path.join(projectDir, "src", "migrations", "generated", "verify.ts"));
+		expect(() =>
+			runCli("node", [entryPath, "migrations", "verify", "--all"], {
+				cwd: projectDir,
+			}),
+		).toThrow(/Generated verify script is missing[\s\S]*1\.0\.0[\s\S]*migrations scaffold --from 1\.0\.0[\s\S]*migrations doctor --all/);
+
+		runCli("node", [entryPath, "migrations", "scaffold", "--from", "1.0.0"], {
+			cwd: projectDir,
+		});
+		fs.rmSync(path.join(projectDir, "src", "migrations", "generated", "fuzz.ts"));
+		expect(() =>
+			runCli(
+				"node",
+				[entryPath, "migrations", "fuzz", "--all", "--iterations", "1", "--seed", "0"],
+				{ cwd: projectDir },
+			),
+		).toThrow(/Generated fuzz script is missing[\s\S]*1\.0\.0[\s\S]*migrations scaffold --from 1\.0\.0[\s\S]*migrations doctor --all/);
 	});
 });


### PR DESCRIPTION
## Summary
- improve migration CLI diagnostics for unsupported versions, missing snapshots, and missing generated inputs
- fail fast on same-version diff/scaffold edges and wrap snapshot sync failures with recovery guidance
- add interactive overwrite confirmation for `fixtures --force` while preserving non-interactive script behavior

## Testing
- `bun test packages/create/tests/migrations.test.ts`
- `bun run --filter @wp-typia/create test`
- `bun run typecheck`
- `bun run changesets:validate`

Closes #119

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Interactive confirmation prompts now appear when overwriting existing fixtures in terminal mode.
  * Enhanced migration CLI with improved error recovery guidance.

* **Bug Fixes**
  * Validation added to prevent same-version migrations.
  * Improved error messages now list available snapshot versions and recovery steps.

* **Documentation**
  * Clarified default behavior for migration commands (first version only vs. `--all` flag).
  * Added troubleshooting guidance for missing generated inputs.
  * Documented TTY vs. non-interactive fixture handling differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->