### PR TITLE
Patch scaffold DX regressions

### DIFF
--- a/.sampo/changesets/scaffold-dx-regressions.md
+++ b/.sampo/changesets/scaffold-dx-regressions.md
@@ -1,0 +1,8 @@
+---
+npm/@wp-typia/create: patch
+---
+
+Patch scaffold DX regressions in `@wp-typia/create` by preserving the published
+`@wp-typia/block-runtime` dependency range during version resolution, clarifying
+fixture refresh messaging, and documenting the intentional static/basic
+template defaults.

--- a/docs/API.md
+++ b/docs/API.md
@@ -406,7 +406,9 @@ version only; `--all` runs across every configured legacy migration version and 
 block target. `migrations wizard` requires a TTY; use `migrations plan --from-migration-version
 <label>` in non-interactive shells. In TTY usage, `migrations fixtures --force`
 asks before overwriting existing fixture files, while non-interactive runs
-overwrite immediately for script compatibility.
+overwrite immediately for script compatibility. Existing fixture files are
+otherwise preserved and reported as skipped, so `--force` is the explicit
+refresh path even when `--all` is present.
 
 The built-in `persistence` template adds another predictable layer:
 

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -229,12 +229,17 @@ Scaffolded rules expose:
 - deprecated / generated registry drift
 - fixture coverage for default, rename, transform, and supported union-branch cases
 
-`migration:fixtures` is the explicit refresh path for edge fixtures. Without `--force`, existing fixture files are preserved and reported as skipped.
+`migration:fixtures` is the explicit refresh path for edge fixtures. Without
+`--force`, existing fixture files are preserved and reported as skipped. Use
+`--force` when you want the CLI to refresh those files from the current
+generated edge output.
 
 In TTY usage, `migration:fixtures -- --force` asks once before overwriting
 existing fixture files and reports how many files will be replaced. In
 non-interactive usage, `--force` still overwrites immediately so scripted flows
-stay compatible.
+stay compatible. `--all` does not change that overwrite rule by itself; it only
+widens the set of legacy migration versions and block targets considered for
+generation.
 
 `migration:fuzz` is intentionally separate from `migration:verify`. `verify` stays deterministic and fixture-driven, while `fuzz` replays fixture cases and then generates seeded random current samples with `validators.random()`, converts the safe subset back into legacy-shaped inputs, migrates them, and validates the result against the current Typia validator.
 

--- a/packages/create/README.md
+++ b/packages/create/README.md
@@ -86,6 +86,14 @@ Defaults keep these concerns separate:
 - text domains default to the kebab-case slug
 - PHP symbols default to a snake_case prefix derived from the slug
 
+For the built-in `basic` template, those defaults also imply a few intentional
+baselines:
+
+- it remains a static block, so no `render.php` file is generated
+- `src/save.tsx` always returns stable saved markup instead of `null`
+- the generated webpack config stays on the current `@wordpress/scripts` CommonJS baseline
+- wrapper CSS classes still follow `wp-block-namespace-slug`; when namespace and slug match, duplicated segments such as `wp-block-demo-block-demo-block` are expected
+
 Every generated project exposes `sync-types`, and persistence-enabled scaffolds also expose `sync-rest`. `start` still runs the relevant sync scripts for you, while `build` and `typecheck` verify that generated metadata/schema artifacts are already current and fail if they are stale. Run the sync scripts manually when you want generated metadata/schema artifacts refreshed before `build`, `typecheck`, or commit. `sync-types` stays warn-only by default, supports `-- --fail-on-lossy` when CI should fail only on lossy WordPress projections, and supports `-- --strict --report json` when CI should fail on every warning while reading a machine-friendly JSON report from stdout. These syncs do not create migration history.
 
 Generated projects can also reuse small runtime helpers from `@wp-typia/block-runtime` instead of copying local utility code:

--- a/packages/create/src/runtime/migrations.ts
+++ b/packages/create/src/runtime/migrations.ts
@@ -147,6 +147,8 @@ Notes:
   \`migrations wizard\` is TTY-only and helps you choose one legacy migration version to preview.
   \`migrations plan\` and \`migrations wizard\` are read-only previews; they do not scaffold rules or fixtures.
   --all runs across every configured legacy migration version and every configured block target.
+  Existing fixture files are preserved and reported as skipped unless you pass \`--force\`.
+  Use \`migrations fixtures --force\` as the explicit refresh path for generated fixture files.
   In TTY usage, \`migrations fixtures --force\` asks before overwriting existing fixture files.
   In non-interactive usage, \`migrations fixtures --force\` overwrites immediately for script compatibility.`;
 }
@@ -1140,14 +1142,19 @@ export function fixturesProjectMigrations(
 	}
 
 	for (const { block, fixturePath, scopedLabel, version } of fixtureTargets) {
+		const existed = fs.existsSync(fixturePath);
 		const diff = createMigrationDiff(state, block, version, targetMigrationVersion);
 		const result = ensureEdgeFixtureFile(projectDir, block, version, targetMigrationVersion, diff, { force });
 		if (result.written) {
 			generatedVersions.push(scopedLabel);
-			renderLine(`Generated fixture ${path.relative(projectDir, fixturePath)}`);
+			renderLine(
+				`${existed ? "Refreshed" : "Generated"} fixture ${path.relative(projectDir, fixturePath)}`,
+			);
 		} else {
 			skippedVersions.push(scopedLabel);
-			renderLine(`Skipped existing fixture ${path.relative(projectDir, fixturePath)}`);
+			renderLine(
+				`Preserved existing fixture ${path.relative(projectDir, fixturePath)} (use --force to refresh)`,
+			);
 		}
 	}
 

--- a/packages/create/src/runtime/package-versions.ts
+++ b/packages/create/src/runtime/package-versions.ts
@@ -80,7 +80,10 @@ export function getPackageVersions(): PackageVersions {
 			createManifest.dependencies?.["@wp-typia/api-client"] ??
 				resolveInstalledPackageManifest("@wp-typia/api-client")?.version,
 		),
-		blockRuntimePackageVersion: normalizeVersionRange(blockRuntimeManifest.version),
+		blockRuntimePackageVersion: normalizeVersionRange(
+			createManifest.dependencies?.["@wp-typia/block-runtime"] ??
+				blockRuntimeManifest.version,
+		),
 		blockTypesPackageVersion: normalizeVersionRange(
 			createManifest.dependencies?.["@wp-typia/block-types"] ??
 				resolveInstalledPackageManifest("@wp-typia/block-types")?.version,

--- a/packages/create/src/runtime/scaffold-onboarding.ts
+++ b/packages/create/src/runtime/scaffold-onboarding.ts
@@ -99,7 +99,7 @@ export function getTemplateSourceOfTruthNote(
 		return "`src/types.ts` remains the source of truth for `block.json`, `typia.manifest.json`, and `typia-validator.php`. Fresh scaffolds include a starter `typia.manifest.json` so editor imports resolve before the first sync. `src/api-types.ts` remains the source of truth for `src/api-schemas/*` when you run `sync-rest`. This scaffold is intentionally server-rendered: `src/render.php` is the canonical frontend entry, and `src/save.tsx` returns `null` so PHP can inject post context, storage-backed state, and write-policy bootstrap data before hydration.";
 	}
 
-	return "`src/types.ts` remains the source of truth for `block.json`, `typia.manifest.json`, and `typia-validator.php`. Fresh scaffolds include a starter `typia.manifest.json` so editor imports resolve before the first sync.";
+	return "`src/types.ts` remains the source of truth for `block.json`, `typia.manifest.json`, and `typia-validator.php`. Fresh scaffolds include a starter `typia.manifest.json` so editor imports resolve before the first sync. The basic scaffold stays static by design: it does not generate `render.php`, `src/save.tsx` always returns stable markup, and the generated webpack config keeps the current `@wordpress/scripts` CommonJS baseline.";
 }
 
 /**

--- a/packages/create/tests/create-cli.test.ts
+++ b/packages/create/tests/create-cli.test.ts
@@ -226,6 +226,7 @@ describe("@wp-typia/create scaffolding", () => {
 			fs.readFileSync(path.join(targetDir, "src", "typia.manifest.json"), "utf8"),
 		);
 		const generatedSave = fs.readFileSync(path.join(targetDir, "src", "save.tsx"), "utf8");
+		const generatedStyle = fs.readFileSync(path.join(targetDir, "src", "style.scss"), "utf8");
 		const generatedTypes = fs.readFileSync(path.join(targetDir, "src", "types.ts"), "utf8");
 		const generatedValidators = fs.readFileSync(path.join(targetDir, "src", "validators.ts"), "utf8");
 		const generatedValidatorToolkit = fs.readFileSync(
@@ -244,6 +245,7 @@ describe("@wp-typia/create scaffolding", () => {
 		expect(packageJson.name).toBe("demo-npm");
 		expect(packageJson.packageManager).toBe("npm@11.6.1");
 		expect(packageJson.devDependencies["@wp-typia/block-runtime"]).toBe(blockRuntimePackageVersion);
+		expect(packageJson.devDependencies["@wp-typia/block-runtime"]).not.toBe("^0.0.0");
 		expect(packageJson.devDependencies["@wp-typia/block-types"]).toBe(blockTypesPackageVersion);
 		expect(packageJson.devDependencies["@wp-typia/create"]).toBeUndefined();
 		expect(packageJson.devDependencies["chokidar-cli"]).toBe("^3.0.0");
@@ -285,6 +287,7 @@ describe("@wp-typia/create scaffolding", () => {
 		expect(generatedEdit).toContain("useTypedAttributeUpdater");
 		expect(generatedSave).toContain("RichText.Content");
 		expect(generatedSave).not.toContain("return null;");
+		expect(generatedStyle).toContain(".wp-block-demo-space-demo-npm");
 		expect(generatedHooks).toContain("@wp-typia/block-runtime/validation");
 		expect(generatedHooks).toContain("createUseTypiaValidationHook");
 		expect(generatedIndex).toContain("@wp-typia/block-runtime/blocks");
@@ -1810,6 +1813,29 @@ describe("@wp-typia/create scaffolding", () => {
 		expect(answers.phpPrefix).toBe("demo_recovered");
 		expect(answers.textDomain).toBe("demo-recovered");
 		expect(answers.title).toBe("Demo Recovered");
+	});
+
+	test("runScaffoldFlow keeps the default namespace equal to the slug for wrapper classes", async () => {
+		const projectInput = "demo-default-class";
+		const flow = await runScaffoldFlow({
+			cwd: tempRoot,
+			noInstall: true,
+			packageManager: "npm",
+			projectInput,
+			templateId: "basic",
+			yes: true,
+		});
+
+		const blockJson = JSON.parse(
+			fs.readFileSync(path.join(flow.projectDir, "src", "block.json"), "utf8"),
+		);
+		const generatedStyle = fs.readFileSync(
+			path.join(flow.projectDir, "src", "style.scss"),
+			"utf8",
+		);
+
+		expect(blockJson.name).toBe("demo-default-class/demo-default-class");
+		expect(generatedStyle).toContain(".wp-block-demo-default-class-demo-default-class");
 	});
 
 	test("runScaffoldFlow keeps compound next steps minimal while surfacing optional sync guidance", async () => {

--- a/packages/create/tests/migrations.test.ts
+++ b/packages/create/tests/migrations.test.ts
@@ -1646,7 +1646,7 @@ describe("wp-typia migrations", () => {
 
 	test("migrations help text explains retrofit auto-detection, read-only planning, and --all workspace scope", () => {
 		expect(() => runCli("node", [entryPath, "migrations"])).toThrow(
-			/`migrations init` auto-detects supported single-block and `src\/blocks\/\*` multi-block layouts[\s\S]*Migration versions use strict schema labels like `v1`, `v2`, and `v3`[\s\S]*`migrations wizard` is TTY-only[\s\S]*`migrations plan` and `migrations wizard` are read-only previews[\s\S]*--all runs across every configured legacy migration version and every configured block target\./,
+			/`migrations init` auto-detects supported single-block and `src\/blocks\/\*` multi-block layouts[\s\S]*Migration versions use strict schema labels like `v1`, `v2`, and `v3`[\s\S]*`migrations wizard` is TTY-only[\s\S]*`migrations plan` and `migrations wizard` are read-only previews[\s\S]*--all runs across every configured legacy migration version and every configured block target\.[\s\S]*Existing fixture files are preserved and reported as skipped unless you pass `--force`\.[\s\S]*Use `migrations fixtures --force` as the explicit refresh path/,
 		);
 	});
 
@@ -2421,13 +2421,14 @@ describe("wp-typia migrations", () => {
 		const skipOutput = runCli("node", [entryPath, "migrations", "fixtures", "--all"], {
 			cwd: projectDir,
 		});
-		expect(skipOutput).toContain("Skipped existing fixture");
+		expect(skipOutput).toContain("Preserved existing fixture");
+		expect(skipOutput).toContain("use --force to refresh");
 		expect(fs.readFileSync(fixturePath, "utf8")).toContain('"custom"');
 
 		const forceOutput = runCli("node", [entryPath, "migrations", "fixtures", "--all", "--force"], {
 			cwd: projectDir,
 		});
-		expect(forceOutput).toContain("Generated fixture");
+		expect(forceOutput).toContain("Refreshed fixture");
 		expect(fs.readFileSync(fixturePath, "utf8")).toContain('"default"');
 		expect(fs.readFileSync(fixturePath, "utf8")).not.toContain('"custom"');
 	});

--- a/tests/helpers/scaffold-template-variables.ts
+++ b/tests/helpers/scaffold-template-variables.ts
@@ -6,7 +6,7 @@ export function createTestScaffoldTemplateVariables(
 	const base: ScaffoldTemplateVariables = {
 		apiClientPackageVersion: "^0.2.0",
 		author: "Test Author",
-		blockRuntimePackageVersion: "^0.2.3",
+		blockRuntimePackageVersion: "^0.3.0",
 		blockTypesPackageVersion: "^0.2.0",
 		category: "widgets",
 		compoundChildTitle: "Demo Item",

--- a/tests/unit/package-versions.test.ts
+++ b/tests/unit/package-versions.test.ts
@@ -123,6 +123,32 @@ describe("package version helpers", () => {
 		});
 	});
 
+	test("uses the packaged create dependency range when no sibling block-runtime manifest is available", async () => {
+		const createPackageRoot = createTempDir("wp-typia-packaged-create-root-");
+
+		writeJsonFile(path.join(createPackageRoot, "package.json"), {
+			dependencies: {
+				"@wp-typia/api-client": "^0.4.0",
+				"@wp-typia/block-runtime": "^0.3.0",
+				"@wp-typia/block-types": "^0.2.0",
+				"@wp-typia/rest": "^0.3.1",
+			},
+			version: "0.11.0",
+		});
+
+		const module = await importPackageVersionsModule({
+			createPackageRoot,
+		});
+
+		expect(module.getPackageVersions()).toEqual({
+			apiClientPackageVersion: "^0.4.0",
+			blockRuntimePackageVersion: "^0.3.0",
+			blockTypesPackageVersion: "^0.2.0",
+			createPackageVersion: "^0.11.0",
+			restPackageVersion: "^0.3.1",
+		});
+	});
+
 	test("defaults missing version data to ^0.0.0 and caches the computed result", async () => {
 		const createPackageRoot = path.join(
 			createTempDir("wp-typia-empty-create-root-"),


### PR DESCRIPTION
## Summary
- fix packaged `@wp-typia/create` version resolution so generated projects keep the real `@wp-typia/block-runtime` range instead of falling back to `^0.0.0`
- clarify fixture refresh messaging so preserved files and explicit `--force` refreshes are easier to distinguish
- document the intentional static/basic template defaults and the `wp-block-namespace-slug` wrapper-class behavior

## Testing
- `bun test tests/unit/package-versions.test.ts`
- `bun run --filter @wp-typia/create test`
- `bun run typecheck`
- `bun run build`
- `bun run changesets:validate`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that `--force` is required to refresh existing fixture files; otherwise they are preserved.
  * Updated guidance on basic template defaults (static design, no `render.php`, stable markup).

* **New Features**
  * Enhanced console messaging to distinguish between "Generated," "Refreshed," and "Preserved" fixtures.

* **Bug Fixes**
  * Fixed block-runtime dependency version resolution to respect package manifests.

* **Tests**
  * Extended test coverage for package version handling and scaffold flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->