### PR TITLE
Tighten CI coverage and workspace hygiene

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI/CD Pipeline
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -93,7 +97,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
-          files: ./coverage/unit/lcov.info,./packages/wp-typia-rest/coverage/lcov.info,./packages/wp-typia-project-tools/coverage/lcov.info
+          files: ./coverage/unit/lcov.info,./packages/wp-typia-api-client/coverage/lcov.info,./packages/wp-typia-block-runtime/coverage/lcov.info,./packages/wp-typia-rest/coverage/lcov.info,./packages/wp-typia-project-tools/coverage/lcov.info,./packages/wp-typia/coverage/lcov.info
           flags: unittests
           name: codecov-umbrella
 

--- a/bun.lock
+++ b/bun.lock
@@ -138,10 +138,6 @@
         "typia": "^12.0.1",
       },
     },
-    "packages/create": {
-      "name": "@wp-typia/create",
-      "version": "1.0.0",
-    },
     "packages/create-workspace-template": {
       "name": "@wp-typia/create-workspace-template",
       "version": "0.13.0",
@@ -1589,8 +1585,6 @@
     "@wp-typia/block-runtime": ["@wp-typia/block-runtime@workspace:packages/wp-typia-block-runtime"],
 
     "@wp-typia/block-types": ["@wp-typia/block-types@workspace:packages/wp-typia-block-types"],
-
-    "@wp-typia/create": ["@wp-typia/create@workspace:packages/create"],
 
     "@wp-typia/create-workspace-template": ["@wp-typia/create-workspace-template@workspace:packages/create-workspace-template"],
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "workspaces": [
     "packages/wp-typia",
     "packages/wp-typia-project-tools",
-    "packages/create",
     "packages/create-workspace-template",
     "packages/wp-typia-block-runtime",
     "packages/wp-typia-rest",


### PR DESCRIPTION
## Summary
- add CI workflow concurrency to cancel superseded runs on the same PR/branch
- expand Codecov upload coverage paths for api-client, block-runtime, and wp-typia
- remove deprecated packages/create from the root Bun workspaces while keeping it publishable on disk

## Validation
- bun install
- bun run publish:validate
- bun run typecheck
- bun run test
- bun run build
- bun run changesets:validate

Refs #110

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD workflow execution and monitoring
  * Expanded test coverage metrics collection
  * Updated monorepo workspace configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->