### PR TITLE
Harden release PR labeling and npm publish automation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,11 +1,10 @@
 name: Publish to npm
 
 on:
+  push:
+    branches: [main]
   release:
     types: [published]
-  workflow_run:
-    workflows: ["Create GitHub Release"]
-    types: [completed]
   workflow_dispatch:
 
 permissions:
@@ -13,7 +12,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: publish-${{ github.event.release.tag_name || github.event.workflow_run.head_sha || github.run_id }}
+  group: publish-${{ github.event.release.target_commitish || github.sha || github.run_id }}
   cancel-in-progress: false
 
 env:
@@ -29,7 +28,7 @@ jobs:
       ${{
         github.event_name == 'workflow_dispatch' ||
         github.event_name == 'release' ||
-        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+        (github.event_name == 'push' && startsWith(github.event.head_commit.message, 'release: version packages'))
       }}
     runs-on: ubuntu-latest
     steps:
@@ -37,7 +36,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          ref: ${{ github.event.release.tag_name || github.event.workflow_run.head_sha || github.ref }}
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: publish-${{ github.event.release.target_commitish || github.sha || github.run_id }}
+  group: publish-${{ github.sha || github.run_id }}
   cancel-in-progress: false
 
 env:

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -63,6 +63,7 @@ jobs:
           exit "$status"
 
       - name: Create or update release PR
+        id: release_pr
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -78,9 +79,27 @@ jobs:
             - consumes pending `.sampo/changesets/*`
 
             Merge this PR with **Squash and merge** to automatically create a GitHub Release and trigger npm OIDC publish from `main`.
-          labels: |
-            release
           add-paths: |
             .sampo/**
             packages/**/package.json
             packages/**/CHANGELOG.md
+
+      - name: Add release label
+        if: steps.release_pr.outputs.pull-request-number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.release_pr.outputs.pull-request-number }}
+        shell: bash
+        run: |
+          set +e
+
+          for attempt in 1 2 3; do
+            if gh pr edit "$PR_NUMBER" --add-label release; then
+              exit 0
+            fi
+
+            echo "Attempt ${attempt} to add the release label failed; retrying..."
+            sleep $((attempt * 5))
+          done
+
+          echo "::warning::Failed to add the release label to PR #${PR_NUMBER}; continuing."


### PR DESCRIPTION
## Summary
- harden `release-pr.yml` so release label attachment becomes best-effort instead of a workflow-failing inline side effect
- make `publish.yml` trigger from the release squash commit landing on `main`, with `release.published` and manual dispatch as secondary paths
- stop relying on `workflow_run(Create GitHub Release)` for the normal npm publish path

Closes #190

## Validation
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `bun run publish:validate`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release automation: publish workflow now runs on direct pushes to main with safer checkout and simplified concurrency, and is gated by an explicit release-commit pattern.
  * More reliable release PR handling: labeling step added with retry/backoff and non-fatal warnings to reduce failures when applying the release label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->