### PR TITLE
Add upgrade, security, and GitHub contribution meta docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,42 @@
+name: Bug report
+description: Report a reproducible product, scaffold, runtime, or release problem.
+title: "[Bug]: "
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug. Please include enough detail for someone else to reproduce it locally.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What broke, and what did you expect instead?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: List exact commands, template choices, or repo steps.
+      placeholder: |
+        1. Run ...
+        2. Create ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include Node, Bun, package versions, OS, and package manager when relevant.
+    validations:
+      required: true
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation output
+      description: Paste failing logs, CI links, or stack traces.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability report
+    url: https://github.com/imjlk/wp-typia/security/advisories/new
+    about: Please report vulnerabilities privately through GitHub security advisories.

--- a/.github/ISSUE_TEMPLATE/docs-process.yml
+++ b/.github/ISSUE_TEMPLATE/docs-process.yml
@@ -1,0 +1,26 @@
+name: Docs or process update
+description: Request documentation, release-process, contributor-flow, or repo-meta improvements.
+title: "[Docs/Process]: "
+labels: []
+body:
+  - type: textarea
+    id: gap
+    attributes:
+      label: What is missing or confusing?
+      description: Describe the current docs/process gap.
+    validations:
+      required: true
+  - type: textarea
+    id: audience
+    attributes:
+      label: Who is affected?
+      description: New users, maintainers, plugin authors, migration users, etc.
+    validations:
+      required: true
+  - type: textarea
+    id: suggested_change
+    attributes:
+      label: Suggested update
+      description: If you already know the right doc or workflow surface, note it here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,26 @@
+name: Feature request
+description: Propose a user-facing capability or workflow improvement.
+title: "[Feature]: "
+labels: []
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to solve
+      description: What user or maintainer pain point is this addressing?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed direction
+      description: Describe the intended behavior or workflow at a high level.
+    validations:
+      required: true
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints or non-goals
+      description: Call out compatibility concerns, rollout boundaries, or explicit non-goals.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Summary
+
+- what changed?
+- why does it matter?
+
+## Validation
+
+- `bun run ci:local`
+- additional targeted checks, if any
+
+## Release notes
+
+- changeset added? If not, explain why this PR should not affect a release.
+
+## Docs
+
+- user-facing docs updated where behavior or workflow changed
+
+## Migration / compatibility
+
+- migration-sensitive change? If yes, note the compatibility impact and what was verified

--- a/.sampo/changesets/issue-110-meta-docs.md
+++ b/.sampo/changesets/issue-110-meta-docs.md
@@ -1,0 +1,6 @@
+---
+npm/wp-typia: patch
+---
+
+Add repository upgrade and security docs, GitHub issue/PR templates, and link
+the new meta guidance from the published `wp-typia` README.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,15 @@ node scripts/run-generated-project-smoke.mjs --runtime node --template basic --p
 bun run docs:build
 ```
 
+## Project meta docs
+
+- [`README.md`](./README.md) is the main product/audience entry point
+- [`UPGRADE.md`](./UPGRADE.md) collects high-signal maintainer upgrade notes
+- [`SECURITY.md`](./SECURITY.md) explains private vulnerability reporting
+
+If you change user-facing workflows, keep the relevant meta docs in sync in the
+same PR.
+
 ## Releases
 
 Release management now uses Sampo for release metadata and GitHub Actions for publish:
@@ -112,3 +121,4 @@ those jobs can fail even when the source tree and release PR look correct.
 - Add or update tests when behavior changes.
 - If a template workflow changes, update the user-facing README or tutorial in the same PR.
 - If migration behavior or snapshot tooling changes, verify at least one `migration:*` flow in `examples/my-typia-block` before opening the PR.
+- Do not file security issues publicly; use the private reporting flow described in [`SECURITY.md`](./SECURITY.md).

--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ Build WordPress blocks that can evolve safely.
 
 It is built for projects where block attributes change over time, saved content must stay compatible, and data-backed or multi-block patterns should not turn into one-off glue code.
 
+## Who this is for
+
+`wp-typia` is for teams building WordPress blocks that are expected to evolve:
+
+- long-lived blocks with changing attributes and compatibility pressure
+- blocks that need typed persistence or REST contracts
+- plugin workspaces that may grow into multi-block, variation, pattern, binding-source, or hooked-block workflows
+
+If you only need the smallest possible starter for a single block, `@wordpress/create-block` is still the better default.
+
 ## Why wp-typia
 
 - Type-driven block metadata from `src/types.ts`
@@ -172,6 +182,8 @@ npx wp-typia create my-block --template @scope/create-block-template --variant h
 - [Architecture Guide](docs/architecture.md)
 - [API Guide](docs/API.md)
 - [Migration Guide](docs/migrations.md)
+- [Upgrade Guide](UPGRADE.md)
+- [Security Policy](SECURITY.md)
 - [Interactivity Guide](docs/interactivity.md)
 - [Examples Guide](examples/EXAMPLES.md)
 - [Package Graduation](docs/package-graduation.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+Please do not report security vulnerabilities through public GitHub issues,
+pull requests, or discussions.
+
+## Reporting a vulnerability
+
+Use GitHub private vulnerability reporting for this repository:
+
+- <https://github.com/imjlk/wp-typia/security/advisories/new>
+
+Include as much of the following as you can:
+
+- affected package or generated-project surface
+- version or commit range
+- reproduction steps or proof of concept
+- impact assessment
+- any suggested mitigation if you already have one
+
+## What to expect
+
+- reports will be triaged privately first
+- maintainers may ask follow-up questions to confirm scope and impact
+- fixes and disclosure timing will be coordinated before public discussion
+
+This repository does not currently promise a formal SLA, but good-faith reports
+will be handled as quickly as possible.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,76 @@
+# Upgrade Guide
+
+Use this document for high-signal `wp-typia` upgrade notes that are easy to miss
+if you only skim package changelogs.
+
+## What this guide covers
+
+- command or package role changes that affect maintainer workflows
+- scaffold/runtime defaults that may change how generated projects are operated
+- deprecations that need a migration step
+
+It does not replace per-package `CHANGELOG.md` files.
+
+## Recent upgrade checkpoints
+
+### CLI shape moved to explicit `create` and `add` commands
+
+Recent releases standardized the CLI around explicit top-level verbs:
+
+- `wp-typia create <project-dir>`
+- `wp-typia add <kind> ...`
+- `wp-typia migrate <subcommand>`
+
+Compatibility aliases still exist in some places, but maintainers should update
+docs, shell scripts, and CI examples to use the explicit command group shape.
+
+### Workspace flow is now an official external template
+
+Multi-block plugin workflows now live behind the official external workspace
+template package instead of the built-in template list:
+
+- `@wp-typia/create-workspace-template`
+
+Use that template when you want a plugin workspace that can grow via:
+
+- `wp-typia add block`
+- `wp-typia add variation`
+- `wp-typia add pattern`
+- `wp-typia add binding-source`
+- `wp-typia add hooked-block`
+
+If you only need a single block scaffold, stay on the built-in templates.
+
+### Canonical runtime/import surfaces were narrowed
+
+The current package-role split is:
+
+- `wp-typia` owns the CLI
+- `@wp-typia/project-tools` owns programmatic scaffold/migrate/doctor helpers
+- `@wp-typia/block-runtime/*` owns generated-project runtime helpers
+
+Generated projects and examples should import runtime helpers from
+`@wp-typia/block-runtime/*`, not local copied helpers or deprecated compatibility
+paths.
+
+### Deprecated package shells should not be used for new installs
+
+These packages are retained only for compatibility or history:
+
+- `@wp-typia/create`
+- `create-wp-typia`
+
+For new installs, use:
+
+- `wp-typia`
+- `@wp-typia/create-workspace-template` for empty workspaces
+
+## Upgrade checklist
+
+When upgrading maintainers or generated project docs, verify:
+
+1. CLI examples use `wp-typia create`, `add`, and `migrate`.
+2. Multi-block plugin guidance points to the workspace template package.
+3. Runtime helper imports use `@wp-typia/block-runtime/*`.
+4. Deprecated package shells are not suggested for new installs.
+5. Release/process changes still match [`CONTRIBUTING.md`](./CONTRIBUTING.md).

--- a/packages/wp-typia/README.md
+++ b/packages/wp-typia/README.md
@@ -22,3 +22,9 @@ Compatibility notes:
 
 Maintainers: see [`docs/bunli-cli-migration.md`](../../docs/bunli-cli-migration.md)
 for the active CLI ownership contract and the staged Bunli cutover plan.
+
+Project meta docs:
+
+- [Upgrade Guide](https://github.com/imjlk/wp-typia/blob/main/UPGRADE.md)
+- [Security Policy](https://github.com/imjlk/wp-typia/blob/main/SECURITY.md)
+- [Contributing Guide](https://github.com/imjlk/wp-typia/blob/main/CONTRIBUTING.md)

--- a/tests/unit/repo-dx-baseline.test.ts
+++ b/tests/unit/repo-dx-baseline.test.ts
@@ -38,6 +38,24 @@ describe('repository DX baseline', () => {
 		expect(fs.existsSync(path.join(repoRoot, '.vscode', 'settings.json'))).toBe(true);
 	});
 
+	test('repo meta docs and GitHub templates exist', () => {
+		expect(fs.existsSync(path.join(repoRoot, 'UPGRADE.md'))).toBe(true);
+		expect(fs.existsSync(path.join(repoRoot, 'SECURITY.md'))).toBe(true);
+		expect(fs.existsSync(path.join(repoRoot, '.github', 'PULL_REQUEST_TEMPLATE.md'))).toBe(true);
+		expect(fs.existsSync(path.join(repoRoot, '.github', 'ISSUE_TEMPLATE', 'bug-report.yml'))).toBe(
+			true,
+		);
+		expect(
+			fs.existsSync(path.join(repoRoot, '.github', 'ISSUE_TEMPLATE', 'feature-request.yml')),
+		).toBe(true);
+		expect(
+			fs.existsSync(path.join(repoRoot, '.github', 'ISSUE_TEMPLATE', 'docs-process.yml')),
+		).toBe(true);
+		expect(fs.existsSync(path.join(repoRoot, '.github', 'ISSUE_TEMPLATE', 'config.yml'))).toBe(
+			true,
+		);
+	});
+
 	test('example build cleanliness guard exists', () => {
 		const guardScript = fs.readFileSync(
 			path.join(repoRoot, 'scripts', 'run-clean-examples-build.mjs'),
@@ -51,10 +69,18 @@ describe('repository DX baseline', () => {
 	test('docs explain lint ownership and ci:local guidance', () => {
 		const readme = fs.readFileSync(path.join(repoRoot, 'README.md'), 'utf8');
 		const contributing = fs.readFileSync(path.join(repoRoot, 'CONTRIBUTING.md'), 'utf8');
+		const cliReadme = fs.readFileSync(path.join(repoRoot, 'packages', 'wp-typia', 'README.md'), 'utf8');
 
 		expect(readme).toContain('bun run ci:local');
 		expect(readme).toContain('Root ESLint covers repository infrastructure code');
+		expect(readme).toContain('## Who this is for');
+		expect(readme).toContain('[Upgrade Guide](UPGRADE.md)');
+		expect(readme).toContain('[Security Policy](SECURITY.md)');
 		expect(contributing).toContain('Linting ownership is intentionally split');
 		expect(contributing).toContain('bun run lint:repo');
+		expect(contributing).toContain('## Project meta docs');
+		expect(contributing).toContain('[`SECURITY.md`](./SECURITY.md)');
+		expect(cliReadme).toContain('https://github.com/imjlk/wp-typia/blob/main/UPGRADE.md');
+		expect(cliReadme).toContain('https://github.com/imjlk/wp-typia/blob/main/SECURITY.md');
 	});
 });

--- a/tests/unit/repo-dx-baseline.test.ts
+++ b/tests/unit/repo-dx-baseline.test.ts
@@ -80,7 +80,11 @@ describe('repository DX baseline', () => {
 		expect(contributing).toContain('bun run lint:repo');
 		expect(contributing).toContain('## Project meta docs');
 		expect(contributing).toContain('[`SECURITY.md`](./SECURITY.md)');
-		expect(cliReadme).toContain('https://github.com/imjlk/wp-typia/blob/main/UPGRADE.md');
-		expect(cliReadme).toContain('https://github.com/imjlk/wp-typia/blob/main/SECURITY.md');
+		expect(cliReadme).toMatch(
+			/https:\/\/github\.com\/[^/]+\/[^/]+\/blob\/main\/UPGRADE\.md/,
+		);
+		expect(cliReadme).toMatch(
+			/https:\/\/github\.com\/[^/]+\/[^/]+\/blob\/main\/SECURITY\.md/,
+		);
 	});
 });

--- a/tests/unit/repo-dx-baseline.test.ts
+++ b/tests/unit/repo-dx-baseline.test.ts
@@ -79,12 +79,13 @@ describe('repository DX baseline', () => {
 		expect(contributing).toContain('Linting ownership is intentionally split');
 		expect(contributing).toContain('bun run lint:repo');
 		expect(contributing).toContain('## Project meta docs');
+		expect(contributing).toContain('[`UPGRADE.md`](./UPGRADE.md)');
 		expect(contributing).toContain('[`SECURITY.md`](./SECURITY.md)');
 		expect(cliReadme).toMatch(
-			/https:\/\/github\.com\/[^/]+\/[^/]+\/blob\/main\/UPGRADE\.md/,
+			/https:\/\/github\.com\/[^/]+\/[^/]+\/blob\/[^/]+\/UPGRADE\.md/,
 		);
 		expect(cliReadme).toMatch(
-			/https:\/\/github\.com\/[^/]+\/[^/]+\/blob\/main\/SECURITY\.md/,
+			/https:\/\/github\.com\/[^/]+\/[^/]+\/blob\/[^/]+\/SECURITY\.md/,
 		);
 	});
 });


### PR DESCRIPTION
## Summary
- add root upgrade and security meta docs
- add GitHub issue forms and a pull request template
- add repo-level discoverability links in the root README, CONTRIBUTING guide, and published `wp-typia` README
- include a `wp-typia` patch changeset so this PR can exercise the release automation end to end

Closes #110

## Validation
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `bun run changesets:validate`
- `bun run publish:validate`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added security vulnerability reporting policy and guidelines.
  * Added upgrade guidance for ecosystem changes.
  * Enhanced main docs with target-audience clarification and links to meta docs; added release metadata for a patch bump.

* **New Features**
  * Introduced structured GitHub issue templates (bug, feature, docs/process) and a pull request template.
  * Added a configuration to disable blank issues and provide a private security contact link.

* **Chores**
  * Updated contribution guidelines to reference meta docs.
  * Added/extended tests to validate repository documentation and templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->