### PR TITLE
Fix Typia 12 Webpack compatibility in generated projects

### DIFF
--- a/.sampo/changesets/issue-196-typia-webpack-compat.md
+++ b/.sampo/changesets/issue-196-typia-webpack-compat.md
@@ -1,0 +1,11 @@
+---
+npm/@wp-typia/block-runtime: patch
+npm/@wp-typia/create-workspace-template: patch
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Fix generated-project Typia/Webpack compatibility by moving generic Typia
+factory calls out of the shared validator helper, adding a fail-fast supported
+toolchain guard around the Webpack integration, and covering the path with
+generated-project build smoke tests.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,19 @@ bun run docs:build
 If you change user-facing workflows, keep the relevant meta docs in sync in the
 same PR.
 
+## Generated project toolchain matrix
+
+Generated project Webpack defaults are currently regression-covered against:
+
+- `typia` 12.x
+- `@typia/unplugin` 12.x
+- `@wordpress/scripts` 30.x with Webpack 5
+
+The generated Webpack helpers now fail fast outside that matrix so broken
+version tuples surface as a clear compatibility error instead of a cryptic
+transform crash. If you intentionally expand the supported matrix, add or update
+generated-project build smoke coverage in the same PR before relaxing the guard.
+
 ## Releases
 
 Release management now uses Sampo for release metadata and GitHub Actions for publish:

--- a/packages/create-workspace-template/webpack.config.js.mustache
+++ b/packages/create-workspace-template/webpack.config.js.mustache
@@ -231,9 +231,13 @@ function getOptionalModuleEntries() {
 }
 
 module.exports = async () => {
-	const { default: UnpluginTypia } = await import(
-		'@typia/unplugin/webpack'
+	const { loadCompatibleTypiaWebpackPlugin } = await import(
+		'@wp-typia/block-runtime/blocks'
 	);
+	const UnpluginTypia = await loadCompatibleTypiaWebpackPlugin( {
+		importTypiaWebpackPlugin: () => import( '@typia/unplugin/webpack' ),
+		projectRoot: process.cwd(),
+	} );
 	const resolvedDefaultConfig =
 		typeof defaultConfig === 'function'
 			? await defaultConfig()

--- a/packages/wp-typia-block-runtime/src/blocks.ts
+++ b/packages/wp-typia-block-runtime/src/blocks.ts
@@ -345,28 +345,24 @@ function resolveWebpackVersion(
 	requireFromProject: NodeJS.Require,
 	createRequire: NodeModuleBuiltin["createRequire"],
 ): string | null {
-	const directVersion = resolveInstalledPackageVersion(
-		readFileSync,
-		requireFromProject,
-		"webpack",
-	);
-	if (directVersion) {
-		return directVersion;
-	}
-
 	try {
 		const wordpressScriptsPackageJsonPath = requireFromProject.resolve(
 			"@wordpress/scripts/package.json",
 		);
 		const requireFromWordPressScripts = createRequire(wordpressScriptsPackageJsonPath);
-		return resolveInstalledPackageVersion(
+		const bundledWebpackVersion = resolveInstalledPackageVersion(
 			readFileSync,
 			requireFromWordPressScripts,
 			"webpack",
 		);
+		if (bundledWebpackVersion) {
+			return bundledWebpackVersion;
+		}
 	} catch {
-		return null;
+		// fall through to the project-level webpack resolution below
 	}
+
+	return resolveInstalledPackageVersion(readFileSync, requireFromProject, "webpack");
 }
 
 async function getTypiaWebpackVersionMatrix(

--- a/packages/wp-typia-block-runtime/src/blocks.ts
+++ b/packages/wp-typia-block-runtime/src/blocks.ts
@@ -71,6 +71,7 @@ type NodeModuleBuiltin = typeof import("node:module");
 type NodePathBuiltin = typeof import("node:path");
 type NodePathJoiner = {
 	join(...paths: string[]): string;
+	resolve(...paths: string[]): string;
 };
 
 type OverrideProperties<TBase, TOverride> = Omit<TBase, keyof TOverride> & TOverride;
@@ -369,7 +370,7 @@ async function getTypiaWebpackVersionMatrix(
 	projectRoot = process.cwd(),
 ): Promise<TypiaWebpackVersionMatrix> {
 	const { createRequire, pathModule, readFileSync } = await loadNodeRuntimeHelpers();
-	const packageJsonPath = pathModule.join(projectRoot, "package.json");
+	const packageJsonPath = pathModule.resolve(projectRoot, "package.json");
 	const requireFromProject = createRequire(packageJsonPath);
 
 	return {

--- a/packages/wp-typia-block-runtime/src/blocks.ts
+++ b/packages/wp-typia-block-runtime/src/blocks.ts
@@ -51,7 +51,27 @@ export interface TypiaWebpackConfigOptions {
 	path: {
 		join(...paths: string[]): string;
 	};
+	projectRoot?: string;
 }
+
+export interface TypiaWebpackPluginLoaderOptions {
+	importTypiaWebpackPlugin: () => Promise<{ default: () => unknown }>;
+	projectRoot?: string;
+}
+
+interface TypiaWebpackVersionMatrix {
+	"@typia/unplugin": string | null;
+	"@wordpress/scripts": string | null;
+	typia: string | null;
+	webpack: string | null;
+}
+
+type NodeFsModule = typeof import("node:fs");
+type NodeModuleBuiltin = typeof import("node:module");
+type NodePathBuiltin = typeof import("node:path");
+type NodePathJoiner = {
+	join(...paths: string[]): string;
+};
 
 type OverrideProperties<TBase, TOverride> = Omit<TBase, keyof TOverride> & TOverride;
 type ScaffoldSupportDefaultControls<TFeature extends string> = Readonly<
@@ -265,6 +285,163 @@ function isModuleConfig(config: unknown): boolean {
 	);
 }
 
+function parseMajorVersion(version: string | null): number | null {
+	if (!version) {
+		return null;
+	}
+
+	const match = /^(\d+)/u.exec(version);
+	return match ? Number.parseInt(match[1], 10) : null;
+}
+
+function readPackageVersion(
+	readFileSync: NodeFsModule["readFileSync"],
+	packageJsonPath: string,
+): string | null {
+	try {
+		return (
+			JSON.parse(readFileSync(packageJsonPath, "utf8")) as { version?: unknown }
+		).version as string | null;
+	} catch {
+		return null;
+	}
+}
+
+async function loadNodeRuntimeHelpers() {
+	const importNodeModule = Function(
+		"specifier",
+		"return import(specifier);",
+	) as (specifier: string) => Promise<unknown>;
+	const [fsModule, moduleBuiltin, pathBuiltin] = (await Promise.all([
+		importNodeModule("node:fs"),
+		importNodeModule("node:module"),
+		importNodeModule("node:path"),
+	])) as [NodeFsModule, NodeModuleBuiltin, NodePathBuiltin];
+
+	return {
+		createRequire: moduleBuiltin.createRequire,
+		pathModule: pathBuiltin as unknown as NodePathJoiner,
+		readFileSync: fsModule.readFileSync,
+	};
+}
+
+function resolveInstalledPackageVersion(
+	readFileSync: NodeFsModule["readFileSync"],
+	requireFromProject: NodeJS.Require,
+	packageName: string,
+): string | null {
+	try {
+		return readPackageVersion(
+			readFileSync,
+			requireFromProject.resolve(`${packageName}/package.json`),
+		);
+	} catch {
+		return null;
+	}
+}
+
+function resolveWebpackVersion(
+	readFileSync: NodeFsModule["readFileSync"],
+	requireFromProject: NodeJS.Require,
+	createRequire: NodeModuleBuiltin["createRequire"],
+): string | null {
+	const directVersion = resolveInstalledPackageVersion(
+		readFileSync,
+		requireFromProject,
+		"webpack",
+	);
+	if (directVersion) {
+		return directVersion;
+	}
+
+	try {
+		const wordpressScriptsPackageJsonPath = requireFromProject.resolve(
+			"@wordpress/scripts/package.json",
+		);
+		const requireFromWordPressScripts = createRequire(wordpressScriptsPackageJsonPath);
+		return resolveInstalledPackageVersion(
+			readFileSync,
+			requireFromWordPressScripts,
+			"webpack",
+		);
+	} catch {
+		return null;
+	}
+}
+
+async function getTypiaWebpackVersionMatrix(
+	projectRoot = process.cwd(),
+): Promise<TypiaWebpackVersionMatrix> {
+	const { createRequire, pathModule, readFileSync } = await loadNodeRuntimeHelpers();
+	const packageJsonPath = pathModule.join(projectRoot, "package.json");
+	const requireFromProject = createRequire(packageJsonPath);
+
+	return {
+		"@typia/unplugin": resolveInstalledPackageVersion(
+			readFileSync,
+			requireFromProject,
+			"@typia/unplugin",
+		),
+		"@wordpress/scripts": resolveInstalledPackageVersion(
+			readFileSync,
+			requireFromProject,
+			"@wordpress/scripts",
+		),
+		typia: resolveInstalledPackageVersion(readFileSync, requireFromProject, "typia"),
+		webpack: resolveWebpackVersion(
+			readFileSync,
+			requireFromProject,
+			createRequire,
+		),
+	};
+}
+
+function formatInstalledMatrix(
+	versionMatrix: TypiaWebpackVersionMatrix,
+): string {
+	return [
+		`typia=${versionMatrix.typia ?? "missing"}`,
+		`@typia/unplugin=${versionMatrix["@typia/unplugin"] ?? "missing"}`,
+		`@wordpress/scripts=${versionMatrix["@wordpress/scripts"] ?? "missing"}`,
+		`webpack=${versionMatrix.webpack ?? "missing"}`,
+	].join(", ");
+}
+
+export async function assertTypiaWebpackCompatibility({
+	projectRoot = process.cwd(),
+}: {
+	projectRoot?: string;
+} = {}): Promise<TypiaWebpackVersionMatrix> {
+	const versionMatrix = await getTypiaWebpackVersionMatrix(projectRoot);
+	const isSupported =
+		parseMajorVersion(versionMatrix.typia) === 12 &&
+		parseMajorVersion(versionMatrix["@typia/unplugin"]) === 12 &&
+		parseMajorVersion(versionMatrix["@wordpress/scripts"]) === 30 &&
+		parseMajorVersion(versionMatrix.webpack) === 5;
+
+	if (isSupported) {
+		return versionMatrix;
+	}
+
+	throw new Error(
+		[
+			"Unsupported Typia/Webpack toolchain for generated wp-typia projects.",
+			`Installed versions: ${formatInstalledMatrix(versionMatrix)}.`,
+			"Supported matrix: typia 12.x, @typia/unplugin 12.x, @wordpress/scripts 30.x with webpack 5.x.",
+			"Generated project defaults were tested against this matrix.",
+		].join(" "),
+	);
+}
+
+export async function loadCompatibleTypiaWebpackPlugin({
+	importTypiaWebpackPlugin,
+	projectRoot = process.cwd(),
+}: TypiaWebpackPluginLoaderOptions): Promise<() => unknown> {
+	await assertTypiaWebpackCompatibility({ projectRoot });
+	const { default: UnpluginTypia } = await importTypiaWebpackPlugin();
+	return UnpluginTypia;
+}
+
 function mergeEntries(
 	existingEntries: Record<string, unknown>,
 	nextEntries: EntryMap | undefined,
@@ -315,8 +492,12 @@ export async function createTypiaWebpackConfig({
 	moduleEntriesMode = "merge",
 	nonModuleEntriesMode = "merge",
 	path,
+	projectRoot = process.cwd(),
 }: TypiaWebpackConfigOptions) {
-	const { default: UnpluginTypia } = await importTypiaWebpackPlugin();
+	const UnpluginTypia = await loadCompatibleTypiaWebpackPlugin({
+		importTypiaWebpackPlugin,
+		projectRoot,
+	});
 	const resolvedDefaultConfig =
 		typeof defaultConfig === "function"
 			? await (defaultConfig as () => Promise<unknown> | unknown)()

--- a/packages/wp-typia-block-runtime/tests/block-runtime.test.ts
+++ b/packages/wp-typia-block-runtime/tests/block-runtime.test.ts
@@ -132,4 +132,47 @@ describe("@wp-typia/block-runtime", () => {
 			rmSync(projectRoot, { force: true, recursive: true });
 		}
 	});
+
+	test("Typia/Webpack compatibility preflight prefers webpack resolved from @wordpress/scripts", async () => {
+		const blocksModule = await import("@wp-typia/block-runtime/blocks");
+		const projectRoot = mkdtempSync(resolve(tmpdir(), "wp-typia-compat-nested-"));
+
+		try {
+			writeFileSync(
+				resolve(projectRoot, "package.json"),
+				JSON.stringify({ name: "compat-nested", private: true }, null, 2),
+				"utf8",
+			);
+			writeMockPackage(projectRoot, "typia", "12.0.1");
+			writeMockPackage(projectRoot, "@typia/unplugin", "12.0.1");
+			writeMockPackage(projectRoot, "@wordpress/scripts", "30.22.0");
+			writeMockPackage(projectRoot, "webpack", "4.47.0");
+
+			const wordpressScriptsNodeModules = resolve(
+				projectRoot,
+				"node_modules",
+				"@wordpress",
+				"scripts",
+				"node_modules",
+			);
+			mkdirSync(resolve(wordpressScriptsNodeModules, "webpack"), {
+				recursive: true,
+			});
+			writeFileSync(
+				resolve(wordpressScriptsNodeModules, "webpack", "package.json"),
+				JSON.stringify({ name: "webpack", version: "5.106.0" }, null, 2),
+				"utf8",
+			);
+
+			await expect(
+				blocksModule.assertTypiaWebpackCompatibility({ projectRoot }),
+			).resolves.toEqual(
+				expect.objectContaining({
+					webpack: "5.106.0",
+				}),
+			);
+		} finally {
+			rmSync(projectRoot, { force: true, recursive: true });
+		}
+	});
 });

--- a/packages/wp-typia-block-runtime/tests/block-runtime.test.ts
+++ b/packages/wp-typia-block-runtime/tests/block-runtime.test.ts
@@ -1,8 +1,19 @@
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 
 const importModule = (specifier: string) => import(specifier);
+
+function writeMockPackage(projectRoot: string, packageName: string, version: string) {
+	const packageDir = resolve(projectRoot, "node_modules", ...packageName.split("/"));
+	mkdirSync(packageDir, { recursive: true });
+	writeFileSync(
+		resolve(packageDir, "package.json"),
+		JSON.stringify({ name: packageName, version }, null, 2),
+		"utf8",
+	);
+}
 
 describe("@wp-typia/block-runtime", () => {
 	test("supported self imports resolve through the published entrypoints", async () => {
@@ -40,6 +51,8 @@ describe("@wp-typia/block-runtime", () => {
 		expect(typeof identifiersModule.generatePublicWriteRequestId).toBe("function");
 		expect(typeof inspectorModule.useEditorFields).toBe("function");
 		expect(typeof validationModule.toValidationResult).toBe("function");
+		expect(typeof blocksModule.assertTypiaWebpackCompatibility).toBe("function");
+		expect(typeof blocksModule.loadCompatibleTypiaWebpackPlugin).toBe("function");
 
 		expect("generateBlockId" in rootModule).toBe(false);
 		expect("manifestToOpenApi" in rootModule).toBe(false);
@@ -63,5 +76,60 @@ describe("@wp-typia/block-runtime", () => {
 		expect(builtIndexDts).toContain('export * from "./defaults.js";');
 		expect(builtIndexDts).toContain('export * from "./editor.js";');
 		expect(builtIndexDts).toContain('export * from "./validation.js";');
+	});
+
+	test("Typia/Webpack compatibility preflight accepts the supported matrix", async () => {
+		const blocksModule = await import("@wp-typia/block-runtime/blocks");
+		const projectRoot = mkdtempSync(resolve(tmpdir(), "wp-typia-compat-ok-"));
+
+		try {
+			writeFileSync(
+				resolve(projectRoot, "package.json"),
+				JSON.stringify({ name: "compat-ok", private: true }, null, 2),
+				"utf8",
+			);
+			writeMockPackage(projectRoot, "typia", "12.0.1");
+			writeMockPackage(projectRoot, "@typia/unplugin", "12.0.1");
+			writeMockPackage(projectRoot, "@wordpress/scripts", "30.22.0");
+			writeMockPackage(projectRoot, "webpack", "5.106.0");
+
+			await expect(
+				blocksModule.assertTypiaWebpackCompatibility({ projectRoot }),
+			).resolves.toEqual(
+				expect.objectContaining({
+					"@typia/unplugin": "12.0.1",
+					"@wordpress/scripts": "30.22.0",
+					typia: "12.0.1",
+					webpack: "5.106.0",
+				}),
+			);
+		} finally {
+			rmSync(projectRoot, { force: true, recursive: true });
+		}
+	});
+
+	test("Typia/Webpack compatibility preflight explains unsupported tuples", async () => {
+		const blocksModule = await import("@wp-typia/block-runtime/blocks");
+		const projectRoot = mkdtempSync(resolve(tmpdir(), "wp-typia-compat-bad-"));
+
+		try {
+			writeFileSync(
+				resolve(projectRoot, "package.json"),
+				JSON.stringify({ name: "compat-bad", private: true }, null, 2),
+				"utf8",
+			);
+			writeMockPackage(projectRoot, "typia", "11.0.0");
+			writeMockPackage(projectRoot, "@typia/unplugin", "12.0.1");
+			writeMockPackage(projectRoot, "@wordpress/scripts", "30.22.0");
+			writeMockPackage(projectRoot, "webpack", "5.106.0");
+
+			await expect(
+				blocksModule.assertTypiaWebpackCompatibility({ projectRoot }),
+			).rejects.toThrow(
+				/Installed versions: typia=11\.0\.0, @typia\/unplugin=12\.0\.1, @wordpress\/scripts=30\.22\.0, webpack=5\.106\.0\..*Supported matrix: typia 12\.x, @typia\/unplugin 12\.x, @wordpress\/scripts 30\.x with webpack 5\.x\./s,
+			);
+		} finally {
+			rmSync(projectRoot, { force: true, recursive: true });
+		}
 	});
 });

--- a/packages/wp-typia-project-tools/src/runtime/cli-add.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add.ts
@@ -902,13 +902,23 @@ const LEGACY_TOOLKIT_CALL_PATTERN =
 	/createTemplateValidatorToolkit<\s*(?<typeName>[A-Za-z0-9_]+)\s*>\s*\(\s*\{/u;
 const LEGACY_VALIDATOR_TOOLKIT_IMPORT_PATTERN =
 	/from\s*["']\.\.\/\.\.\/validator-toolkit["']/u;
+const COMPATIBLE_COMPOUND_TOOLKIT_PATTERNS = [
+	/interface\s+TemplateValidatorFunctions\s*<\s*T\s+extends\s+object\s*>\s*\{/u,
+	/\bassert\s*:\s*ScaffoldValidatorToolkitOptions\s*<\s*T\s*>\s*\[\s*["']assert["']\s*\]/u,
+	/\bclone\s*:\s*ScaffoldValidatorToolkitOptions\s*<\s*T\s*>\s*\[\s*["']clone["']\s*\]/u,
+	/\bis\s*:\s*ScaffoldValidatorToolkitOptions\s*<\s*T\s*>\s*\[\s*["']is["']\s*\]/u,
+	/\bprune\s*:\s*ScaffoldValidatorToolkitOptions\s*<\s*T\s*>\s*\[\s*["']prune["']\s*\]/u,
+	/\brandom\s*:\s*ScaffoldValidatorToolkitOptions\s*<\s*T\s*>\s*\[\s*["']random["']\s*\]/u,
+	/\bvalidate\s*:\s*ScaffoldValidatorToolkitOptions\s*<\s*T\s*>\s*\[\s*["']validate["']\s*\]/u,
+	/createTemplateValidatorToolkit\s*<\s*T\s+extends\s+object\s*>\s*\(\s*\{/u,
+] as const;
 
 function shouldRefreshCompoundValidatorToolkit(source: string | null): boolean {
 	return (
 		source === null ||
-		!source.includes("interface TemplateValidatorFunctions<") ||
-		!source.includes("assert: ScaffoldValidatorToolkitOptions< T >['assert'];") ||
-		!source.includes("validate,")
+		!COMPATIBLE_COMPOUND_TOOLKIT_PATTERNS.every((pattern) =>
+			pattern.test(source),
+		)
 	);
 }
 

--- a/packages/wp-typia-project-tools/src/runtime/cli-add.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add.ts
@@ -916,7 +916,7 @@ function isLegacyCompoundValidatorSource(source: string | null): source is strin
 
 function upgradeLegacyCompoundValidatorSource(source: string): string {
 	const typeNameMatch = source.match(
-		/import type \{ (?<typeName>[A-Za-z0-9_]+) \} from '\.\/types';/u,
+		/createTemplateValidatorToolkit<\s*(?<typeName>[A-Za-z0-9_]+)\s*>\s*\(\s*\{/u,
 	);
 	const typeName = typeNameMatch?.groups?.typeName;
 	if (!typeName) {

--- a/packages/wp-typia-project-tools/src/runtime/cli-add.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add.ts
@@ -906,9 +906,85 @@ function shouldRefreshCompoundValidatorToolkit(source: string | null): boolean {
 	);
 }
 
+function isLegacyCompoundValidatorSource(source: string | null): source is string {
+	return (
+		typeof source === "string" &&
+		source.includes("from '../../validator-toolkit'") &&
+		!source.includes("assert: typia.createAssert<")
+	);
+}
+
+function upgradeLegacyCompoundValidatorSource(source: string): string {
+	const typeNameMatch = source.match(
+		/import type \{ (?<typeName>[A-Za-z0-9_]+) \} from '\.\/types';/u,
+	);
+	const typeName = typeNameMatch?.groups?.typeName;
+	if (!typeName) {
+		throw new Error(
+			"Unable to upgrade a legacy compound validator without a generated type import.",
+		);
+	}
+
+	let nextSource = source;
+	if (!nextSource.includes("import typia from 'typia';")) {
+		nextSource = `import typia from 'typia';\n${nextSource}`;
+	}
+
+	nextSource = nextSource.replace(
+		new RegExp(
+			`createTemplateValidatorToolkit<\\s*${typeName}\\s*>\\s*\\(\\s*\\{\\n`,
+			"u",
+		),
+		[
+			`createTemplateValidatorToolkit< ${typeName} >( {`,
+			`\tassert: typia.createAssert< ${typeName} >(),`,
+			`\tclone: typia.misc.createClone< ${typeName} >() as (`,
+			`\t\tvalue: ${typeName},`,
+			`\t) => ${typeName},`,
+			`\tis: typia.createIs< ${typeName} >(),`,
+		].join("\n") + "\n",
+	);
+
+	nextSource = nextSource.replace(
+		"\n\tmanifest: currentManifest,",
+		[
+			"",
+			"\tmanifest: currentManifest,",
+			`\tprune: typia.misc.createPrune< ${typeName} >(),`,
+			`\trandom: typia.createRandom< ${typeName} >() as (`,
+			"\t\t...args: unknown[]",
+			`\t) => ${typeName},`,
+			`\tvalidate: typia.createValidate< ${typeName} >(),`,
+		].join("\n"),
+	);
+
+	return nextSource;
+}
+
+async function collectLegacyCompoundValidatorPaths(projectDir: string): Promise<string[]> {
+	const blocksDir = path.join(projectDir, "src", "blocks");
+	if (!fs.existsSync(blocksDir)) {
+		return [];
+	}
+
+	const blockEntries = await fsp.readdir(blocksDir, { withFileTypes: true });
+	const validatorPaths = await Promise.all(
+		blockEntries
+			.filter((entry) => entry.isDirectory())
+			.map(async (entry) => {
+				const validatorPath = path.join(blocksDir, entry.name, "validators.ts");
+				const validatorSource = await readOptionalFile(validatorPath);
+				return isLegacyCompoundValidatorSource(validatorSource) ? validatorPath : null;
+			}),
+	);
+
+	return validatorPaths.filter((validatorPath): validatorPath is string => validatorPath !== null);
+}
+
 async function ensureCompoundWorkspaceSupportFiles(
 	projectDir: string,
 	tempProjectDir: string,
+	legacyValidatorPaths: readonly string[],
 ): Promise<void> {
 	for (const fileName of COMPOUND_SHARED_SUPPORT_FILES) {
 		const sourcePath = path.join(tempProjectDir, "src", fileName);
@@ -927,6 +1003,19 @@ async function ensureCompoundWorkspaceSupportFiles(
 			await fsp.copyFile(sourcePath, targetPath);
 		}
 	}
+
+	for (const validatorPath of legacyValidatorPaths) {
+		const currentSource = await readOptionalFile(validatorPath);
+		if (!isLegacyCompoundValidatorSource(currentSource)) {
+			continue;
+		}
+
+		await fsp.writeFile(
+			validatorPath,
+			upgradeLegacyCompoundValidatorSource(currentSource),
+			"utf8",
+		);
+	}
 }
 
 async function copyScaffoldedBlockSlice(
@@ -934,9 +1023,14 @@ async function copyScaffoldedBlockSlice(
 	templateId: AddBlockTemplateId,
 	tempProjectDir: string,
 	variables: ScaffoldTemplateVariables,
+	legacyValidatorPaths: readonly string[] = [],
 ): Promise<void> {
 	if (templateId === "compound") {
-		await ensureCompoundWorkspaceSupportFiles(projectDir, tempProjectDir);
+		await ensureCompoundWorkspaceSupportFiles(
+			projectDir,
+			tempProjectDir,
+			legacyValidatorPaths,
+		);
 		await copyTempDirectory(
 			path.join(tempProjectDir, "src", "blocks", variables.slugKebabCase),
 			path.join(projectDir, "src", "blocks", variables.slugKebabCase),
@@ -1216,6 +1310,10 @@ export async function runAddBlockCommand({
 						path.join(workspace.projectDir, "src", fileName),
 					)
 				: [];
+		const legacyCompoundValidatorPaths =
+			resolvedTemplateId === "compound"
+				? await collectLegacyCompoundValidatorPaths(workspace.projectDir)
+				: [];
 		const result = await scaffoldProject({
 			answers: {
 				...defaults,
@@ -1240,6 +1338,7 @@ export async function runAddBlockCommand({
 				blockConfigPath,
 				migrationConfigPath,
 				...compoundSupportPaths,
+				...legacyCompoundValidatorPaths,
 			]),
 			snapshotDirs:
 				migrationConfig === null
@@ -1265,6 +1364,7 @@ export async function runAddBlockCommand({
 				resolvedTemplateId,
 				tempProjectDir,
 				result.variables,
+				legacyCompoundValidatorPaths,
 			);
 			await addCollectionImportsForTemplate(
 				workspace.projectDir,

--- a/packages/wp-typia-project-tools/src/runtime/cli-add.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add.ts
@@ -895,6 +895,40 @@ async function renderWorkspacePersistenceServerModule(
 	await copyInterpolatedDirectory(templateDir, targetDir, variables);
 }
 
+const COMPOUND_SHARED_SUPPORT_FILES = ["hooks.ts", "validator-toolkit.ts"] as const;
+
+function shouldRefreshCompoundValidatorToolkit(source: string | null): boolean {
+	return (
+		source === null ||
+		!source.includes("interface TemplateValidatorFunctions<") ||
+		!source.includes("assert: ScaffoldValidatorToolkitOptions< T >['assert'];") ||
+		!source.includes("validate,")
+	);
+}
+
+async function ensureCompoundWorkspaceSupportFiles(
+	projectDir: string,
+	tempProjectDir: string,
+): Promise<void> {
+	for (const fileName of COMPOUND_SHARED_SUPPORT_FILES) {
+		const sourcePath = path.join(tempProjectDir, "src", fileName);
+		if (!fs.existsSync(sourcePath)) {
+			continue;
+		}
+
+		const targetPath = path.join(projectDir, "src", fileName);
+		const currentSource = await readOptionalFile(targetPath);
+		if (
+			fileName === "validator-toolkit.ts"
+				? shouldRefreshCompoundValidatorToolkit(currentSource)
+				: currentSource === null
+		) {
+			await fsp.mkdir(path.dirname(targetPath), { recursive: true });
+			await fsp.copyFile(sourcePath, targetPath);
+		}
+	}
+}
+
 async function copyScaffoldedBlockSlice(
 	projectDir: string,
 	templateId: AddBlockTemplateId,
@@ -902,6 +936,7 @@ async function copyScaffoldedBlockSlice(
 	variables: ScaffoldTemplateVariables,
 ): Promise<void> {
 	if (templateId === "compound") {
+		await ensureCompoundWorkspaceSupportFiles(projectDir, tempProjectDir);
 		await copyTempDirectory(
 			path.join(tempProjectDir, "src", "blocks", variables.slugKebabCase),
 			path.join(projectDir, "src", "blocks", variables.slugKebabCase),
@@ -1175,6 +1210,12 @@ export async function runAddBlockCommand({
 		const migrationConfigSource = await readOptionalFile(migrationConfigPath);
 		const migrationConfig =
 			migrationConfigSource === null ? null : parseMigrationConfig(migrationConfigSource);
+		const compoundSupportPaths =
+			resolvedTemplateId === "compound"
+				? COMPOUND_SHARED_SUPPORT_FILES.map((fileName) =>
+						path.join(workspace.projectDir, "src", fileName),
+					)
+				: [];
 		const result = await scaffoldProject({
 			answers: {
 				...defaults,
@@ -1195,7 +1236,11 @@ export async function runAddBlockCommand({
 		});
 		assertBlockTargetsDoNotExist(workspace.projectDir, resolvedTemplateId, result.variables);
 		const mutationSnapshot: WorkspaceMutationSnapshot = {
-			fileSources: await snapshotWorkspaceFiles([blockConfigPath, migrationConfigPath]),
+			fileSources: await snapshotWorkspaceFiles([
+				blockConfigPath,
+				migrationConfigPath,
+				...compoundSupportPaths,
+			]),
 			snapshotDirs:
 				migrationConfig === null
 					? []

--- a/packages/wp-typia-project-tools/src/runtime/cli-add.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add.ts
@@ -896,6 +896,12 @@ async function renderWorkspacePersistenceServerModule(
 }
 
 const COMPOUND_SHARED_SUPPORT_FILES = ["hooks.ts", "validator-toolkit.ts"] as const;
+const LEGACY_ASSERT_PATTERN = /assert:\s*typia\.createAssert</u;
+const LEGACY_MANIFEST_PATTERN = /\r?\n[ \t]*manifest:\s*currentManifest,/u;
+const LEGACY_TOOLKIT_CALL_PATTERN =
+	/createTemplateValidatorToolkit<\s*(?<typeName>[A-Za-z0-9_]+)\s*>\s*\(\s*\{/u;
+const LEGACY_VALIDATOR_TOOLKIT_IMPORT_PATTERN =
+	/from\s*["']\.\.\/\.\.\/validator-toolkit["']/u;
 
 function shouldRefreshCompoundValidatorToolkit(source: string | null): boolean {
 	return (
@@ -909,15 +915,13 @@ function shouldRefreshCompoundValidatorToolkit(source: string | null): boolean {
 function isLegacyCompoundValidatorSource(source: string | null): source is string {
 	return (
 		typeof source === "string" &&
-		source.includes("from '../../validator-toolkit'") &&
-		!source.includes("assert: typia.createAssert<")
+		LEGACY_VALIDATOR_TOOLKIT_IMPORT_PATTERN.test(source) &&
+		!LEGACY_ASSERT_PATTERN.test(source)
 	);
 }
 
 function upgradeLegacyCompoundValidatorSource(source: string): string {
-	const typeNameMatch = source.match(
-		/createTemplateValidatorToolkit<\s*(?<typeName>[A-Za-z0-9_]+)\s*>\s*\(\s*\{/u,
-	);
+	const typeNameMatch = source.match(LEGACY_TOOLKIT_CALL_PATTERN);
 	const typeName = typeNameMatch?.groups?.typeName;
 	if (!typeName) {
 		throw new Error(
@@ -931,10 +935,7 @@ function upgradeLegacyCompoundValidatorSource(source: string): string {
 	}
 
 	nextSource = nextSource.replace(
-		new RegExp(
-			`createTemplateValidatorToolkit<\\s*${typeName}\\s*>\\s*\\(\\s*\\{\\n`,
-			"u",
-		),
+		LEGACY_TOOLKIT_CALL_PATTERN,
 		[
 			`createTemplateValidatorToolkit< ${typeName} >( {`,
 			`\tassert: typia.createAssert< ${typeName} >(),`,
@@ -945,8 +946,8 @@ function upgradeLegacyCompoundValidatorSource(source: string): string {
 		].join("\n") + "\n",
 	);
 
-	nextSource = nextSource.replace(
-		"\n\tmanifest: currentManifest,",
+	const replacedManifest = nextSource.replace(
+		LEGACY_MANIFEST_PATTERN,
 		[
 			"",
 			"\tmanifest: currentManifest,",
@@ -957,8 +958,13 @@ function upgradeLegacyCompoundValidatorSource(source: string): string {
 			`\tvalidate: typia.createValidate< ${typeName} >(),`,
 		].join("\n"),
 	);
+	if (replacedManifest === nextSource) {
+		throw new Error(
+			"Unable to upgrade legacy compound validator: manifest anchor not found.",
+		);
+	}
 
-	return nextSource;
+	return replacedManifest;
 }
 
 async function collectLegacyCompoundValidatorPaths(projectDir: string): Promise<string[]> {

--- a/packages/wp-typia-project-tools/templates/_shared/base/src/validator-toolkit.ts.mustache
+++ b/packages/wp-typia-project-tools/templates/_shared/base/src/validator-toolkit.ts.mustache
@@ -1,30 +1,44 @@
-import typia from 'typia';
-
 import type { ManifestDefaultsDocument } from '@wp-typia/block-runtime/defaults';
 import {
 	createScaffoldValidatorToolkit,
 	type ScaffoldValidatorToolkitOptions,
 } from '@wp-typia/block-runtime/validation';
 
-interface TemplateValidatorToolkitOptions< T extends object > {
+interface TemplateValidatorFunctions< T extends object > {
+	assert: ScaffoldValidatorToolkitOptions< T >['assert'];
+	clone: ScaffoldValidatorToolkitOptions< T >['clone'];
+	is: ScaffoldValidatorToolkitOptions< T >['is'];
+	prune: ScaffoldValidatorToolkitOptions< T >['prune'];
+	random: ScaffoldValidatorToolkitOptions< T >['random'];
+	validate: ScaffoldValidatorToolkitOptions< T >['validate'];
+}
+
+interface TemplateValidatorToolkitOptions< T extends object >
+	extends TemplateValidatorFunctions< T > {
 	finalize?: ScaffoldValidatorToolkitOptions< T >['finalize'];
 	manifest: unknown;
 	onValidationError?: ScaffoldValidatorToolkitOptions< T >['onValidationError'];
 }
 
 export function createTemplateValidatorToolkit< T extends object >( {
+	assert,
+	clone,
 	finalize,
+	is,
 	manifest,
 	onValidationError,
+	prune,
+	random,
+	validate,
 }: TemplateValidatorToolkitOptions< T > ) {
 	return createScaffoldValidatorToolkit< T >( {
 		manifest: manifest as ManifestDefaultsDocument,
-		validate: typia.createValidate< T >(),
-		assert: typia.createAssert< T >(),
-		is: typia.createIs< T >(),
-		random: typia.createRandom< T >() as ( ...args: unknown[] ) => T,
-		clone: typia.misc.createClone< T >() as ( value: T ) => T,
-		prune: typia.misc.createPrune< T >(),
+		validate,
+		assert,
+		is,
+		random,
+		clone,
+		prune,
 		finalize,
 		onValidationError,
 	} );

--- a/packages/wp-typia-project-tools/templates/_shared/base/webpack.config.js.mustache
+++ b/packages/wp-typia-project-tools/templates/_shared/base/webpack.config.js.mustache
@@ -95,5 +95,6 @@ module.exports = async () => {
 		getArtifactEntries,
 		getOptionalModuleEntries: () => optionalModuleEntries,
 		importTypiaWebpackPlugin: () => import("@typia/unplugin/webpack"),
+		projectRoot: process.cwd(),
 	});
 };

--- a/packages/wp-typia-project-tools/templates/_shared/compound/core/webpack.config.js.mustache
+++ b/packages/wp-typia-project-tools/templates/_shared/compound/core/webpack.config.js.mustache
@@ -137,5 +137,6 @@ module.exports = async () => {
 		importTypiaWebpackPlugin: () => import( '@typia/unplugin/webpack' ),
 		moduleEntriesMode: 'replace',
 		nonModuleEntriesMode: 'replace',
+		projectRoot: process.cwd(),
 	} );
 };

--- a/packages/wp-typia-project-tools/templates/_shared/compound/persistence/src/blocks/{{slugKebabCase}}/validators.ts.mustache
+++ b/packages/wp-typia-project-tools/templates/_shared/compound/persistence/src/blocks/{{slugKebabCase}}/validators.ts.mustache
@@ -1,3 +1,4 @@
+import typia from 'typia';
 import currentManifest from './typia.manifest.json';
 import type {
 	{{pascalCase}}Attributes,
@@ -7,7 +8,16 @@ import { generateResourceKey } from '@wp-typia/block-runtime/identifiers';
 import { createTemplateValidatorToolkit } from '../../validator-toolkit';
 
 const scaffoldValidators = createTemplateValidatorToolkit< {{pascalCase}}Attributes >( {
+	assert: typia.createAssert< {{pascalCase}}Attributes >(),
+	clone: typia.misc.createClone< {{pascalCase}}Attributes >() as (
+		value: {{pascalCase}}Attributes,
+	) => {{pascalCase}}Attributes,
+	is: typia.createIs< {{pascalCase}}Attributes >(),
 	manifest: currentManifest,
+	prune: typia.misc.createPrune< {{pascalCase}}Attributes >(),
+	random: typia.createRandom< {{pascalCase}}Attributes >() as (
+		...args: unknown[]
+	) => {{pascalCase}}Attributes,
 	finalize: ( normalized ) => ( {
 		...normalized,
 		resourceKey:
@@ -15,6 +25,7 @@ const scaffoldValidators = createTemplateValidatorToolkit< {{pascalCase}}Attribu
 				? normalized.resourceKey
 				: generateResourceKey( '{{slugKebabCase}}' ),
 	} ),
+	validate: typia.createValidate< {{pascalCase}}Attributes >(),
 } );
 
 export const validators = scaffoldValidators.validators;

--- a/packages/wp-typia-project-tools/templates/_shared/persistence/core/src/validators.ts.mustache
+++ b/packages/wp-typia-project-tools/templates/_shared/persistence/core/src/validators.ts.mustache
@@ -1,3 +1,4 @@
+import typia from 'typia';
 import currentManifest from './typia.manifest.json';
 import type {
 	{{pascalCase}}Attributes,
@@ -7,7 +8,16 @@ import { generateResourceKey } from '@wp-typia/block-runtime/identifiers';
 import { createTemplateValidatorToolkit } from './validator-toolkit';
 
 const scaffoldValidators = createTemplateValidatorToolkit< {{pascalCase}}Attributes >( {
+	assert: typia.createAssert< {{pascalCase}}Attributes >(),
+	clone: typia.misc.createClone< {{pascalCase}}Attributes >() as (
+		value: {{pascalCase}}Attributes,
+	) => {{pascalCase}}Attributes,
+	is: typia.createIs< {{pascalCase}}Attributes >(),
 	manifest: currentManifest,
+	prune: typia.misc.createPrune< {{pascalCase}}Attributes >(),
+	random: typia.createRandom< {{pascalCase}}Attributes >() as (
+		...args: unknown[]
+	) => {{pascalCase}}Attributes,
 	finalize: ( normalized ) => ( {
 		...normalized,
 		resourceKey:
@@ -15,6 +25,7 @@ const scaffoldValidators = createTemplateValidatorToolkit< {{pascalCase}}Attribu
 				? normalized.resourceKey
 				: generateResourceKey( '{{slugKebabCase}}' ),
 	} ),
+	validate: typia.createValidate< {{pascalCase}}Attributes >(),
 } );
 
 export const validators = scaffoldValidators.validators;

--- a/packages/wp-typia-project-tools/templates/basic/src/validators.ts.mustache
+++ b/packages/wp-typia-project-tools/templates/basic/src/validators.ts.mustache
@@ -1,14 +1,25 @@
+import typia from 'typia';
 import currentManifest from "./typia.manifest.json";
 import { {{pascalCase}}Attributes, {{pascalCase}}ValidationResult } from "./types";
 import { generateBlockId } from "@wp-typia/block-runtime/identifiers";
 import { createTemplateValidatorToolkit } from "./validator-toolkit";
 
 const scaffoldValidators = createTemplateValidatorToolkit<{{pascalCase}}Attributes>({
+  assert: typia.createAssert<{{pascalCase}}Attributes>(),
+  clone: typia.misc.createClone<{{pascalCase}}Attributes>() as (
+    value: {{pascalCase}}Attributes,
+  ) => {{pascalCase}}Attributes,
+  is: typia.createIs<{{pascalCase}}Attributes>(),
   manifest: currentManifest,
+  prune: typia.misc.createPrune<{{pascalCase}}Attributes>(),
+  random: typia.createRandom<{{pascalCase}}Attributes>() as (
+    ...args: unknown[]
+  ) => {{pascalCase}}Attributes,
   finalize: (normalized) => ({
     ...normalized,
     id: normalized.id && normalized.id.length > 0 ? normalized.id : generateBlockId(),
   }),
+  validate: typia.createValidate<{{pascalCase}}Attributes>(),
 });
 
 export const validate{{pascalCase}}Attributes =

--- a/packages/wp-typia-project-tools/templates/compound/src/blocks/{{slugKebabCase}}-item/validators.ts.mustache
+++ b/packages/wp-typia-project-tools/templates/compound/src/blocks/{{slugKebabCase}}-item/validators.ts.mustache
@@ -1,9 +1,20 @@
+import typia from 'typia';
 import currentManifest from './typia.manifest.json';
 import type { {{pascalCase}}ItemAttributes } from './types';
 import { createTemplateValidatorToolkit } from '../../validator-toolkit';
 
 const scaffoldValidators = createTemplateValidatorToolkit< {{pascalCase}}ItemAttributes >( {
+	assert: typia.createAssert< {{pascalCase}}ItemAttributes >(),
+	clone: typia.misc.createClone< {{pascalCase}}ItemAttributes >() as (
+		value: {{pascalCase}}ItemAttributes,
+	) => {{pascalCase}}ItemAttributes,
+	is: typia.createIs< {{pascalCase}}ItemAttributes >(),
 	manifest: currentManifest,
+	prune: typia.misc.createPrune< {{pascalCase}}ItemAttributes >(),
+	random: typia.createRandom< {{pascalCase}}ItemAttributes >() as (
+		...args: unknown[]
+	) => {{pascalCase}}ItemAttributes,
+	validate: typia.createValidate< {{pascalCase}}ItemAttributes >(),
 } );
 
 export const validate{{pascalCase}}ItemAttributes =

--- a/packages/wp-typia-project-tools/templates/compound/src/blocks/{{slugKebabCase}}/validators.ts.mustache
+++ b/packages/wp-typia-project-tools/templates/compound/src/blocks/{{slugKebabCase}}/validators.ts.mustache
@@ -1,9 +1,20 @@
+import typia from 'typia';
 import currentManifest from './typia.manifest.json';
 import type { {{pascalCase}}Attributes } from './types';
 import { createTemplateValidatorToolkit } from '../../validator-toolkit';
 
 const scaffoldValidators = createTemplateValidatorToolkit< {{pascalCase}}Attributes >( {
+	assert: typia.createAssert< {{pascalCase}}Attributes >(),
+	clone: typia.misc.createClone< {{pascalCase}}Attributes >() as (
+		value: {{pascalCase}}Attributes,
+	) => {{pascalCase}}Attributes,
+	is: typia.createIs< {{pascalCase}}Attributes >(),
 	manifest: currentManifest,
+	prune: typia.misc.createPrune< {{pascalCase}}Attributes >(),
+	random: typia.createRandom< {{pascalCase}}Attributes >() as (
+		...args: unknown[]
+	) => {{pascalCase}}Attributes,
+	validate: typia.createValidate< {{pascalCase}}Attributes >(),
 } );
 
 export const validate{{pascalCase}}Attributes =

--- a/packages/wp-typia-project-tools/templates/interactivity/src/validators.ts.mustache
+++ b/packages/wp-typia-project-tools/templates/interactivity/src/validators.ts.mustache
@@ -1,10 +1,20 @@
+import typia from 'typia';
 import currentManifest from "./typia.manifest.json";
 import { {{pascalCase}}Attributes, {{pascalCase}}ValidationResult } from "./types";
 import { generateScopedClientId } from "@wp-typia/block-runtime/identifiers";
 import { createTemplateValidatorToolkit } from "./validator-toolkit";
 
 const scaffoldValidators = createTemplateValidatorToolkit<{{pascalCase}}Attributes>({
+  assert: typia.createAssert<{{pascalCase}}Attributes>(),
+  clone: typia.misc.createClone<{{pascalCase}}Attributes>() as (
+    value: {{pascalCase}}Attributes,
+  ) => {{pascalCase}}Attributes,
+  is: typia.createIs<{{pascalCase}}Attributes>(),
   manifest: currentManifest,
+  prune: typia.misc.createPrune<{{pascalCase}}Attributes>(),
+  random: typia.createRandom<{{pascalCase}}Attributes>() as (
+    ...args: unknown[]
+  ) => {{pascalCase}}Attributes,
   finalize: (normalized) => ({
     ...normalized,
     uniqueId:
@@ -12,6 +22,7 @@ const scaffoldValidators = createTemplateValidatorToolkit<{{pascalCase}}Attribut
         ? normalized.uniqueId
         : generateScopedClientId("{{slugKebabCase}}"),
   }),
+  validate: typia.createValidate<{{pascalCase}}Attributes>(),
 });
 
 export const validate{{pascalCase}}Attributes =

--- a/packages/wp-typia-project-tools/tests/create-cli.test.ts
+++ b/packages/wp-typia-project-tools/tests/create-cli.test.ts
@@ -4903,7 +4903,9 @@ console.log(JSON.stringify({ initial, updated, reread }));
         path.join(targetDir, "src", "blocks", blockSlug, "validators.ts"),
         [
           `import currentManifest from './typia.manifest.json';`,
-          `import type { ${typeName} } from './types';`,
+          "import type {",
+          `\t${typeName},`,
+          "} from './types';",
           `import { createTemplateValidatorToolkit } from '../../validator-toolkit';`,
           "",
           `const scaffoldValidators = createTemplateValidatorToolkit< ${typeName} >( {`,

--- a/packages/wp-typia-project-tools/tests/create-cli.test.ts
+++ b/packages/wp-typia-project-tools/tests/create-cli.test.ts
@@ -711,81 +711,85 @@ describe("@wp-typia/project-tools scaffolding", () => {
     const buildOutput = buildGeneratedProject(targetDir);
     expect(buildOutput).not.toContain("non-specified generic argument");
     },
-    { timeout: 15_000 }
+    { timeout: 20_000 }
   );
 
-  test("scaffoldProject can opt into migration UI for built-in single-block templates", async () => {
-    const targetDir = path.join(tempRoot, "demo-migration-ui");
+  test(
+    "scaffoldProject can opt into migration UI for built-in single-block templates",
+    async () => {
+      const targetDir = path.join(tempRoot, "demo-migration-ui");
 
-    await scaffoldProject({
-      projectDir: targetDir,
-      templateId: "basic",
-      packageManager: "npm",
-      noInstall: true,
-      withMigrationUi: true,
-      answers: {
-        author: "Test Runner",
-        description: "Demo migration UI block",
-        namespace: "demo-space",
-        slug: "demo-migration-ui",
-        title: "Demo Migration UI",
-      },
-    });
+      await scaffoldProject({
+        projectDir: targetDir,
+        templateId: "basic",
+        packageManager: "npm",
+        noInstall: true,
+        withMigrationUi: true,
+        answers: {
+          author: "Test Runner",
+          description: "Demo migration UI block",
+          namespace: "demo-space",
+          slug: "demo-migration-ui",
+          title: "Demo Migration UI",
+        },
+      });
 
-    const packageJson = JSON.parse(
-      fs.readFileSync(path.join(targetDir, "package.json"), "utf8")
-    );
-    const readme = fs.readFileSync(path.join(targetDir, "README.md"), "utf8");
-    const generatedEdit = fs.readFileSync(
-      path.join(targetDir, "src", "edit.tsx"),
-      "utf8"
-    );
-    const generatedIndex = fs.readFileSync(
-      path.join(targetDir, "src", "index.tsx"),
-      "utf8"
-    );
-    const migrationConfig = fs.readFileSync(
-      path.join(targetDir, "src", "migrations", "config.ts"),
-      "utf8"
-    );
+      const packageJson = JSON.parse(
+        fs.readFileSync(path.join(targetDir, "package.json"), "utf8")
+      );
+      const readme = fs.readFileSync(path.join(targetDir, "README.md"), "utf8");
+      const generatedEdit = fs.readFileSync(
+        path.join(targetDir, "src", "edit.tsx"),
+        "utf8"
+      );
+      const generatedIndex = fs.readFileSync(
+        path.join(targetDir, "src", "index.tsx"),
+        "utf8"
+      );
+      const migrationConfig = fs.readFileSync(
+        path.join(targetDir, "src", "migrations", "config.ts"),
+        "utf8"
+      );
 
-    expect(packageJson.dependencies["@wordpress/api-fetch"]).toBe("^7.42.0");
-    expect(
-      packageJson.devDependencies["@wp-typia/project-tools"]
-    ).toBeUndefined();
-    expect(packageJson.scripts["migration:init"]).toBe(
-      `npx --yes wp-typia@${wpTypiaPackageManifest.version} migrate init --current-migration-version v1`
-    );
-    expect(packageJson.scripts["migration:doctor"]).toBe(
-      `npx --yes wp-typia@${wpTypiaPackageManifest.version} migrate doctor --all`
-    );
-    expect(readme).toContain("## Migration UI");
-    expect(readme).toContain("initialized migration workspace at `v1`");
-    expect(generatedEdit).toContain("MigrationDashboard");
-    expect(generatedIndex).toContain(
-      "./migrations/generated/demo-migration-ui/deprecated"
-    );
-    expect(generatedIndex).toContain(
-      "deprecated as NonNullable<BlockConfiguration<DemoMigrationUiAttributes>['deprecated']>"
-    );
-    expect(migrationConfig).toContain("key: 'demo-migration-ui'");
-    expect(migrationConfig).toContain("blockJsonFile: 'src/block.json'");
-    expect(
-      fs.existsSync(
-        path.join(targetDir, "src", "admin", "migration-dashboard.tsx")
-      )
-    ).toBe(true);
-    expect(
-      fs.existsSync(
-        path.join(targetDir, "src", "migrations", "generated", "index.ts")
-      )
-    ).toBe(true);
-    expect(
-      fs.existsSync(path.join(targetDir, "typia-migration-registry.php"))
-    ).toBe(true);
+      expect(packageJson.dependencies["@wordpress/api-fetch"]).toBe("^7.42.0");
+      expect(
+        packageJson.devDependencies["@wp-typia/project-tools"]
+      ).toBeUndefined();
+      expect(packageJson.scripts["migration:init"]).toBe(
+        `npx --yes wp-typia@${wpTypiaPackageManifest.version} migrate init --current-migration-version v1`
+      );
+      expect(packageJson.scripts["migration:doctor"]).toBe(
+        `npx --yes wp-typia@${wpTypiaPackageManifest.version} migrate doctor --all`
+      );
+      expect(readme).toContain("## Migration UI");
+      expect(readme).toContain("initialized migration workspace at `v1`");
+      expect(generatedEdit).toContain("MigrationDashboard");
+      expect(generatedIndex).toContain(
+        "./migrations/generated/demo-migration-ui/deprecated"
+      );
+      expect(generatedIndex).toContain(
+        "deprecated as NonNullable<BlockConfiguration<DemoMigrationUiAttributes>['deprecated']>"
+      );
+      expect(migrationConfig).toContain("key: 'demo-migration-ui'");
+      expect(migrationConfig).toContain("blockJsonFile: 'src/block.json'");
+      expect(
+        fs.existsSync(
+          path.join(targetDir, "src", "admin", "migration-dashboard.tsx")
+        )
+      ).toBe(true);
+      expect(
+        fs.existsSync(
+          path.join(targetDir, "src", "migrations", "generated", "index.ts")
+        )
+      ).toBe(true);
+      expect(
+        fs.existsSync(path.join(targetDir, "typia-migration-registry.php"))
+      ).toBe(true);
 
-    typecheckGeneratedProject(targetDir);
-  });
+      typecheckGeneratedProject(targetDir);
+    },
+    { timeout: 15_000 }
+  );
 
   test(
     "generated sync-types scripts support strict and JSON report modes",

--- a/packages/wp-typia-project-tools/tests/create-cli.test.ts
+++ b/packages/wp-typia-project-tools/tests/create-cli.test.ts
@@ -347,12 +347,22 @@ function buildGeneratedProject(targetDir: string) {
     {
       cwd: targetDir,
       encoding: "utf8",
+      maxBuffer: 10 * 1024 * 1024,
     }
   );
   const output = [result.stdout, result.stderr].filter(Boolean).join("\n");
 
   if (result.error) {
-    throw result.error;
+    const error = new Error(
+      output || `Generated project build failed to start for ${targetDir}.`,
+      { cause: result.error }
+    );
+    Object.assign(error, {
+      status: result.status,
+      stderr: result.stderr,
+      stdout: result.stdout,
+    });
+    throw error;
   }
   if (result.status !== 0) {
     const error = new Error(output || "Generated project build failed.");

--- a/packages/wp-typia-project-tools/tests/create-cli.test.ts
+++ b/packages/wp-typia-project-tools/tests/create-cli.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, describe, expect, test } from "bun:test";
-import { execFile, execFileSync } from "node:child_process";
+import { execFile, execFileSync, spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -339,6 +339,34 @@ function typecheckGeneratedProject(targetDir: string) {
   );
 }
 
+function buildGeneratedProject(targetDir: string) {
+  linkWorkspaceNodeModules(targetDir);
+  const result = spawnSync(
+    path.join(targetDir, "node_modules", ".bin", "wp-scripts"),
+    ["build", "--experimental-modules"],
+    {
+      cwd: targetDir,
+      encoding: "utf8",
+    }
+  );
+  const output = [result.stdout, result.stderr].filter(Boolean).join("\n");
+
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    const error = new Error(output || "Generated project build failed.");
+    Object.assign(error, {
+      status: result.status,
+      stderr: result.stderr,
+      stdout: result.stdout,
+    });
+    throw error;
+  }
+
+  return output;
+}
+
 function replaceGeneratedTransportBaseUrls(
   transportPath: string,
   baseUrl: string
@@ -438,7 +466,9 @@ describe("@wp-typia/project-tools scaffolding", () => {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   });
 
-  test("scaffoldProject creates an npm-ready basic template", async () => {
+  test(
+    "scaffoldProject creates an npm-ready basic template",
+    async () => {
     const targetDir = path.join(tempRoot, "demo-npm");
 
     await scaffoldProject({
@@ -615,10 +645,14 @@ describe("@wp-typia/project-tools scaffolding", () => {
     expect(generatedIndex).toContain("Typia-powered type-safe block");
     expect(generatedTypes).not.toMatch(/[가-힣]/u);
     expect(generatedValidators).toContain('from "./validator-toolkit"');
+    expect(generatedValidators).toContain("import typia from 'typia';");
     expect(generatedValidators).toContain(
       "@wp-typia/block-runtime/identifiers"
     );
     expect(generatedValidators).toContain("generateBlockId");
+    expect(generatedValidators).toMatch(
+      /typia\.createValidate<\s*DemoNpmAttributes\s*>\(\)/
+    );
     expect(generatedValidators).not.toContain("createScaffoldValidatorToolkit");
     expect(generatedValidators).not.toContain(
       "applyTemplateDefaultsFromManifest"
@@ -627,7 +661,8 @@ describe("@wp-typia/project-tools scaffolding", () => {
     expect(generatedValidatorToolkit).toContain(
       "createScaffoldValidatorToolkit"
     );
-    expect(generatedValidatorToolkit).toContain("typia.createValidate");
+    expect(generatedValidatorToolkit).not.toContain("import typia from 'typia';");
+    expect(generatedValidatorToolkit).not.toContain("typia.createValidate");
     expect(generatedPluginBootstrap).toContain("Plugin Name:       Demo Npm");
     expect(generatedPluginBootstrap).toContain("Text Domain:       demo-npm");
     expect(generatedPluginBootstrap).toContain("load_plugin_textdomain(");
@@ -662,7 +697,12 @@ describe("@wp-typia/project-tools scaffolding", () => {
     expect(readme).not.toContain("## PHP REST Extension Points");
 
     typecheckGeneratedProject(targetDir);
-  });
+    runGeneratedScript(targetDir, "scripts/sync-types-to-block-json.ts");
+    const buildOutput = buildGeneratedProject(targetDir);
+    expect(buildOutput).not.toContain("non-specified generic argument");
+    },
+    { timeout: 15_000 }
+  );
 
   test("scaffoldProject can opt into migration UI for built-in single-block templates", async () => {
     const targetDir = path.join(tempRoot, "demo-migration-ui");
@@ -1378,10 +1418,14 @@ describe("@wp-typia/project-tools scaffolding", () => {
       expect(generatedValidatorToolkit).toContain(
         "createScaffoldValidatorToolkit"
       );
+      expect(generatedValidatorToolkit).not.toContain("typia.createValidate");
       expect(generatedValidators).toContain(
         "@wp-typia/block-runtime/identifiers"
       );
       expect(generatedValidators).toContain("generateResourceKey");
+      expect(generatedValidators).toMatch(
+        /typia\.createValidate<\s*DemoPersistencePublicAttributes\s*>\(\)/
+      );
       expect(generatedValidators).not.toContain("const generateResourceKey");
       expect(generatedData).toContain("useDemoPersistencePublicStateQuery");
       expect(generatedData).toContain(
@@ -2326,7 +2370,9 @@ console.log(JSON.stringify({ initial, updated, reread }));
     );
   });
 
-  test("scaffoldProject creates a pure compound template with parent and hidden child blocks", async () => {
+  test(
+    "scaffoldProject creates a pure compound template with parent and hidden child blocks",
+    async () => {
     const targetDir = path.join(tempRoot, "demo-compound");
 
     await scaffoldProject({
@@ -2518,10 +2564,12 @@ console.log(JSON.stringify({ initial, updated, reread }));
     expect(parentHooks).toContain("useTypiaValidation");
     expect(parentHooks).toContain("from '../../hooks'");
     expect(parentValidators).toContain("validator-toolkit");
+    expect(parentValidators).toContain("import typia from 'typia';");
     expect(parentValidators).not.toContain("createScaffoldValidatorToolkit");
     expect(generatedValidatorToolkit).toContain(
       "createScaffoldValidatorToolkit"
     );
+    expect(generatedValidatorToolkit).not.toContain("typia.createValidate");
     expect(parentChildren).toContain("DEFAULT_CHILD_BLOCK_NAME");
     expect(parentChildren).toContain(
       "add-child: insert new allowed child block names here"
@@ -2537,6 +2585,7 @@ console.log(JSON.stringify({ initial, updated, reread }));
     expect(childHooks).toContain("useTypiaValidation");
     expect(childHooks).toContain("from '../../hooks'");
     expect(childValidators).toContain("validator-toolkit");
+    expect(childValidators).toContain("import typia from 'typia';");
     expect(childValidators).not.toContain("createScaffoldValidatorToolkit");
     expect(childBlockJson.attributes.title.selector).toBe(
       ".wp-block-create-block-demo-compound-item__title"
@@ -2563,7 +2612,12 @@ console.log(JSON.stringify({ initial, updated, reread }));
     expect(blockConfig).not.toContain("restManifest");
 
     typecheckGeneratedProject(targetDir);
-  });
+    runGeneratedScript(targetDir, "scripts/sync-types-to-block-json.ts");
+    const buildOutput = buildGeneratedProject(targetDir);
+    expect(buildOutput).not.toContain("non-specified generic argument");
+    },
+    { timeout: 20_000 }
+  );
 
   test("compound scaffolds can opt into migration UI and keep add-child migration-aware", async () => {
     const targetDir = path.join(tempRoot, "demo-compound-migration");
@@ -2990,10 +3044,12 @@ console.log(JSON.stringify({ initial, updated, reread }));
       expect(childHooks).toContain("useTypiaValidation");
       expect(childHooks).toContain("from '../../hooks'");
       expect(childValidators).toContain("validator-toolkit");
+      expect(childValidators).toContain("import typia from 'typia';");
       expect(childValidators).not.toContain("createScaffoldValidatorToolkit");
       expect(generatedValidatorToolkit).toContain(
         "createScaffoldValidatorToolkit"
       );
+      expect(generatedValidatorToolkit).not.toContain("typia.createValidate");
       expect(generatedAddChild).toContain("ALLOWED_CHILD_MARKER");
       expect(generatedAddChild).toContain("buildScaffoldBlockRegistration");
       expect(generatedAddChild).toContain("type ScaffoldBlockMetadata");

--- a/packages/wp-typia-project-tools/tests/create-cli.test.ts
+++ b/packages/wp-typia-project-tools/tests/create-cli.test.ts
@@ -4991,6 +4991,126 @@ console.log(JSON.stringify({ initial, updated, reread }));
     typecheckGeneratedProject(targetDir);
   }, 30_000);
 
+  test("add compound block preserves a compatible shared validator toolkit with different formatting", async () => {
+    const targetDir = path.join(
+      tempRoot,
+      "demo-workspace-add-compound-compatible-validator-toolkit"
+    );
+
+    await scaffoldProject({
+      projectDir: targetDir,
+      templateId: workspaceTemplatePackageManifest.name,
+      packageManager: "npm",
+      noInstall: true,
+      answers: {
+        author: "Test Runner",
+        description: "Demo workspace add compound compatible validator toolkit",
+        namespace: "demo-space",
+        phpPrefix: "demo_space",
+        slug: "demo-workspace-add-compound-compatible-validator-toolkit",
+        textDomain: "demo-space",
+        title: "Demo Workspace Add Compound Compatible Validator Toolkit",
+      },
+    });
+
+    linkWorkspaceNodeModules(targetDir);
+
+    runCli(
+      "node",
+      [
+        entryPath,
+        "add",
+        "block",
+        "faq-stack",
+        "--template",
+        "compound",
+      ],
+      {
+        cwd: targetDir,
+      }
+    );
+
+    const validatorToolkitPath = path.join(
+      targetDir,
+      "src",
+      "validator-toolkit.ts"
+    );
+    fs.writeFileSync(
+      validatorToolkitPath,
+      [
+        "// preserve-compatible-toolkit",
+        "import type { ManifestDefaultsDocument } from \"@wp-typia/block-runtime/defaults\";",
+        "import {",
+        "\tcreateScaffoldValidatorToolkit,",
+        "\ttype ScaffoldValidatorToolkitOptions,",
+        "} from \"@wp-typia/block-runtime/validation\";",
+        "",
+        "interface TemplateValidatorFunctions<T extends object>{",
+        "\tassert:ScaffoldValidatorToolkitOptions<T>[\"assert\"];",
+        "\tclone:ScaffoldValidatorToolkitOptions<T>[\"clone\"];",
+        "\tis:ScaffoldValidatorToolkitOptions<T>[\"is\"];",
+        "\tprune:ScaffoldValidatorToolkitOptions<T>[\"prune\"];",
+        "\trandom:ScaffoldValidatorToolkitOptions<T>[\"random\"];",
+        "\tvalidate:ScaffoldValidatorToolkitOptions<T>[\"validate\"];",
+        "}",
+        "",
+        "interface TemplateValidatorToolkitOptions<T extends object>",
+        "\textends TemplateValidatorFunctions<T> {",
+        "\tfinalize?: ScaffoldValidatorToolkitOptions<T>[\"finalize\"];",
+        "\tmanifest: unknown;",
+        "\tonValidationError?: ScaffoldValidatorToolkitOptions<T>[\"onValidationError\"];",
+        "}",
+        "",
+        "export function createTemplateValidatorToolkit<T extends object>({",
+        "\tassert,",
+        "\tclone,",
+        "\tfinalize,",
+        "\tis,",
+        "\tmanifest,",
+        "\tonValidationError,",
+        "\tprune,",
+        "\trandom,",
+        "\tvalidate ,",
+        "}: TemplateValidatorToolkitOptions<T>) {",
+        "\treturn createScaffoldValidatorToolkit<T>({",
+        "\t\tmanifest: manifest as ManifestDefaultsDocument,",
+        "\t\tvalidate,",
+        "\t\tassert,",
+        "\t\tis,",
+        "\t\trandom,",
+        "\t\tclone,",
+        "\t\tprune,",
+        "\t\tfinalize,",
+        "\t\tonValidationError,",
+        "\t});",
+        "}",
+        "",
+      ].join("\n"),
+      "utf8"
+    );
+
+    runCli(
+      "node",
+      [
+        entryPath,
+        "add",
+        "block",
+        "feature-grid",
+        "--template",
+        "compound",
+      ],
+      {
+        cwd: targetDir,
+      }
+    );
+
+    const validatorToolkitSource = fs.readFileSync(validatorToolkitPath, "utf8");
+
+    expect(validatorToolkitSource).toContain("// preserve-compatible-toolkit");
+
+    typecheckGeneratedProject(targetDir);
+  }, 30_000);
+
   test("add block updates migration config in a migration-enabled workspace template", async () => {
     const targetDir = path.join(tempRoot, "demo-workspace-add-migration");
 

--- a/packages/wp-typia-project-tools/tests/create-cli.test.ts
+++ b/packages/wp-typia-project-tools/tests/create-cli.test.ts
@@ -4846,6 +4846,23 @@ console.log(JSON.stringify({ initial, updated, reread }));
       },
     });
 
+    linkWorkspaceNodeModules(targetDir);
+
+    runCli(
+      "node",
+      [
+        entryPath,
+        "add",
+        "block",
+        "faq-stack",
+        "--template",
+        "compound",
+      ],
+      {
+        cwd: targetDir,
+      }
+    );
+
     fs.writeFileSync(
       path.join(targetDir, "src", "validator-toolkit.ts"),
       [
@@ -4877,7 +4894,47 @@ console.log(JSON.stringify({ initial, updated, reread }));
       "utf8"
     );
 
-    linkWorkspaceNodeModules(targetDir);
+    const writeLegacyCompoundValidator = (
+      blockSlug: string,
+      typeName: string,
+      exportSuffix: string
+    ) => {
+      fs.writeFileSync(
+        path.join(targetDir, "src", "blocks", blockSlug, "validators.ts"),
+        [
+          `import currentManifest from './typia.manifest.json';`,
+          `import type { ${typeName} } from './types';`,
+          `import { createTemplateValidatorToolkit } from '../../validator-toolkit';`,
+          "",
+          `const scaffoldValidators = createTemplateValidatorToolkit< ${typeName} >( {`,
+          "\tmanifest: currentManifest,",
+          "} );",
+          "",
+          `export const validate${exportSuffix} =`,
+          "\tscaffoldValidators.validateAttributes;",
+          "",
+          "export const validators = scaffoldValidators.validators;",
+          "",
+          `export const sanitize${exportSuffix} =`,
+          "\tscaffoldValidators.sanitizeAttributes;",
+          "",
+          "export const createAttributeUpdater = scaffoldValidators.createAttributeUpdater;",
+          "",
+        ].join("\n"),
+        "utf8"
+      );
+    };
+
+    writeLegacyCompoundValidator(
+      "faq-stack",
+      "FaqStackAttributes",
+      "FaqStackAttributes"
+    );
+    writeLegacyCompoundValidator(
+      "faq-stack-item",
+      "FaqStackItemAttributes",
+      "FaqStackItemAttributes"
+    );
 
     runCli(
       "node",
@@ -4885,7 +4942,7 @@ console.log(JSON.stringify({ initial, updated, reread }));
         entryPath,
         "add",
         "block",
-        "faq-stack",
+        "feature-grid",
         "--template",
         "compound",
       ],
@@ -4898,10 +4955,26 @@ console.log(JSON.stringify({ initial, updated, reread }));
       path.join(targetDir, "src", "validator-toolkit.ts"),
       "utf8"
     );
+    const repairedParentValidatorSource = fs.readFileSync(
+      path.join(targetDir, "src", "blocks", "faq-stack", "validators.ts"),
+      "utf8"
+    );
+    const repairedChildValidatorSource = fs.readFileSync(
+      path.join(targetDir, "src", "blocks", "faq-stack-item", "validators.ts"),
+      "utf8"
+    );
 
     expect(validatorToolkitSource).toContain("interface TemplateValidatorFunctions<");
     expect(validatorToolkitSource).toContain(
       "assert: ScaffoldValidatorToolkitOptions< T >['assert'];"
+    );
+    expect(repairedParentValidatorSource).toContain("import typia from 'typia';");
+    expect(repairedParentValidatorSource).toContain(
+      "assert: typia.createAssert< FaqStackAttributes >()"
+    );
+    expect(repairedChildValidatorSource).toContain("import typia from 'typia';");
+    expect(repairedChildValidatorSource).toContain(
+      "assert: typia.createAssert< FaqStackItemAttributes >()"
     );
     typecheckGeneratedProject(targetDir);
   }, 30_000);

--- a/packages/wp-typia-project-tools/tests/create-cli.test.ts
+++ b/packages/wp-typia-project-tools/tests/create-cli.test.ts
@@ -4812,12 +4812,98 @@ console.log(JSON.stringify({ initial, updated, reread }));
     expect(serverModuleSource).toContain("is_post_publicly_viewable( $post )");
     expect(serverModuleSource).toContain(": 'primary';");
     expect(parentBlockJson.name).toBe("demo-space/faq-stack");
+    expect(fs.existsSync(path.join(targetDir, "src", "hooks.ts"))).toBe(true);
+    expect(fs.existsSync(path.join(targetDir, "src", "validator-toolkit.ts"))).toBe(
+      true
+    );
     runGeneratedScript(targetDir, "scripts/sync-types-to-block-json.ts", [
       "--check",
     ]);
     runGeneratedScript(targetDir, "scripts/sync-rest-contracts.ts", [
       "--check",
     ]);
+  }, 30_000);
+
+  test("add compound block repairs a legacy shared validator toolkit in an official workspace template", async () => {
+    const targetDir = path.join(
+      tempRoot,
+      "demo-workspace-add-compound-legacy-validator-toolkit"
+    );
+
+    await scaffoldProject({
+      projectDir: targetDir,
+      templateId: workspaceTemplatePackageManifest.name,
+      packageManager: "npm",
+      noInstall: true,
+      answers: {
+        author: "Test Runner",
+        description: "Demo workspace add compound legacy validator toolkit",
+        namespace: "demo-space",
+        phpPrefix: "demo_space",
+        slug: "demo-workspace-add-compound-legacy-validator-toolkit",
+        textDomain: "demo-space",
+        title: "Demo Workspace Add Compound Legacy Validator Toolkit",
+      },
+    });
+
+    fs.writeFileSync(
+      path.join(targetDir, "src", "validator-toolkit.ts"),
+      [
+        "import type { ManifestDefaultsDocument } from '@wp-typia/block-runtime/defaults';",
+        "import {",
+        "\tcreateScaffoldValidatorToolkit,",
+        "\ttype ScaffoldValidatorToolkitOptions,",
+        "} from '@wp-typia/block-runtime/validation';",
+        "",
+        "interface TemplateValidatorToolkitOptions< T extends object > {",
+        "\tfinalize?: ScaffoldValidatorToolkitOptions< T >['finalize'];",
+        "\tmanifest: unknown;",
+        "\tonValidationError?: ScaffoldValidatorToolkitOptions< T >['onValidationError'];",
+        "}",
+        "",
+        "export function createTemplateValidatorToolkit< T extends object >( {",
+        "\tfinalize,",
+        "\tmanifest,",
+        "\tonValidationError,",
+        "}: TemplateValidatorToolkitOptions< T > ) {",
+        "\treturn createScaffoldValidatorToolkit< T >( {",
+        "\t\tmanifest: manifest as ManifestDefaultsDocument,",
+        "\t\tfinalize,",
+        "\t\tonValidationError,",
+        "\t} );",
+        "}",
+        "",
+      ].join("\n"),
+      "utf8"
+    );
+
+    linkWorkspaceNodeModules(targetDir);
+
+    runCli(
+      "node",
+      [
+        entryPath,
+        "add",
+        "block",
+        "faq-stack",
+        "--template",
+        "compound",
+      ],
+      {
+        cwd: targetDir,
+      }
+    );
+
+    const validatorToolkitSource = fs.readFileSync(
+      path.join(targetDir, "src", "validator-toolkit.ts"),
+      "utf8"
+    );
+
+    expect(validatorToolkitSource).toContain("interface TemplateValidatorFunctions<");
+    expect(validatorToolkitSource).toContain(
+      "assert: ScaffoldValidatorToolkitOptions< T >['assert'];"
+    );
+    typecheckGeneratedProject(targetDir);
   }, 30_000);
 
   test("add block updates migration config in a migration-enabled workspace template", async () => {

--- a/packages/wp-typia-project-tools/tests/create-cli.test.ts
+++ b/packages/wp-typia-project-tools/tests/create-cli.test.ts
@@ -4897,16 +4897,22 @@ console.log(JSON.stringify({ initial, updated, reread }));
     const writeLegacyCompoundValidator = (
       blockSlug: string,
       typeName: string,
-      exportSuffix: string
+      exportSuffix: string,
+      options?: {
+        lineEnding?: "\n" | "\r\n";
+        quoteStyle?: "'" | '"';
+      }
     ) => {
+      const lineEnding = options?.lineEnding ?? "\n";
+      const quoteStyle = options?.quoteStyle ?? "'";
       fs.writeFileSync(
         path.join(targetDir, "src", "blocks", blockSlug, "validators.ts"),
         [
-          `import currentManifest from './typia.manifest.json';`,
+          `import currentManifest from ${quoteStyle}./typia.manifest.json${quoteStyle};`,
           "import type {",
           `\t${typeName},`,
-          "} from './types';",
-          `import { createTemplateValidatorToolkit } from '../../validator-toolkit';`,
+          `} from ${quoteStyle}./types${quoteStyle};`,
+          `import { createTemplateValidatorToolkit } from ${quoteStyle}../../validator-toolkit${quoteStyle};`,
           "",
           `const scaffoldValidators = createTemplateValidatorToolkit< ${typeName} >( {`,
           "\tmanifest: currentManifest,",
@@ -4922,7 +4928,7 @@ console.log(JSON.stringify({ initial, updated, reread }));
           "",
           "export const createAttributeUpdater = scaffoldValidators.createAttributeUpdater;",
           "",
-        ].join("\n"),
+        ].join(lineEnding),
         "utf8"
       );
     };
@@ -4935,7 +4941,11 @@ console.log(JSON.stringify({ initial, updated, reread }));
     writeLegacyCompoundValidator(
       "faq-stack-item",
       "FaqStackItemAttributes",
-      "FaqStackItemAttributes"
+      "FaqStackItemAttributes",
+      {
+        lineEnding: "\r\n",
+        quoteStyle: '"',
+      }
     );
 
     runCli(

--- a/packages/wp-typia-rest/tests/react.test.tsx
+++ b/packages/wp-typia-rest/tests/react.test.tsx
@@ -568,7 +568,7 @@ describe("@wp-typia/rest/react", () => {
 			expect(fetchCount).toBe(2);
 			expect(rendered.current.data).toEqual({ count: 2 });
 			expect(rendered.current.error).toBeNull();
-		});
+		}, 5_000);
 
 		await rendered.unmount();
 	});

--- a/tests/unit/blocks-runtime.test.ts
+++ b/tests/unit/blocks-runtime.test.ts
@@ -46,6 +46,30 @@ function createWebpackFsAdapter() {
 	};
 }
 
+function writeMockPackage(projectRoot: string, packageName: string, version: string) {
+	const packageDir = path.join(projectRoot, "node_modules", ...packageName.split("/"));
+	fs.mkdirSync(packageDir, { recursive: true });
+	fs.writeFileSync(
+		path.join(packageDir, "package.json"),
+		JSON.stringify({ name: packageName, version }, null, 2),
+		"utf8",
+	);
+}
+
+function createSupportedWebpackProjectRoot() {
+	const projectRoot = createTempDir("wp-typia-webpack-project-");
+	writeTextFile(
+		path.join(projectRoot, "package.json"),
+		JSON.stringify({ name: "webpack-project", private: true }, null, 2),
+	);
+	writeMockPackage(projectRoot, "typia", "12.0.1");
+	writeMockPackage(projectRoot, "@typia/unplugin", "12.0.1");
+	writeMockPackage(projectRoot, "@wordpress/scripts", "30.22.0");
+	writeMockPackage(projectRoot, "webpack", "5.106.0");
+
+	return projectRoot;
+}
+
 function createFakeCompilation(
 	initialAssets: Record<string, unknown> = {},
 	outputPath?: string,
@@ -195,6 +219,7 @@ describe("block runtime helpers", () => {
 
 	test("createTypiaWebpackConfig merges editor and module entries and preserves plugin ordering", async () => {
 		const existingPlugin = { name: "existing-plugin" };
+		const projectRoot = createSupportedWebpackProjectRoot();
 		const config = await createTypiaWebpackConfig({
 			defaultConfig: async () => [
 				{
@@ -224,6 +249,7 @@ describe("block runtime helpers", () => {
 				default: () => ({ name: "typia-plugin" }),
 			}),
 			path,
+			projectRoot,
 		});
 
 		expect(Array.isArray(config)).toBe(true);
@@ -249,6 +275,7 @@ describe("block runtime helpers", () => {
 	});
 
 	test("createTypiaWebpackConfig respects replace modes for editor and module entries", async () => {
+		const projectRoot = createSupportedWebpackProjectRoot();
 		const config = await createTypiaWebpackConfig({
 			defaultConfig: [
 				{
@@ -279,6 +306,7 @@ describe("block runtime helpers", () => {
 			moduleEntriesMode: "replace",
 			nonModuleEntriesMode: "replace",
 			path,
+			projectRoot,
 		});
 
 		const [editorConfig, moduleConfig] = config as Array<{
@@ -295,6 +323,7 @@ describe("block runtime helpers", () => {
 
 	test("createTypiaWebpackConfig copies missing artifacts and normalizes script-module assets", async () => {
 		const outputDir = createTempDir("wp-typia-webpack-output-");
+		const projectRoot = createSupportedWebpackProjectRoot();
 		const artifactPath = path.join(outputDir, "typia.manifest.json");
 		const emittedAssetPath = path.join(outputDir, "view.asset.php");
 		const rawAssetSource =
@@ -319,6 +348,7 @@ describe("block runtime helpers", () => {
 			}),
 			isScriptModuleAsset: (assetName) => assetName === "view.asset.php",
 			path,
+			projectRoot,
 		});
 		const plugin = (config as { plugins: unknown[] }).plugins.find(
 			(candidate) =>

--- a/tests/unit/repo-dx-baseline.test.ts
+++ b/tests/unit/repo-dx-baseline.test.ts
@@ -70,6 +70,10 @@ describe('repository DX baseline', () => {
 		const readme = fs.readFileSync(path.join(repoRoot, 'README.md'), 'utf8');
 		const contributing = fs.readFileSync(path.join(repoRoot, 'CONTRIBUTING.md'), 'utf8');
 		const cliReadme = fs.readFileSync(path.join(repoRoot, 'packages', 'wp-typia', 'README.md'), 'utf8');
+		const workspaceWebpackTemplate = fs.readFileSync(
+			path.join(repoRoot, 'packages', 'create-workspace-template', 'webpack.config.js.mustache'),
+			'utf8',
+		);
 
 		expect(readme).toContain('bun run ci:local');
 		expect(readme).toContain('Root ESLint covers repository infrastructure code');
@@ -81,11 +85,16 @@ describe('repository DX baseline', () => {
 		expect(contributing).toContain('## Project meta docs');
 		expect(contributing).toContain('[`UPGRADE.md`](./UPGRADE.md)');
 		expect(contributing).toContain('[`SECURITY.md`](./SECURITY.md)');
+		expect(contributing).toContain('## Generated project toolchain matrix');
+		expect(contributing).toContain('`typia` 12.x');
+		expect(contributing).toContain('`@wordpress/scripts` 30.x');
 		expect(cliReadme).toMatch(
 			/https:\/\/github\.com\/[^/]+\/[^/]+\/blob\/[^/]+\/UPGRADE\.md/,
 		);
 		expect(cliReadme).toMatch(
 			/https:\/\/github\.com\/[^/]+\/[^/]+\/blob\/[^/]+\/SECURITY\.md/,
 		);
+		expect(workspaceWebpackTemplate).toContain('loadCompatibleTypiaWebpackPlugin');
+		expect(workspaceWebpackTemplate).toContain('projectRoot: process.cwd()');
 	});
 });


### PR DESCRIPTION
Closes #196

## Summary
- move generic Typia factory calls out of the shared validator helper into concrete generated validators
- add a fail-fast Typia/Webpack compatibility preflight for generated project webpack helpers
- cover the supported matrix with block-runtime unit tests and generated-project build smoke tests

## Validation
- bun run typecheck
- bun run test
- bun run build
- bun run changesets:validate
- bun run publish:validate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fail-fast Typia/Webpack compatibility guard and compatibility-aware plugin loader.
  * Generated projects now include Typia-backed validators and updated validator toolkit wiring.
  * CLI add command can repair/upgrade legacy validator sources during scaffolding.

* **Documentation**
  * Added generated-project toolchain compatibility matrix and contributor guidance for expanding coverage.

* **Tests**
  * Added generated-project build smoke tests and unit/integration tests for compatibility, loader behavior, and validator generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->