### PR TITLE
Avoid duplicate typia imports in legacy compound validator repairs

### DIFF
--- a/.sampo/changesets/issue-196-typia-import-guard.md
+++ b/.sampo/changesets/issue-196-typia-import-guard.md
@@ -1,0 +1,7 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Avoid duplicating existing `typia` imports when `wp-typia add block --template compound`
+repairs legacy compound validator files inside older workspaces.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add.ts
@@ -932,6 +932,10 @@ function isLegacyCompoundValidatorSource(source: string | null): source is strin
 	);
 }
 
+function hasTypiaImport(source: string): boolean {
+	return TYPIA_IMPORT_PATTERN.test(source.replace(/\/\*[\s\S]*?\*\//gu, ""));
+}
+
 function upgradeLegacyCompoundValidatorSource(source: string): string {
 	const typeNameMatch = source.match(LEGACY_TOOLKIT_CALL_PATTERN);
 	const typeName = typeNameMatch?.groups?.typeName;
@@ -942,7 +946,7 @@ function upgradeLegacyCompoundValidatorSource(source: string): string {
 	}
 
 	let nextSource = source;
-	if (!TYPIA_IMPORT_PATTERN.test(nextSource)) {
+	if (!hasTypiaImport(nextSource)) {
 		nextSource = `import typia from 'typia';\n${nextSource}`;
 	}
 

--- a/packages/wp-typia-project-tools/src/runtime/cli-add.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add.ts
@@ -902,6 +902,7 @@ const LEGACY_TOOLKIT_CALL_PATTERN =
 	/createTemplateValidatorToolkit<\s*(?<typeName>[A-Za-z0-9_]+)\s*>\s*\(\s*\{/u;
 const LEGACY_VALIDATOR_TOOLKIT_IMPORT_PATTERN =
 	/from\s*["']\.\.\/\.\.\/validator-toolkit["']/u;
+const TYPIA_IMPORT_PATTERN = /import\s+typia\s+from\s*["']typia["'];?/u;
 const COMPATIBLE_COMPOUND_TOOLKIT_PATTERNS = [
 	/interface\s+TemplateValidatorFunctions\s*<\s*T\s+extends\s+object\s*>\s*\{/u,
 	/\bassert\s*:\s*ScaffoldValidatorToolkitOptions\s*<\s*T\s*>\s*\[\s*["']assert["']\s*\]/u,
@@ -940,7 +941,7 @@ function upgradeLegacyCompoundValidatorSource(source: string): string {
 	}
 
 	let nextSource = source;
-	if (!nextSource.includes("import typia from 'typia';")) {
+	if (!TYPIA_IMPORT_PATTERN.test(nextSource)) {
 		nextSource = `import typia from 'typia';\n${nextSource}`;
 	}
 

--- a/packages/wp-typia-project-tools/src/runtime/cli-add.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add.ts
@@ -903,7 +903,7 @@ const LEGACY_TOOLKIT_CALL_PATTERN =
 const LEGACY_VALIDATOR_TOOLKIT_IMPORT_PATTERN =
 	/from\s*["']\.\.\/\.\.\/validator-toolkit["']/u;
 const TYPIA_IMPORT_PATTERN =
-	/^[ \t]*import\s+typia\s+from\s*["']typia["'];?/mu;
+	/^[\uFEFF \t]*import\s+typia\s+from\s*["']typia["'];?/mu;
 const COMPATIBLE_COMPOUND_TOOLKIT_PATTERNS = [
 	/interface\s+TemplateValidatorFunctions\s*<\s*T\s+extends\s+object\s*>\s*\{/u,
 	/\bassert\s*:\s*ScaffoldValidatorToolkitOptions\s*<\s*T\s*>\s*\[\s*["']assert["']\s*\]/u,

--- a/packages/wp-typia-project-tools/src/runtime/cli-add.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add.ts
@@ -902,7 +902,8 @@ const LEGACY_TOOLKIT_CALL_PATTERN =
 	/createTemplateValidatorToolkit<\s*(?<typeName>[A-Za-z0-9_]+)\s*>\s*\(\s*\{/u;
 const LEGACY_VALIDATOR_TOOLKIT_IMPORT_PATTERN =
 	/from\s*["']\.\.\/\.\.\/validator-toolkit["']/u;
-const TYPIA_IMPORT_PATTERN = /import\s+typia\s+from\s*["']typia["'];?/u;
+const TYPIA_IMPORT_PATTERN =
+	/^[ \t]*import\s+typia\s+from\s*["']typia["'];?/mu;
 const COMPATIBLE_COMPOUND_TOOLKIT_PATTERNS = [
 	/interface\s+TemplateValidatorFunctions\s*<\s*T\s+extends\s+object\s*>\s*\{/u,
 	/\bassert\s*:\s*ScaffoldValidatorToolkitOptions\s*<\s*T\s*>\s*\[\s*["']assert["']\s*\]/u,

--- a/packages/wp-typia-project-tools/tests/create-cli.test.ts
+++ b/packages/wp-typia-project-tools/tests/create-cli.test.ts
@@ -4899,15 +4899,20 @@ console.log(JSON.stringify({ initial, updated, reread }));
       typeName: string,
       exportSuffix: string,
       options?: {
+        includeTypiaImport?: boolean;
         lineEnding?: "\n" | "\r\n";
         quoteStyle?: "'" | '"';
       }
     ) => {
+      const includeTypiaImport = options?.includeTypiaImport ?? false;
       const lineEnding = options?.lineEnding ?? "\n";
       const quoteStyle = options?.quoteStyle ?? "'";
       fs.writeFileSync(
         path.join(targetDir, "src", "blocks", blockSlug, "validators.ts"),
         [
+          ...(includeTypiaImport
+            ? [`import typia from ${quoteStyle}typia${quoteStyle};`]
+            : []),
           `import currentManifest from ${quoteStyle}./typia.manifest.json${quoteStyle};`,
           "import type {",
           `\t${typeName},`,
@@ -4988,6 +4993,147 @@ console.log(JSON.stringify({ initial, updated, reread }));
     expect(repairedChildValidatorSource).toContain(
       "assert: typia.createAssert< FaqStackItemAttributes >()"
     );
+    typecheckGeneratedProject(targetDir);
+  }, 30_000);
+
+  test("add compound block does not duplicate an existing typia import during legacy validator repair", async () => {
+    const targetDir = path.join(
+      tempRoot,
+      "demo-workspace-add-compound-legacy-validator-typia-import"
+    );
+
+    await scaffoldProject({
+      projectDir: targetDir,
+      templateId: workspaceTemplatePackageManifest.name,
+      packageManager: "npm",
+      noInstall: true,
+      answers: {
+        author: "Test Runner",
+        description: "Demo workspace add compound legacy validator typia import",
+        namespace: "demo-space",
+        phpPrefix: "demo_space",
+        slug: "demo-workspace-add-compound-legacy-validator-typia-import",
+        textDomain: "demo-space",
+        title: "Demo Workspace Add Compound Legacy Validator Typia Import",
+      },
+    });
+
+    linkWorkspaceNodeModules(targetDir);
+
+    runCli(
+      "node",
+      [
+        entryPath,
+        "add",
+        "block",
+        "faq-stack",
+        "--template",
+        "compound",
+      ],
+      {
+        cwd: targetDir,
+      }
+    );
+
+    fs.writeFileSync(
+      path.join(targetDir, "src", "validator-toolkit.ts"),
+      [
+        "import type { ManifestDefaultsDocument } from '@wp-typia/block-runtime/defaults';",
+        "import {",
+        "\tcreateScaffoldValidatorToolkit,",
+        "\ttype ScaffoldValidatorToolkitOptions,",
+        "} from '@wp-typia/block-runtime/validation';",
+        "",
+        "interface TemplateValidatorToolkitOptions< T extends object > {",
+        "\tfinalize?: ScaffoldValidatorToolkitOptions< T >['finalize'];",
+        "\tmanifest: unknown;",
+        "\tonValidationError?: ScaffoldValidatorToolkitOptions< T >['onValidationError'];",
+        "}",
+        "",
+        "export function createTemplateValidatorToolkit< T extends object >( {",
+        "\tfinalize,",
+        "\tmanifest,",
+        "\tonValidationError,",
+        "}: TemplateValidatorToolkitOptions< T > ) {",
+        "\treturn createScaffoldValidatorToolkit< T >( {",
+        "\t\tmanifest: manifest as ManifestDefaultsDocument,",
+        "\t\tfinalize,",
+        "\t\tonValidationError,",
+        "\t} );",
+        "}",
+        "",
+      ].join("\n"),
+      "utf8"
+    );
+
+    const writeLegacyCompoundValidator = (
+      blockSlug: string,
+      typeName: string,
+      exportSuffix: string
+    ) => {
+      fs.writeFileSync(
+        path.join(targetDir, "src", "blocks", blockSlug, "validators.ts"),
+        [
+          'import typia from "typia";',
+          'import currentManifest from "./typia.manifest.json";',
+          "import type {",
+          `\t${typeName},`,
+          '} from "./types";',
+          'import { createTemplateValidatorToolkit } from "../../validator-toolkit";',
+          "",
+          `const scaffoldValidators = createTemplateValidatorToolkit< ${typeName} >( {`,
+          "\tmanifest: currentManifest,",
+          "} );",
+          "",
+          `export const validate${exportSuffix} =`,
+          "\tscaffoldValidators.validateAttributes;",
+          "",
+          "export const validators = scaffoldValidators.validators;",
+          "",
+          `export const sanitize${exportSuffix} =`,
+          "\tscaffoldValidators.sanitizeAttributes;",
+          "",
+          "export const createAttributeUpdater = scaffoldValidators.createAttributeUpdater;",
+          "",
+        ].join("\n"),
+        "utf8"
+      );
+    };
+
+    writeLegacyCompoundValidator(
+      "faq-stack",
+      "FaqStackAttributes",
+      "FaqStackAttributes"
+    );
+
+    runCli(
+      "node",
+      [
+        entryPath,
+        "add",
+        "block",
+        "feature-grid",
+        "--template",
+        "compound",
+      ],
+      {
+        cwd: targetDir,
+      }
+    );
+
+    const repairedParentValidatorSource = fs.readFileSync(
+      path.join(targetDir, "src", "blocks", "faq-stack", "validators.ts"),
+      "utf8"
+    );
+    const typiaImportMatches = repairedParentValidatorSource.match(
+      /import typia from ['"]typia['"];/gu
+    );
+
+    expect(typiaImportMatches).toHaveLength(1);
+    expect(repairedParentValidatorSource).toContain(
+      "assert: typia.createAssert< FaqStackAttributes >()"
+    );
+
     typecheckGeneratedProject(targetDir);
   }, 30_000);
 

--- a/packages/wp-typia-project-tools/tests/create-cli.test.ts
+++ b/packages/wp-typia-project-tools/tests/create-cli.test.ts
@@ -5137,6 +5137,140 @@ console.log(JSON.stringify({ initial, updated, reread }));
     typecheckGeneratedProject(targetDir);
   }, 30_000);
 
+  test("add compound block ignores a commented typia import during legacy validator repair", async () => {
+    const targetDir = path.join(
+      tempRoot,
+      "demo-workspace-add-compound-legacy-validator-commented-typia-import"
+    );
+
+    await scaffoldProject({
+      projectDir: targetDir,
+      templateId: workspaceTemplatePackageManifest.name,
+      packageManager: "npm",
+      noInstall: true,
+      answers: {
+        author: "Test Runner",
+        description:
+          "Demo workspace add compound legacy validator commented typia import",
+        namespace: "demo-space",
+        phpPrefix: "demo_space",
+        slug: "demo-workspace-add-compound-legacy-validator-commented-typia-import",
+        textDomain: "demo-space",
+        title:
+          "Demo Workspace Add Compound Legacy Validator Commented Typia Import",
+      },
+    });
+
+    linkWorkspaceNodeModules(targetDir);
+
+    runCli(
+      "node",
+      [
+        entryPath,
+        "add",
+        "block",
+        "faq-stack",
+        "--template",
+        "compound",
+      ],
+      {
+        cwd: targetDir,
+      }
+    );
+
+    fs.writeFileSync(
+      path.join(targetDir, "src", "validator-toolkit.ts"),
+      [
+        "import type { ManifestDefaultsDocument } from '@wp-typia/block-runtime/defaults';",
+        "import {",
+        "\tcreateScaffoldValidatorToolkit,",
+        "\ttype ScaffoldValidatorToolkitOptions,",
+        "} from '@wp-typia/block-runtime/validation';",
+        "",
+        "interface TemplateValidatorToolkitOptions< T extends object > {",
+        "\tfinalize?: ScaffoldValidatorToolkitOptions< T >['finalize'];",
+        "\tmanifest: unknown;",
+        "\tonValidationError?: ScaffoldValidatorToolkitOptions< T >['onValidationError'];",
+        "}",
+        "",
+        "export function createTemplateValidatorToolkit< T extends object >( {",
+        "\tfinalize,",
+        "\tmanifest,",
+        "\tonValidationError,",
+        "}: TemplateValidatorToolkitOptions< T > ) {",
+        "\treturn createScaffoldValidatorToolkit< T >( {",
+        "\t\tmanifest: manifest as ManifestDefaultsDocument,",
+        "\t\tfinalize,",
+        "\t\tonValidationError,",
+        "\t} );",
+        "}",
+        "",
+      ].join("\n"),
+      "utf8"
+    );
+
+    fs.writeFileSync(
+      path.join(targetDir, "src", "blocks", "faq-stack", "validators.ts"),
+      [
+        '// import typia from "typia";',
+        'import currentManifest from "./typia.manifest.json";',
+        "import type {",
+        "\tFaqStackAttributes,",
+        '} from "./types";',
+        'import { createTemplateValidatorToolkit } from "../../validator-toolkit";',
+        "",
+        "const scaffoldValidators = createTemplateValidatorToolkit< FaqStackAttributes >( {",
+        "\tmanifest: currentManifest,",
+        "} );",
+        "",
+        "export const validateFaqStackAttributes =",
+        "\tscaffoldValidators.validateAttributes;",
+        "",
+        "export const validators = scaffoldValidators.validators;",
+        "",
+        "export const sanitizeFaqStackAttributes =",
+        "\tscaffoldValidators.sanitizeAttributes;",
+        "",
+        "export const createAttributeUpdater = scaffoldValidators.createAttributeUpdater;",
+        "",
+      ].join("\n"),
+      "utf8"
+    );
+
+    runCli(
+      "node",
+      [
+        entryPath,
+        "add",
+        "block",
+        "feature-grid",
+        "--template",
+        "compound",
+      ],
+      {
+        cwd: targetDir,
+      }
+    );
+
+    const repairedParentValidatorSource = fs.readFileSync(
+      path.join(targetDir, "src", "blocks", "faq-stack", "validators.ts"),
+      "utf8"
+    );
+    const typiaImportMatches = repairedParentValidatorSource.match(
+      /^[ \t]*import typia from ['"]typia['"];/gmu
+    );
+
+    expect(typiaImportMatches).toHaveLength(1);
+    expect(repairedParentValidatorSource).toContain(
+      '// import typia from "typia";'
+    );
+    expect(repairedParentValidatorSource).toContain(
+      "assert: typia.createAssert< FaqStackAttributes >()"
+    );
+
+    typecheckGeneratedProject(targetDir);
+  }, 30_000);
+
   test("add compound block preserves a compatible shared validator toolkit with different formatting", async () => {
     const targetDir = path.join(
       tempRoot,

--- a/packages/wp-typia-project-tools/tests/create-cli.test.ts
+++ b/packages/wp-typia-project-tools/tests/create-cli.test.ts
@@ -5137,6 +5137,135 @@ console.log(JSON.stringify({ initial, updated, reread }));
     typecheckGeneratedProject(targetDir);
   }, 30_000);
 
+  test("add compound block does not duplicate a BOM-prefixed typia import during legacy validator repair", async () => {
+    const targetDir = path.join(
+      tempRoot,
+      "demo-workspace-add-compound-legacy-validator-bom-typia-import"
+    );
+
+    await scaffoldProject({
+      projectDir: targetDir,
+      templateId: workspaceTemplatePackageManifest.name,
+      packageManager: "npm",
+      noInstall: true,
+      answers: {
+        author: "Test Runner",
+        description: "Demo workspace add compound legacy validator BOM typia import",
+        namespace: "demo-space",
+        phpPrefix: "demo_space",
+        slug: "demo-workspace-add-compound-legacy-validator-bom-typia-import",
+        textDomain: "demo-space",
+        title: "Demo Workspace Add Compound Legacy Validator BOM Typia Import",
+      },
+    });
+
+    linkWorkspaceNodeModules(targetDir);
+
+    runCli(
+      "node",
+      [
+        entryPath,
+        "add",
+        "block",
+        "faq-stack",
+        "--template",
+        "compound",
+      ],
+      {
+        cwd: targetDir,
+      }
+    );
+
+    fs.writeFileSync(
+      path.join(targetDir, "src", "validator-toolkit.ts"),
+      [
+        "import type { ManifestDefaultsDocument } from '@wp-typia/block-runtime/defaults';",
+        "import {",
+        "\tcreateScaffoldValidatorToolkit,",
+        "\ttype ScaffoldValidatorToolkitOptions,",
+        "} from '@wp-typia/block-runtime/validation';",
+        "",
+        "interface TemplateValidatorToolkitOptions< T extends object > {",
+        "\tfinalize?: ScaffoldValidatorToolkitOptions< T >['finalize'];",
+        "\tmanifest: unknown;",
+        "\tonValidationError?: ScaffoldValidatorToolkitOptions< T >['onValidationError'];",
+        "}",
+        "",
+        "export function createTemplateValidatorToolkit< T extends object >( {",
+        "\tfinalize,",
+        "\tmanifest,",
+        "\tonValidationError,",
+        "}: TemplateValidatorToolkitOptions< T > ) {",
+        "\treturn createScaffoldValidatorToolkit< T >( {",
+        "\t\tmanifest: manifest as ManifestDefaultsDocument,",
+        "\t\tfinalize,",
+        "\t\tonValidationError,",
+        "\t} );",
+        "}",
+        "",
+      ].join("\n"),
+      "utf8"
+    );
+
+    fs.writeFileSync(
+      path.join(targetDir, "src", "blocks", "faq-stack", "validators.ts"),
+      [
+        '\uFEFFimport typia from "typia";',
+        'import currentManifest from "./typia.manifest.json";',
+        "import type {",
+        "\tFaqStackAttributes,",
+        '} from "./types";',
+        'import { createTemplateValidatorToolkit } from "../../validator-toolkit";',
+        "",
+        "const scaffoldValidators = createTemplateValidatorToolkit< FaqStackAttributes >( {",
+        "\tmanifest: currentManifest,",
+        "} );",
+        "",
+        "export const validateFaqStackAttributes =",
+        "\tscaffoldValidators.validateAttributes;",
+        "",
+        "export const validators = scaffoldValidators.validators;",
+        "",
+        "export const sanitizeFaqStackAttributes =",
+        "\tscaffoldValidators.sanitizeAttributes;",
+        "",
+        "export const createAttributeUpdater = scaffoldValidators.createAttributeUpdater;",
+        "",
+      ].join("\n"),
+      "utf8"
+    );
+
+    runCli(
+      "node",
+      [
+        entryPath,
+        "add",
+        "block",
+        "feature-grid",
+        "--template",
+        "compound",
+      ],
+      {
+        cwd: targetDir,
+      }
+    );
+
+    const repairedParentValidatorSource = fs.readFileSync(
+      path.join(targetDir, "src", "blocks", "faq-stack", "validators.ts"),
+      "utf8"
+    );
+    const typiaImportMatches = repairedParentValidatorSource.match(
+      /^[\uFEFF \t]*import typia from ['"]typia['"];/gmu
+    );
+
+    expect(typiaImportMatches).toHaveLength(1);
+    expect(repairedParentValidatorSource).toContain(
+      "assert: typia.createAssert< FaqStackAttributes >()"
+    );
+
+    typecheckGeneratedProject(targetDir);
+  }, 30_000);
+
   test("add compound block ignores a commented typia import during legacy validator repair", async () => {
     const targetDir = path.join(
       tempRoot,

--- a/packages/wp-typia-project-tools/tests/create-cli.test.ts
+++ b/packages/wp-typia-project-tools/tests/create-cli.test.ts
@@ -5256,14 +5256,148 @@ console.log(JSON.stringify({ initial, updated, reread }));
       path.join(targetDir, "src", "blocks", "faq-stack", "validators.ts"),
       "utf8"
     );
-    const typiaImportMatches = repairedParentValidatorSource.match(
-      /^[ \t]*import typia from ['"]typia['"];/gmu
-    );
+    const typiaImportMatches = repairedParentValidatorSource
+      .replace(/\/\*[\s\S]*?\*\//gu, "")
+      .match(/^[ \t]*import typia from ['"]typia['"];/gmu);
 
     expect(typiaImportMatches).toHaveLength(1);
     expect(repairedParentValidatorSource).toContain(
       '// import typia from "typia";'
     );
+    expect(repairedParentValidatorSource).toContain(
+      "assert: typia.createAssert< FaqStackAttributes >()"
+    );
+
+    typecheckGeneratedProject(targetDir);
+  }, 30_000);
+
+  test("add compound block ignores a block-commented typia import during legacy validator repair", async () => {
+    const targetDir = path.join(
+      tempRoot,
+      "demo-workspace-add-compound-legacy-validator-block-commented-typia-import"
+    );
+
+    await scaffoldProject({
+      projectDir: targetDir,
+      templateId: workspaceTemplatePackageManifest.name,
+      packageManager: "npm",
+      noInstall: true,
+      answers: {
+        author: "Test Runner",
+        description:
+          "Demo workspace add compound legacy validator block commented typia import",
+        namespace: "demo-space",
+        phpPrefix: "demo_space",
+        slug: "demo-workspace-add-compound-legacy-validator-block-commented-typia-import",
+        textDomain: "demo-space",
+        title:
+          "Demo Workspace Add Compound Legacy Validator Block Commented Typia Import",
+      },
+    });
+
+    linkWorkspaceNodeModules(targetDir);
+
+    runCli(
+      "node",
+      [
+        entryPath,
+        "add",
+        "block",
+        "faq-stack",
+        "--template",
+        "compound",
+      ],
+      {
+        cwd: targetDir,
+      }
+    );
+
+    fs.writeFileSync(
+      path.join(targetDir, "src", "validator-toolkit.ts"),
+      [
+        "import type { ManifestDefaultsDocument } from '@wp-typia/block-runtime/defaults';",
+        "import {",
+        "\tcreateScaffoldValidatorToolkit,",
+        "\ttype ScaffoldValidatorToolkitOptions,",
+        "} from '@wp-typia/block-runtime/validation';",
+        "",
+        "interface TemplateValidatorToolkitOptions< T extends object > {",
+        "\tfinalize?: ScaffoldValidatorToolkitOptions< T >['finalize'];",
+        "\tmanifest: unknown;",
+        "\tonValidationError?: ScaffoldValidatorToolkitOptions< T >['onValidationError'];",
+        "}",
+        "",
+        "export function createTemplateValidatorToolkit< T extends object >( {",
+        "\tfinalize,",
+        "\tmanifest,",
+        "\tonValidationError,",
+        "}: TemplateValidatorToolkitOptions< T > ) {",
+        "\treturn createScaffoldValidatorToolkit< T >( {",
+        "\t\tmanifest: manifest as ManifestDefaultsDocument,",
+        "\t\tfinalize,",
+        "\t\tonValidationError,",
+        "\t} );",
+        "}",
+        "",
+      ].join("\n"),
+      "utf8"
+    );
+
+    fs.writeFileSync(
+      path.join(targetDir, "src", "blocks", "faq-stack", "validators.ts"),
+      [
+        "/*",
+        'import typia from "typia";',
+        "*/",
+        'import currentManifest from "./typia.manifest.json";',
+        "import type {",
+        "\tFaqStackAttributes,",
+        '} from "./types";',
+        'import { createTemplateValidatorToolkit } from "../../validator-toolkit";',
+        "",
+        "const scaffoldValidators = createTemplateValidatorToolkit< FaqStackAttributes >( {",
+        "\tmanifest: currentManifest,",
+        "} );",
+        "",
+        "export const validateFaqStackAttributes =",
+        "\tscaffoldValidators.validateAttributes;",
+        "",
+        "export const validators = scaffoldValidators.validators;",
+        "",
+        "export const sanitizeFaqStackAttributes =",
+        "\tscaffoldValidators.sanitizeAttributes;",
+        "",
+        "export const createAttributeUpdater = scaffoldValidators.createAttributeUpdater;",
+        "",
+      ].join("\n"),
+      "utf8"
+    );
+
+    runCli(
+      "node",
+      [
+        entryPath,
+        "add",
+        "block",
+        "feature-grid",
+        "--template",
+        "compound",
+      ],
+      {
+        cwd: targetDir,
+      }
+    );
+
+    const repairedParentValidatorSource = fs.readFileSync(
+      path.join(targetDir, "src", "blocks", "faq-stack", "validators.ts"),
+      "utf8"
+    );
+    const typiaImportMatches = repairedParentValidatorSource
+      .replace(/\/\*[\s\S]*?\*\//gu, "")
+      .match(/^[ \t]*import typia from ['"]typia['"];/gmu);
+
+    expect(typiaImportMatches).toHaveLength(1);
+    expect(repairedParentValidatorSource).toContain("/*");
     expect(repairedParentValidatorSource).toContain(
       "assert: typia.createAssert< FaqStackAttributes >()"
     );


### PR DESCRIPTION
Follow-up to #196.

Fixes the legacy compound validator repair path so an existing `import typia from "typia";` is detected before prepending another import, and adds a regression test for the double-quoted import case.

Validation:
- bun test packages/wp-typia-project-tools/tests/create-cli.test.ts -t "add compound block repairs a legacy shared validator toolkit in an official workspace template"
- bun test packages/wp-typia-project-tools/tests/create-cli.test.ts -t "add compound block does not duplicate an existing typia import during legacy validator repair"
- bun run typecheck
- bun run changesets:validate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate typia imports when adding a compound block template.
  * Improved repair of legacy compound validator files in older workspaces.

* **Tests**
  * Added end-to-end tests ensuring a single typia import is produced and legacy validator repairs typecheck.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->