### PR TITLE
Fix post-merge typecheck regression in changeset validator

### DIFF
--- a/scripts/validate-sampo-changesets.d.mts
+++ b/scripts/validate-sampo-changesets.d.mts
@@ -25,6 +25,10 @@ export declare function parseChangesetFrontmatter(
 	source: string,
 	filePath?: string,
 ): ParsedChangesetEntry[];
+export declare function toPosixRelativePath(
+	repoRoot: string,
+	targetPath: string,
+): string;
 export declare function validateSampoChangesets(
 	repoRoot: string,
 ): SampoChangesetValidationResult;


### PR DESCRIPTION
This fixes the post-merge `main` typecheck regression caused by a missing declaration export for `toPosixRelativePath` in `scripts/validate-sampo-changesets.d.mts`.

Validation:
- bun run typecheck
- bun test tests/unit/sampo-changesets.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved path handling utilities in build scripts for enhanced cross-platform compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->