### PR TITLE
Harden alternate-buffer TUI exit handling

### DIFF
--- a/.sampo/changesets/issue-207-tui-exit-lifecycle.md
+++ b/.sampo/changesets/issue-207-tui-exit-lifecycle.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Fixed alternate-buffer TUI lifecycle handling so interactive create/add/migrate flows exit cleanly on submit, cancel, quit, lazy-load failure, and runtime command failure.

--- a/docs/bunli-cli-migration.md
+++ b/docs/bunli-cli-migration.md
@@ -40,6 +40,16 @@ to the canonical `create` surface in docs and review notes.
 - doctor checks
 - schema/OpenAPI project helpers
 
+## Alternate-buffer TUI exit contract
+
+- Commands that use Bunli `render` with `bufferMode: "alternate"` must have explicit
+  `runtime.exit()` ownership.
+- `packages/wp-typia/src/ui/lazy-flow.tsx` owns loader-stage failure and loading-stage quit behavior.
+- Mounted `create`, `add`, and `migrate` flows use a shared lifecycle helper for submit,
+  cancel, quit, and runtime failure handling.
+- Runtime failures are exit-on-failure: report the error, then exit instead of leaving the
+  form mounted in the alternate buffer.
+
 ## Canonical Bunli command tree
 
 - `create`

--- a/packages/wp-typia/src/ui/README.md
+++ b/packages/wp-typia/src/ui/README.md
@@ -15,3 +15,10 @@ Constraints:
   shell automation.
 - `@wp-typia/project-tools` remains the runtime library; these screens should only
   collect input and hand the resolved command state back to `wp-typia`.
+
+Alternate-buffer lifecycle contract:
+
+- `LazyFlow` owns pre-mount lifecycle safety for lazy loader failures and loading-time quit.
+- Mounted flows must use the shared alternate-buffer lifecycle helper instead of ad hoc exit logic.
+- `create`, `add`, and `migrate` must always call `runtime.exit()` on submit success, cancel, and quit.
+- Runtime execution failures use exit-on-failure: report the error, then exit immediately.

--- a/packages/wp-typia/src/ui/add-flow.tsx
+++ b/packages/wp-typia/src/ui/add-flow.tsx
@@ -1,11 +1,9 @@
-import { useState } from "react";
-
-import { useRuntime } from "@bunli/runtime/app";
-import { Alert, SchemaForm } from "@bunli/tui";
+import { SchemaForm } from "@bunli/tui";
 import { HOOKED_BLOCK_POSITION_IDS } from "@wp-typia/project-tools";
 import { z } from "zod";
 
 import { executeAddCommand } from "../runtime-bridge";
+import { useAlternateBufferLifecycle } from "./alternate-buffer-lifecycle";
 
 const addFlowSchema = z.object({
 	anchor: z.string().optional(),
@@ -41,16 +39,11 @@ const HOOKED_BLOCK_POSITION_DESCRIPTIONS: Record<
 };
 
 export function AddFlow({ cwd, initialValues, workspaceBlockOptions }: AddFlowProps) {
-	const runtime = useRuntime();
-	const [errorMessage, setErrorMessage] = useState<string | null>(null);
+	const { handleCancel, handleSubmit } = useAlternateBufferLifecycle("wp-typia add failed");
 
 	return (
-		<>
-			{errorMessage ? (
-				<Alert message={errorMessage} title="Add failed" tone="danger" />
-			) : null}
-			<SchemaForm
-				fields={[
+		<SchemaForm
+			fields={[
 					{
 						kind: "select",
 						label: "Kind",
@@ -195,25 +188,20 @@ export function AddFlow({ cwd, initialValues, workspaceBlockOptions }: AddFlowPr
 							(values.template === "persistence" || values.template === "compound"),
 					},
 				]}
-				initialValues={initialValues}
-				onCancel={() => runtime.exit()}
-				onSubmit={async (values) => {
-					try {
-						setErrorMessage(null);
+			initialValues={initialValues}
+			onCancel={handleCancel}
+			onSubmit={async (values) =>
+				handleSubmit(async () => {
 						await executeAddCommand({
 							cwd,
 							flags: values,
 							kind: values.kind,
 							name: values.name,
 						});
-						runtime.exit();
-					} catch (error) {
-						setErrorMessage(error instanceof Error ? error.message : String(error));
-					}
-				}}
-				schema={addFlowSchema}
-				title="Extend a wp-typia workspace"
-			/>
-		</>
+				})
+			}
+			schema={addFlowSchema}
+			title="Extend a wp-typia workspace"
+		/>
 	);
 }

--- a/packages/wp-typia/src/ui/alternate-buffer-lifecycle.ts
+++ b/packages/wp-typia/src/ui/alternate-buffer-lifecycle.ts
@@ -83,7 +83,7 @@ export function useAlternateBufferExitKeys(options: {
 	exit?: () => void;
 } = {}): void {
 	const runtime = useRuntime();
-	const exit = options.exit ?? runtime.exit;
+	const exit = options.exit ?? (() => runtime.exit());
 	const enabled = options.enabled ?? true;
 
 	useKeyboard((key: AlternateBufferKeyEvent) => {
@@ -108,25 +108,28 @@ export function useAlternateBufferLifecycle(
 	handleSubmit: (action: () => Promise<void>) => Promise<void>;
 } {
 	const runtime = useRuntime();
+	const exit = useCallback(() => {
+		runtime.exit();
+	}, [runtime]);
 
 	useAlternateBufferExitKeys({
 		enabled: options.enableExitKeys ?? true,
-		exit: runtime.exit,
+		exit,
 	});
 
 	const handleCancel = useCallback(() => {
-		runtime.exit();
-	}, [runtime]);
+		exit();
+	}, [exit]);
 
 	const handleFailure = useCallback(
 		(error: unknown) => {
 			reportAlternateBufferFailure({
 				context,
 				error,
-				exit: runtime.exit,
+				exit,
 			});
 		},
-		[context, runtime],
+		[context, exit],
 	);
 
 	const handleSubmit = useCallback(
@@ -134,10 +137,10 @@ export function useAlternateBufferLifecycle(
 			await runAlternateBufferAction({
 				action,
 				context,
-				exit: runtime.exit,
+				exit,
 			});
 		},
-		[context, runtime],
+		[context, exit],
 	);
 
 	return {

--- a/packages/wp-typia/src/ui/alternate-buffer-lifecycle.ts
+++ b/packages/wp-typia/src/ui/alternate-buffer-lifecycle.ts
@@ -37,8 +37,9 @@ export function reportAlternateBufferFailure({
 	exit,
 	log = console.error,
 }: AlternateBufferFailureOptions): void {
-	log(describeAlternateBufferFailure(context, error));
+	const message = describeAlternateBufferFailure(context, error);
 	exit();
+	log(message);
 }
 
 export async function runAlternateBufferAction({

--- a/packages/wp-typia/src/ui/alternate-buffer-lifecycle.ts
+++ b/packages/wp-typia/src/ui/alternate-buffer-lifecycle.ts
@@ -97,14 +97,22 @@ export function useAlternateBufferExitKeys(options: {
 	});
 }
 
-export function useAlternateBufferLifecycle(context: string): {
+export function useAlternateBufferLifecycle(
+	context: string,
+	options: {
+		enableExitKeys?: boolean;
+	} = {},
+): {
 	handleCancel: () => void;
 	handleFailure: (error: unknown) => void;
 	handleSubmit: (action: () => Promise<void>) => Promise<void>;
 } {
 	const runtime = useRuntime();
 
-	useAlternateBufferExitKeys({ exit: runtime.exit });
+	useAlternateBufferExitKeys({
+		enabled: options.enableExitKeys ?? true,
+		exit: runtime.exit,
+	});
 
 	const handleCancel = useCallback(() => {
 		runtime.exit();

--- a/packages/wp-typia/src/ui/alternate-buffer-lifecycle.ts
+++ b/packages/wp-typia/src/ui/alternate-buffer-lifecycle.ts
@@ -1,0 +1,140 @@
+import { useCallback } from "react";
+
+import { useRuntime } from "@bunli/runtime/app";
+import { useKeyboard } from "@bunli/tui";
+
+type AlternateBufferKeyEvent = {
+	ctrl?: boolean;
+	name?: string;
+};
+
+type AlternateBufferFailureOptions = {
+	context: string;
+	error: unknown;
+	exit: () => void;
+	log?: (message: string) => void;
+};
+
+type RunAlternateBufferActionOptions = {
+	action: () => Promise<void>;
+	context: string;
+	exit: () => void;
+	log?: (message: string) => void;
+};
+
+export function describeAlternateBufferFailure(context: string, error: unknown): string {
+	const message = error instanceof Error ? error.message : String(error);
+	return `${context}: ${message}`;
+}
+
+export function isAlternateBufferExitKey(key: AlternateBufferKeyEvent): boolean {
+	return key.name === "q" || (key.ctrl === true && key.name === "c");
+}
+
+export function reportAlternateBufferFailure({
+	context,
+	error,
+	exit,
+	log = console.error,
+}: AlternateBufferFailureOptions): void {
+	log(describeAlternateBufferFailure(context, error));
+	exit();
+}
+
+export async function runAlternateBufferAction({
+	action,
+	context,
+	exit,
+	log = console.error,
+}: RunAlternateBufferActionOptions): Promise<void> {
+	try {
+		await action();
+		exit();
+	} catch (error) {
+		reportAlternateBufferFailure({ context, error, exit, log });
+	}
+}
+
+export async function resolveLazyFlowComponent<TProps>({
+	loader,
+	onLoaded,
+	onFailure,
+	isDisposed,
+}: {
+	loader: () => Promise<{ default: React.ComponentType<TProps> }>;
+	onLoaded: (component: React.ComponentType<TProps>) => void;
+	onFailure: (error: unknown) => void;
+	isDisposed: () => boolean;
+}): Promise<void> {
+	try {
+		const module = await loader();
+		if (!isDisposed()) {
+			onLoaded(module.default);
+		}
+	} catch (error) {
+		if (!isDisposed()) {
+			onFailure(error);
+		}
+	}
+}
+
+export function useAlternateBufferExitKeys(options: {
+	enabled?: boolean;
+	exit?: () => void;
+} = {}): void {
+	const runtime = useRuntime();
+	const exit = options.exit ?? runtime.exit;
+	const enabled = options.enabled ?? true;
+
+	useKeyboard((key: AlternateBufferKeyEvent) => {
+		if (!enabled) {
+			return;
+		}
+
+		if (isAlternateBufferExitKey(key)) {
+			exit();
+		}
+	});
+}
+
+export function useAlternateBufferLifecycle(context: string): {
+	handleCancel: () => void;
+	handleFailure: (error: unknown) => void;
+	handleSubmit: (action: () => Promise<void>) => Promise<void>;
+} {
+	const runtime = useRuntime();
+
+	useAlternateBufferExitKeys({ exit: runtime.exit });
+
+	const handleCancel = useCallback(() => {
+		runtime.exit();
+	}, [runtime]);
+
+	const handleFailure = useCallback(
+		(error: unknown) => {
+			reportAlternateBufferFailure({
+				context,
+				error,
+				exit: runtime.exit,
+			});
+		},
+		[context, runtime],
+	);
+
+	const handleSubmit = useCallback(
+		async (action: () => Promise<void>) => {
+			await runAlternateBufferAction({
+				action,
+				context,
+				exit: runtime.exit,
+			});
+		},
+		[context, runtime],
+	);
+
+	return {
+		handleCancel,
+		handleFailure,
+		handleSubmit,
+	};
+}

--- a/packages/wp-typia/src/ui/create-flow.tsx
+++ b/packages/wp-typia/src/ui/create-flow.tsx
@@ -1,10 +1,8 @@
-import { useState } from "react";
-
-import { useRuntime } from "@bunli/runtime/app";
-import { Alert, SchemaForm } from "@bunli/tui";
+import { SchemaForm } from "@bunli/tui";
 import { z } from "zod";
 
 import { executeCreateCommand } from "../runtime-bridge";
+import { useAlternateBufferLifecycle } from "./alternate-buffer-lifecycle";
 
 const createFlowSchema = z.object({
 	"data-storage": z.string().optional(),
@@ -31,8 +29,7 @@ type CreateFlowProps = {
 };
 
 export function CreateFlow({ cwd, initialValues }: CreateFlowProps) {
-	const runtime = useRuntime();
-	const [errorMessage, setErrorMessage] = useState<string | null>(null);
+	const { handleCancel, handleSubmit } = useAlternateBufferLifecycle("wp-typia create failed");
 	const defaultPrompt = {
 		close() {},
 		select<T extends string>(_message: string, options: Array<{ value: T }>, defaultValue = 1) {
@@ -45,16 +42,8 @@ export function CreateFlow({ cwd, initialValues }: CreateFlowProps) {
 	};
 
 	return (
-		<>
-			{errorMessage ? (
-				<Alert
-					message={errorMessage}
-					title="Create failed"
-					tone="danger"
-				/>
-			) : null}
-			<SchemaForm
-				fields={[
+		<SchemaForm
+			fields={[
 					{ kind: "text", label: "Project directory", name: "project-dir", required: true },
 					{
 						kind: "select",
@@ -146,11 +135,10 @@ export function CreateFlow({ cwd, initialValues }: CreateFlowProps) {
 						name: "with-migration-ui",
 					},
 				]}
-				initialValues={initialValues}
-				onCancel={() => runtime.exit()}
-				onSubmit={async (values) => {
-					try {
-						setErrorMessage(null);
+			initialValues={initialValues}
+			onCancel={handleCancel}
+			onSubmit={async (values) =>
+				handleSubmit(async () => {
 						await executeCreateCommand({
 							cwd,
 							flags: values,
@@ -158,14 +146,10 @@ export function CreateFlow({ cwd, initialValues }: CreateFlowProps) {
 							projectDir: values["project-dir"],
 							prompt: defaultPrompt,
 						});
-						runtime.exit();
-					} catch (error) {
-						setErrorMessage(error instanceof Error ? error.message : String(error));
-					}
-				}}
-				schema={createFlowSchema}
-				title="Create a wp-typia project"
-			/>
-		</>
+				})
+			}
+			schema={createFlowSchema}
+			title="Create a wp-typia project"
+		/>
 	);
 }

--- a/packages/wp-typia/src/ui/lazy-flow.tsx
+++ b/packages/wp-typia/src/ui/lazy-flow.tsx
@@ -1,5 +1,11 @@
 import { createElement, useEffect, useState, type ComponentType } from "react";
 
+import {
+	resolveLazyFlowComponent,
+	useAlternateBufferExitKeys,
+	useAlternateBufferLifecycle,
+} from "./alternate-buffer-lifecycle";
+
 type LazyFlowProps<TProps> = {
 	loader: () => Promise<{ default: ComponentType<TProps> }>;
 	props: TProps;
@@ -7,31 +13,28 @@ type LazyFlowProps<TProps> = {
 
 export function LazyFlow<TProps>({ loader, props }: LazyFlowProps<TProps>) {
 	const [Component, setComponent] = useState<ComponentType<TProps> | null>(null);
-	const [errorMessage, setErrorMessage] = useState<string | null>(null);
+	const { handleFailure } = useAlternateBufferLifecycle("wp-typia TUI flow failed");
+
+	useAlternateBufferExitKeys({
+		enabled: Component === null,
+	});
 
 	useEffect(() => {
 		let disposed = false;
 
-		void loader()
-			.then((module) => {
-				if (!disposed) {
-					setComponent(() => module.default);
-				}
-			})
-			.catch((error) => {
-				if (!disposed) {
-					setErrorMessage(error instanceof Error ? error.message : String(error));
-				}
-			});
+		void resolveLazyFlowComponent({
+			isDisposed: () => disposed,
+			loader,
+			onFailure: handleFailure,
+			onLoaded: (component) => {
+				setComponent(() => component);
+			},
+		});
 
 		return () => {
 			disposed = true;
 		};
-	}, [loader]);
-
-	if (errorMessage) {
-		return errorMessage;
-	}
+	}, [handleFailure, loader]);
 
 	if (!Component) {
 		return null;

--- a/packages/wp-typia/src/ui/lazy-flow.tsx
+++ b/packages/wp-typia/src/ui/lazy-flow.tsx
@@ -13,7 +13,9 @@ type LazyFlowProps<TProps> = {
 
 export function LazyFlow<TProps>({ loader, props }: LazyFlowProps<TProps>) {
 	const [Component, setComponent] = useState<ComponentType<TProps> | null>(null);
-	const { handleFailure } = useAlternateBufferLifecycle("wp-typia TUI flow failed");
+	const { handleFailure } = useAlternateBufferLifecycle("wp-typia TUI flow failed", {
+		enableExitKeys: false,
+	});
 
 	useAlternateBufferExitKeys({
 		enabled: Component === null,

--- a/packages/wp-typia/src/ui/migrate-flow.tsx
+++ b/packages/wp-typia/src/ui/migrate-flow.tsx
@@ -1,10 +1,8 @@
-import { useState } from "react";
-
-import { useRuntime } from "@bunli/runtime/app";
-import { Alert, SchemaForm } from "@bunli/tui";
+import { SchemaForm } from "@bunli/tui";
 import { z } from "zod";
 
 import { executeMigrateCommand } from "../runtime-bridge";
+import { useAlternateBufferLifecycle } from "./alternate-buffer-lifecycle";
 
 const migrateFlowSchema = z.object({
 	all: z.boolean().default(false),
@@ -48,16 +46,11 @@ function sanitizeMigrateValues(values: MigrateFlowValues): Record<string, unknow
 }
 
 export function MigrateFlow({ cwd, initialValues }: MigrateFlowProps) {
-	const runtime = useRuntime();
-	const [errorMessage, setErrorMessage] = useState<string | null>(null);
+	const { handleCancel, handleSubmit } = useAlternateBufferLifecycle("wp-typia migrate failed");
 
 	return (
-		<>
-			{errorMessage ? (
-				<Alert message={errorMessage} title="Migrate failed" tone="danger" />
-			) : null}
-			<SchemaForm
-				fields={[
+		<SchemaForm
+			fields={[
 					{
 						kind: "select",
 						label: "Migration command",
@@ -164,24 +157,19 @@ export function MigrateFlow({ cwd, initialValues }: MigrateFlowProps) {
 						visibleWhen: (values) => values.command === "fuzz",
 					},
 				]}
-				initialValues={initialValues}
-				onCancel={() => runtime.exit()}
-				onSubmit={async (values) => {
-					try {
-						setErrorMessage(null);
+			initialValues={initialValues}
+			onCancel={handleCancel}
+			onSubmit={async (values) =>
+				handleSubmit(async () => {
 						await executeMigrateCommand({
 							command: values.command,
 							cwd,
 							flags: sanitizeMigrateValues(values),
 						});
-						runtime.exit();
-					} catch (error) {
-						setErrorMessage(error instanceof Error ? error.message : String(error));
-					}
-				}}
-				schema={migrateFlowSchema}
-				title="Run wp-typia migration workflows"
-			/>
-		</>
+				})
+			}
+			schema={migrateFlowSchema}
+			title="Run wp-typia migration workflows"
+		/>
 	);
 }

--- a/packages/wp-typia/tests/tui-lifecycle.test.ts
+++ b/packages/wp-typia/tests/tui-lifecycle.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from "bun:test";
+
+import { addCommand } from "../src/commands/add";
+import { createCommand } from "../src/commands/create";
+import { migrateCommand } from "../src/commands/migrate";
+import {
+	describeAlternateBufferFailure,
+	isAlternateBufferExitKey,
+	reportAlternateBufferFailure,
+	resolveLazyFlowComponent,
+	runAlternateBufferAction,
+} from "../src/ui/alternate-buffer-lifecycle";
+
+describe("alternate-buffer TUI lifecycle", () => {
+	test("matches the shared quit keys", () => {
+		expect(isAlternateBufferExitKey({ name: "q" })).toBe(true);
+		expect(isAlternateBufferExitKey({ ctrl: true, name: "c" })).toBe(true);
+		expect(isAlternateBufferExitKey({ name: "escape" })).toBe(false);
+		expect(isAlternateBufferExitKey({ ctrl: true, name: "x" })).toBe(false);
+	});
+
+	test("describes failures with context", () => {
+		expect(describeAlternateBufferFailure("wp-typia create failed", new Error("boom"))).toBe(
+			"wp-typia create failed: boom",
+		);
+		expect(describeAlternateBufferFailure("wp-typia add failed", "plain")).toBe(
+			"wp-typia add failed: plain",
+		);
+	});
+
+	test("reports failures and exits immediately", () => {
+		const messages: string[] = [];
+		let exited = 0;
+
+		reportAlternateBufferFailure({
+			context: "wp-typia migrate failed",
+			error: new Error("bad state"),
+			exit: () => {
+				exited += 1;
+			},
+			log: (message) => {
+				messages.push(message);
+			},
+		});
+
+		expect(messages).toEqual(["wp-typia migrate failed: bad state"]);
+		expect(exited).toBe(1);
+	});
+
+	test("run helper exits after success", async () => {
+		const messages: string[] = [];
+		let exited = 0;
+
+		await runAlternateBufferAction({
+			action: async () => {},
+			context: "wp-typia create failed",
+			exit: () => {
+				exited += 1;
+			},
+			log: (message) => {
+				messages.push(message);
+			},
+		});
+
+		expect(messages).toEqual([]);
+		expect(exited).toBe(1);
+	});
+
+	test("run helper reports failure and exits", async () => {
+		const messages: string[] = [];
+		let exited = 0;
+
+		await runAlternateBufferAction({
+			action: async () => {
+				throw new Error("command exploded");
+			},
+			context: "wp-typia add failed",
+			exit: () => {
+				exited += 1;
+			},
+			log: (message) => {
+				messages.push(message);
+			},
+		});
+
+		expect(messages).toEqual(["wp-typia add failed: command exploded"]);
+		expect(exited).toBe(1);
+	});
+
+	test("lazy-flow loader resolves the component when still mounted", async () => {
+		let loaded = false;
+		let failed = false;
+
+		await resolveLazyFlowComponent({
+			isDisposed: () => false,
+			loader: async () => ({
+				default: () => null,
+			}),
+			onFailure: () => {
+				failed = true;
+			},
+			onLoaded: () => {
+				loaded = true;
+			},
+		});
+
+		expect(loaded).toBe(true);
+		expect(failed).toBe(false);
+	});
+
+	test("lazy-flow loader reports failures while mounted", async () => {
+		let loaded = false;
+		let failure: unknown;
+
+		await resolveLazyFlowComponent({
+			isDisposed: () => false,
+			loader: async () => {
+				throw new Error("lazy import failed");
+			},
+			onFailure: (error) => {
+				failure = error;
+			},
+			onLoaded: () => {
+				loaded = true;
+			},
+		});
+
+		expect(loaded).toBe(false);
+		expect(failure).toBeInstanceOf(Error);
+		expect((failure as Error).message).toBe("lazy import failed");
+	});
+
+	test("lazy-flow loader stays silent after disposal", async () => {
+		let loaded = false;
+		let failed = false;
+
+		await resolveLazyFlowComponent({
+			isDisposed: () => true,
+			loader: async () => {
+				throw new Error("lazy import failed");
+			},
+			onFailure: () => {
+				failed = true;
+			},
+			onLoaded: () => {
+				loaded = true;
+			},
+		});
+
+		expect(loaded).toBe(false);
+		expect(failed).toBe(false);
+	});
+
+	test("interactive commands keep alternate-buffer rendering enabled", () => {
+		expect(createCommand.tui?.renderer?.bufferMode).toBe("alternate");
+		expect(addCommand.tui?.renderer?.bufferMode).toBe("alternate");
+		expect(migrateCommand.tui?.renderer?.bufferMode).toBe("alternate");
+		expect(typeof createCommand.render).toBe("function");
+		expect(typeof addCommand.render).toBe("function");
+		expect(typeof migrateCommand.render).toBe("function");
+	});
+});

--- a/packages/wp-typia/tests/tui-lifecycle.test.ts
+++ b/packages/wp-typia/tests/tui-lifecycle.test.ts
@@ -47,7 +47,7 @@ describe("alternate-buffer TUI lifecycle", () => {
 		});
 
 		expect(messages).toEqual(["wp-typia migrate failed: bad state"]);
-		expect(events).toEqual(["log", "exit"]);
+		expect(events).toEqual(["exit", "log"]);
 		expect(exited).toBe(1);
 	});
 

--- a/packages/wp-typia/tests/tui-lifecycle.test.ts
+++ b/packages/wp-typia/tests/tui-lifecycle.test.ts
@@ -30,29 +30,36 @@ describe("alternate-buffer TUI lifecycle", () => {
 
 	test("reports failures and exits immediately", () => {
 		const messages: string[] = [];
+		const events: string[] = [];
 		let exited = 0;
 
 		reportAlternateBufferFailure({
 			context: "wp-typia migrate failed",
 			error: new Error("bad state"),
 			exit: () => {
+				events.push("exit");
 				exited += 1;
 			},
 			log: (message) => {
+				events.push("log");
 				messages.push(message);
 			},
 		});
 
 		expect(messages).toEqual(["wp-typia migrate failed: bad state"]);
+		expect(events).toEqual(["log", "exit"]);
 		expect(exited).toBe(1);
 	});
 
 	test("run helper exits after success", async () => {
 		const messages: string[] = [];
 		let exited = 0;
+		let ran = false;
 
 		await runAlternateBufferAction({
-			action: async () => {},
+			action: async () => {
+				ran = true;
+			},
 			context: "wp-typia create failed",
 			exit: () => {
 				exited += 1;
@@ -62,6 +69,7 @@ describe("alternate-buffer TUI lifecycle", () => {
 			},
 		});
 
+		expect(ran).toBe(true);
 		expect(messages).toEqual([]);
 		expect(exited).toBe(1);
 	});


### PR DESCRIPTION
## Summary
- add a shared alternate-buffer lifecycle helper for create/add/migrate TUI flows
- move lazy loader failures and runtime command failures to exit-on-failure behavior
- add lifecycle regression coverage and document the Bunli exit contract

Closes #207

## Validation
- `bun test packages/wp-typia/tests/tui-lifecycle.test.ts`
- `bun run changesets:validate`
- `bun run typecheck`
- `bun test packages/wp-typia/tests/*.test.ts`
- `bun run publish:validate`
- `bun run build`
- `bun run test`
- `bun run lint:repo`
- manual PTY smoke: `bun src/cli.ts create` then `q` clean exit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Interactive create, add, and migrate workflows now exit cleanly on submit, cancel, quit, lazy-load failure, and runtime failures; forms no longer remain mounted showing inline error UI.

* **Documentation**
  * Added an “alternate-buffer TUI exit contract” detailing lifecycle and explicit exit requirements for TUI flows.

* **Tests**
  * Added tests validating exit keys, failure reporting, lazy-load behavior, and lifecycle action semantics.

* **Chores**
  * Added a changeset entry for a patch release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->