### PR TITLE
Normalize the workspace template alias before npm resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,7 +253,7 @@ jobs:
             add_variation_name: hero-card
             add_variation_block: counter-card
           - runtime: node
-            template: "@wp-typia/create-workspace-template"
+            template: "workspace"
             package_manager: npm
             project_name: smoke-workspace-add-pattern-npm
             add_pattern_name: hero-layout

--- a/.sampo/changesets/issue-212-workspace-template-alias.md
+++ b/.sampo/changesets/issue-212-workspace-template-alias.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Fix `wp-typia create --template workspace` to normalize the shorthand alias before npm template resolution.

--- a/packages/wp-typia-project-tools/src/runtime/cli-help.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-help.ts
@@ -35,7 +35,7 @@ Package managers: ${PACKAGE_MANAGER_IDS.join(", ")}
 Notes:
   \`wp-typia create\` is the canonical scaffold command.
   \`wp-typia <project-dir>\` remains a backward-compatible alias to \`create\`.
-  Use \`--template @wp-typia/create-workspace-template\` for the official empty workspace scaffold behind \`wp-typia add ...\`.
+  Use \`--template workspace\` as shorthand for \`@wp-typia/create-workspace-template\`, the official empty workspace scaffold behind \`wp-typia add ...\`.
   \`add variation\` uses an existing workspace block from \`scripts/block-config.ts\`.
   \`add pattern\` scaffolds a namespaced PHP pattern shell under \`src/patterns/\`.
   \`add binding-source\` scaffolds shared PHP and editor registration under \`src/bindings/\`.

--- a/packages/wp-typia-project-tools/src/runtime/scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold.ts
@@ -60,6 +60,7 @@ const BLOCK_SLUG_PATTERN = /^[a-z][a-z0-9-]*$/;
 const PHP_PREFIX_PATTERN = /^[a-z_][a-z0-9_]*$/;
 const PHP_PREFIX_MAX_LENGTH = 50;
 const OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE = "@wp-typia/create-workspace-template";
+const WORKSPACE_TEMPLATE_ALIAS = "workspace";
 const EPHEMERAL_NODE_MODULES_LINK_TYPE = process.platform === "win32" ? "junction" : "dir";
 const LOCKFILES: Record<PackageManagerId, string[]> = {
 	bun: ["bun.lock", "bun.lockb"],
@@ -391,6 +392,9 @@ export async function resolveTemplateId({
 	selectTemplate,
 }: ResolveTemplateOptions): Promise<string> {
 	if (templateId) {
+		if (templateId === WORKSPACE_TEMPLATE_ALIAS) {
+			return OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE;
+		}
 		if (isRemovedBuiltInTemplateId(templateId)) {
 			throw new Error(getRemovedBuiltInTemplateMessage(templateId));
 		}
@@ -1052,16 +1056,19 @@ export async function scaffoldProject({
 	withTestPreset = false,
 	withWpEnv = false,
 }: ScaffoldProjectOptions): Promise<ScaffoldProjectResult> {
+	const resolvedTemplateId = templateId === WORKSPACE_TEMPLATE_ALIAS
+		? OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE
+		: templateId;
 	const resolvedPackageManager = getPackageManager(packageManager).id;
-	const isBuiltInTemplate = isBuiltInTemplateId(templateId);
+	const isBuiltInTemplate = isBuiltInTemplateId(resolvedTemplateId);
 
-	const variables = getTemplateVariables(templateId, {
+	const variables = getTemplateVariables(resolvedTemplateId, {
 		...answers,
 		dataStorageMode: dataStorageMode ?? answers.dataStorageMode,
 		persistencePolicy: persistencePolicy ?? answers.persistencePolicy,
 	});
 	const templateSource = await resolveTemplateSource(
-		templateId,
+		resolvedTemplateId,
 		cwd,
 		variables,
 		variant,
@@ -1088,8 +1095,8 @@ export async function scaffoldProject({
 	}
 	const isOfficialWorkspace = isOfficialWorkspaceProject(projectDir);
 	if (isBuiltInTemplate) {
-		await writeStarterManifestFiles(projectDir, templateId, variables);
-		await seedBuiltInPersistenceArtifacts(projectDir, templateId, variables);
+		await writeStarterManifestFiles(projectDir, resolvedTemplateId, variables);
+		await seedBuiltInPersistenceArtifacts(projectDir, resolvedTemplateId, variables);
 		await applyLocalDevPresetFiles({
 			projectDir,
 			variables,
@@ -1100,7 +1107,7 @@ export async function scaffoldProject({
 			await applyMigrationUiCapability({
 				packageManager: resolvedPackageManager,
 				projectDir,
-				templateId,
+				templateId: resolvedTemplateId,
 				variables,
 			});
 		}
@@ -1111,7 +1118,7 @@ export async function scaffoldProject({
 	if (!fs.existsSync(readmePath)) {
 		await fsp.writeFile(
 			readmePath,
-			buildReadme(templateId, variables, resolvedPackageManager, {
+			buildReadme(resolvedTemplateId, variables, resolvedPackageManager, {
 				withMigrationUi:
 					isBuiltInTemplate || isOfficialWorkspace ? withMigrationUi : false,
 				withTestPreset: isBuiltInTemplate ? withTestPreset : false,
@@ -1135,7 +1142,7 @@ export async function scaffoldProject({
 			compoundPersistenceEnabled: variables.compoundPersistenceEnabled === "true",
 			packageManager: resolvedPackageManager,
 			projectDir,
-			templateId,
+			templateId: resolvedTemplateId,
 			withTestPreset,
 			withWpEnv,
 		});
@@ -1155,7 +1162,7 @@ export async function scaffoldProject({
 	return {
 		projectDir,
 		selectedVariant: templateSource.selectedVariant ?? null,
-		templateId,
+		templateId: resolvedTemplateId,
 		packageManager: resolvedPackageManager,
 		variables,
 		warnings: templateSource.warnings ?? [],

--- a/packages/wp-typia-project-tools/src/runtime/scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold.ts
@@ -385,6 +385,12 @@ export function getDefaultAnswers(
 	};
 }
 
+function normalizeTemplateSelection(templateId: string): string {
+	return templateId === WORKSPACE_TEMPLATE_ALIAS
+		? OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE
+		: templateId;
+}
+
 export async function resolveTemplateId({
 	templateId,
 	yes = false,
@@ -392,16 +398,14 @@ export async function resolveTemplateId({
 	selectTemplate,
 }: ResolveTemplateOptions): Promise<string> {
 	if (templateId) {
-		if (templateId === WORKSPACE_TEMPLATE_ALIAS) {
-			return OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE;
-		}
+		const normalizedTemplateId = normalizeTemplateSelection(templateId);
 		if (isRemovedBuiltInTemplateId(templateId)) {
 			throw new Error(getRemovedBuiltInTemplateMessage(templateId));
 		}
-		if (isBuiltInTemplateId(templateId)) {
-			return getTemplateById(templateId).id;
+		if (isBuiltInTemplateId(normalizedTemplateId)) {
+			return getTemplateById(normalizedTemplateId).id;
 		}
-		return templateId;
+		return normalizedTemplateId;
 	}
 
 	if (yes) {
@@ -414,7 +418,7 @@ export async function resolveTemplateId({
 		);
 	}
 
-	return selectTemplate();
+	return normalizeTemplateSelection(await selectTemplate());
 }
 
 export async function resolvePackageManagerId({
@@ -1056,9 +1060,7 @@ export async function scaffoldProject({
 	withTestPreset = false,
 	withWpEnv = false,
 }: ScaffoldProjectOptions): Promise<ScaffoldProjectResult> {
-	const resolvedTemplateId = templateId === WORKSPACE_TEMPLATE_ALIAS
-		? OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE
-		: templateId;
+	const resolvedTemplateId = normalizeTemplateSelection(templateId);
 	const resolvedPackageManager = getPackageManager(packageManager).id;
 	const isBuiltInTemplate = isBuiltInTemplateId(resolvedTemplateId);
 

--- a/packages/wp-typia-project-tools/tests/create-cli.test.ts
+++ b/packages/wp-typia-project-tools/tests/create-cli.test.ts
@@ -15,7 +15,10 @@ import {
   getOptionalOnboarding,
   runScaffoldFlow,
 } from "../src/runtime/cli-core.js";
-import { collectScaffoldAnswers } from "../src/runtime/scaffold.js";
+import {
+  collectScaffoldAnswers,
+  resolveTemplateId,
+} from "../src/runtime/scaffold.js";
 import { copyRenderedDirectory } from "../src/runtime/template-render.js";
 import {
   parseGitHubTemplateLocator,
@@ -3944,6 +3947,8 @@ console.log(JSON.stringify({ initial, updated, reread }));
     expect(externalPathLine).not.toContain("--with-migration-ui");
     expect(externalPackageLine).toBeDefined();
     expect(externalPackageLine).not.toContain("--with-migration-ui");
+    expect(helpText).toContain("--template workspace");
+    expect(helpText).toContain("@wp-typia/create-workspace-template");
   });
 
   test("cli-core barrel preserves doctor helper exports", () => {
@@ -7083,6 +7088,53 @@ export const BINDING_SOURCES: WorkspaceBindingSourceConfig[] = [
       raw: "@scope/template-package@^1.2.0",
       rawSpec: "^1.2.0",
       type: "range",
+    });
+  });
+
+  test("normalizes the workspace template alias to the official package id", async () => {
+    await expect(
+      resolveTemplateId({
+        templateId: "workspace",
+      })
+    ).resolves.toBe("@wp-typia/create-workspace-template");
+
+    await expect(
+      resolveTemplateId({
+        templateId: "@wp-typia/create-workspace-template",
+      })
+    ).resolves.toBe("@wp-typia/create-workspace-template");
+  });
+
+  test("workspace alias scaffolds through the official local template resolver", async () => {
+    const targetDir = path.join(tempRoot, "demo-workspace-template-alias");
+
+    const result = await scaffoldProject({
+      projectDir: targetDir,
+      templateId: "workspace",
+      packageManager: "npm",
+      noInstall: true,
+      answers: {
+        author: "Test Runner",
+        description: "Demo empty workspace alias",
+        namespace: "demo-space",
+        phpPrefix: "demo_space",
+        slug: "demo-workspace-template-alias",
+        textDomain: "demo-space",
+        title: "Demo Workspace Template Alias",
+      },
+    });
+
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(targetDir, "package.json"), "utf8")
+    );
+
+    expect(result.templateId).toBe("@wp-typia/create-workspace-template");
+    expect(packageJson.wpTypia).toEqual({
+      projectType: "workspace",
+      templatePackage: "@wp-typia/create-workspace-template",
+      namespace: "demo-space",
+      textDomain: "demo-space",
+      phpPrefix: "demo_space",
     });
   });
 

--- a/packages/wp-typia-project-tools/tests/create-cli.test.ts
+++ b/packages/wp-typia-project-tools/tests/create-cli.test.ts
@@ -7096,13 +7096,20 @@ export const BINDING_SOURCES: WorkspaceBindingSourceConfig[] = [
       resolveTemplateId({
         templateId: "workspace",
       })
-    ).resolves.toBe("@wp-typia/create-workspace-template");
+    ).resolves.toBe(workspaceTemplatePackageManifest.name);
 
     await expect(
       resolveTemplateId({
-        templateId: "@wp-typia/create-workspace-template",
+        templateId: workspaceTemplatePackageManifest.name,
       })
-    ).resolves.toBe("@wp-typia/create-workspace-template");
+    ).resolves.toBe(workspaceTemplatePackageManifest.name);
+
+    await expect(
+      resolveTemplateId({
+        isInteractive: true,
+        selectTemplate: async () => "workspace",
+      })
+    ).resolves.toBe(workspaceTemplatePackageManifest.name);
   });
 
   test("workspace alias scaffolds through the official local template resolver", async () => {
@@ -7128,10 +7135,10 @@ export const BINDING_SOURCES: WorkspaceBindingSourceConfig[] = [
       fs.readFileSync(path.join(targetDir, "package.json"), "utf8")
     );
 
-    expect(result.templateId).toBe("@wp-typia/create-workspace-template");
+    expect(result.templateId).toBe(workspaceTemplatePackageManifest.name);
     expect(packageJson.wpTypia).toEqual({
       projectType: "workspace",
-      templatePackage: "@wp-typia/create-workspace-template",
+      templatePackage: workspaceTemplatePackageManifest.name,
       namespace: "demo-space",
       textDomain: "demo-space",
       phpPrefix: "demo_space",

--- a/packages/wp-typia/src/ui/create-flow.tsx
+++ b/packages/wp-typia/src/ui/create-flow.tsx
@@ -67,9 +67,9 @@ export function CreateFlow({ cwd, initialValues }: CreateFlowProps) {
 								value: "compound",
 							},
 							{
-								name: "@wp-typia/create-workspace-template",
+								name: "workspace",
 								description: "Official empty workspace template",
-								value: "@wp-typia/create-workspace-template",
+								value: "workspace",
 							},
 						],
 					},

--- a/scripts/run-generated-project-smoke.mjs
+++ b/scripts/run-generated-project-smoke.mjs
@@ -723,6 +723,14 @@ function assertWorkspaceTemplateScaffold(projectDir) {
 	}
 }
 
+function isWorkspaceTemplateRequest(template, packageJson) {
+	return (
+		template === "workspace" ||
+		template === "@wp-typia/create-workspace-template" ||
+		packageJson.wpTypia?.projectType === "workspace"
+	);
+}
+
 function assertWorkspaceBlockArtifacts(projectDir, blockSlugs) {
 	for (const slug of blockSlugs) {
 		const blockDir = path.join(projectDir, "build", "blocks", slug);
@@ -1030,7 +1038,7 @@ function main() {
 			);
 		}
 
-		if (template === "@wp-typia/create-workspace-template") {
+		if (isWorkspaceTemplateRequest(template, packageJson)) {
 			runLocalDoctor(projectDir, runtime);
 		}
 
@@ -1041,7 +1049,7 @@ function main() {
 		const [buildCommand, buildArgs] = getRunCommand(packageManager);
 		run(buildCommand, buildArgs, { cwd: projectDir });
 
-		if (template === "@wp-typia/create-workspace-template") {
+		if (isWorkspaceTemplateRequest(template, packageJson)) {
 			assertWorkspaceTemplateScaffold(projectDir);
 			assertWorkspaceBlockArtifacts(
 				projectDir,


### PR DESCRIPTION
Closes #212

## Summary
- normalize `--template workspace` to the official workspace template package before npm resolution
- keep canonical template listing/inspect surfaces unchanged
- add regression coverage for the alias path and route one CI workspace smoke through it

## Validation
- `node packages/wp-typia/bin/wp-typia.js create "$(mktemp -d /tmp/wp-typia-212-check2-XXXXXX)/demo-ws" -t workspace --namespace test-ns --package-manager npm --no-install -y`
- `bun test packages/wp-typia-project-tools/tests/create-cli.test.ts --test-name-pattern 'workspace alias scaffolds through the official local template resolver|workspace template alias|formatHelpText keeps migration UI flags out of external template usage'`\n- `bun run typecheck`\n- `bun run changesets:validate`\n- `bun run publish:validate`\n- `bun run test`\n- `bun run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `workspace` shorthand that resolves to the official empty workspace scaffold.

* **Documentation**
  * Updated CLI help to document the `--template workspace` shorthand.

* **Tests**
  * Added tests validating alias normalization and scaffold output when using `workspace`.

* **Chores**
  * CI/smoke tooling updated to treat the workspace alias as the official workspace scaffold.
  * Added a changeset to record the patch fixing the alias normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->