### PR TITLE
Fix persistence scaffold bootstrap typing and storage mode handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,9 +235,10 @@ jobs:
             project_name: smoke-compound-authenticated-bun
           - runtime: node
             template: compound
+            data_storage: post-meta
             persistence_policy: public
             package_manager: npm
-            project_name: smoke-compound-public-npm
+            project_name: smoke-compound-public-post-meta-npm
           - runtime: node
             template: ./packages/wp-typia-project-tools/tests/fixtures/create-block-external
             variant: hero

--- a/.sampo/changesets/issue-213-persistence-scaffold-regressions.md
+++ b/.sampo/changesets/issue-213-persistence-scaffold-regressions.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Fix persistence scaffold regressions in authenticated bootstrap typing and generated PHP storage-mode handling.

--- a/packages/wp-typia-project-tools/templates/_shared/compound/persistence-auth/{{slugKebabCase}}.php.mustache
+++ b/packages/wp-typia-project-tools/templates/_shared/compound/persistence-auth/{{slugKebabCase}}.php.mustache
@@ -79,7 +79,7 @@ function {{phpPrefix}}_with_counter_lock( $post_id, $resource_key, $callback ) {
 }
 
 function {{phpPrefix}}_maybe_install_storage() {
-	if ( 'custom-table' !== '{{dataStorageMode}}' ) {
+	if ( 'custom-table' !== {{phpPrefixUpper}}_DATA_STORAGE_MODE ) {
 		return;
 	}
 
@@ -110,7 +110,7 @@ function {{phpPrefix}}_maybe_install_storage() {
 }
 
 function {{phpPrefix}}_ensure_storage_installed() {
-	if ( 'custom-table' === '{{dataStorageMode}}' && '1.0.0' !== get_option( '{{phpPrefix}}_storage_version', '' ) ) {
+	if ( 'custom-table' === {{phpPrefixUpper}}_DATA_STORAGE_MODE && '1.0.0' !== get_option( '{{phpPrefix}}_storage_version', '' ) ) {
 		{{phpPrefix}}_maybe_install_storage();
 	}
 }
@@ -122,7 +122,7 @@ function {{phpPrefix}}_get_rest_build_dir() {
 function {{phpPrefix}}_get_counter( $post_id, $resource_key ) {
 	global $wpdb;
 
-	if ( 'custom-table' === '{{dataStorageMode}}' ) {
+	if ( 'custom-table' === {{phpPrefixUpper}}_DATA_STORAGE_MODE ) {
 		$table_name = {{phpPrefix}}_get_counter_table_name();
 		$count      = $wpdb->get_var(
 			$wpdb->prepare(
@@ -144,7 +144,7 @@ function {{phpPrefix}}_get_counter( $post_id, $resource_key ) {
 function {{phpPrefix}}_increment_counter( $post_id, $resource_key, $delta ) {
 	global $wpdb;
 
-	if ( 'custom-table' === '{{dataStorageMode}}' ) {
+	if ( 'custom-table' === {{phpPrefixUpper}}_DATA_STORAGE_MODE ) {
 		$table_name    = {{phpPrefix}}_get_counter_table_name();
 		$delta_value   = (int) $delta;
 		$initial_count = max( 0, $delta_value );
@@ -188,7 +188,7 @@ function {{phpPrefix}}_build_state_response( $post_id, $resource_key, $count ) {
 		'postId'      => (int) $post_id,
 		'resourceKey' => (string) $resource_key,
 		'count'       => (int) $count,
-		'storage'     => '{{dataStorageMode}}',
+		'storage'     => {{phpPrefixUpper}}_DATA_STORAGE_MODE,
 	);
 }
 

--- a/packages/wp-typia-project-tools/templates/_shared/compound/persistence-public/{{slugKebabCase}}.php.mustache
+++ b/packages/wp-typia-project-tools/templates/_shared/compound/persistence-public/{{slugKebabCase}}.php.mustache
@@ -82,7 +82,7 @@ function {{phpPrefix}}_with_counter_lock( $post_id, $resource_key, $callback ) {
 }
 
 function {{phpPrefix}}_maybe_install_storage() {
-	if ( 'custom-table' !== '{{dataStorageMode}}' ) {
+	if ( 'custom-table' !== {{phpPrefixUpper}}_DATA_STORAGE_MODE ) {
 		return;
 	}
 
@@ -113,7 +113,7 @@ function {{phpPrefix}}_maybe_install_storage() {
 }
 
 function {{phpPrefix}}_ensure_storage_installed() {
-	if ( 'custom-table' === '{{dataStorageMode}}' && '1.0.0' !== get_option( '{{phpPrefix}}_storage_version', '' ) ) {
+	if ( 'custom-table' === {{phpPrefixUpper}}_DATA_STORAGE_MODE && '1.0.0' !== get_option( '{{phpPrefix}}_storage_version', '' ) ) {
 		{{phpPrefix}}_maybe_install_storage();
 	}
 }
@@ -125,7 +125,7 @@ function {{phpPrefix}}_get_rest_build_dir() {
 function {{phpPrefix}}_get_counter( $post_id, $resource_key ) {
 	global $wpdb;
 
-	if ( 'custom-table' === '{{dataStorageMode}}' ) {
+	if ( 'custom-table' === {{phpPrefixUpper}}_DATA_STORAGE_MODE ) {
 		$table_name = {{phpPrefix}}_get_counter_table_name();
 		$count      = $wpdb->get_var(
 			$wpdb->prepare(
@@ -147,7 +147,7 @@ function {{phpPrefix}}_get_counter( $post_id, $resource_key ) {
 function {{phpPrefix}}_increment_counter( $post_id, $resource_key, $delta ) {
 	global $wpdb;
 
-	if ( 'custom-table' === '{{dataStorageMode}}' ) {
+	if ( 'custom-table' === {{phpPrefixUpper}}_DATA_STORAGE_MODE ) {
 		$table_name    = {{phpPrefix}}_get_counter_table_name();
 		$delta_value   = (int) $delta;
 		$initial_count = max( 0, $delta_value );
@@ -191,7 +191,7 @@ function {{phpPrefix}}_build_state_response( $post_id, $resource_key, $count ) {
 		'postId'      => (int) $post_id,
 		'resourceKey' => (string) $resource_key,
 		'count'       => (int) $count,
-		'storage'     => '{{dataStorageMode}}',
+		'storage'     => {{phpPrefixUpper}}_DATA_STORAGE_MODE,
 	);
 }
 

--- a/packages/wp-typia-project-tools/templates/_shared/compound/persistence/src/blocks/{{slugKebabCase}}/interactivity.ts.mustache
+++ b/packages/wp-typia-project-tools/templates/_shared/compound/persistence/src/blocks/{{slugKebabCase}}/interactivity.ts.mustache
@@ -123,6 +123,8 @@ const { actions, state } = store( '{{slugKebabCase}}', {
 			let bootstrapSucceeded = false;
 			let lastBootstrapError =
 				'Unable to initialize write access';
+			const includePublicWriteCredentials = {{isPublicPersistencePolicy}};
+			const includeRestNonce = {{isAuthenticatedPersistencePolicy}};
 
 			for ( let attempt = 1; attempt <= BOOTSTRAP_MAX_ATTEMPTS; attempt += 1 ) {
 				try {
@@ -146,16 +148,22 @@ const { actions, state } = store( '{{slugKebabCase}}', {
 					}
 
 					clientState.writeExpiry =
+						includePublicWriteCredentials &&
+						'publicWriteExpiresAt' in result.data &&
 						typeof result.data.publicWriteExpiresAt === 'number' &&
 						result.data.publicWriteExpiresAt > 0
 							? result.data.publicWriteExpiresAt
 							: 0;
 					clientState.writeToken =
+						includePublicWriteCredentials &&
+						'publicWriteToken' in result.data &&
 						typeof result.data.publicWriteToken === 'string' &&
 						result.data.publicWriteToken.length > 0
 							? result.data.publicWriteToken
 							: '';
 					clientState.writeNonce =
+						includeRestNonce &&
+						'restNonce' in result.data &&
 						typeof result.data.restNonce === 'string' &&
 						result.data.restNonce.length > 0
 							? result.data.restNonce

--- a/packages/wp-typia-project-tools/templates/_shared/persistence/auth/{{slugKebabCase}}.php.mustache
+++ b/packages/wp-typia-project-tools/templates/_shared/persistence/auth/{{slugKebabCase}}.php.mustache
@@ -84,7 +84,7 @@ function {{phpPrefix}}_with_counter_lock( $post_id, $resource_key, $callback ) {
 }
 
 function {{phpPrefix}}_maybe_install_storage() {
-	if ( 'custom-table' !== '{{dataStorageMode}}' ) {
+	if ( 'custom-table' !== {{phpPrefixUpper}}_DATA_STORAGE_MODE ) {
 		return;
 	}
 
@@ -115,7 +115,7 @@ function {{phpPrefix}}_maybe_install_storage() {
 }
 
 function {{phpPrefix}}_ensure_storage_installed() {
-	if ( 'custom-table' === '{{dataStorageMode}}' && '1.0.0' !== get_option( '{{phpPrefix}}_storage_version', '' ) ) {
+	if ( 'custom-table' === {{phpPrefixUpper}}_DATA_STORAGE_MODE && '1.0.0' !== get_option( '{{phpPrefix}}_storage_version', '' ) ) {
 		{{phpPrefix}}_maybe_install_storage();
 	}
 }
@@ -127,7 +127,7 @@ function {{phpPrefix}}_get_rest_build_dir() {
 function {{phpPrefix}}_get_counter( $post_id, $resource_key ) {
 	global $wpdb;
 
-	if ( 'custom-table' === '{{dataStorageMode}}' ) {
+	if ( 'custom-table' === {{phpPrefixUpper}}_DATA_STORAGE_MODE ) {
 		$table_name = {{phpPrefix}}_get_counter_table_name();
 		$count      = $wpdb->get_var(
 			$wpdb->prepare(
@@ -149,7 +149,7 @@ function {{phpPrefix}}_get_counter( $post_id, $resource_key ) {
 function {{phpPrefix}}_increment_counter( $post_id, $resource_key, $delta ) {
 	global $wpdb;
 
-	if ( 'custom-table' === '{{dataStorageMode}}' ) {
+	if ( 'custom-table' === {{phpPrefixUpper}}_DATA_STORAGE_MODE ) {
 		$table_name    = {{phpPrefix}}_get_counter_table_name();
 		$delta_value   = (int) $delta;
 		$initial_count = max( 0, $delta_value );
@@ -193,7 +193,7 @@ function {{phpPrefix}}_build_state_response( $post_id, $resource_key, $count ) {
 		'postId'      => (int) $post_id,
 		'resourceKey' => (string) $resource_key,
 		'count'       => (int) $count,
-		'storage'     => '{{dataStorageMode}}',
+		'storage'     => {{phpPrefixUpper}}_DATA_STORAGE_MODE,
 	);
 }
 

--- a/packages/wp-typia-project-tools/templates/_shared/persistence/core/src/interactivity.ts.mustache
+++ b/packages/wp-typia-project-tools/templates/_shared/persistence/core/src/interactivity.ts.mustache
@@ -126,6 +126,7 @@ const { actions, state } = store( '{{slugKebabCase}}', {
 			let bootstrapSucceeded = false;
 			let lastBootstrapError =
 				'Unable to initialize write access';
+			const includePublicWriteCredentials = {{isPublicPersistencePolicy}};
 			const includeRestNonce = {{isAuthenticatedPersistencePolicy}};
 
 			for ( let attempt = 1; attempt <= BOOTSTRAP_MAX_ATTEMPTS; attempt += 1 ) {
@@ -150,11 +151,15 @@ const { actions, state } = store( '{{slugKebabCase}}', {
 					}
 
 					clientState.writeExpiry =
+						includePublicWriteCredentials &&
+						'publicWriteExpiresAt' in result.data &&
 						typeof result.data.publicWriteExpiresAt === 'number' &&
 						result.data.publicWriteExpiresAt > 0
 							? result.data.publicWriteExpiresAt
 							: 0;
 					clientState.writeToken =
+						includePublicWriteCredentials &&
+						'publicWriteToken' in result.data &&
 						typeof result.data.publicWriteToken === 'string' &&
 						result.data.publicWriteToken.length > 0
 							? result.data.publicWriteToken

--- a/packages/wp-typia-project-tools/templates/_shared/persistence/core/{{slugKebabCase}}.php.mustache
+++ b/packages/wp-typia-project-tools/templates/_shared/persistence/core/{{slugKebabCase}}.php.mustache
@@ -81,7 +81,7 @@ function {{phpPrefix}}_with_counter_lock( $post_id, $resource_key, $callback ) {
 }
 
 function {{phpPrefix}}_maybe_install_storage() {
-	if ( 'custom-table' !== '{{dataStorageMode}}' ) {
+	if ( 'custom-table' !== {{phpPrefixUpper}}_DATA_STORAGE_MODE ) {
 		return;
 	}
 
@@ -112,7 +112,7 @@ function {{phpPrefix}}_maybe_install_storage() {
 }
 
 function {{phpPrefix}}_ensure_storage_installed() {
-	if ( 'custom-table' === '{{dataStorageMode}}' && '1.0.0' !== get_option( '{{phpPrefix}}_storage_version', '' ) ) {
+	if ( 'custom-table' === {{phpPrefixUpper}}_DATA_STORAGE_MODE && '1.0.0' !== get_option( '{{phpPrefix}}_storage_version', '' ) ) {
 		{{phpPrefix}}_maybe_install_storage();
 	}
 }
@@ -170,7 +170,7 @@ function {{phpPrefix}}_validate_and_sanitize_request( $value, $schema_name, $par
 function {{phpPrefix}}_get_counter( $post_id, $resource_key ) {
 	global $wpdb;
 
-	if ( 'custom-table' === '{{dataStorageMode}}' ) {
+	if ( 'custom-table' === {{phpPrefixUpper}}_DATA_STORAGE_MODE ) {
 		$table_name = {{phpPrefix}}_get_counter_table_name();
 		$count      = $wpdb->get_var(
 			$wpdb->prepare(
@@ -191,7 +191,7 @@ function {{phpPrefix}}_get_counter( $post_id, $resource_key ) {
 function {{phpPrefix}}_increment_counter( $post_id, $resource_key, $delta ) {
 	global $wpdb;
 
-	if ( 'custom-table' === '{{dataStorageMode}}' ) {
+	if ( 'custom-table' === {{phpPrefixUpper}}_DATA_STORAGE_MODE ) {
 		$table_name    = {{phpPrefix}}_get_counter_table_name();
 		$delta_value   = (int) $delta;
 		$initial_count = max( 0, $delta_value );
@@ -235,7 +235,7 @@ function {{phpPrefix}}_build_state_response( $post_id, $resource_key, $count ) {
 		'postId'      => (int) $post_id,
 		'resourceKey' => (string) $resource_key,
 		'count'       => (int) $count,
-		'storage'     => '{{dataStorageMode}}',
+		'storage'     => {{phpPrefixUpper}}_DATA_STORAGE_MODE,
 	);
 }
 

--- a/packages/wp-typia-project-tools/templates/_shared/persistence/public/{{slugKebabCase}}.php.mustache
+++ b/packages/wp-typia-project-tools/templates/_shared/persistence/public/{{slugKebabCase}}.php.mustache
@@ -87,7 +87,7 @@ function {{phpPrefix}}_with_counter_lock( $post_id, $resource_key, $callback ) {
 }
 
 function {{phpPrefix}}_maybe_install_storage() {
-	if ( 'custom-table' !== '{{dataStorageMode}}' ) {
+	if ( 'custom-table' !== {{phpPrefixUpper}}_DATA_STORAGE_MODE ) {
 		return;
 	}
 
@@ -118,7 +118,7 @@ function {{phpPrefix}}_maybe_install_storage() {
 }
 
 function {{phpPrefix}}_ensure_storage_installed() {
-	if ( 'custom-table' === '{{dataStorageMode}}' && '1.0.0' !== get_option( '{{phpPrefix}}_storage_version', '' ) ) {
+	if ( 'custom-table' === {{phpPrefixUpper}}_DATA_STORAGE_MODE && '1.0.0' !== get_option( '{{phpPrefix}}_storage_version', '' ) ) {
 		{{phpPrefix}}_maybe_install_storage();
 	}
 }
@@ -130,7 +130,7 @@ function {{phpPrefix}}_get_rest_build_dir() {
 function {{phpPrefix}}_get_counter( $post_id, $resource_key ) {
 	global $wpdb;
 
-	if ( 'custom-table' === '{{dataStorageMode}}' ) {
+	if ( 'custom-table' === {{phpPrefixUpper}}_DATA_STORAGE_MODE ) {
 		$table_name = {{phpPrefix}}_get_counter_table_name();
 		$count      = $wpdb->get_var(
 			$wpdb->prepare(
@@ -152,7 +152,7 @@ function {{phpPrefix}}_get_counter( $post_id, $resource_key ) {
 function {{phpPrefix}}_increment_counter( $post_id, $resource_key, $delta ) {
 	global $wpdb;
 
-	if ( 'custom-table' === '{{dataStorageMode}}' ) {
+	if ( 'custom-table' === {{phpPrefixUpper}}_DATA_STORAGE_MODE ) {
 		$table_name    = {{phpPrefix}}_get_counter_table_name();
 		$delta_value   = (int) $delta;
 		$initial_count = max( 0, $delta_value );
@@ -196,7 +196,7 @@ function {{phpPrefix}}_build_state_response( $post_id, $resource_key, $count ) {
 		'postId'      => (int) $post_id,
 		'resourceKey' => (string) $resource_key,
 		'count'       => (int) $count,
-		'storage'     => '{{dataStorageMode}}',
+		'storage'     => {{phpPrefixUpper}}_DATA_STORAGE_MODE,
 	);
 }
 

--- a/packages/wp-typia-project-tools/templates/_shared/workspace/persistence-auth/server.php.mustache
+++ b/packages/wp-typia-project-tools/templates/_shared/workspace/persistence-auth/server.php.mustache
@@ -7,6 +7,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 require_once __DIR__ . '/inc/rest-shared.php';
 require_once __DIR__ . '/inc/rest-auth.php';
 
+define( '{{phpPrefixUpper}}_DATA_STORAGE_MODE', '{{dataStorageMode}}' );
+
 function {{phpPrefix}}_get_rest_build_dir() {
 	return dirname( __DIR__, 3 ) . '/build/blocks/{{slugKebabCase}}';
 }
@@ -50,7 +52,7 @@ function {{phpPrefix}}_with_counter_lock( $post_id, $resource_key, $callback ) {
 }
 
 function {{phpPrefix}}_maybe_install_storage() {
-	if ( 'custom-table' !== '{{dataStorageMode}}' ) {
+	if ( 'custom-table' !== {{phpPrefixUpper}}_DATA_STORAGE_MODE ) {
 		return;
 	}
 
@@ -81,7 +83,7 @@ function {{phpPrefix}}_maybe_install_storage() {
 }
 
 function {{phpPrefix}}_ensure_storage_installed() {
-	if ( 'custom-table' === '{{dataStorageMode}}' && '1.0.0' !== get_option( '{{phpPrefix}}_storage_version', '' ) ) {
+	if ( 'custom-table' === {{phpPrefixUpper}}_DATA_STORAGE_MODE && '1.0.0' !== get_option( '{{phpPrefix}}_storage_version', '' ) ) {
 		{{phpPrefix}}_maybe_install_storage();
 	}
 }
@@ -89,7 +91,7 @@ function {{phpPrefix}}_ensure_storage_installed() {
 function {{phpPrefix}}_get_counter( $post_id, $resource_key ) {
 	global $wpdb;
 
-	if ( 'custom-table' === '{{dataStorageMode}}' ) {
+	if ( 'custom-table' === {{phpPrefixUpper}}_DATA_STORAGE_MODE ) {
 		$table_name = {{phpPrefix}}_get_counter_table_name();
 		$count      = $wpdb->get_var(
 			$wpdb->prepare(
@@ -110,7 +112,7 @@ function {{phpPrefix}}_get_counter( $post_id, $resource_key ) {
 function {{phpPrefix}}_increment_counter( $post_id, $resource_key, $delta ) {
 	global $wpdb;
 
-	if ( 'custom-table' === '{{dataStorageMode}}' ) {
+	if ( 'custom-table' === {{phpPrefixUpper}}_DATA_STORAGE_MODE ) {
 		$table_name    = {{phpPrefix}}_get_counter_table_name();
 		$delta_value   = (int) $delta;
 		$initial_count = max( 0, $delta_value );
@@ -154,7 +156,7 @@ function {{phpPrefix}}_build_state_response( $post_id, $resource_key, $count ) {
 		'postId'      => (int) $post_id,
 		'resourceKey' => (string) $resource_key,
 		'count'       => (int) $count,
-		'storage'     => '{{dataStorageMode}}',
+		'storage'     => {{phpPrefixUpper}}_DATA_STORAGE_MODE,
 	);
 }
 

--- a/packages/wp-typia-project-tools/templates/_shared/workspace/persistence-public/server.php.mustache
+++ b/packages/wp-typia-project-tools/templates/_shared/workspace/persistence-public/server.php.mustache
@@ -7,6 +7,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 require_once __DIR__ . '/inc/rest-shared.php';
 require_once __DIR__ . '/inc/rest-public.php';
 
+define( '{{phpPrefixUpper}}_DATA_STORAGE_MODE', '{{dataStorageMode}}' );
+
 function {{phpPrefix}}_get_rest_build_dir() {
 	return dirname( __DIR__, 3 ) . '/build/blocks/{{slugKebabCase}}';
 }
@@ -50,7 +52,7 @@ function {{phpPrefix}}_with_counter_lock( $post_id, $resource_key, $callback ) {
 }
 
 function {{phpPrefix}}_maybe_install_storage() {
-	if ( 'custom-table' !== '{{dataStorageMode}}' ) {
+	if ( 'custom-table' !== {{phpPrefixUpper}}_DATA_STORAGE_MODE ) {
 		return;
 	}
 
@@ -81,7 +83,7 @@ function {{phpPrefix}}_maybe_install_storage() {
 }
 
 function {{phpPrefix}}_ensure_storage_installed() {
-	if ( 'custom-table' === '{{dataStorageMode}}' && '1.0.0' !== get_option( '{{phpPrefix}}_storage_version', '' ) ) {
+	if ( 'custom-table' === {{phpPrefixUpper}}_DATA_STORAGE_MODE && '1.0.0' !== get_option( '{{phpPrefix}}_storage_version', '' ) ) {
 		{{phpPrefix}}_maybe_install_storage();
 	}
 }
@@ -89,7 +91,7 @@ function {{phpPrefix}}_ensure_storage_installed() {
 function {{phpPrefix}}_get_counter( $post_id, $resource_key ) {
 	global $wpdb;
 
-	if ( 'custom-table' === '{{dataStorageMode}}' ) {
+	if ( 'custom-table' === {{phpPrefixUpper}}_DATA_STORAGE_MODE ) {
 		$table_name = {{phpPrefix}}_get_counter_table_name();
 		$count      = $wpdb->get_var(
 			$wpdb->prepare(
@@ -110,7 +112,7 @@ function {{phpPrefix}}_get_counter( $post_id, $resource_key ) {
 function {{phpPrefix}}_increment_counter( $post_id, $resource_key, $delta ) {
 	global $wpdb;
 
-	if ( 'custom-table' === '{{dataStorageMode}}' ) {
+	if ( 'custom-table' === {{phpPrefixUpper}}_DATA_STORAGE_MODE ) {
 		$table_name    = {{phpPrefix}}_get_counter_table_name();
 		$delta_value   = (int) $delta;
 		$initial_count = max( 0, $delta_value );
@@ -154,7 +156,7 @@ function {{phpPrefix}}_build_state_response( $post_id, $resource_key, $count ) {
 		'postId'      => (int) $post_id,
 		'resourceKey' => (string) $resource_key,
 		'count'       => (int) $count,
-		'storage'     => '{{dataStorageMode}}',
+		'storage'     => {{phpPrefixUpper}}_DATA_STORAGE_MODE,
 	);
 }
 

--- a/packages/wp-typia-project-tools/tests/create-cli.test.ts
+++ b/packages/wp-typia-project-tools/tests/create-cli.test.ts
@@ -1698,6 +1698,10 @@ describe("@wp-typia/project-tools scaffolding", () => {
       path.join(targetDir, "src", "transport.ts"),
       "utf8"
     );
+    const generatedInteractivity = fs.readFileSync(
+      path.join(targetDir, "src", "interactivity.ts"),
+      "utf8"
+    );
     const generatedSyncRest = fs.readFileSync(
       path.join(targetDir, "scripts", "sync-rest-contracts.ts"),
       "utf8"
@@ -1813,9 +1817,22 @@ describe("@wp-typia/project-tools scaffolding", () => {
     expect(generatedApiTypes).toContain("restNonce?: string");
     expect(generatedApiTypes).not.toContain("publicWriteExpiresAt?: number");
     expect(generatedApiTypes).not.toContain("{{#isPublicPersistencePolicy}}");
+    expect(generatedInteractivity).toContain("includePublicWriteCredentials = false");
+    expect(generatedInteractivity).toContain("'publicWriteExpiresAt' in result.data");
+    expect(generatedInteractivity).toContain("'publicWriteToken' in result.data");
+    expect(generatedInteractivity).toContain("'restNonce' in result.data");
     expect(generatedTransport).toContain("resolveRestNonce");
     expect(generatedTransport).toContain("includeRestNonce: true");
     expect(generatedTransport).toContain("includeRestNonce: false");
+    expect(pluginBootstrap).toContain(
+      "define( 'DEMO_PERSISTENCE_AUTHENTICATED_DATA_STORAGE_MODE', 'custom-table' );"
+    );
+    expect(pluginBootstrap).toContain(
+      "if ( 'custom-table' === DEMO_PERSISTENCE_AUTHENTICATED_DATA_STORAGE_MODE"
+    );
+    expect(pluginBootstrap).toContain(
+      "'storage'     => DEMO_PERSISTENCE_AUTHENTICATED_DATA_STORAGE_MODE,"
+    );
     expect(generatedTypes).toContain(
       "persistencePolicy: 'authenticated' | 'public';"
     );
@@ -1843,6 +1860,7 @@ describe("@wp-typia/project-tools scaffolding", () => {
     expect(restAuthHelper).toContain(
       "Customize authenticated write policy here"
     );
+    typecheckGeneratedProject(targetDir);
   });
 
   test("generated public persistence transport skips nonce injection even when wpApiSettings is present", async () => {
@@ -2459,6 +2477,15 @@ console.log(JSON.stringify({ initial, updated, reread }));
       "Text Domain:       demo-persistence-text"
     );
     expect(pluginBootstrap).toContain("function ab_test_metrics_get_counter");
+    expect(pluginBootstrap).toContain(
+      "define( 'AB_TEST_METRICS_DATA_STORAGE_MODE', 'post-meta' );"
+    );
+    expect(pluginBootstrap).toContain(
+      "if ( 'custom-table' !== AB_TEST_METRICS_DATA_STORAGE_MODE )"
+    );
+    expect(pluginBootstrap).toContain(
+      "'storage'     => AB_TEST_METRICS_DATA_STORAGE_MODE,"
+    );
     expect(restPublicHelper).toContain(
       "function ab_test_metrics_create_public_write_token"
     );
@@ -3081,6 +3108,16 @@ console.log(JSON.stringify({ initial, updated, reread }));
       expect(generatedApiTypes).toContain("restNonce?: string");
       expect(generatedApiTypes).not.toContain("publicWriteExpiresAt?: number");
       expect(generatedApiTypes).not.toContain("{{#isPublicPersistencePolicy}}");
+      expect(parentInteractivity).toContain(
+        "includePublicWriteCredentials = false"
+      );
+      expect(parentInteractivity).toContain(
+        "'publicWriteExpiresAt' in result.data"
+      );
+      expect(parentInteractivity).toContain(
+        "'publicWriteToken' in result.data"
+      );
+      expect(parentInteractivity).toContain("'restNonce' in result.data");
       expect(
         fs.existsSync(
           path.join(
@@ -3123,6 +3160,15 @@ console.log(JSON.stringify({ initial, updated, reread }));
       );
       expect(parentInteractivity).toContain("await actions.loadBootstrap();");
       expect(parentInteractivity).toContain("transportTarget: 'frontend'");
+      expect(pluginBootstrap).toContain(
+        "define( 'DEMO_COMPOUND_STORAGE_DATA_STORAGE_MODE', 'post-meta' );"
+      );
+      expect(pluginBootstrap).toContain(
+        "if ( 'custom-table' !== DEMO_COMPOUND_STORAGE_DATA_STORAGE_MODE )"
+      );
+      expect(pluginBootstrap).toContain(
+        "'storage'     => DEMO_COMPOUND_STORAGE_DATA_STORAGE_MODE,"
+      );
       expect(generatedTransport).toContain("resolveTransportCallOptions");
       expect(generatedTransport).toContain("includeRestNonce: true");
       expect(generatedTransport).toContain("includeRestNonce: false");
@@ -4999,6 +5045,15 @@ console.log(JSON.stringify({ initial, updated, reread }));
     expect(serverModuleSource).toContain("rest-public.php");
     expect(serverModuleSource).toContain(
       "array_key_exists( 'resourceKey', $attributes )"
+    );
+    expect(serverModuleSource).toContain(
+      "define( 'DEMO_SPACE_FAQ_STACK_DATA_STORAGE_MODE', 'custom-table' );"
+    );
+    expect(serverModuleSource).toContain(
+      "if ( 'custom-table' === DEMO_SPACE_FAQ_STACK_DATA_STORAGE_MODE"
+    );
+    expect(serverModuleSource).toContain(
+      "'storage'     => DEMO_SPACE_FAQ_STACK_DATA_STORAGE_MODE,"
     );
     expect(serverModuleSource).toContain("is_post_publicly_viewable( $post )");
     expect(serverModuleSource).toContain(": 'primary';");


### PR DESCRIPTION
## Summary
- fix authenticated persistence scaffold interactivity so generated bootstrap field access narrows policy-specific properties instead of assuming public-write credentials on authenticated responses
- route persistence PHP storage handling through generated `*_DATA_STORAGE_MODE` constants instead of rendered string literals
- add regression coverage for authenticated single-block, authenticated compound, post-meta single-block, and workspace persistence server output

## Root Cause
Generated persistence scaffolds were mixing policy-specific bootstrap fields in `interactivity.ts`, and the PHP templates defined a storage-mode constant but still branched on rendered literals like `'custom-table'` and `'post-meta'`.

## Validation
- `bun test packages/wp-typia-project-tools/tests/create-cli.test.ts --test-name-pattern "scaffoldProject creates a persistence template with authenticated writes by default|scaffoldProject supports combined identifier overrides on persistence templates|compound scaffolds enable authenticated persistence when only data storage is provided|canonical CLI can add a compound persistence block to an official workspace template"`
- `bun run changesets:validate`
- `bun run typecheck`
- `bun run publish:validate`
- `bun run test`
- `bun run build`
- `node scripts/run-generated-project-smoke.mjs --runtime node --template compound --data-storage post-meta --persistence-policy public --package-manager npm --project-name smoke-compound-public-post-meta-local`

Closes #213

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed persistence scaffold regressions in authenticated bootstrap typing and PHP storage-mode handling.

* **Improvements**
  * Enhanced storage configuration references for more robust mode handling.
  * Updated write credential initialization to be conditional based on configured persistence policies.
  * Extended CI smoke test coverage to include additional data storage configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->