### PR TITLE
Fix create TUI navigation and small-screen form rendering

### DIFF
--- a/packages/wp-typia-project-tools/tests/create-cli.test.ts
+++ b/packages/wp-typia-project-tools/tests/create-cli.test.ts
@@ -2739,7 +2739,7 @@ console.log(JSON.stringify({ initial, updated, reread }));
     const buildOutput = buildGeneratedProject(targetDir);
     expect(buildOutput).not.toContain("non-specified generic argument");
     },
-    { timeout: 20_000 }
+    { timeout: 90_000 }
   );
 
   test("compound scaffolds can opt into migration UI and keep add-child migration-aware", async () => {

--- a/packages/wp-typia/src/ui/create-flow-model.ts
+++ b/packages/wp-typia/src/ui/create-flow-model.ts
@@ -54,23 +54,27 @@ export const CREATE_FIELD_ORDER = [
 	...CREATE_CHECKBOX_FIELD_NAMES,
 ] as const satisfies ReadonlyArray<CreateFieldName>;
 
+export const CREATE_FIELD_GAP = 1;
+export const CREATE_SELECT_FIELD_LABEL_GAP = 1;
+export const CREATE_SELECT_FIELD_CONTROL_HEIGHT = 3;
+export const CREATE_SELECT_FIELD_BODY_HEIGHT =
+	1 + CREATE_SELECT_FIELD_LABEL_GAP + CREATE_SELECT_FIELD_CONTROL_HEIGHT + 1;
+
 const CREATE_FIELD_HEIGHTS: Record<CreateFieldName, number> = {
-	"data-storage": 5,
+	"data-storage": CREATE_SELECT_FIELD_BODY_HEIGHT,
 	namespace: 6,
 	"no-install": 2,
-	"package-manager": 5,
-	"persistence-policy": 5,
+	"package-manager": CREATE_SELECT_FIELD_BODY_HEIGHT,
+	"persistence-policy": CREATE_SELECT_FIELD_BODY_HEIGHT,
 	"php-prefix": 6,
 	"project-dir": 6,
-	template: 5,
+	template: CREATE_SELECT_FIELD_BODY_HEIGHT,
 	"text-domain": 6,
 	yes: 2,
 	"with-migration-ui": 2,
 	"with-test-preset": 2,
 	"with-wp-env": 2,
 };
-
-const CREATE_FIELD_GAP = 1;
 
 export function isCreatePersistenceTemplate(template?: string): boolean {
 	return template === "persistence" || template === "compound";

--- a/packages/wp-typia/src/ui/create-flow-model.ts
+++ b/packages/wp-typia/src/ui/create-flow-model.ts
@@ -122,3 +122,15 @@ export function getCreateScrollTop(options: {
 
 	return 0;
 }
+
+export function sanitizeCreateSubmitValues(values: CreateFlowValues): CreateFlowValues {
+	if (isCreatePersistenceTemplate(values.template)) {
+		return values;
+	}
+
+	return {
+		...values,
+		"data-storage": undefined,
+		"persistence-policy": undefined,
+	};
+}

--- a/packages/wp-typia/src/ui/create-flow-model.ts
+++ b/packages/wp-typia/src/ui/create-flow-model.ts
@@ -1,0 +1,124 @@
+import { z } from "zod";
+
+export const createFlowSchema = z.object({
+	"data-storage": z.string().optional(),
+	namespace: z.string().optional(),
+	"no-install": z.boolean().default(false),
+	"package-manager": z.string().optional(),
+	"persistence-policy": z.string().optional(),
+	"php-prefix": z.string().optional(),
+	"project-dir": z.string().min(1),
+	template: z.string().optional(),
+	"text-domain": z.string().optional(),
+	variant: z.string().optional(),
+	"with-migration-ui": z.boolean().default(false),
+	"with-test-preset": z.boolean().default(false),
+	"with-wp-env": z.boolean().default(false),
+	yes: z.boolean().default(false),
+});
+
+export type CreateFlowValues = z.infer<typeof createFlowSchema>;
+
+export type CreateFieldName =
+	| "project-dir"
+	| "template"
+	| "package-manager"
+	| "namespace"
+	| "text-domain"
+	| "php-prefix"
+	| "data-storage"
+	| "persistence-policy"
+	| "no-install"
+	| "yes"
+	| "with-wp-env"
+	| "with-test-preset"
+	| "with-migration-ui";
+
+export const CREATE_CHECKBOX_FIELD_NAMES = [
+	"no-install",
+	"yes",
+	"with-wp-env",
+	"with-test-preset",
+	"with-migration-ui",
+] as const satisfies ReadonlyArray<CreateFieldName>;
+
+export const CREATE_FIELD_ORDER = [
+	"project-dir",
+	"template",
+	"package-manager",
+	"namespace",
+	"text-domain",
+	"php-prefix",
+	"data-storage",
+	"persistence-policy",
+	...CREATE_CHECKBOX_FIELD_NAMES,
+] as const satisfies ReadonlyArray<CreateFieldName>;
+
+const CREATE_FIELD_HEIGHTS: Record<CreateFieldName, number> = {
+	"data-storage": 5,
+	namespace: 6,
+	"no-install": 2,
+	"package-manager": 5,
+	"persistence-policy": 5,
+	"php-prefix": 6,
+	"project-dir": 6,
+	template: 5,
+	"text-domain": 6,
+	yes: 2,
+	"with-migration-ui": 2,
+	"with-test-preset": 2,
+	"with-wp-env": 2,
+};
+
+const CREATE_FIELD_GAP = 1;
+
+export function isCreatePersistenceTemplate(template?: string): boolean {
+	return template === "persistence" || template === "compound";
+}
+
+export function getVisibleCreateFieldNames(
+	values: Partial<CreateFlowValues>,
+): Array<CreateFieldName> {
+	return CREATE_FIELD_ORDER.filter((name) => {
+		if (name === "data-storage" || name === "persistence-policy") {
+			return isCreatePersistenceTemplate(values.template);
+		}
+
+		return true;
+	});
+}
+
+export function getCreateViewportHeight(terminalHeight = 24): number {
+	return Math.max(8, Math.min(28, terminalHeight - 12));
+}
+
+export function getCreateScrollTop(options: {
+	activeFieldName: string | null;
+	values: Partial<CreateFlowValues>;
+	viewportHeight: number;
+}): number {
+	const { activeFieldName, values, viewportHeight } = options;
+	if (!activeFieldName) {
+		return 0;
+	}
+
+	const visibleFields = getVisibleCreateFieldNames(values);
+	let offset = 0;
+
+	for (const fieldName of visibleFields) {
+		const fieldHeight = CREATE_FIELD_HEIGHTS[fieldName];
+		if (fieldName === activeFieldName) {
+			const safeViewportHeight = Math.max(4, viewportHeight - 2);
+			const fieldBottom = offset + fieldHeight;
+			if (fieldBottom <= safeViewportHeight) {
+				return 0;
+			}
+
+			return Math.max(0, fieldBottom - safeViewportHeight + 1);
+		}
+
+		offset += fieldHeight + CREATE_FIELD_GAP;
+	}
+
+	return 0;
+}

--- a/packages/wp-typia/src/ui/create-flow.tsx
+++ b/packages/wp-typia/src/ui/create-flow.tsx
@@ -15,8 +15,11 @@ import {
 import { executeCreateCommand } from "../runtime-bridge";
 import { useAlternateBufferLifecycle } from "./alternate-buffer-lifecycle";
 import {
+	CREATE_FIELD_GAP,
 	type CreateFlowValues,
 	CREATE_CHECKBOX_FIELD_NAMES,
+	CREATE_SELECT_FIELD_CONTROL_HEIGHT,
+	CREATE_SELECT_FIELD_LABEL_GAP,
 	createFlowSchema,
 	getCreateScrollTop,
 	getCreateViewportHeight,
@@ -71,10 +74,14 @@ type CreateFlowProps = {
 	initialValues: Partial<CreateFlowValues>;
 };
 
+type CreateSelectFieldName = {
+	[K in keyof CreateFlowValues]-?: CreateFlowValues[K] extends string | undefined ? K : never;
+}[keyof CreateFlowValues];
+
 type CreateSelectFieldProps = {
 	defaultValue?: string;
 	label: string;
-	name: keyof CreateFlowValues;
+	name: CreateSelectFieldName;
 	options: SelectOption[];
 };
 
@@ -139,7 +146,13 @@ function CreateSelectField({
 
 	return createElement(
 		"box",
-		{ style: { flexDirection: "column", gap: 1, marginBottom: 1 } },
+		{
+			style: {
+				flexDirection: "column",
+				gap: CREATE_SELECT_FIELD_LABEL_GAP,
+				marginBottom: CREATE_FIELD_GAP,
+			},
+		},
 		createElement("text", {
 			content: `${field.focused ? ">" : " "} ${label}`,
 			fg: field.focused ? tokens.accent : tokens.textPrimary,
@@ -148,7 +161,7 @@ function CreateSelectField({
 			"box",
 			{
 				border: true,
-				height: 3,
+				height: CREATE_SELECT_FIELD_CONTROL_HEIGHT,
 				style: {
 					borderColor: field.error
 						? tokens.textDanger
@@ -212,7 +225,7 @@ function CreateCheckboxField({
 
 	return createElement(
 		"box",
-		{ style: { flexDirection: "column", marginBottom: 1 } },
+		{ style: { flexDirection: "column", marginBottom: CREATE_FIELD_GAP } },
 		createElement("text", {
 			content: `${field.focused ? ">" : " "} ${field.value ? "[x]" : "[ ]"} ${label}`,
 			fg: field.focused ? tokens.accent : tokens.textPrimary,

--- a/packages/wp-typia/src/ui/create-flow.tsx
+++ b/packages/wp-typia/src/ui/create-flow.tsx
@@ -21,6 +21,7 @@ import {
 	getCreateScrollTop,
 	getCreateViewportHeight,
 	isCreatePersistenceTemplate,
+	sanitizeCreateSubmitValues,
 } from "./create-flow-model";
 
 const templateOptions: SelectOption[] = [
@@ -60,6 +61,11 @@ const checkboxKeymap = createKeyMatcher({
 	toggle: ["space", "enter"],
 });
 
+const selectKeymap = createKeyMatcher({
+	next: ["down", "enter", "right", "space"],
+	previous: ["left", "up"],
+});
+
 type CreateFlowProps = {
 	cwd: string;
 	initialValues: Partial<CreateFlowValues>;
@@ -89,16 +95,46 @@ function CreateSelectField({
 		return index >= 0 ? index : 0;
 	}, [field.value, options]);
 
-	const handleChange = useCallback(
-		(_index: number, option: SelectOption | null) => {
-			if (!option) {
+	const selectedOption = options[selectedIndex] ?? options[0];
+	const keyboardScopeId = `create-select:${name}`;
+
+	const moveSelection = useCallback(
+		(delta: number) => {
+			if (!selectedOption || options.length === 0) {
 				return;
 			}
 
-			field.setValue(String(option.value));
-			field.blur();
+			const nextIndex = (selectedIndex + delta + options.length) % options.length;
+			const nextOption = options[nextIndex];
+			if (!nextOption) {
+				return;
+			}
+
+			field.setValue(String(nextOption.value));
 		},
-		[field],
+		[field, options, selectedIndex, selectedOption],
+	);
+
+	useScopedKeyboard(
+		keyboardScopeId,
+		(key) => {
+			if (!field.focused) {
+				return false;
+			}
+
+			if (selectKeymap.match("next", key)) {
+				moveSelection(1);
+				return true;
+			}
+
+			if (selectKeymap.match("previous", key)) {
+				moveSelection(-1);
+				return true;
+			}
+
+			return false;
+		},
+		{ active: field.focused },
 	);
 
 	return createElement(
@@ -112,7 +148,7 @@ function CreateSelectField({
 			"box",
 			{
 				border: true,
-				height: 5,
+				height: 3,
 				style: {
 					borderColor: field.error
 						? tokens.textDanger
@@ -121,14 +157,17 @@ function CreateSelectField({
 							: tokens.borderMuted,
 				},
 			},
-			createElement("select", {
-				focused: field.focused,
-				onChange: handleChange,
-				options,
-				selectedIndex,
-				style: { flexGrow: 1 },
+			createElement("text", {
+				content: `${field.focused ? "▶" : " "} ${selectedOption?.name ?? ""}`,
+				fg: field.focused ? tokens.accent : tokens.textPrimary,
 			}),
 		),
+		selectedOption?.description
+			? createElement("text", {
+					content: `  ${selectedOption.description}`,
+					fg: tokens.textMuted,
+				})
+			: null,
 		field.error
 			? createElement("text", { content: field.error, fg: tokens.textDanger })
 			: null,
@@ -274,9 +313,10 @@ export function CreateFlow({ cwd, initialValues }: CreateFlowProps) {
 			onCancel={handleCancel}
 			onSubmit={async (values) =>
 				handleSubmit(async () => {
+					const flags = sanitizeCreateSubmitValues(values);
 					await executeCreateCommand({
 						cwd,
-						flags: values,
+						flags,
 						interactive: true,
 						projectDir: values["project-dir"],
 						prompt: defaultPrompt,

--- a/packages/wp-typia/src/ui/create-flow.tsx
+++ b/packages/wp-typia/src/ui/create-flow.tsx
@@ -1,32 +1,259 @@
-import { SchemaForm } from "@bunli/tui";
-import { z } from "zod";
+import { createElement, useCallback, useEffect, useId, useMemo, useRef } from "react";
+
+import { useScopedKeyboard } from "@bunli/runtime/app";
+import {
+	Form,
+	FormField,
+	type SelectOption,
+	createKeyMatcher,
+	useFormContext,
+	useFormField,
+	useTerminalDimensions,
+	useTuiTheme,
+} from "@bunli/tui";
 
 import { executeCreateCommand } from "../runtime-bridge";
 import { useAlternateBufferLifecycle } from "./alternate-buffer-lifecycle";
+import {
+	type CreateFlowValues,
+	CREATE_CHECKBOX_FIELD_NAMES,
+	createFlowSchema,
+	getCreateScrollTop,
+	getCreateViewportHeight,
+	isCreatePersistenceTemplate,
+} from "./create-flow-model";
 
-const createFlowSchema = z.object({
-	"data-storage": z.string().optional(),
-	namespace: z.string().optional(),
-	"no-install": z.boolean().default(false),
-	"package-manager": z.string().optional(),
-	"persistence-policy": z.string().optional(),
-	"php-prefix": z.string().optional(),
-	"project-dir": z.string().min(1),
-	template: z.string().optional(),
-	"text-domain": z.string().optional(),
-	variant: z.string().optional(),
-	"with-migration-ui": z.boolean().default(false),
-	"with-test-preset": z.boolean().default(false),
-	"with-wp-env": z.boolean().default(false),
-	yes: z.boolean().default(false),
+const templateOptions: SelectOption[] = [
+	{ description: "Basic block scaffold", name: "basic", value: "basic" },
+	{ description: "Interactivity API block scaffold", name: "interactivity", value: "interactivity" },
+	{ description: "Persistence-enabled block scaffold", name: "persistence", value: "persistence" },
+	{ description: "Compound parent + child scaffold", name: "compound", value: "compound" },
+	{ description: "Official empty workspace template", name: "workspace", value: "workspace" },
+];
+
+const packageManagerOptions: SelectOption[] = [
+	{ description: "Use npm", name: "npm", value: "npm" },
+	{ description: "Use pnpm", name: "pnpm", value: "pnpm" },
+	{ description: "Use yarn", name: "yarn", value: "yarn" },
+	{ description: "Use bun", name: "bun", value: "bun" },
+];
+
+const dataStorageOptions: SelectOption[] = [
+	{ description: "Dedicated custom table storage", name: "custom-table", value: "custom-table" },
+	{ description: "Persist through post meta", name: "post-meta", value: "post-meta" },
+];
+
+const persistencePolicyOptions: SelectOption[] = [
+	{ description: "Authenticated write policy", name: "authenticated", value: "authenticated" },
+	{ description: "Public token policy", name: "public", value: "public" },
+];
+
+const checkboxLabels: Record<(typeof CREATE_CHECKBOX_FIELD_NAMES)[number], string> = {
+	"no-install": "Skip dependency install",
+	yes: "Use defaults without prompts",
+	"with-wp-env": "Add wp-env preset",
+	"with-test-preset": "Add test preset",
+	"with-migration-ui": "Add migration UI",
+};
+
+const checkboxKeymap = createKeyMatcher({
+	toggle: ["space", "enter"],
 });
-
-type CreateFlowValues = z.infer<typeof createFlowSchema>;
 
 type CreateFlowProps = {
 	cwd: string;
 	initialValues: Partial<CreateFlowValues>;
 };
+
+type CreateSelectFieldProps = {
+	defaultValue?: string;
+	label: string;
+	name: keyof CreateFlowValues;
+	options: SelectOption[];
+};
+
+function CreateSelectField({
+	defaultValue,
+	label,
+	name,
+	options,
+}: CreateSelectFieldProps) {
+	const { tokens } = useTuiTheme();
+	const field = useFormField<string>(name, {
+		defaultValue: defaultValue ?? String(options[0]?.value ?? ""),
+		submitOnEnter: false,
+	});
+
+	const selectedIndex = useMemo(() => {
+		const index = options.findIndex((option) => option.value === field.value);
+		return index >= 0 ? index : 0;
+	}, [field.value, options]);
+
+	const handleChange = useCallback(
+		(_index: number, option: SelectOption | null) => {
+			if (!option) {
+				return;
+			}
+
+			field.setValue(String(option.value));
+			field.blur();
+		},
+		[field],
+	);
+
+	return createElement(
+		"box",
+		{ style: { flexDirection: "column", gap: 1, marginBottom: 1 } },
+		createElement("text", {
+			content: `${field.focused ? ">" : " "} ${label}`,
+			fg: field.focused ? tokens.accent : tokens.textPrimary,
+		}),
+		createElement(
+			"box",
+			{
+				border: true,
+				height: 5,
+				style: {
+					borderColor: field.error
+						? tokens.textDanger
+						: field.focused
+							? tokens.accent
+							: tokens.borderMuted,
+				},
+			},
+			createElement("select", {
+				focused: field.focused,
+				onChange: handleChange,
+				options,
+				selectedIndex,
+				style: { flexGrow: 1 },
+			}),
+		),
+		field.error
+			? createElement("text", { content: field.error, fg: tokens.textDanger })
+			: null,
+	);
+}
+
+function CreateCheckboxField({
+	label,
+	name,
+}: {
+	label: string;
+	name: (typeof CREATE_CHECKBOX_FIELD_NAMES)[number];
+}) {
+	const { tokens } = useTuiTheme();
+	const reactScopeId = useId();
+	const field = useFormField<boolean>(name, {
+		defaultValue: false,
+		submitOnEnter: false,
+	});
+	const keyboardScopeId = `create-checkbox:${name}:${reactScopeId}`;
+
+	const toggle = useCallback(() => {
+		field.setValue(!field.value);
+	}, [field]);
+
+	useScopedKeyboard(
+		keyboardScopeId,
+		(key) => {
+			if (!field.focused) {
+				return false;
+			}
+
+			if (checkboxKeymap.match("toggle", key)) {
+				toggle();
+				return true;
+			}
+
+			return false;
+		},
+		{ active: field.focused },
+	);
+
+	return createElement(
+		"box",
+		{ style: { flexDirection: "column", marginBottom: 1 } },
+		createElement("text", {
+			content: `${field.focused ? ">" : " "} ${field.value ? "[x]" : "[ ]"} ${label}`,
+			fg: field.focused ? tokens.accent : tokens.textPrimary,
+		}),
+		field.error
+			? createElement("text", { content: field.error, fg: tokens.textDanger })
+			: null,
+	);
+}
+
+function CreateFlowFields() {
+	const { tokens } = useTuiTheme();
+	const { activeFieldName, values } = useFormContext();
+	const { height: terminalHeight = 24 } = useTerminalDimensions();
+	const bodyRef = useRef<{ scrollTop: number } | null>(null);
+	const createValues = values as Partial<CreateFlowValues>;
+	const template = createValues.template;
+	const viewportHeight = getCreateViewportHeight(terminalHeight);
+
+	useEffect(() => {
+		if (!bodyRef.current) {
+			return;
+		}
+
+		bodyRef.current.scrollTop = getCreateScrollTop({
+			activeFieldName,
+			values: createValues,
+			viewportHeight,
+		});
+	}, [activeFieldName, createValues, viewportHeight]);
+
+	return createElement(
+		"scrollbox",
+		{
+			ref: bodyRef,
+			height: viewportHeight,
+			scrollY: true,
+			scrollbarOptions: {
+				visible: true,
+				trackOptions: {
+					backgroundColor: tokens.backgroundMuted,
+					foregroundColor: tokens.borderMuted,
+				},
+			},
+			viewportOptions: { width: "100%" },
+			contentOptions: { width: "100%" },
+		},
+		createElement(
+			"box",
+			{ width: "100%", style: { flexDirection: "column" } },
+			<FormField label="Project directory" name="project-dir" required />,
+			<CreateSelectField label="Template" name="template" options={templateOptions} />,
+			<CreateSelectField
+				label="Package manager"
+				name="package-manager"
+				options={packageManagerOptions}
+			/>,
+			<FormField label="Namespace" name="namespace" />,
+			<FormField label="Text domain" name="text-domain" />,
+			<FormField label="PHP prefix" name="php-prefix" />,
+			isCreatePersistenceTemplate(template) ? (
+				<CreateSelectField
+					label="Data storage"
+					name="data-storage"
+					options={dataStorageOptions}
+				/>
+			) : null,
+			isCreatePersistenceTemplate(template) ? (
+				<CreateSelectField
+					label="Persistence policy"
+					name="persistence-policy"
+					options={persistencePolicyOptions}
+				/>
+			) : null,
+			...CREATE_CHECKBOX_FIELD_NAMES.map((name) => (
+				<CreateCheckboxField key={name} label={checkboxLabels[name]} name={name} />
+			)),
+		),
+	);
+}
 
 export function CreateFlow({ cwd, initialValues }: CreateFlowProps) {
 	const { handleCancel, handleSubmit } = useAlternateBufferLifecycle("wp-typia create failed");
@@ -42,114 +269,24 @@ export function CreateFlow({ cwd, initialValues }: CreateFlowProps) {
 	};
 
 	return (
-		<SchemaForm
-			fields={[
-					{ kind: "text", label: "Project directory", name: "project-dir", required: true },
-					{
-						kind: "select",
-						label: "Template",
-						name: "template",
-						options: [
-							{ name: "basic", description: "Basic block scaffold", value: "basic" },
-							{
-								name: "interactivity",
-								description: "Interactivity API block scaffold",
-								value: "interactivity",
-							},
-							{
-								name: "persistence",
-								description: "Persistence-enabled block scaffold",
-								value: "persistence",
-							},
-							{
-								name: "compound",
-								description: "Compound parent + child scaffold",
-								value: "compound",
-							},
-							{
-								name: "workspace",
-								description: "Official empty workspace template",
-								value: "workspace",
-							},
-						],
-					},
-					{
-						kind: "select",
-						label: "Package manager",
-						name: "package-manager",
-						options: [
-							{ name: "npm", description: "Use npm", value: "npm" },
-							{ name: "pnpm", description: "Use pnpm", value: "pnpm" },
-							{ name: "yarn", description: "Use yarn", value: "yarn" },
-							{ name: "bun", description: "Use bun", value: "bun" },
-						],
-					},
-					{ kind: "text", label: "Namespace", name: "namespace" },
-					{ kind: "text", label: "Text domain", name: "text-domain" },
-					{ kind: "text", label: "PHP prefix", name: "php-prefix" },
-					{
-						kind: "select",
-						label: "Data storage",
-						name: "data-storage",
-						options: [
-							{
-								name: "custom-table",
-								description: "Dedicated custom table storage",
-								value: "custom-table",
-							},
-							{
-								name: "post-meta",
-								description: "Persist through post meta",
-								value: "post-meta",
-							},
-						],
-						visibleWhen: (values) =>
-							values.template === "persistence" || values.template === "compound",
-					},
-					{
-						kind: "select",
-						label: "Persistence policy",
-						name: "persistence-policy",
-						options: [
-							{
-								name: "authenticated",
-								description: "Authenticated write policy",
-								value: "authenticated",
-							},
-							{ name: "public", description: "Public token policy", value: "public" },
-						],
-						visibleWhen: (values) =>
-							values.template === "persistence" || values.template === "compound",
-					},
-					{ kind: "checkbox", label: "Skip dependency install", name: "no-install" },
-					{ kind: "checkbox", label: "Use defaults without prompts", name: "yes" },
-					{ kind: "checkbox", label: "Add wp-env preset", name: "with-wp-env" },
-					{
-						kind: "checkbox",
-						label: "Add test preset",
-						name: "with-test-preset",
-					},
-					{
-						kind: "checkbox",
-						label: "Add migration UI",
-						name: "with-migration-ui",
-					},
-				]}
+		<Form
 			initialValues={initialValues}
 			onCancel={handleCancel}
 			onSubmit={async (values) =>
 				handleSubmit(async () => {
-						await executeCreateCommand({
-							cwd,
-							flags: values,
-							interactive: true,
-							projectDir: values["project-dir"],
-							prompt: defaultPrompt,
-						});
+					await executeCreateCommand({
+						cwd,
+						flags: values,
+						interactive: true,
+						projectDir: values["project-dir"],
+						prompt: defaultPrompt,
+					});
 				})
 			}
 			schema={createFlowSchema}
 			title="Create a wp-typia project"
-		/>
+		>
+			<CreateFlowFields />
+		</Form>
 	);
 }

--- a/packages/wp-typia/tests/create-flow-layout.test.ts
+++ b/packages/wp-typia/tests/create-flow-layout.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+	CREATE_CHECKBOX_FIELD_NAMES,
+	getCreateScrollTop,
+	getCreateViewportHeight,
+	getVisibleCreateFieldNames,
+	isCreatePersistenceTemplate,
+} from "../src/ui/create-flow-model";
+
+describe("create flow layout model", () => {
+	test("keeps the checkbox cluster order stable", () => {
+		const basicFields = getVisibleCreateFieldNames({ template: "basic" });
+		expect(basicFields.slice(-CREATE_CHECKBOX_FIELD_NAMES.length)).toEqual([
+			...CREATE_CHECKBOX_FIELD_NAMES,
+		]);
+	});
+
+	test("shows persistence fields only for persistence-capable templates", () => {
+		expect(isCreatePersistenceTemplate("persistence")).toBe(true);
+		expect(isCreatePersistenceTemplate("compound")).toBe(true);
+		expect(isCreatePersistenceTemplate("basic")).toBe(false);
+
+		expect(getVisibleCreateFieldNames({ template: "basic" })).not.toContain("data-storage");
+		expect(getVisibleCreateFieldNames({ template: "basic" })).not.toContain(
+			"persistence-policy",
+		);
+
+		expect(getVisibleCreateFieldNames({ template: "persistence" })).toContain("data-storage");
+		expect(getVisibleCreateFieldNames({ template: "compound" })).toContain(
+			"persistence-policy",
+		);
+	});
+
+	test("inserts persistence fields before the checkbox cluster", () => {
+		const persistenceFields = getVisibleCreateFieldNames({ template: "persistence" });
+		expect(persistenceFields).toEqual([
+			"project-dir",
+			"template",
+			"package-manager",
+			"namespace",
+			"text-domain",
+			"php-prefix",
+			"data-storage",
+			"persistence-policy",
+			...CREATE_CHECKBOX_FIELD_NAMES,
+		]);
+	});
+
+	test("keeps early fields pinned at the top in a small viewport", () => {
+		const viewportHeight = getCreateViewportHeight(18);
+		expect(viewportHeight).toBe(8);
+		expect(
+			getCreateScrollTop({
+				activeFieldName: "project-dir",
+				values: { template: "basic" },
+				viewportHeight,
+			}),
+		).toBe(0);
+	});
+
+	test("scrolls trailing checkbox fields into view in a small viewport", () => {
+		const viewportHeight = getCreateViewportHeight(18);
+		expect(
+			getCreateScrollTop({
+				activeFieldName: "with-migration-ui",
+				values: { template: "basic" },
+				viewportHeight,
+			}),
+		).toBeGreaterThan(0);
+	});
+
+	test("scrolls persistence checkbox traversal in a small viewport", () => {
+		const viewportHeight = getCreateViewportHeight(18);
+		expect(
+			getCreateScrollTop({
+				activeFieldName: "with-test-preset",
+				values: { template: "compound" },
+				viewportHeight,
+			}),
+		).toBeGreaterThan(
+			getCreateScrollTop({
+				activeFieldName: "persistence-policy",
+				values: { template: "compound" },
+				viewportHeight,
+			}),
+		);
+	});
+});

--- a/packages/wp-typia/tests/create-flow-layout.test.ts
+++ b/packages/wp-typia/tests/create-flow-layout.test.ts
@@ -6,6 +6,7 @@ import {
 	getCreateViewportHeight,
 	getVisibleCreateFieldNames,
 	isCreatePersistenceTemplate,
+	sanitizeCreateSubmitValues,
 } from "../src/ui/create-flow-model";
 
 describe("create flow layout model", () => {
@@ -85,5 +86,54 @@ describe("create flow layout model", () => {
 				viewportHeight,
 			}),
 		);
+	});
+
+	test("strips persistence-only fields before submitting non-persistence templates", () => {
+		expect(
+			sanitizeCreateSubmitValues({
+				"data-storage": "custom-table",
+				namespace: "demo",
+				"no-install": false,
+				"package-manager": "npm",
+				"persistence-policy": "authenticated",
+				"php-prefix": "DEMO",
+				"project-dir": "demo-project",
+				template: "basic",
+				"text-domain": "demo",
+				variant: undefined,
+				"with-migration-ui": false,
+				"with-test-preset": false,
+				"with-wp-env": true,
+				yes: false,
+			}),
+		).toMatchObject({
+			"data-storage": undefined,
+			"persistence-policy": undefined,
+			template: "basic",
+			"with-wp-env": true,
+		});
+
+		expect(
+			sanitizeCreateSubmitValues({
+				"data-storage": "custom-table",
+				namespace: "demo",
+				"no-install": false,
+				"package-manager": "npm",
+				"persistence-policy": "authenticated",
+				"php-prefix": "DEMO",
+				"project-dir": "demo-project",
+				template: "compound",
+				"text-domain": "demo",
+				variant: undefined,
+				"with-migration-ui": false,
+				"with-test-preset": false,
+				"with-wp-env": true,
+				yes: false,
+			}),
+		).toMatchObject({
+			"data-storage": "custom-table",
+			"persistence-policy": "authenticated",
+			template: "compound",
+		});
 	});
 });


### PR DESCRIPTION
Closes #216

## Summary
- replace the create TUI's SchemaForm usage with a create-specific scrollable form surface
- keep checkbox UI while fixing keyboard traversal through the trailing option cluster
- add create-flow layout regressions and widen the pure compound generated-project smoke timeout for local validation stability

## Validation
- bun run typecheck
- bun run test
- bun run build
- bun run changesets:validate
- bun run publish:validate
- manual 24x100 PTY smoke for \

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Revamped create flow: new form schema, improved select and checkbox controls, conditional display of persistence fields, viewport-aware scrolling, and sanitized submit payloads.

* **Tests**
  * Added layout tests for field ordering, template-based visibility, scrolling behavior, and submit-value sanitization.

* **Chores**
  * Increased test timeout to improve stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->