### PR TITLE
fix: generated interactivity class directive syntax

### DIFF
--- a/.sampo/changesets/issue-214-interactivity-class-directive.md
+++ b/.sampo/changesets/issue-214-interactivity-class-directive.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Fix generated interactivity scaffolds to emit valid `data-wp-class--is-active` directives for animation state toggling.

--- a/packages/wp-typia-project-tools/templates/interactivity/src/edit.tsx.mustache
+++ b/packages/wp-typia-project-tools/templates/interactivity/src/edit.tsx.mustache
@@ -258,7 +258,7 @@ export default function Edit({ attributes, setAttributes, isSelected }: {
           {animation !== 'none' && (
             <div
               className={`{{cssClassName}}__animation ${attributes.isAnimating ? 'is-active' : ''}`}
-              data-wp-class="is-active"
+              data-wp-class--is-active="state.isAnimating"
             >
               {animation}
             </div>

--- a/packages/wp-typia-project-tools/templates/interactivity/src/save.tsx.mustache
+++ b/packages/wp-typia-project-tools/templates/interactivity/src/save.tsx.mustache
@@ -70,7 +70,7 @@ export default function Save({ attributes }: { attributes: {{pascalCase}}Attribu
         <div
           className={`{{cssClassName}}__animation ${attributes.animation}`}
           aria-hidden="true"
-          data-wp-class="is-active"
+          data-wp-class--is-active="state.isAnimating"
         />
 
         {attributes.maxClicks > 0 && (

--- a/packages/wp-typia-project-tools/tests/create-cli.test.ts
+++ b/packages/wp-typia-project-tools/tests/create-cli.test.ts
@@ -1068,6 +1068,10 @@ describe("@wp-typia/project-tools scaffolding", () => {
     expect(generatedEdit).toContain(
       "wp-block-demo-space-demo-interactivity__content"
     );
+    expect(generatedEdit).toContain(
+      'data-wp-class--is-active="state.isAnimating"'
+    );
+    expect(generatedEdit).not.toContain('data-wp-class="is-active"');
     expect(generatedValidators).toContain('from "./validator-toolkit"');
     expect(generatedIndex).toContain("@wp-typia/block-runtime/blocks");
     expect(generatedIndex).toContain("buildScaffoldBlockRegistration");
@@ -1104,6 +1108,10 @@ describe("@wp-typia/project-tools scaffolding", () => {
     expect(generatedSave).toContain(
       "wp-block-demo-space-demo-interactivity__content"
     );
+    expect(generatedSave).toContain(
+      'data-wp-class--is-active="state.isAnimating"'
+    );
+    expect(generatedSave).not.toContain('data-wp-class="is-active"');
     expect(generatedSave).not.toContain(
       'data-wp-text="state.clicks"\n              aria-live='
     );


### PR DESCRIPTION
## Summary

- fix the generated interactivity scaffold to emit valid `data-wp-class--is-active` directives
- align both `save.tsx` and `edit.tsx` templates so saved markup and editor preview use the same Interactivity API syntax
- add regression coverage for the generated `save.tsx` and `edit.tsx` output

## Why This Matters

The generated interactivity scaffold was emitting `data-wp-class="is-active"`, which is not valid WordPress Interactivity API class directive syntax. Because the directive is ignored at runtime, the intended `.is-active` animation-state class toggle never activates.

This changes the generated markup to `data-wp-class--is-active="state.isAnimating"`, which matches the existing state shape and restores the intended runtime behavior.

Closes #214.

## Validation

- `bun test packages/wp-typia-project-tools/tests/create-cli.test.ts -t "scaffoldProject creates an interactivity template with typed validation wiring"`
- `bun run ci:local`

## Release notes

- changeset added for `@wp-typia/project-tools` and `wp-typia`

## Docs

- no user-facing docs changes required

## Migration / compatibility

- no new CLI flags or public API surface changes
- generated interactivity scaffold markup now uses valid `data-wp-class--*` syntax


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed interactivity template scaffolds to emit correct state-driven animation directives, ensuring animation classes are properly applied based on runtime state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->