### PR TITLE
fix: align persistence and compound scaffold conventions

### DIFF
--- a/.sampo/changesets/issue-215-scaffold-convention-alignment.md
+++ b/.sampo/changesets/issue-215-scaffold-convention-alignment.md
@@ -1,0 +1,7 @@
+---
+npm/@wp-typia/block-runtime: patch
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Align persistence and compound scaffold validator and inspector conventions, including generated storage-mode labels and compound add-child validator wiring.

--- a/packages/wp-typia-block-runtime/src/inspector-runtime.tsx
+++ b/packages/wp-typia-block-runtime/src/inspector-runtime.tsx
@@ -99,13 +99,13 @@ export interface UseEditorFieldsResult {
 	fields: EditorFieldDescriptor[];
 	fieldMap: Map<string, EditorFieldDescriptor>;
 	getBooleanValue: (
-		source: UnknownRecord,
+		source: object,
 		path: string,
 		fallback: boolean,
 	) => boolean;
 	getField: (path: string) => EditorFieldDescriptor | undefined;
 	getNumberValue: (
-		source: UnknownRecord,
+		source: object,
 		path: string,
 		fallback: number,
 	) => number;
@@ -114,7 +114,7 @@ export interface UseEditorFieldsResult {
 		labelMap?: Record<string, string>,
 	) => InspectorSelectOption[];
 	getStringValue: (
-		source: UnknownRecord,
+		source: object,
 		path: string,
 		fallback: string,
 	) => string;
@@ -167,7 +167,7 @@ export interface InspectorFieldOverride {
 	step?: number;
 }
 
-export interface InspectorFromManifestProps<T extends UnknownRecord> {
+export interface InspectorFromManifestProps<T extends object> {
 	attributes: T;
 	children?: ReactNode;
 	components?: InspectorComponentMap;
@@ -194,14 +194,14 @@ function getDefaultValue(
 	return fallback;
 }
 
-function getValueAtPath(source: UnknownRecord, path: string): unknown {
+function getValueAtPath(source: object, path: string): unknown {
 	return getPathSegments(path).reduce<unknown>((current, segment) => {
 		if (!isRecord(current)) {
 			return undefined;
 		}
 
 		return current[segment];
-	}, source);
+	}, source as UnknownRecord);
 }
 
 function toStringValue(value: unknown, fallback: string): string {
@@ -280,7 +280,7 @@ function resolveInspectorComponents(
 
 function getFieldValue(
 	field: EditorFieldDescriptor,
-	source: UnknownRecord,
+	source: object,
 ): unknown {
 	const currentValue = getValueAtPath(source, field.path);
 
@@ -441,7 +441,7 @@ export function useEditorFields(
 
 	const getField = (path: string) => fieldMap.get(path);
 	const getStringValue = (
-		source: UnknownRecord,
+		source: object,
 		path: string,
 		fallback: string,
 	) =>
@@ -450,7 +450,7 @@ export function useEditorFields(
 			fallback,
 		);
 	const getNumberValue = (
-		source: UnknownRecord,
+		source: object,
 		path: string,
 		fallback: number,
 	) =>
@@ -459,7 +459,7 @@ export function useEditorFields(
 			fallback,
 		);
 	const getBooleanValue = (
-		source: UnknownRecord,
+		source: object,
 		path: string,
 		fallback: boolean,
 	) =>
@@ -675,7 +675,7 @@ export function FieldControl({
 	}
 }
 
-export function InspectorFromManifest<T extends UnknownRecord>({
+export function InspectorFromManifest<T extends object>({
 	attributes,
 	children,
 	components,

--- a/packages/wp-typia-project-tools/templates/_shared/compound/core/scripts/add-compound-child.ts.mustache
+++ b/packages/wp-typia-project-tools/templates/_shared/compound/core/scripts/add-compound-child.ts.mustache
@@ -346,8 +346,15 @@ function renderBlockJson(
 	) }\n`;
 }
 
-function renderTypesFile( childTypeName: string, childTitle: string ): string {
-	return `import { tags } from 'typia';
+function renderTypesFile(
+	childTypeName: string,
+	childInterfaceName: string,
+	childTitle: string
+): string {
+	return `import type { ValidationResult } from '@wp-typia/block-runtime/validation';
+import { tags } from 'typia';
+
+export type { ValidationResult } from '@wp-typia/block-runtime/validation';
 
 export interface ${ childTypeName } {
 \ttitle: string &
@@ -359,6 +366,8 @@ export interface ${ childTypeName } {
 \t\ttags.MaxLength< 280 > &
 \t\ttags.Default< ${ JSON.stringify( CHILD_PLACEHOLDER ) } >;
 }
+
+export type ${ childInterfaceName }ValidationResult = ValidationResult< ${ childTypeName } >;
 `;
 }
 
@@ -407,36 +416,37 @@ function renderValidatorsFile(
 ): string {
 	return `import typia from 'typia';
 import currentManifest from './typia.manifest.json';
-import {
-\ttype ManifestDefaultsDocument,
-} from '@wp-typia/block-runtime/defaults';
-import {
-\tcreateScaffoldValidatorToolkit,
-} from '@wp-typia/block-runtime/validation';
+import type {
+\t${ childTypeName },
+\t${ childInterfaceName }ValidationResult,
+} from './types';
+import { createTemplateValidatorToolkit } from '../../validator-toolkit';
 
-import type { ${ childTypeName } } from './types';
-
-const validate = typia.createValidate< ${ childTypeName } >();
-const assert = typia.createAssert< ${ childTypeName } >();
-const is = typia.createIs< ${ childTypeName } >();
-const random = typia.createRandom< ${ childTypeName } >();
-const clone = typia.misc.createClone< ${ childTypeName } >();
-const prune = typia.misc.createPrune< ${ childTypeName } >();
-const scaffoldValidators = createScaffoldValidatorToolkit< ${ childTypeName } >( {
-\tmanifest: currentManifest as ManifestDefaultsDocument,
-\tvalidate,
-\tassert,
-\tis,
-\trandom,
-\tclone,
-\tprune,
+const scaffoldValidators = createTemplateValidatorToolkit< ${ childTypeName } >( {
+\tassert: typia.createAssert< ${ childTypeName } >(),
+\tclone: typia.misc.createClone< ${ childTypeName } >() as (
+\t\tvalue: ${ childTypeName },
+\t) => ${ childTypeName },
+\tis: typia.createIs< ${ childTypeName } >(),
+\tmanifest: currentManifest,
+\tprune: typia.misc.createPrune< ${ childTypeName } >(),
+\trandom: typia.createRandom< ${ childTypeName } >() as (
+\t\t...args: unknown[]
+\t) => ${ childTypeName },
+\tvalidate: typia.createValidate< ${ childTypeName } >(),
 } );
 
-export const validate${ childInterfaceName } = scaffoldValidators.validateAttributes;
+export const validate${ childInterfaceName } =
+\tscaffoldValidators.validateAttributes as (
+\t\tattributes: unknown
+\t) => ${ childInterfaceName }ValidationResult;
 
 export const validators = scaffoldValidators.validators;
 
-export const sanitize${ childInterfaceName } = scaffoldValidators.sanitizeAttributes;
+export const sanitize${ childInterfaceName } =
+\tscaffoldValidators.sanitizeAttributes as (
+\t\tattributes: Partial< ${ childTypeName } >
+\t) => ${ childTypeName };
 
 export const createAttributeUpdater = scaffoldValidators.createAttributeUpdater;
 `;
@@ -605,7 +615,11 @@ function main() {
 		renderBlockJson( childBlockName, childFolderSlug, childTitle ),
 		'utf8'
 	);
-	fs.writeFileSync( path.join( childDir, 'types.ts' ), renderTypesFile( childTypeName, childTitle ), 'utf8' );
+	fs.writeFileSync(
+		path.join( childDir, 'types.ts' ),
+		renderTypesFile( childTypeName, childInterfaceName, childTitle ),
+		'utf8'
+	);
 	fs.writeFileSync(
 		path.join( childDir, 'typia.manifest.json' ),
 		renderStarterManifestFile( childTypeName, childTitle ),

--- a/packages/wp-typia-project-tools/templates/compound/src/blocks/{{slugKebabCase}}-item/types.ts.mustache
+++ b/packages/wp-typia-project-tools/templates/compound/src/blocks/{{slugKebabCase}}-item/types.ts.mustache
@@ -1,4 +1,7 @@
+import type { ValidationResult } from '@wp-typia/block-runtime/validation';
 import { tags } from 'typia';
+
+export type { ValidationResult } from '@wp-typia/block-runtime/validation';
 
 export interface {{pascalCase}}ItemAttributes {
 	title: string &
@@ -10,3 +13,5 @@ export interface {{pascalCase}}ItemAttributes {
 		tags.MaxLength< 280 > &
 		tags.Default< 'Add supporting details for this internal item.' >;
 }
+
+export type {{pascalCase}}ItemValidationResult = ValidationResult< {{pascalCase}}ItemAttributes >;

--- a/packages/wp-typia-project-tools/templates/compound/src/blocks/{{slugKebabCase}}-item/validators.ts.mustache
+++ b/packages/wp-typia-project-tools/templates/compound/src/blocks/{{slugKebabCase}}-item/validators.ts.mustache
@@ -1,6 +1,9 @@
 import typia from 'typia';
 import currentManifest from './typia.manifest.json';
-import type { {{pascalCase}}ItemAttributes } from './types';
+import type {
+	{{pascalCase}}ItemAttributes,
+	{{pascalCase}}ItemValidationResult,
+} from './types';
 import { createTemplateValidatorToolkit } from '../../validator-toolkit';
 
 const scaffoldValidators = createTemplateValidatorToolkit< {{pascalCase}}ItemAttributes >( {
@@ -18,11 +21,15 @@ const scaffoldValidators = createTemplateValidatorToolkit< {{pascalCase}}ItemAtt
 } );
 
 export const validate{{pascalCase}}ItemAttributes =
-	scaffoldValidators.validateAttributes;
+	scaffoldValidators.validateAttributes as (
+		attributes: unknown
+	) => {{pascalCase}}ItemValidationResult;
 
 export const validators = scaffoldValidators.validators;
 
 export const sanitize{{pascalCase}}ItemAttributes =
-	scaffoldValidators.sanitizeAttributes;
+	scaffoldValidators.sanitizeAttributes as (
+		attributes: Partial< {{pascalCase}}ItemAttributes >
+	) => {{pascalCase}}ItemAttributes;
 
 export const createAttributeUpdater = scaffoldValidators.createAttributeUpdater;

--- a/packages/wp-typia-project-tools/templates/compound/src/blocks/{{slugKebabCase}}/types.ts.mustache
+++ b/packages/wp-typia-project-tools/templates/compound/src/blocks/{{slugKebabCase}}/types.ts.mustache
@@ -1,4 +1,7 @@
+import type { ValidationResult } from '@wp-typia/block-runtime/validation';
 import { tags } from 'typia';
+
+export type { ValidationResult } from '@wp-typia/block-runtime/validation';
 
 export interface {{pascalCase}}Attributes {
 	heading: string &
@@ -11,3 +14,5 @@ export interface {{pascalCase}}Attributes {
 		tags.Default< 'Add and reorder internal items inside this compound block.' >;
 	showDividers?: boolean & tags.Default< true >;
 }
+
+export type {{pascalCase}}ValidationResult = ValidationResult< {{pascalCase}}Attributes >;

--- a/packages/wp-typia-project-tools/templates/compound/src/blocks/{{slugKebabCase}}/validators.ts.mustache
+++ b/packages/wp-typia-project-tools/templates/compound/src/blocks/{{slugKebabCase}}/validators.ts.mustache
@@ -1,6 +1,9 @@
 import typia from 'typia';
 import currentManifest from './typia.manifest.json';
-import type { {{pascalCase}}Attributes } from './types';
+import type {
+	{{pascalCase}}Attributes,
+	{{pascalCase}}ValidationResult,
+} from './types';
 import { createTemplateValidatorToolkit } from '../../validator-toolkit';
 
 const scaffoldValidators = createTemplateValidatorToolkit< {{pascalCase}}Attributes >( {
@@ -18,11 +21,15 @@ const scaffoldValidators = createTemplateValidatorToolkit< {{pascalCase}}Attribu
 } );
 
 export const validate{{pascalCase}}Attributes =
-	scaffoldValidators.validateAttributes;
+	scaffoldValidators.validateAttributes as (
+		attributes: unknown
+	) => {{pascalCase}}ValidationResult;
 
 export const validators = scaffoldValidators.validators;
 
 export const sanitize{{pascalCase}}Attributes =
-	scaffoldValidators.sanitizeAttributes;
+	scaffoldValidators.sanitizeAttributes as (
+		attributes: Partial< {{pascalCase}}Attributes >
+	) => {{pascalCase}}Attributes;
 
 export const createAttributeUpdater = scaffoldValidators.createAttributeUpdater;

--- a/packages/wp-typia-project-tools/templates/persistence/src/edit.tsx.mustache
+++ b/packages/wp-typia-project-tools/templates/persistence/src/edit.tsx.mustache
@@ -66,7 +66,7 @@ export default function Edit( {
 		validateEditorUpdate
 	);
 	const alignmentValue = editorFields.getStringValue(
-		attributes as unknown as Record< string, unknown >,
+		attributes,
 		'alignment',
 		'left'
 	);
@@ -91,7 +91,7 @@ export default function Edit( {
 			</BlockControls>
 			<InspectorControls>
 				<InspectorFromManifest
-					attributes={ attributes as unknown as Record< string, unknown > }
+					attributes={ attributes }
 					fieldLookup={ editorFields }
 					onChange={ updateField }
 					paths={ [ 'alignment', 'isVisible', 'showCount', 'buttonLabel' ] }

--- a/packages/wp-typia-project-tools/tests/create-cli.test.ts
+++ b/packages/wp-typia-project-tools/tests/create-cli.test.ts
@@ -1310,6 +1310,10 @@ describe("@wp-typia/project-tools scaffolding", () => {
         path.join(targetDir, "src", "types.ts"),
         "utf8"
       );
+      const generatedEdit = fs.readFileSync(
+        path.join(targetDir, "src", "edit.tsx"),
+        "utf8"
+      );
       const generatedValidators = fs.readFileSync(
         path.join(targetDir, "src", "validators.ts"),
         "utf8"
@@ -1466,6 +1470,20 @@ describe("@wp-typia/project-tools scaffolding", () => {
         /typia\.createValidate<\s*DemoPersistencePublicAttributes\s*>\(\)/
       );
       expect(generatedValidators).not.toContain("const generateResourceKey");
+      expect(generatedEdit).toContain(
+        "const alignmentValue = editorFields.getStringValue("
+      );
+      expect(generatedEdit).toContain("\t\tattributes,");
+      expect(generatedEdit).toContain("attributes={ attributes }");
+      expect(generatedEdit).not.toContain(
+        "attributes as unknown as Record< string, unknown >"
+      );
+      expect(generatedEdit).toContain(
+        "{ __( 'Storage mode: post-meta', 'demo-persistence-public' ) }"
+      );
+      expect(generatedEdit).toContain(
+        "{ __( 'Storage mode:', 'demo-persistence-public' ) } post-meta"
+      );
       expect(generatedData).toContain("useDemoPersistencePublicStateQuery");
       expect(generatedData).toContain(
         "useWriteDemoPersistencePublicStateMutation"
@@ -1843,6 +1861,20 @@ describe("@wp-typia/project-tools scaffolding", () => {
     );
     expect(generatedTypes).toContain(
       "persistencePolicy: 'authenticated' | 'public';"
+    );
+    expect(generatedEdit).toContain(
+      "const alignmentValue = editorFields.getStringValue("
+    );
+    expect(generatedEdit).toContain("\t\tattributes,");
+    expect(generatedEdit).toContain("attributes={ attributes }");
+    expect(generatedEdit).not.toContain(
+      "attributes as unknown as Record< string, unknown >"
+    );
+    expect(generatedEdit).toContain(
+      "{ __( 'Storage mode: custom-table', 'demo-persistence-authenticated' ) }"
+    );
+    expect(generatedEdit).toContain(
+      "{ __( 'Storage mode:', 'demo-persistence-authenticated' ) } custom-table"
     );
     expect(generatedEdit).toContain(
       "Stable persisted identifier used by the storage-backed counter endpoint."
@@ -2696,6 +2728,10 @@ console.log(JSON.stringify({ initial, updated, reread }));
     expect(parentValidators).toContain("validator-toolkit");
     expect(parentValidators).toContain("import typia from 'typia';");
     expect(parentValidators).not.toContain("createScaffoldValidatorToolkit");
+    expect(parentValidators).toContain("DemoCompoundValidationResult");
+    expect(parentValidators).toContain(
+      "scaffoldValidators.validateAttributes as ("
+    );
     expect(generatedValidatorToolkit).toContain(
       "createScaffoldValidatorToolkit"
     );
@@ -2717,6 +2753,10 @@ console.log(JSON.stringify({ initial, updated, reread }));
     expect(childValidators).toContain("validator-toolkit");
     expect(childValidators).toContain("import typia from 'typia';");
     expect(childValidators).not.toContain("createScaffoldValidatorToolkit");
+    expect(childValidators).toContain("DemoCompoundItemValidationResult");
+    expect(childValidators).toContain(
+      "scaffoldValidators.validateAttributes as ("
+    );
     expect(childBlockJson.attributes.title.selector).toBe(
       ".wp-block-create-block-demo-compound-item__title"
     );
@@ -2724,7 +2764,8 @@ console.log(JSON.stringify({ initial, updated, reread }));
       ".wp-block-create-block-demo-compound-item__body"
     );
     expect(addChildScript).toContain("createUseTypiaValidationHook");
-    expect(addChildScript).toContain("createScaffoldValidatorToolkit");
+    expect(addChildScript).toContain("createTemplateValidatorToolkit");
+    expect(addChildScript).not.toContain("createScaffoldValidatorToolkit");
     expect(addChildScript).toContain("buildScaffoldBlockRegistration");
     expect(addChildScript).toContain("type ScaffoldBlockMetadata");
     expect(addChildScript).toContain("ALLOWED_CHILD_MARKER");
@@ -3197,6 +3238,10 @@ console.log(JSON.stringify({ initial, updated, reread }));
       expect(childValidators).toContain("validator-toolkit");
       expect(childValidators).toContain("import typia from 'typia';");
       expect(childValidators).not.toContain("createScaffoldValidatorToolkit");
+      expect(childValidators).toContain("DemoCompoundStorageItemValidationResult");
+      expect(childValidators).toContain(
+        "scaffoldValidators.validateAttributes as ("
+      );
       expect(generatedValidatorToolkit).toContain(
         "createScaffoldValidatorToolkit"
       );
@@ -3204,6 +3249,8 @@ console.log(JSON.stringify({ initial, updated, reread }));
       expect(generatedAddChild).toContain("ALLOWED_CHILD_MARKER");
       expect(generatedAddChild).toContain("buildScaffoldBlockRegistration");
       expect(generatedAddChild).toContain("type ScaffoldBlockMetadata");
+      expect(generatedAddChild).toContain("createTemplateValidatorToolkit");
+      expect(generatedAddChild).not.toContain("createScaffoldValidatorToolkit");
       expect(packageJson.scripts["add-child"]).toBe(
         "tsx scripts/add-compound-child.ts"
       );
@@ -3469,7 +3516,14 @@ console.log(JSON.stringify({ initial, updated, reread }));
         "'create-block/demo-compound-add-child-faq-item'"
       );
       expect(newChildHooks).toContain("createUseTypiaValidationHook");
-      expect(newChildValidators).toContain("createScaffoldValidatorToolkit");
+      expect(newChildValidators).toContain("createTemplateValidatorToolkit");
+      expect(newChildValidators).not.toContain("createScaffoldValidatorToolkit");
+      expect(newChildValidators).toContain(
+        "DemoCompoundAddChildFaqItemValidationResult"
+      );
+      expect(newChildValidators).toContain(
+        "scaffoldValidators.validateAttributes as ("
+      );
       expect(newChildIndex).toContain("buildScaffoldBlockRegistration");
       expect(newChildIndex).toContain("type ScaffoldBlockMetadata");
       expect(newChildEdit).toContain(

--- a/packages/wp-typia-project-tools/tests/create-cli.test.ts
+++ b/packages/wp-typia-project-tools/tests/create-cli.test.ts
@@ -1473,7 +1473,9 @@ describe("@wp-typia/project-tools scaffolding", () => {
       expect(generatedEdit).toContain(
         "const alignmentValue = editorFields.getStringValue("
       );
-      expect(generatedEdit).toContain("\t\tattributes,");
+      expect(generatedEdit).toMatch(
+        /editorFields\.getStringValue\(\s*attributes,\s*['"]alignment['"]/u
+      );
       expect(generatedEdit).toContain("attributes={ attributes }");
       expect(generatedEdit).not.toContain(
         "attributes as unknown as Record< string, unknown >"
@@ -1865,7 +1867,9 @@ describe("@wp-typia/project-tools scaffolding", () => {
     expect(generatedEdit).toContain(
       "const alignmentValue = editorFields.getStringValue("
     );
-    expect(generatedEdit).toContain("\t\tattributes,");
+    expect(generatedEdit).toMatch(
+      /editorFields\.getStringValue\(\s*attributes,\s*['"]alignment['"]/u
+    );
     expect(generatedEdit).toContain("attributes={ attributes }");
     expect(generatedEdit).not.toContain(
       "attributes as unknown as Record< string, unknown >"


### PR DESCRIPTION
## Summary

- align persistence scaffolds with the current inspector conventions by removing the generated double-cast in `edit.tsx` and relaxing the shared inspector runtime helpers to accept object-like attribute sources
- align compound parent, child, and add-child validator generation around the same `createTemplateValidatorToolkit` + explicit `ValidationResult` typing pattern so generated validators match the current template conventions
- extend scaffold regression coverage for persistence storage-mode labels and compound add-child validator output so `post-meta`/`custom-table` strings and validator wiring stay stable
- Closes #215

## Validation

- `bun test packages/wp-typia-project-tools/tests/create-cli.test.ts`
- `bun run --filter @wp-typia/block-runtime build`
- `bun run ci:local`

## Release notes

- changeset added for `@wp-typia/block-runtime`, `@wp-typia/project-tools`, and `wp-typia`

## Docs

- no docs update needed; this change keeps generated scaffold output aligned with the existing workflow rather than introducing a new one

## Migration / compatibility

- no migration format change or new CLI surface
- verified generated persistence and compound scaffolds continue to typecheck and pass the full local CI gate after the inspector typing relaxation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added generated storage-mode labels for persistence blocks.
  * Improved compound block "add-child" validator behavior and wiring.

* **Refactor**
  * Aligned scaffold validation and inspection conventions to improve consistency.

* **Tests**
  * Expanded test coverage to assert persistence label rendering and compound validator workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->