### PR TITLE
fix: unblock published wp-typia create installs

### DIFF
--- a/.sampo/changesets/fix-published-cli-install-bugs.md
+++ b/.sampo/changesets/fix-published-cli-install-bugs.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Fix the published CLI create flow so it no longer eagerly loads project-tools runtime modules that drag in TypeScript during startup, and align the CLI React dependency range with Bunli's current React peer floor to avoid duplicate-React crashes in interactive `wp-typia create`.

--- a/bun.lock
+++ b/bun.lock
@@ -28,8 +28,8 @@
         "eslint-config-prettier": "8.10.2",
         "globals": "13.24.0",
         "prettier": "2.8.8",
-        "react": "^19.2.0",
-        "react-dom": "^19.2.0",
+        "react": "^19.2.5",
+        "react-dom": "^19.2.5",
         "typedoc": "^0.25.4",
         "typedoc-plugin-markdown": "^3.16.0",
         "typescript": "^5.9.2",
@@ -3290,7 +3290,7 @@
 
     "re-resizable": ["re-resizable@6.11.2", "", { "peerDependencies": { "react": "^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-2xI2P3OHs5qw7K0Ud1aLILK6MQxW50TcO+DetD9eIV58j84TqYeHoZcL9H4GXFXXIh7afhH8mv5iUCXII7OW7A=="],
 
-    "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
+    "react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 
     "react-autosize-textarea": ["react-autosize-textarea@7.1.0", "", { "dependencies": { "autosize": "^4.0.2", "line-height": "^0.3.1", "prop-types": "^15.5.6" }, "peerDependencies": { "react": "^0.14.0 || ^15.0.0 || ^16.0.0", "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0" } }, "sha512-BHpjCDkuOlllZn3nLazY2F8oYO1tS2jHnWhcjTWQdcKiiMU6gHLNt/fzmqMSyerR0eTdKtfSIqtSeTtghNwS+g=="],
 
@@ -3300,7 +3300,7 @@
 
     "react-devtools-core": ["react-devtools-core@7.0.1", "", { "dependencies": { "shell-quote": "^1.6.1", "ws": "^7" } }, "sha512-C3yNvRHaizlpiASzy7b9vbnBGLrhvdhl1CbdU6EnZgxPNbai60szdLtl+VL76UNOt5bOoVTOz5rNWZxgGt+Gsw=="],
 
-    "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
+    "react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
 
     "react-easy-crop": ["react-easy-crop@5.5.7", "", { "dependencies": { "normalize-wheel": "^1.0.1", "tslib": "^2.0.1" }, "peerDependencies": { "react": ">=16.4.0", "react-dom": ">=16.4.0" } }, "sha512-kYo4NtMeXFQB7h1U+h5yhUkE46WQbQdq7if54uDlbMdZHdRgNehfvaFrXnFw5NR1PNoUOJIfTwLnWmEx/MaZnA=="],
 
@@ -4278,11 +4278,7 @@
 
     "@wp-playground/wordpress/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
 
-    "@wp-typia/block-runtime/react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
-
     "@wp-typia/block-types/@types/react": ["@types/react@18.3.28", "", { "dependencies": { "@types/prop-types": "*", "csstype": "^3.2.2" } }, "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw=="],
-
-    "@wp-typia/project-tools/react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 
     "accepts/negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
 
@@ -4645,10 +4641,6 @@
     "webpack-dev-server/rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
 
     "webpack-merge/clone-deep": ["clone-deep@4.0.1", "", { "dependencies": { "is-plain-object": "^2.0.4", "kind-of": "^6.0.2", "shallow-clone": "^3.0.0" } }, "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ=="],
-
-    "wp-typia/react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
-
-    "wp-typia/react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
 
     "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -140,11 +140,11 @@
     },
     "packages/create-workspace-template": {
       "name": "@wp-typia/create-workspace-template",
-      "version": "0.13.0",
+      "version": "0.14.0",
     },
     "packages/wp-typia": {
       "name": "wp-typia",
-      "version": "0.15.1",
+      "version": "0.16.2",
       "bin": {
         "wp-typia": "bin/wp-typia.js",
       },
@@ -158,11 +158,11 @@
         "@bunli/runtime": "0.3.1",
         "@bunli/tui": "0.6.0",
         "@bunli/utils": "0.6.0",
-        "@wp-typia/api-client": "^0.4.1",
-        "@wp-typia/project-tools": "0.15.1",
+        "@wp-typia/api-client": "^0.4.2",
+        "@wp-typia/project-tools": "0.16.1",
         "better-result": "^2.7.0",
-        "react": "19.2.0",
-        "react-dom": "19.2.0",
+        "react": "^19.2.5",
+        "react-dom": "^19.2.5",
         "zod": "4.3.6",
       },
       "devDependencies": {
@@ -182,7 +182,7 @@
     },
     "packages/wp-typia-api-client": {
       "name": "@wp-typia/api-client",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
         "@typia/interface": "^12.0.1",
       },
@@ -192,9 +192,9 @@
     },
     "packages/wp-typia-block-runtime": {
       "name": "@wp-typia/block-runtime",
-      "version": "0.4.1",
+      "version": "0.4.4",
       "dependencies": {
-        "@wp-typia/api-client": "^0.4.1",
+        "@wp-typia/api-client": "^0.4.2",
         "typescript": "^5.9.2",
       },
       "devDependencies": {
@@ -210,7 +210,7 @@
     },
     "packages/wp-typia-block-types": {
       "name": "@wp-typia/block-types",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "devDependencies": {
         "@types/react": "^18.3.12",
         "@types/wordpress__block-editor": "^11.5.17",
@@ -219,12 +219,12 @@
     },
     "packages/wp-typia-project-tools": {
       "name": "@wp-typia/project-tools",
-      "version": "0.15.1",
+      "version": "0.16.1",
       "dependencies": {
-        "@wp-typia/api-client": "^0.4.1",
-        "@wp-typia/block-runtime": "^0.4.1",
-        "@wp-typia/block-types": "^0.2.0",
-        "@wp-typia/rest": "^0.3.4",
+        "@wp-typia/api-client": "^0.4.2",
+        "@wp-typia/block-runtime": "workspace:*",
+        "@wp-typia/block-types": "^0.2.1",
+        "@wp-typia/rest": "^0.3.5",
         "mustache": "^4.2.0",
         "npm-package-arg": "^13.0.0",
         "semver": "^7.7.3",
@@ -240,7 +240,7 @@
     },
     "packages/wp-typia-rest": {
       "name": "@wp-typia/rest",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "dependencies": {
         "@typia/interface": "^12.0.1",
         "@wordpress/api-fetch": "^7.42.0",
@@ -4278,7 +4278,11 @@
 
     "@wp-playground/wordpress/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
 
+    "@wp-typia/block-runtime/react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
+
     "@wp-typia/block-types/@types/react": ["@types/react@18.3.28", "", { "dependencies": { "@types/prop-types": "*", "csstype": "^3.2.2" } }, "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw=="],
+
+    "@wp-typia/project-tools/react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 
     "accepts/negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
 
@@ -4642,9 +4646,9 @@
 
     "webpack-merge/clone-deep": ["clone-deep@4.0.1", "", { "dependencies": { "is-plain-object": "^2.0.4", "kind-of": "^6.0.2", "shallow-clone": "^3.0.0" } }, "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ=="],
 
-    "wp-typia/react": ["react@19.2.0", "", {}, "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ=="],
+    "wp-typia/react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 
-    "wp-typia/react-dom": ["react-dom@19.2.0", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.0" } }, "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ=="],
+    "wp-typia/react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
 
     "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 

--- a/package.json
+++ b/package.json
@@ -121,8 +121,8 @@
     "eslint-config-prettier": "8.10.2",
     "globals": "13.24.0",
     "prettier": "2.8.8",
-    "react": "^19.2.0",
-    "react-dom": "^19.2.0",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
     "typedoc": "^0.25.4",
     "typedoc-plugin-markdown": "^3.16.0",
     "typescript": "^5.9.2"

--- a/packages/wp-typia-project-tools/package.json
+++ b/packages/wp-typia-project-tools/package.json
@@ -12,10 +12,55 @@
       "import": "./dist/runtime/index.js",
       "default": "./dist/runtime/index.js"
     },
+    "./cli-add": {
+      "types": "./dist/runtime/cli-add.d.ts",
+      "import": "./dist/runtime/cli-add.js",
+      "default": "./dist/runtime/cli-add.js"
+    },
+    "./cli-doctor": {
+      "types": "./dist/runtime/cli-doctor.d.ts",
+      "import": "./dist/runtime/cli-doctor.js",
+      "default": "./dist/runtime/cli-doctor.js"
+    },
+    "./cli-prompt": {
+      "types": "./dist/runtime/cli-prompt.d.ts",
+      "import": "./dist/runtime/cli-prompt.js",
+      "default": "./dist/runtime/cli-prompt.js"
+    },
+    "./cli-scaffold": {
+      "types": "./dist/runtime/cli-scaffold.d.ts",
+      "import": "./dist/runtime/cli-scaffold.js",
+      "default": "./dist/runtime/cli-scaffold.js"
+    },
+    "./cli-templates": {
+      "types": "./dist/runtime/cli-templates.d.ts",
+      "import": "./dist/runtime/cli-templates.js",
+      "default": "./dist/runtime/cli-templates.js"
+    },
+    "./hooked-blocks": {
+      "types": "./dist/runtime/hooked-blocks.d.ts",
+      "import": "./dist/runtime/hooked-blocks.js",
+      "default": "./dist/runtime/hooked-blocks.js"
+    },
+    "./migrations": {
+      "types": "./dist/runtime/migrations.d.ts",
+      "import": "./dist/runtime/migrations.js",
+      "default": "./dist/runtime/migrations.js"
+    },
+    "./package-managers": {
+      "types": "./dist/runtime/package-managers.d.ts",
+      "import": "./dist/runtime/package-managers.js",
+      "default": "./dist/runtime/package-managers.js"
+    },
     "./schema-core": {
       "types": "./dist/runtime/schema-core.d.ts",
       "import": "./dist/runtime/schema-core.js",
       "default": "./dist/runtime/schema-core.js"
+    },
+    "./workspace-project": {
+      "types": "./dist/runtime/workspace-project.d.ts",
+      "import": "./dist/runtime/workspace-project.js",
+      "default": "./dist/runtime/workspace-project.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/wp-typia/package.json
+++ b/packages/wp-typia/package.json
@@ -67,8 +67,8 @@
     "@wp-typia/api-client": "^0.4.2",
     "@wp-typia/project-tools": "0.16.1",
     "better-result": "^2.7.0",
-    "react": "19.2.0",
-    "react-dom": "19.2.0",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
     "zod": "4.3.6"
   },
   "devDependencies": {

--- a/packages/wp-typia/src/commands/add.ts
+++ b/packages/wp-typia/src/commands/add.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 
 import { getAddBlockDefaults } from "../config";
 import { resolveBundledModuleHref } from "../render-loader";
-import { executeAddCommand, getAddWorkspaceBlockOptions } from "../runtime-bridge";
+import { executeAddCommand } from "../runtime-bridge";
 import type { WpTypiaRenderArgs } from "./render-types";
 import { LazyFlow } from "../ui/lazy-flow";
 
@@ -94,7 +94,6 @@ export const addCommand = defineCommand({
 								template:
 									(args.flags.template as string | undefined) ?? config.template,
 							},
-							workspaceBlockOptions: getAddWorkspaceBlockOptions(args.cwd),
 						},
 					});
 				},

--- a/packages/wp-typia/src/commands/doctor.ts
+++ b/packages/wp-typia/src/commands/doctor.ts
@@ -1,6 +1,5 @@
 import { defineCommand } from "@bunli/core";
-
-import { getDoctorChecks, runDoctor } from "@wp-typia/project-tools";
+import { executeDoctorCommand } from "../runtime-bridge";
 
 export const doctorCommand = defineCommand({
 	description: "Run repository and project diagnostics.",
@@ -10,6 +9,7 @@ export const doctorCommand = defineCommand({
 			args.agent ||
 			Boolean(args.context?.store?.isAIAgent);
 		if (prefersStructuredOutput) {
+			const { getDoctorChecks } = await import("@wp-typia/project-tools/cli-doctor");
 			const checks = await getDoctorChecks(args.cwd);
 			args.output({ checks });
 			if (checks.some((check) => check.status === "fail")) {
@@ -17,7 +17,7 @@ export const doctorCommand = defineCommand({
 			}
 			return;
 		}
-		await runDoctor(args.cwd);
+		await executeDoctorCommand(args.cwd);
 	},
 	name: "doctor",
 });

--- a/packages/wp-typia/src/runtime-bridge.ts
+++ b/packages/wp-typia/src/runtime-bridge.ts
@@ -3,29 +3,15 @@ import fs from "node:fs";
 import path from "node:path";
 
 import {
-	createReadlinePrompt,
-	formatRunScript,
-	formatAddHelpText,
-	formatMigrationHelpText,
 	formatTemplateDetails,
 	formatTemplateFeatures,
 	formatTemplateSummary,
-	getWorkspaceBlockSelectOptions,
 	getTemplateById,
-	getTemplateSelectOptions,
 	listTemplates,
-	parseMigrationArgs,
-	tryResolveWorkspaceProject,
-	runAddBindingSourceCommand,
-	runAddBlockCommand,
-	runAddHookedBlockCommand,
-	runAddPatternCommand,
-	runAddVariationCommand,
-	runDoctor,
-	runMigrationCommand,
-	runScaffoldFlow,
-} from "@wp-typia/project-tools";
-import type { ReadlinePrompt } from "@wp-typia/project-tools";
+} from "@wp-typia/project-tools/cli-templates";
+import { formatRunScript } from "@wp-typia/project-tools/package-managers";
+import { tryResolveWorkspaceProject } from "@wp-typia/project-tools/workspace-project";
+import type { ReadlinePrompt } from "@wp-typia/project-tools/cli-prompt";
 
 type CreateExecutionInput = {
 	projectDir: string;
@@ -71,6 +57,13 @@ type SyncProjectContext = {
 	packageManager: PackageManagerId;
 	scripts: Partial<Record<"sync" | "sync-rest" | "sync-types", string>>;
 };
+
+const loadCliAddRuntime = () => import("@wp-typia/project-tools/cli-add");
+const loadCliDoctorRuntime = () => import("@wp-typia/project-tools/cli-doctor");
+const loadCliPromptRuntime = () => import("@wp-typia/project-tools/cli-prompt");
+const loadCliScaffoldRuntime = () => import("@wp-typia/project-tools/cli-scaffold");
+const loadCliTemplatesRuntime = () => import("@wp-typia/project-tools/cli-templates");
+const loadMigrationsRuntime = () => import("@wp-typia/project-tools/migrations");
 
 function printBlock(lines: string[], printLine: PrintLine): void {
 	for (const line of lines) {
@@ -272,6 +265,15 @@ export async function executeCreateCommand({
 	interactive,
 	prompt,
 }: CreateExecutionInput): Promise<void> {
+	const [
+		{ createReadlinePrompt },
+		{ runScaffoldFlow },
+		{ getTemplateSelectOptions },
+	] = await Promise.all([
+		loadCliPromptRuntime(),
+		loadCliScaffoldRuntime(),
+		loadCliTemplatesRuntime(),
+	]);
 	const shouldPrompt =
 		interactive ?? (!Boolean(flags.yes) && Boolean(process.stdin.isTTY) && Boolean(process.stdout.isTTY));
 	const activePrompt = shouldPrompt ? (prompt ?? createReadlinePrompt()) : undefined;
@@ -364,9 +366,12 @@ export async function executeAddCommand({
 	name,
 }: AddExecutionInput): Promise<void> {
 	if (!kind) {
+		const { formatAddHelpText } = await loadCliAddRuntime();
 		console.log(formatAddHelpText());
 		return;
 	}
+
+	const addRuntime = await loadCliAddRuntime();
 
 	if (kind === "variation") {
 		if (!name) {
@@ -380,7 +385,7 @@ export async function executeAddCommand({
 			throw new Error("`wp-typia add variation` requires --block <block-slug>.");
 		}
 
-		const result = await runAddVariationCommand({
+		const result = await addRuntime.runAddVariationCommand({
 			blockName: blockSlug,
 			cwd,
 			variationName: name,
@@ -396,7 +401,7 @@ export async function executeAddCommand({
 			);
 		}
 
-		const result = await runAddPatternCommand({
+		const result = await addRuntime.runAddPatternCommand({
 			cwd,
 			patternName: name,
 		});
@@ -411,7 +416,7 @@ export async function executeAddCommand({
 			);
 		}
 
-		const result = await runAddBindingSourceCommand({
+		const result = await addRuntime.runAddBindingSourceCommand({
 			bindingSourceName: name,
 			cwd,
 		});
@@ -438,7 +443,7 @@ export async function executeAddCommand({
 			);
 		}
 
-		const result = await runAddHookedBlockCommand({
+		const result = await addRuntime.runAddHookedBlockCommand({
 			anchorBlockName,
 			blockName: name,
 			cwd,
@@ -468,7 +473,7 @@ export async function executeAddCommand({
 		);
 	}
 
-	const result = await runAddBlockCommand({
+	const result = await addRuntime.runAddBlockCommand({
 		blockName: name,
 		cwd,
 		dataStorageMode: readOptionalStringFlag(flags, "data-storage"),
@@ -524,6 +529,7 @@ export async function executeTemplatesCommand(
 }
 
 export async function executeDoctorCommand(cwd: string): Promise<void> {
+	const { runDoctor } = await loadCliDoctorRuntime();
 	await runDoctor(cwd);
 }
 
@@ -553,6 +559,8 @@ export async function executeMigrateCommand({
 	prompt,
 	renderLine,
 }: MigrateExecutionInput): Promise<void> {
+	const { formatMigrationHelpText, parseMigrationArgs, runMigrationCommand } =
+		await loadMigrationsRuntime();
 	if (!command) {
 		console.log(formatMigrationHelpText());
 		return;
@@ -593,7 +601,27 @@ export function getAddWorkspaceBlockOptions(cwd: string) {
 		return [];
 	}
 
-	return getWorkspaceBlockSelectOptions(workspace.projectDir);
+	const blocksDir = path.join(workspace.projectDir, "src", "blocks");
+	if (!fs.existsSync(blocksDir)) {
+		return [];
+	}
+
+	return fs
+		.readdirSync(blocksDir, { withFileTypes: true })
+		.filter((entry) => entry.isDirectory())
+		.map((entry) => {
+			const blockSlug = entry.name;
+			const typesFile = path.join("src", "blocks", blockSlug, "types.ts");
+			const fallbackFile = path.join("src", "blocks", blockSlug, "block.json");
+			return {
+				description: fs.existsSync(path.join(workspace.projectDir, typesFile))
+					? typesFile
+					: fallbackFile,
+				name: blockSlug,
+				value: blockSlug,
+			};
+		})
+		.sort((left, right) => left.name.localeCompare(right.name));
 }
 
-export { formatAddHelpText, formatMigrationHelpText, listTemplates };
+export { listTemplates };

--- a/packages/wp-typia/src/runtime-bridge.ts
+++ b/packages/wp-typia/src/runtime-bridge.ts
@@ -533,6 +533,16 @@ export async function executeDoctorCommand(cwd: string): Promise<void> {
 	await runDoctor(cwd);
 }
 
+export async function loadAddWorkspaceBlockOptions(cwd: string) {
+	const workspace = tryResolveWorkspaceProject(cwd);
+	if (!workspace) {
+		return [];
+	}
+
+	const { getWorkspaceBlockSelectOptions } = await loadCliAddRuntime();
+	return getWorkspaceBlockSelectOptions(workspace.projectDir);
+}
+
 export async function executeSyncCommand({
 	check = false,
 	cwd,
@@ -593,35 +603,6 @@ export async function executeMigrateCommand({
 		prompt,
 		renderLine,
 	});
-}
-
-export function getAddWorkspaceBlockOptions(cwd: string) {
-	const workspace = tryResolveWorkspaceProject(cwd);
-	if (!workspace) {
-		return [];
-	}
-
-	const blocksDir = path.join(workspace.projectDir, "src", "blocks");
-	if (!fs.existsSync(blocksDir)) {
-		return [];
-	}
-
-	return fs
-		.readdirSync(blocksDir, { withFileTypes: true })
-		.filter((entry) => entry.isDirectory())
-		.map((entry) => {
-			const blockSlug = entry.name;
-			const typesFile = path.join("src", "blocks", blockSlug, "types.ts");
-			const fallbackFile = path.join("src", "blocks", blockSlug, "block.json");
-			return {
-				description: fs.existsSync(path.join(workspace.projectDir, typesFile))
-					? typesFile
-					: fallbackFile,
-				name: blockSlug,
-				value: blockSlug,
-			};
-		})
-		.sort((left, right) => left.name.localeCompare(right.name));
 }
 
 export { listTemplates };

--- a/packages/wp-typia/src/ui/add-flow.tsx
+++ b/packages/wp-typia/src/ui/add-flow.tsx
@@ -1,4 +1,4 @@
-import { createElement, useMemo } from "react";
+import { createElement, useEffect, useMemo, useState } from "react";
 
 import {
 	Form,
@@ -8,7 +8,7 @@ import {
 } from "@bunli/tui";
 import { HOOKED_BLOCK_POSITION_IDS } from "@wp-typia/project-tools/hooked-blocks";
 
-import { executeAddCommand } from "../runtime-bridge";
+import { executeAddCommand, loadAddWorkspaceBlockOptions } from "../runtime-bridge";
 import { useAlternateBufferLifecycle } from "./alternate-buffer-lifecycle";
 import {
 	type AddFlowValues,
@@ -104,11 +104,12 @@ const HOOKED_BLOCK_POSITION_DESCRIPTIONS: Record<
 type AddFlowProps = {
 	cwd: string;
 	initialValues: Partial<AddFlowValues>;
-	workspaceBlockOptions: Array<{
-		description: string;
-		name: string;
-		value: string;
-	}>;
+};
+
+type WorkspaceBlockOption = {
+	description: string;
+	name: string;
+	value: string;
 };
 
 type AddSelectFieldName = {
@@ -134,7 +135,7 @@ function getAddNameLabel(kind?: string): string {
 function AddFlowFields({
 	workspaceBlockOptions,
 }: {
-	workspaceBlockOptions: AddFlowProps["workspaceBlockOptions"];
+	workspaceBlockOptions: WorkspaceBlockOption[];
 }) {
 	const { activeFieldName, values } = useFormContext();
 	const { height: terminalHeight = 24 } = useTerminalDimensions();
@@ -255,8 +256,31 @@ function AddFlowFields({
 	);
 }
 
-export function AddFlow({ cwd, initialValues, workspaceBlockOptions }: AddFlowProps) {
-	const { handleCancel, handleSubmit } = useAlternateBufferLifecycle("wp-typia add failed");
+export function AddFlow({ cwd, initialValues }: AddFlowProps) {
+	const { handleCancel, handleFailure, handleSubmit } = useAlternateBufferLifecycle(
+		"wp-typia add failed",
+	);
+	const [workspaceBlockOptions, setWorkspaceBlockOptions] = useState<WorkspaceBlockOption[]>([]);
+
+	useEffect(() => {
+		let disposed = false;
+
+		void loadAddWorkspaceBlockOptions(cwd)
+			.then((options) => {
+				if (!disposed) {
+					setWorkspaceBlockOptions(options);
+				}
+			})
+			.catch((error) => {
+				if (!disposed) {
+					handleFailure(error);
+				}
+			});
+
+		return () => {
+			disposed = true;
+		};
+	}, [cwd, handleFailure]);
 
 	return (
 		<Form

--- a/packages/wp-typia/src/ui/add-flow.tsx
+++ b/packages/wp-typia/src/ui/add-flow.tsx
@@ -264,6 +264,7 @@ export function AddFlow({ cwd, initialValues }: AddFlowProps) {
 
 	useEffect(() => {
 		let disposed = false;
+		setWorkspaceBlockOptions([]);
 
 		void loadAddWorkspaceBlockOptions(cwd)
 			.then((options) => {

--- a/packages/wp-typia/src/ui/add-flow.tsx
+++ b/packages/wp-typia/src/ui/add-flow.tsx
@@ -6,7 +6,7 @@ import {
 	useFormContext,
 	useTerminalDimensions,
 } from "@bunli/tui";
-import { HOOKED_BLOCK_POSITION_IDS } from "@wp-typia/project-tools";
+import { HOOKED_BLOCK_POSITION_IDS } from "@wp-typia/project-tools/hooked-blocks";
 
 import { executeAddCommand } from "../runtime-bridge";
 import { useAlternateBufferLifecycle } from "./alternate-buffer-lifecycle";

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -15,6 +15,18 @@ const packageManifest = JSON.parse(
 const projectToolsPackageManifest = JSON.parse(
 	fs.readFileSync(path.resolve(packageRoot, "..", "wp-typia-project-tools", "package.json"), "utf8"),
 );
+const runtimeBridgeSource = fs.readFileSync(
+	path.join(packageRoot, "src", "runtime-bridge.ts"),
+	"utf8",
+);
+const doctorCommandSource = fs.readFileSync(
+	path.join(packageRoot, "src", "commands", "doctor.ts"),
+	"utf8",
+);
+const addFlowSource = fs.readFileSync(
+	path.join(packageRoot, "src", "ui", "add-flow.tsx"),
+	"utf8",
+);
 
 function createSyncFixture(options: {
 	packageManager?: string | null;
@@ -94,6 +106,27 @@ describe("wp-typia package", () => {
 		expect(packageManifest.dependencies["@wp-typia/project-tools"]).toBe(projectToolsPackageManifest.version);
 		expect(projectToolsPackageManifest.bin).toBeUndefined();
 		expect(projectToolsPackageManifest.exports["./cli"]).toBeUndefined();
+		expect(projectToolsPackageManifest.exports["./cli-add"]).toBeDefined();
+		expect(projectToolsPackageManifest.exports["./cli-doctor"]).toBeDefined();
+		expect(projectToolsPackageManifest.exports["./cli-prompt"]).toBeDefined();
+		expect(projectToolsPackageManifest.exports["./cli-scaffold"]).toBeDefined();
+		expect(projectToolsPackageManifest.exports["./cli-templates"]).toBeDefined();
+		expect(projectToolsPackageManifest.exports["./hooked-blocks"]).toBeDefined();
+		expect(projectToolsPackageManifest.exports["./migrations"]).toBeDefined();
+		expect(projectToolsPackageManifest.exports["./package-managers"]).toBeDefined();
+		expect(projectToolsPackageManifest.exports["./workspace-project"]).toBeDefined();
+	});
+
+	test("keeps CLI React dependencies dedupe-friendly for Bunli peers", () => {
+		expect(packageManifest.dependencies.react).toBe(packageManifest.dependencies["react-dom"]);
+		expect(packageManifest.dependencies.react).toMatch(/^\^/);
+		expect(packageManifest.dependencies["react-dom"]).toMatch(/^\^/);
+	});
+
+	test("avoids eager project-tools root imports on CLI startup paths", () => {
+		expect(runtimeBridgeSource).not.toMatch(/from ["']@wp-typia\/project-tools["']/);
+		expect(doctorCommandSource).not.toMatch(/from ["']@wp-typia\/project-tools["']/);
+		expect(addFlowSource).not.toMatch(/from ["']@wp-typia\/project-tools["']/);
 	});
 
 	test("renders help output through the canonical bin", () => {

--- a/packages/wp-typia/tsconfig.json
+++ b/packages/wp-typia/tsconfig.json
@@ -7,6 +7,7 @@
     "moduleResolution": "bundler",
     "paths": {
       "@wp-typia/project-tools": ["../wp-typia-project-tools/src/runtime/index.ts"],
+      "@wp-typia/project-tools/*": ["../wp-typia-project-tools/src/runtime/*.ts"],
       "@wp-typia/project-tools/schema-core": ["../wp-typia-project-tools/src/runtime/schema-core.ts"]
     },
     "resolveJsonModule": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "baseUrl": ".",
     "paths": {
       "@wp-typia/project-tools": ["packages/wp-typia-project-tools/src/runtime/index.ts"],
+      "@wp-typia/project-tools/*": ["packages/wp-typia-project-tools/src/runtime/*.ts"],
       "@wp-typia/project-tools/schema-core": [
         "packages/wp-typia-project-tools/src/runtime/schema-core.ts"
       ],


### PR DESCRIPTION
## Summary
- stop `wp-typia create` startup from eagerly importing the `@wp-typia/project-tools` root barrel
- add publishable project-tools subpath exports for the CLI-only runtime modules
- align `wp-typia` React dependencies with Bunli's current React peer floor to avoid duplicate-React TUI crashes
- add CLI package regression tests for startup imports, publishable exports, and React dependency ranges

## Root cause
- the CLI command tree imported `doctor` and `runtime-bridge` at startup, and those paths pulled in the `@wp-typia/project-tools` root barrel
- the root barrel re-exported `cli-add` / `workspace-inventory`, so even `wp-typia create` tried to load `typescript` before it was needed
- the published CLI also pinned `react` / `react-dom` to `19.2.0`, while `@bunli/tui@0.6.0` peers against the newer React 19.2.x line; npm ended up with two React copies and the interactive create flow crashed with an invalid hook call

## Validation
- `bun run --filter @wp-typia/project-tools build`
- `bun run --filter wp-typia test`
- `bun run typecheck`
- `bun run changesets:validate`
- packed install smoke:
  - `npm install` of packed tarballs + `wp-typia create demo --yes --template basic --package-manager npm --no-install`
  - interactive `wp-typia create` TUI launched from the packed npm install without the previous React hook crash
  - packed `bun` install also succeeded once the fixture pointed `wp-typia` at the updated local `@wp-typia/project-tools` package; the current registry-published nested `0.16.1` copy still reproduces until this pair ships together


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deferred CLI module loading to avoid pulling heavy runtime deps at startup
  * Broadened React version range to prevent duplicate-React crashes during interactive flows
  * Improved CLI install/create reliability

* **Refactor**
  * Converted several CLI runtimes and UI option loads to lazy/asynchronous loading to reduce startup work

* **Tests**
  * Added checks to validate package exports, import structure, and React dependency dedupe

* **Chores**
  * Expanded package export surface and path mappings for runtime modules
<!-- end of auto-generated comment: release notes by coderabbit.ai -->