### PR TITLE
fix: type generated interactivity context and restore docs pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,6 +278,33 @@ jobs:
           flags: project-tools
           name: codecov-project-tools
 
+  docs-build-check:
+    name: Docs Build Check
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Cache Bun install cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.bun/install/cache
+          key: bun-install-${{ runner.os }}-${{ env.BUN_VERSION }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-install-${{ runner.os }}-${{ env.BUN_VERSION }}-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build documentation site
+        run: bun run docs:build:site
+
   build:
     name: Build CLI and Example
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -702,8 +702,8 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Build documentation
-        run: bun run docs:build
+      - name: Build documentation site
+        run: bun run docs:build:site
 
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v6
@@ -711,7 +711,7 @@ jobs:
       - name: Upload documentation artifact
         uses: actions/upload-pages-artifact@v5
         with:
-          path: ./docs
+          path: ./.pages-site
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dist/
 coverage/
 .nyc_output/
 docs/api/
+.pages-site/
 *.lcov
 *.tgz
 *.zip

--- a/.sampo/changesets/issue-226-interactivity-context-pages-fix.md
+++ b/.sampo/changesets/issue-226-interactivity-context-pages-fix.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Fix generated interactivity scaffolds so their WordPress Interactivity context is typed through explicit `getContext<T>()` imports, and restore GitHub Pages publishing by deploying a real static docs site artifact from CI.

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "changesets:validate": "bun scripts/validate-sampo-changesets.mjs",
     "docs:dev": "typedoc --watch",
     "docs:build": "typedoc",
+    "docs:build:site": "bun run docs:build && node scripts/build-docs-site.mjs",
     "wp-env:start": "bun run examples:wp-env:start",
     "wp-env:stop": "bun run examples:wp-env:stop",
     "wp-env:reset": "bun run examples:wp-env:reset"

--- a/packages/wp-typia-project-tools/templates/interactivity/src/edit.tsx.mustache
+++ b/packages/wp-typia-project-tools/templates/interactivity/src/edit.tsx.mustache
@@ -56,12 +56,16 @@ export default function Edit({ attributes, setAttributes, isSelected }: {
     attributes,
     'alignment',
     'left'
-  );
+  ) as NonNullable<{{pascalCase}}Attributes['alignment']>;
+  const autoPlayInterval = attributes.autoPlayInterval ?? 0;
+  const clickCount = attributes.clickCount ?? 0;
   const isVisible = editorFields.getBooleanValue(
     attributes,
     'isVisible',
     true
   );
+  const isAnimating = attributes.isAnimating ?? false;
+  const maxClicks = attributes.maxClicks ?? 0;
   const showCounter = editorFields.getBooleanValue(
     attributes,
     'showCounter',
@@ -71,25 +75,26 @@ export default function Edit({ attributes, setAttributes, isSelected }: {
     attributes,
     'interactiveMode',
     'click'
-  );
+  ) as NonNullable<{{pascalCase}}Attributes['interactiveMode']>;
   const animation = editorFields.getStringValue(
     attributes,
     'animation',
     'none'
-  );
+  ) as NonNullable<{{pascalCase}}Attributes['animation']>;
+  const uniqueId = attributes.uniqueId ?? '';
 
   const blockProps = useBlockProps({
     className: `{{cssClassName}} {{cssClassName}}--${interactiveMode}`,
     'data-wp-interactive': '{{slugKebabCase}}',
     'data-wp-context': JSON.stringify({
-      clicks: attributes.clickCount,
-      isAnimating: attributes.isAnimating,
+      clicks: clickCount,
+      isAnimating,
       isVisible,
       lastInteraction: '',
       animation,
       interactiveMode,
-      maxClicks: attributes.maxClicks,
-      autoPlayInterval: attributes.autoPlayInterval
+      maxClicks,
+      autoPlayInterval
     })
   });
 
@@ -126,8 +131,8 @@ export default function Edit({ attributes, setAttributes, isSelected }: {
         <PanelBody title={__('Counter Settings', '{{textDomain}}')}>
           <RangeControl
             label={__('Max Clicks', '{{textDomain}}')}
-            value={attributes.maxClicks}
-            onChange={(value) => updateField('maxClicks', value ?? attributes.maxClicks ?? 0)}
+            value={maxClicks}
+            onChange={(value) => updateField('maxClicks', value ?? maxClicks)}
             min={0}
             max={100}
             help={__('Set to 0 for unlimited clicks', '{{textDomain}}')}
@@ -136,8 +141,8 @@ export default function Edit({ attributes, setAttributes, isSelected }: {
           {interactiveMode === 'auto' && (
             <RangeControl
               label={__('Auto Play Interval (ms)', '{{textDomain}}')}
-              value={attributes.autoPlayInterval}
-              onChange={(value) => updateField('autoPlayInterval', value ?? attributes.autoPlayInterval ?? 0)}
+              value={autoPlayInterval}
+              onChange={(value) => updateField('autoPlayInterval', value ?? autoPlayInterval)}
               min={100}
               max={5000}
               step={100}
@@ -164,7 +169,7 @@ export default function Edit({ attributes, setAttributes, isSelected }: {
 
           <TextControl
             label={__('Unique ID', '{{textDomain}}')}
-            value={attributes.uniqueId}
+            value={uniqueId}
             onChange={(value) => updateField('uniqueId', value)}
             help={__('Optional unique identifier for this block instance', '{{textDomain}}')}
           />
@@ -193,10 +198,10 @@ export default function Edit({ attributes, setAttributes, isSelected }: {
                 : __('Enable Preview Mode', '{{textDomain}}')}
             </Button>
 
-            {attributes.clickCount > 0 && (
+            {clickCount > 0 && (
               <Notice status="info" isDismissible={false}>
-                {__('Current clicks:', '{{textDomain}}')} {attributes.clickCount}
-                {attributes.maxClicks > 0 && ` / ${attributes.maxClicks}`}
+                {__('Current clicks:', '{{textDomain}}')} {clickCount}
+                {maxClicks > 0 && ` / ${maxClicks}`}
               </Notice>
             )}
           </PanelBody>
@@ -205,7 +210,7 @@ export default function Edit({ attributes, setAttributes, isSelected }: {
 
       <div {...blockProps}>
         <div
-          className={`{{cssClassName}}__content ${attributes.isAnimating ? 'is-animating' : ''}`}
+          className={`{{cssClassName}}__content ${isAnimating ? 'is-animating' : ''}`}
           style={{ textAlign: alignmentValue }}
           data-wp-on--click={isPreviewing ? 'actions.handleClick' : undefined}
           data-wp-on--mouseenter={isPreviewing && interactiveMode === 'hover' ? 'actions.handleMouseEnter' : undefined}
@@ -240,16 +245,16 @@ export default function Edit({ attributes, setAttributes, isSelected }: {
                 className="{{cssClassName}}__counter-value"
                 data-wp-text="state.clicks"
               >
-                {attributes.clickCount}
+                {clickCount}
               </span>
             </div>
           )}
 
-          {attributes.maxClicks > 0 && (
+          {maxClicks > 0 && (
             <div className="{{cssClassName}}__progress">
               <div
                 className="{{cssClassName}}__progress-bar"
-                style={{ width: `${(attributes.clickCount / attributes.maxClicks) * 100}%` }}
+                style={{ width: `${(clickCount / maxClicks) * 100}%` }}
                 data-wp-style--width="state.progress + '%'"
               />
             </div>
@@ -257,7 +262,7 @@ export default function Edit({ attributes, setAttributes, isSelected }: {
 
           {animation !== 'none' && (
             <div
-              className={`{{cssClassName}}__animation ${attributes.isAnimating ? 'is-active' : ''}`}
+              className={`{{cssClassName}}__animation ${isAnimating ? 'is-active' : ''}`}
               data-wp-class--is-active="state.isAnimating"
             >
               {animation}

--- a/packages/wp-typia-project-tools/templates/interactivity/src/interactivity.ts.mustache
+++ b/packages/wp-typia-project-tools/templates/interactivity/src/interactivity.ts.mustache
@@ -2,22 +2,27 @@
  * WordPress Interactivity API implementation for {{title}} block
  */
 import { store, getContext, getElement } from '@wordpress/interactivity';
+import type { {{pascalCase}}Context } from './types';
+
+function getBlockContext() {
+  return getContext<{{pascalCase}}Context>();
+}
 
 // Store configuration
 store('{{slugKebabCase}}', {
   // State - reactive data that updates the UI
   state: {
     get clicks() {
-      return getContext().clicks;
+      return getBlockContext().clicks;
     },
     get isAnimating() {
-      return getContext().isAnimating;
+      return getBlockContext().isAnimating;
     },
     get isVisible() {
-      return getContext().isVisible;
+      return getBlockContext().isVisible;
     },
     get animationClass() {
-      const context = getContext();
+      const context = getBlockContext();
       if (!context.isAnimating) return '';
 
       switch (context.animation) {
@@ -34,17 +39,17 @@ store('{{slugKebabCase}}', {
       }
     },
     get progress() {
-      const context = getContext();
+      const context = getBlockContext();
       return context.maxClicks > 0 ? (context.clicks / context.maxClicks) * 100 : 0;
     },
     get clampedClicks() {
-      const context = getContext();
+      const context = getBlockContext();
       return context.maxClicks > 0
         ? Math.min(context.clicks, context.maxClicks)
         : context.clicks;
     },
     get isComplete() {
-      const context = getContext();
+      const context = getBlockContext();
       return context.clicks >= context.maxClicks && context.maxClicks > 0;
     }
   },
@@ -53,8 +58,12 @@ store('{{slugKebabCase}}', {
   actions: {
     // Handle block click
     handleClick: () => {
-      const context = getContext();
-      const { element } = getElement();
+      const context = getBlockContext();
+      const { ref } = getElement();
+
+      if (!ref) {
+        return;
+      }
 
       // Increment click counter
       context.clicks += 1;
@@ -69,13 +78,13 @@ store('{{slugKebabCase}}', {
       }
 
       // Emit custom event
-      element.dispatchEvent(new CustomEvent('{{slugKebabCase}}:click', {
+      ref.dispatchEvent(new CustomEvent('{{slugKebabCase}}:click', {
         detail: { clicks: context.clicks }
       }));
 
       // Check if max clicks reached
       if (context.maxClicks > 0 && context.clicks >= context.maxClicks) {
-        element.dispatchEvent(new CustomEvent('{{slugKebabCase}}:complete', {
+        ref.dispatchEvent(new CustomEvent('{{slugKebabCase}}:complete', {
           detail: { totalClicks: context.clicks }
         }));
       }
@@ -83,7 +92,7 @@ store('{{slugKebabCase}}', {
 
     // Handle hover events
     handleMouseEnter: () => {
-      const context = getContext();
+      const context = getBlockContext();
       if (context.interactiveMode === 'hover') {
         context.isAnimating = true;
         context.lastInteraction = 'hover';
@@ -91,7 +100,7 @@ store('{{slugKebabCase}}', {
     },
 
     handleMouseLeave: () => {
-      const context = getContext();
+      const context = getBlockContext();
       if (context.interactiveMode === 'hover') {
         context.isAnimating = false;
       }
@@ -99,13 +108,13 @@ store('{{slugKebabCase}}', {
 
     // Toggle visibility
     toggleVisibility: () => {
-      const context = getContext();
+      const context = getBlockContext();
       context.isVisible = !context.isVisible;
     },
 
     // Reset counter
     reset: () => {
-      const context = getContext();
+      const context = getBlockContext();
       context.clicks = 0;
       context.isAnimating = false;
       context.lastInteraction = 'reset';
@@ -113,7 +122,7 @@ store('{{slugKebabCase}}', {
 
     // Start/stop auto play
     toggleAutoPlay: () => {
-      const context = getContext();
+      const context = getBlockContext();
       if (context.autoPlayInterval > 0) {
         if (context.autoPlayTimer) {
           clearInterval(context.autoPlayTimer);
@@ -131,22 +140,3 @@ store('{{slugKebabCase}}', {
     }
   }
 });
-
-// Type definitions for TypeScript
-declare global {
-  namespace WordPress {
-    namespace Interactivity {
-      interface {{pascalCase}}Context {
-        clicks: number;
-        isAnimating: boolean;
-        isVisible: boolean;
-        lastInteraction: string;
-        animation: string;
-        interactiveMode: string;
-        maxClicks: number;
-        autoPlayInterval: number;
-        autoPlayTimer?: number;
-      }
-    }
-  }
-}

--- a/packages/wp-typia-project-tools/templates/interactivity/src/save.tsx.mustache
+++ b/packages/wp-typia-project-tools/templates/interactivity/src/save.tsx.mustache
@@ -2,29 +2,37 @@ import { useBlockProps, RichText } from '@wordpress/block-editor';
 import type { {{pascalCase}}Attributes } from './types';
 
 export default function Save({ attributes }: { attributes: {{pascalCase}}Attributes }) {
+  const autoPlayInterval = attributes.autoPlayInterval ?? 0;
+  const clickCount = attributes.clickCount ?? 0;
+  const interactiveMode = attributes.interactiveMode ?? 'click';
+  const animation = attributes.animation ?? 'none';
+  const isAnimating = attributes.isAnimating ?? false;
+  const isVisible = attributes.isVisible ?? true;
+  const maxClicks = attributes.maxClicks ?? 0;
+  const showCounter = attributes.showCounter ?? true;
   const blockProps = useBlockProps.save({
-    className: `{{cssClassName}} {{cssClassName}}--${attributes.interactiveMode}`,
+    className: `{{cssClassName}} {{cssClassName}}--${interactiveMode}`,
     'data-wp-interactive': '{{slugKebabCase}}',
     'data-wp-context': JSON.stringify({
-      clicks: attributes.clickCount,
-      isAnimating: attributes.isAnimating,
-      isVisible: attributes.isVisible,
+      clicks: clickCount,
+      isAnimating,
+      isVisible,
       lastInteraction: '',
-      animation: attributes.animation,
-      interactiveMode: attributes.interactiveMode,
-      maxClicks: attributes.maxClicks,
-      autoPlayInterval: attributes.autoPlayInterval
+      animation,
+      interactiveMode,
+      maxClicks,
+      autoPlayInterval
     })
   });
 
   return (
     <div {...blockProps}>
       <div
-        className={`{{cssClassName}}__content ${attributes.isAnimating ? 'is-animating' : ''}`}
+        className={`{{cssClassName}}__content ${isAnimating ? 'is-animating' : ''}`}
         style={{ textAlign: attributes.alignment }}
         data-wp-on--click="actions.handleClick"
-        data-wp-on--mouseenter={attributes.interactiveMode === 'hover' ? 'actions.handleMouseEnter' : undefined}
-        data-wp-on--mouseleave={attributes.interactiveMode === 'hover' ? 'actions.handleMouseLeave' : undefined}
+        data-wp-on--mouseenter={interactiveMode === 'hover' ? 'actions.handleMouseEnter' : undefined}
+        data-wp-on--mouseleave={interactiveMode === 'hover' ? 'actions.handleMouseLeave' : undefined}
         data-wp-bind--hidden="!state.isVisible"
       >
         <RichText.Content
@@ -33,7 +41,7 @@ export default function Save({ attributes }: { attributes: {{pascalCase}}Attribu
           className="{{cssClassName}}__text"
         />
 
-        {attributes.showCounter && (
+        {showCounter && (
           <div
             className="{{cssClassName}}__counter"
             role="status"
@@ -47,20 +55,20 @@ export default function Save({ attributes }: { attributes: {{pascalCase}}Attribu
               className="{{cssClassName}}__counter-value"
               data-wp-text="state.clicks"
             >
-              {attributes.clickCount}
+              {clickCount}
             </span>
           </div>
         )}
 
-        {attributes.maxClicks > 0 && (
+        {maxClicks > 0 && (
           <div className="{{cssClassName}}__progress">
             <div
               className="{{cssClassName}}__progress-bar"
               role="progressbar"
               aria-label="Click progress"
               aria-valuemin={0}
-              aria-valuemax={attributes.maxClicks}
-              aria-valuenow={Math.min(attributes.clickCount, attributes.maxClicks)}
+              aria-valuemax={maxClicks}
+              aria-valuenow={Math.min(clickCount, maxClicks)}
               data-wp-bind--aria-valuenow="state.clampedClicks"
               data-wp-style--width="state.progress + '%'"
             />
@@ -68,12 +76,12 @@ export default function Save({ attributes }: { attributes: {{pascalCase}}Attribu
         )}
 
         <div
-          className={`{{cssClassName}}__animation ${attributes.animation}`}
+          className={`{{cssClassName}}__animation ${animation}`}
           aria-hidden="true"
           data-wp-class--is-active="state.isAnimating"
         />
 
-        {attributes.maxClicks > 0 && (
+        {maxClicks > 0 && (
           <div
             className="{{cssClassName}}__completion"
             role="status"

--- a/packages/wp-typia-project-tools/templates/interactivity/src/types.ts.mustache
+++ b/packages/wp-typia-project-tools/templates/interactivity/src/types.ts.mustache
@@ -26,7 +26,11 @@ export interface {{pascalCase}}Context {
   isAnimating: boolean;
   isVisible: boolean;
   lastInteraction: string;
-  animationClass: string;
+  animation: 'none' | 'bounce' | 'pulse' | 'shake' | 'flip';
+  interactiveMode: 'click' | 'hover' | 'auto';
+  maxClicks: number;
+  autoPlayInterval: number;
+  autoPlayTimer?: ReturnType<typeof setInterval> | null;
 }
 
 export type {{pascalCase}}ValidationResult = ValidationResult<{{pascalCase}}Attributes>;

--- a/packages/wp-typia-project-tools/tests/scaffold-basic.test.ts
+++ b/packages/wp-typia-project-tools/tests/scaffold-basic.test.ts
@@ -623,7 +623,21 @@ test("scaffoldProject creates an interactivity template with typed validation wi
   expect(generatedInteractivity).not.toContain("onInit:");
   expect(generatedInteractivity).not.toContain("onInteraction:");
   expect(generatedInteractivity).not.toContain("onDestroy:");
+  expect(generatedInteractivity).toContain(
+    "import type { DemoInteractivityContext } from './types';"
+  );
+  expect(generatedInteractivity).toContain(
+    "return getContext<DemoInteractivityContext>();"
+  );
+  expect(generatedInteractivity).not.toContain("declare global");
   expect(generatedInteractivity).toContain("get clampedClicks()");
+  expect(generatedTypes).toContain("animation: 'none' | 'bounce'");
+  expect(generatedTypes).toContain(
+    "autoPlayTimer?: ReturnType<typeof setInterval> | null;"
+  );
+  expect(generatedSave).toContain("const clickCount = attributes.clickCount ?? 0;");
+  expect(generatedSave).toContain("const maxClicks = attributes.maxClicks ?? 0;");
+  expect(generatedSave).toContain("const interactiveMode = attributes.interactiveMode ?? 'click';");
   expect(generatedSave).toContain('aria-label="Reset counter"');
   expect(generatedSave).toContain('className="screen-reader-text"');
   expect(generatedSave).toContain('role="progressbar"');
@@ -634,7 +648,7 @@ test("scaffoldProject creates an interactivity template with typed validation wi
   expect(generatedSave).toContain('aria-live="polite"');
   expect(generatedSave).toContain('aria-hidden="true"');
   expect(generatedSave).toContain(
-    "className: `wp-block-demo-space-demo-interactivity wp-block-demo-space-demo-interactivity--${attributes.interactiveMode}`"
+    "className: `wp-block-demo-space-demo-interactivity wp-block-demo-space-demo-interactivity--${interactiveMode}`"
   );
   expect(generatedSave).toContain(
     "wp-block-demo-space-demo-interactivity__content"
@@ -654,6 +668,11 @@ test("scaffoldProject creates an interactivity template with typed validation wi
   expect(generatedEditorStyle).toContain(
     ".wp-block-demo-space-demo-interactivity"
   );
+  runGeneratedScript(targetDir, "scripts/sync-types-to-block-json.ts");
+  runGeneratedScript(targetDir, "scripts/sync-types-to-block-json.ts", [
+    "--check",
+  ]);
+  typecheckGeneratedProject(targetDir);
 });
 
 test("scaffoldProject supports the optional local wp-env preset without adding test files", async () => {

--- a/packages/wp-typia-project-tools/tests/scaffold-basic.test.ts
+++ b/packages/wp-typia-project-tools/tests/scaffold-basic.test.ts
@@ -469,95 +469,97 @@ test(
   { timeout: 30_000 }
 );
 
-test("scaffoldProject creates an interactivity template with typed validation wiring", async () => {
-  const targetDir = path.join(tempRoot, "demo-interactivity");
+test(
+  "scaffoldProject creates an interactivity template with typed validation wiring",
+  async () => {
+    const targetDir = path.join(tempRoot, "demo-interactivity");
 
-  await scaffoldProject({
-    projectDir: targetDir,
-    templateId: "interactivity",
-    packageManager: "npm",
-    noInstall: true,
-    answers: {
-      author: "Test Runner",
-      description: "Demo interactivity block",
-      namespace: "demo-space",
-      slug: "demo-interactivity",
-      title: "Demo Interactivity",
-    },
-  });
+    await scaffoldProject({
+      projectDir: targetDir,
+      templateId: "interactivity",
+      packageManager: "npm",
+      noInstall: true,
+      answers: {
+        author: "Test Runner",
+        description: "Demo interactivity block",
+        namespace: "demo-space",
+        slug: "demo-interactivity",
+        title: "Demo Interactivity",
+      },
+    });
 
-  const generatedTypes = fs.readFileSync(
-    path.join(targetDir, "src", "types.ts"),
-    "utf8"
-  );
-  const generatedHooks = fs.readFileSync(
-    path.join(targetDir, "src", "hooks.ts"),
-    "utf8"
-  );
-  const generatedValidators = fs.readFileSync(
-    path.join(targetDir, "src", "validators.ts"),
-    "utf8"
-  );
-  const generatedEdit = fs.readFileSync(
-    path.join(targetDir, "src", "edit.tsx"),
-    "utf8"
-  );
-  const generatedInteractivity = fs.readFileSync(
-    path.join(targetDir, "src", "interactivity.ts"),
-    "utf8"
-  );
-  const generatedManifest = JSON.parse(
-    fs.readFileSync(
-      path.join(targetDir, "src", "typia.manifest.json"),
+    const generatedTypes = fs.readFileSync(
+      path.join(targetDir, "src", "types.ts"),
       "utf8"
-    )
-  );
-  const generatedSave = fs.readFileSync(
-    path.join(targetDir, "src", "save.tsx"),
-    "utf8"
-  );
-  const generatedStyle = fs.readFileSync(
-    path.join(targetDir, "src", "style.scss"),
-    "utf8"
-  );
-  const generatedEditorStyle = fs.readFileSync(
-    path.join(targetDir, "src", "editor.scss"),
-    "utf8"
-  );
-  const generatedIndex = fs.readFileSync(
-    path.join(targetDir, "src", "index.tsx"),
-    "utf8"
-  );
-  const generatedPluginBootstrap = fs.readFileSync(
-    path.join(targetDir, "demo-interactivity.php"),
-    "utf8"
-  );
-  const generatedWebpackConfig = fs.readFileSync(
-    path.join(targetDir, "webpack.config.js"),
-    "utf8"
-  );
-  const packageJson = JSON.parse(
-    fs.readFileSync(path.join(targetDir, "package.json"), "utf8")
-  );
-  const blockJson = JSON.parse(
-    fs.readFileSync(path.join(targetDir, "src", "block.json"), "utf8")
-  );
+    );
+    const generatedHooks = fs.readFileSync(
+      path.join(targetDir, "src", "hooks.ts"),
+      "utf8"
+    );
+    const generatedValidators = fs.readFileSync(
+      path.join(targetDir, "src", "validators.ts"),
+      "utf8"
+    );
+    const generatedEdit = fs.readFileSync(
+      path.join(targetDir, "src", "edit.tsx"),
+      "utf8"
+    );
+    const generatedInteractivity = fs.readFileSync(
+      path.join(targetDir, "src", "interactivity.ts"),
+      "utf8"
+    );
+    const generatedManifest = JSON.parse(
+      fs.readFileSync(
+        path.join(targetDir, "src", "typia.manifest.json"),
+        "utf8"
+      )
+    );
+    const generatedSave = fs.readFileSync(
+      path.join(targetDir, "src", "save.tsx"),
+      "utf8"
+    );
+    const generatedStyle = fs.readFileSync(
+      path.join(targetDir, "src", "style.scss"),
+      "utf8"
+    );
+    const generatedEditorStyle = fs.readFileSync(
+      path.join(targetDir, "src", "editor.scss"),
+      "utf8"
+    );
+    const generatedIndex = fs.readFileSync(
+      path.join(targetDir, "src", "index.tsx"),
+      "utf8"
+    );
+    const generatedPluginBootstrap = fs.readFileSync(
+      path.join(targetDir, "demo-interactivity.php"),
+      "utf8"
+    );
+    const generatedWebpackConfig = fs.readFileSync(
+      path.join(targetDir, "webpack.config.js"),
+      "utf8"
+    );
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(targetDir, "package.json"), "utf8")
+    );
+    const blockJson = JSON.parse(
+      fs.readFileSync(path.join(targetDir, "src", "block.json"), "utf8")
+    );
 
-  expect(packageJson.name).toBe("demo-interactivity");
-  expect(packageJson.scripts.sync).toBe("tsx scripts/sync-project.ts");
-  expect(packageJson.scripts.dev).toBe(
-    'concurrently -k -n sync-types,editor -c yellow,blue "npm run watch:sync-types" "npm run start:editor"'
-  );
-  expect(packageJson.scripts.build).toBe(
-    "npm run sync -- --check && wp-scripts build --experimental-modules"
-  );
-  expect(packageJson.scripts.start).toBe(
-    "npm run sync && wp-scripts start --experimental-modules"
-  );
-  expect(packageJson.scripts.typecheck).toBe(
-    "npm run sync -- --check && tsc --noEmit"
-  );
-  expect(packageJson.scripts["watch:sync-types"]).toBe(
+    expect(packageJson.name).toBe("demo-interactivity");
+    expect(packageJson.scripts.sync).toBe("tsx scripts/sync-project.ts");
+    expect(packageJson.scripts.dev).toBe(
+      'concurrently -k -n sync-types,editor -c yellow,blue "npm run watch:sync-types" "npm run start:editor"'
+    );
+    expect(packageJson.scripts.build).toBe(
+      "npm run sync -- --check && wp-scripts build --experimental-modules"
+    );
+    expect(packageJson.scripts.start).toBe(
+      "npm run sync && wp-scripts start --experimental-modules"
+    );
+    expect(packageJson.scripts.typecheck).toBe(
+      "npm run sync -- --check && tsc --noEmit"
+    );
+    expect(packageJson.scripts["watch:sync-types"]).toBe(
     'chokidar "src/types.ts" --debounce 200 -c "npm run sync-types"'
   );
   expect(blockJson.name).toBe("demo-space/demo-interactivity");
@@ -665,15 +667,17 @@ test("scaffoldProject creates an interactivity template with typed validation wi
   expect(generatedSave).not.toContain("data-is-visible");
   expect(generatedSave).not.toContain("data-unique-id");
   expect(generatedStyle).toContain(".wp-block-demo-space-demo-interactivity");
-  expect(generatedEditorStyle).toContain(
-    ".wp-block-demo-space-demo-interactivity"
-  );
-  runGeneratedScript(targetDir, "scripts/sync-types-to-block-json.ts");
-  runGeneratedScript(targetDir, "scripts/sync-types-to-block-json.ts", [
-    "--check",
-  ]);
-  typecheckGeneratedProject(targetDir);
-});
+    expect(generatedEditorStyle).toContain(
+      ".wp-block-demo-space-demo-interactivity"
+    );
+    runGeneratedScript(targetDir, "scripts/sync-types-to-block-json.ts");
+    runGeneratedScript(targetDir, "scripts/sync-types-to-block-json.ts", [
+      "--check",
+    ]);
+    typecheckGeneratedProject(targetDir);
+  },
+  { timeout: 30_000 }
+);
 
 test("scaffoldProject supports the optional local wp-env preset without adding test files", async () => {
   const targetDir = path.join(tempRoot, "demo-local-wp-env");

--- a/scripts/build-docs-site.mjs
+++ b/scripts/build-docs-site.mjs
@@ -1,0 +1,174 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const rootDir = path.resolve(import.meta.dirname, "..");
+const docsDir = path.join(rootDir, "docs");
+const siteDir = path.join(rootDir, ".pages-site");
+
+const topLevelDocs = fs
+  .readdirSync(docsDir, { withFileTypes: true })
+  .filter(
+    (entry) =>
+      entry.isFile() &&
+      entry.name.endsWith(".md") &&
+      entry.name !== "index.md"
+  )
+  .map((entry) => entry.name)
+  .sort((left, right) => left.localeCompare(right));
+
+const tutorialDocs = fs
+  .readdirSync(path.join(docsDir, "tutorials"), { withFileTypes: true })
+  .filter((entry) => entry.isFile() && entry.name.endsWith(".md"))
+  .map((entry) => entry.name)
+  .sort((left, right) => left.localeCompare(right));
+
+function escapeHtml(value) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+function titleFromFilename(filename) {
+  return filename
+    .replace(/\.md$/u, "")
+    .split(/[-_]/u)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function buildLinkList(basePath, filenames) {
+  return filenames
+    .map(
+      (filename) =>
+        `<li><a href="${escapeHtml(path.posix.join(basePath, filename))}">${escapeHtml(titleFromFilename(filename))}</a></li>`
+    )
+    .join("\n");
+}
+
+function copyDirectory(sourceDir, targetDir) {
+  fs.mkdirSync(targetDir, { recursive: true });
+  for (const entry of fs.readdirSync(sourceDir, { withFileTypes: true })) {
+    const sourcePath = path.join(sourceDir, entry.name);
+    const targetPath = path.join(targetDir, entry.name);
+    if (entry.isDirectory()) {
+      copyDirectory(sourcePath, targetPath);
+      continue;
+    }
+    fs.copyFileSync(sourcePath, targetPath);
+  }
+}
+
+fs.rmSync(siteDir, { recursive: true, force: true });
+copyDirectory(docsDir, siteDir);
+
+const homepage = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>wp-typia Documentation</title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: #f4f6fb;
+        color: #1b263b;
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background:
+          radial-gradient(circle at top left, rgba(54, 118, 255, 0.18), transparent 32rem),
+          linear-gradient(180deg, #f7f9fc 0%, #eef3ff 100%);
+      }
+      main {
+        max-width: 58rem;
+        margin: 0 auto;
+        padding: 4rem 1.5rem 5rem;
+      }
+      h1 {
+        margin: 0 0 0.75rem;
+        font-size: clamp(2rem, 4vw, 3.25rem);
+        line-height: 1.05;
+      }
+      p {
+        line-height: 1.65;
+        max-width: 44rem;
+      }
+      .hero {
+        padding: 2rem 0 2.5rem;
+      }
+      .grid {
+        display: grid;
+        gap: 1.25rem;
+        grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+      }
+      section {
+        background: rgba(255, 255, 255, 0.78);
+        border: 1px solid rgba(27, 38, 59, 0.08);
+        border-radius: 1rem;
+        padding: 1.25rem;
+        box-shadow: 0 18px 45px rgba(27, 38, 59, 0.08);
+        backdrop-filter: blur(8px);
+      }
+      h2 {
+        margin-top: 0;
+        font-size: 1.05rem;
+      }
+      ul {
+        margin: 0.75rem 0 0;
+        padding-left: 1.1rem;
+      }
+      li + li {
+        margin-top: 0.5rem;
+      }
+      a {
+        color: #1f5cff;
+        text-decoration: none;
+      }
+      a:hover {
+        text-decoration: underline;
+      }
+      .meta {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        margin-top: 1.25rem;
+        font-size: 0.95rem;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <div class="hero">
+        <h1>wp-typia documentation</h1>
+        <p>Reference material for the wp-typia packages, scaffolds, migration workflows, and tutorials published from the repository's <code>docs/</code> tree.</p>
+        <div class="meta">
+          <a href="https://github.com/imjlk/wp-typia">Repository</a>
+          <a href="api/README.md">API Reference Index</a>
+          <a href="API.md">Docs Build Notes</a>
+        </div>
+      </div>
+      <div class="grid">
+        <section>
+          <h2>Guides</h2>
+          <ul>
+${buildLinkList(".", topLevelDocs)}
+          </ul>
+        </section>
+        <section>
+          <h2>Tutorials</h2>
+          <ul>
+${buildLinkList("tutorials", tutorialDocs)}
+          </ul>
+        </section>
+      </div>
+    </main>
+  </body>
+</html>
+`;
+
+fs.writeFileSync(path.join(siteDir, "index.html"), homepage, "utf8");
+fs.writeFileSync(path.join(siteDir, ".nojekyll"), "", "utf8");


### PR DESCRIPTION
## Summary
- fix the generated interactivity scaffold so fresh projects pass `tsc --noEmit`
- stop relying on dead global augmentation for `getContext()` typing and use explicit generated context imports instead
- restore the docs deployment path by publishing a real static Pages artifact with a root index page

## Root cause
- `@wordpress/interactivity` infers `getContext()` as `object` unless the scaffold passes an explicit generic, so the current template trips strict TypeScript on the generated context usage
- the current `save.tsx` and `edit.tsx` also compare optional interactivity attributes directly, which leaves `possibly undefined` errors in generated projects
- GitHub Pages is still configured for legacy `gh-pages` serving while CI deploys with `actions/deploy-pages`, and the uploaded docs tree has no root entry point, so the published site currently resolves to a 404 at `/`

## Validation
- `bun test packages/wp-typia-project-tools/tests/scaffold-basic.test.ts -t "scaffoldProject creates an interactivity template with typed validation wiring"`
- `bun run docs:build:site`
- `bun run ci:local`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Static documentation site generation added to CI and package scripts.

* **Bug Fixes**
  * Restored reliable GitHub Pages artifact publishing.
  * Interactivity scaffolds now produce more robust typed contexts.

* **Chores**
  * CI workflow updated to build and validate the docs site on PRs.
  * Generated docs output directory excluded from version control.
* **Tests**
  * Test expectations updated to reflect the scaffold and type changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->