### PR TITLE
fix: clean first-party submit frames and restore docs deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -736,7 +736,7 @@ jobs:
         uses: actions/configure-pages@v6
 
       - name: Upload documentation artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@v5.0.0
         with:
           path: ./.pages-site
 

--- a/.sampo/changesets/issue-231-submit-state-and-pages-followup.md
+++ b/.sampo/changesets/issue-231-submit-state-and-pages-followup.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Fix first-party TUI submit rendering so create/add/migrate replace stale form content with a shared submitting surface, and restore GitHub Pages deploys by pinning the documentation artifact upload action to a real `actions/upload-pages-artifact` release tag.

--- a/packages/wp-typia/src/ui/add-flow.tsx
+++ b/packages/wp-typia/src/ui/add-flow.tsx
@@ -20,7 +20,7 @@ import {
 	sanitizeAddSubmitValues,
 } from "./add-flow-model";
 import {
-	FirstPartyScrollBox,
+	FirstPartyFormViewport,
 	FirstPartySelectField,
 	FirstPartyTextField,
 } from "./first-party-form";
@@ -137,7 +137,7 @@ function AddFlowFields({
 }: {
 	workspaceBlockOptions: WorkspaceBlockOption[];
 }) {
-	const { activeFieldName, values } = useFormContext();
+	const { activeFieldName, isSubmitting, values } = useFormContext();
 	const { height: terminalHeight = 24 } = useTerminalDimensions();
 	const addValues = values as Partial<AddFlowValues>;
 	const kind = addValues.kind ?? "block";
@@ -160,8 +160,14 @@ function AddFlowFields({
 	const variationBlockUsesSelect = kind === "variation" && workspaceBlockOptions.length > 0;
 
 	return createElement(
-		FirstPartyScrollBox,
-		{ scrollTop, viewportHeight },
+		FirstPartyFormViewport,
+		{
+			isSubmitting,
+			scrollTop,
+			submittingDescription: "Applying your workspace changes...",
+			submittingTitle: "Updating workspace...",
+			viewportHeight,
+		},
 		[
 			createElement(FirstPartySelectField, {
 				...getWrappedFieldNeighbors(orderedVisibleFields, "kind"),

--- a/packages/wp-typia/src/ui/create-flow.tsx
+++ b/packages/wp-typia/src/ui/create-flow.tsx
@@ -21,7 +21,7 @@ import {
 } from "./create-flow-model";
 import {
 	FirstPartyCheckboxField,
-	FirstPartyScrollBox,
+	FirstPartyFormViewport,
 	FirstPartySelectField,
 	FirstPartyTextField,
 } from "./first-party-form";
@@ -70,7 +70,7 @@ type CreateSelectFieldName = {
 }[keyof CreateFlowValues];
 
 function CreateFlowFields() {
-	const { activeFieldName, values } = useFormContext();
+	const { activeFieldName, isSubmitting, values } = useFormContext();
 	const { height: terminalHeight = 24 } = useTerminalDimensions();
 	const createValues = values as Partial<CreateFlowValues>;
 	const template = createValues.template;
@@ -88,8 +88,14 @@ function CreateFlowFields() {
 	);
 
 	return createElement(
-		FirstPartyScrollBox,
-		{ scrollTop, viewportHeight },
+		FirstPartyFormViewport,
+		{
+			isSubmitting,
+			scrollTop,
+			submittingDescription: "Preparing your wp-typia project files...",
+			submittingTitle: "Creating project...",
+			viewportHeight,
+		},
 		[
 			createElement(FirstPartyTextField, {
 				...getWrappedFieldNeighbors(visibleFields, "project-dir"),

--- a/packages/wp-typia/src/ui/first-party-form.tsx
+++ b/packages/wp-typia/src/ui/first-party-form.tsx
@@ -10,6 +10,7 @@ import {
 
 import { useScopedKeyboard } from "@bunli/runtime/app";
 import {
+	Spinner,
 	type SelectOption,
 	createKeyMatcher,
 	useFormContext,
@@ -457,4 +458,71 @@ export function FirstPartyScrollBox({
 			children,
 		),
 	);
+}
+
+export function FirstPartySubmittingSurface({
+	description = "Please wait while wp-typia finishes this command.",
+	title = "Submitting...",
+	viewportHeight,
+}: {
+	description?: string;
+	title?: string;
+	viewportHeight: number;
+}) {
+	const { tokens } = useTuiTheme();
+
+	return createElement(
+		"box",
+		{
+			border: true,
+			height: viewportHeight,
+			width: "100%",
+			"data-form-surface": "submitting",
+			style: {
+				alignItems: "center",
+				borderColor: tokens.borderMuted,
+				flexDirection: "column",
+				gap: 1,
+				justifyContent: "center",
+			},
+		},
+		createElement(Spinner, {
+			title,
+			variant: "dot",
+		}),
+		createElement("text", {
+			content: description,
+			fg: tokens.textMuted,
+		}),
+	);
+}
+
+export function FirstPartyFormViewport({
+	children,
+	isSubmitting = false,
+	scrollTop,
+	submittingDescription,
+	submittingTitle,
+	viewportHeight,
+}: {
+	children?: ReactNode;
+	isSubmitting?: boolean;
+	scrollTop: number;
+	submittingDescription?: string;
+	submittingTitle?: string;
+	viewportHeight: number;
+}) {
+	if (isSubmitting) {
+		return createElement(FirstPartySubmittingSurface, {
+			description: submittingDescription,
+			title: submittingTitle,
+			viewportHeight,
+		});
+	}
+
+	return createElement(FirstPartyScrollBox, {
+		scrollTop,
+		viewportHeight,
+		children,
+	});
 }

--- a/packages/wp-typia/src/ui/migrate-flow.tsx
+++ b/packages/wp-typia/src/ui/migrate-flow.tsx
@@ -19,7 +19,7 @@ import {
 } from "./migrate-flow-model";
 import {
 	FirstPartyCheckboxField,
-	FirstPartyScrollBox,
+	FirstPartyFormViewport,
 	FirstPartySelectField,
 	FirstPartyTextField,
 } from "./first-party-form";
@@ -76,7 +76,7 @@ type MigrateCheckboxFieldName = {
 }[keyof MigrateFlowValues];
 
 function MigrateFlowFields() {
-	const { activeFieldName, values } = useFormContext();
+	const { activeFieldName, isSubmitting, values } = useFormContext();
 	const { height: terminalHeight = 24 } = useTerminalDimensions();
 	const migrateValues = values as Partial<MigrateFlowValues>;
 	const command = migrateValues.command ?? "plan";
@@ -98,8 +98,14 @@ function MigrateFlowFields() {
 	);
 
 	return createElement(
-		FirstPartyScrollBox,
-		{ scrollTop, viewportHeight },
+		FirstPartyFormViewport,
+		{
+			isSubmitting,
+			scrollTop,
+			submittingDescription: "Running the selected migration workflow...",
+			submittingTitle: "Running migration...",
+			viewportHeight,
+		},
 		[
 			createElement(FirstPartySelectField, {
 				...getWrappedFieldNeighbors(orderedVisibleFields, "command"),

--- a/packages/wp-typia/tests/tui-lifecycle.test.ts
+++ b/packages/wp-typia/tests/tui-lifecycle.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 
 import { addCommand } from "../src/commands/add";
 import { createCommand } from "../src/commands/create";
@@ -10,6 +12,18 @@ import {
 	resolveLazyFlowComponent,
 	runAlternateBufferAction,
 } from "../src/ui/alternate-buffer-lifecycle";
+import { FirstPartyFormViewport } from "../src/ui/first-party-form";
+
+function renderStaticMarkupSilently(element: ReturnType<typeof createElement>): string {
+	const originalError = console.error;
+	console.error = () => {};
+
+	try {
+		return renderToStaticMarkup(element);
+	} finally {
+		console.error = originalError;
+	}
+}
 
 describe("alternate-buffer TUI lifecycle", () => {
 	test("matches the shared quit keys", () => {
@@ -166,5 +180,50 @@ describe("alternate-buffer TUI lifecycle", () => {
 		expect(typeof createCommand.render).toBe("function");
 		expect(typeof addCommand.render).toBe("function");
 		expect(typeof migrateCommand.render).toBe("function");
+	});
+
+	test("shared first-party submit surface replaces stale create fields while submitting", () => {
+		const rendered = renderStaticMarkupSilently(
+			createElement(
+				FirstPartyFormViewport,
+				{
+					isSubmitting: true,
+					scrollTop: 2,
+					submittingDescription: "Preparing your wp-typia project files...",
+					submittingTitle: "Creating project...",
+					viewportHeight: 8,
+				},
+				createElement("text", { content: "Project directory" }),
+				createElement("text", { content: "Template" }),
+				createElement("text", { content: "Package manager" }),
+			),
+		);
+
+		expect(rendered).toContain('data-form-surface="submitting"');
+		expect(rendered).toContain("Creating project...");
+		expect(rendered).toContain("Preparing your wp-typia project files...");
+		expect(rendered).not.toContain("<scrollbox");
+		expect(rendered).not.toContain("Project directory");
+		expect(rendered).not.toContain("Template");
+		expect(rendered).not.toContain("Package manager");
+	});
+
+	test("shared first-party submit surface keeps the scrollbox body when idle", () => {
+		const rendered = renderStaticMarkupSilently(
+			createElement(
+				FirstPartyFormViewport,
+				{
+					isSubmitting: false,
+					scrollTop: 4,
+					submittingTitle: "Creating project...",
+					viewportHeight: 8,
+				},
+				createElement("text", { content: "Project directory" }),
+			),
+		);
+
+		expect(rendered).toContain("<scrollbox");
+		expect(rendered).toContain("Project directory");
+		expect(rendered).not.toContain('data-form-surface="submitting"');
 	});
 });


### PR DESCRIPTION
## Summary
- fix the first-party TUI submit state so create/add/migrate replace stale form content with a shared submitting surface
- restore docs deploys by pinning `actions/upload-pages-artifact` to the real `v5.0.0` tag
- add a runtime regression that verifies submit surfaces hide stale field content while submitting

## Root cause
- Bunli `Form` already flips `isSubmitting`, but our flow bodies kept rendering the same scrollbox tree while the footer changed to `Submitting...`, so alternate-buffer renders could leave stale fields, borders, and scrollbox fragments visible during submit
- the docs deploy follow-up from the previous PR used `actions/upload-pages-artifact@v5`, but that major tag does not exist; only `v5.0.0` resolves, so the `Deploy Documentation` job failed before upload

## Validation
- `bun run --filter wp-typia test`
- `bun run docs:build:site`
- `bun run changesets:validate`
- `bun run ci:local`

## Release notes
- `wp-typia` patch release: cleaner submit-state rendering in first-party TUI flows and a restored GitHub Pages deploy pipeline

Closes #231.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visual submitting state that displays during form operations across create, add, and migrate workflows. The new interface features a centered spinner and contextual status messages, replacing stale form content to provide clearer feedback on operation progress.

* **Bug Fixes**
  * Restored GitHub Pages documentation deployments.

* **Tests**
  * Added comprehensive test coverage for submission state rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->