### PR TITLE
fix: keep first-party TUI completion output reviewable

### DIFF
--- a/.sampo/changesets/issue-232-reviewable-completion-surface.md
+++ b/.sampo/changesets/issue-232-reviewable-completion-surface.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Keep successful first-party TUI workflows open long enough to review their completion output in-buffer, with shared completion surfaces for `create`, `add`, and `migrate` before exit.

--- a/packages/wp-typia/src/runtime-bridge.ts
+++ b/packages/wp-typia/src/runtime-bridge.ts
@@ -84,7 +84,8 @@ export function printCompletionPayload(
 		warnLine?: PrintLine;
 	} = {},
 ): void {
-	const { printLine = console.log as PrintLine, warnLine = console.warn as PrintLine } = options;
+	const printLine = options.printLine ?? (console.log as PrintLine);
+	const warnLine = options.warnLine ?? printLine;
 
 	for (const line of payload.preambleLines ?? []) {
 		printLine(line);
@@ -98,8 +99,11 @@ export function printCompletionPayload(
 		(payload.nextSteps?.length ?? 0) > 0 ||
 		(payload.optionalLines?.length ?? 0) > 0 ||
 		Boolean(payload.optionalNote);
+	const hasLeadingContext =
+		(payload.preambleLines?.length ?? 0) > 0 ||
+		(payload.warningLines?.length ?? 0) > 0;
 
-	printLine(hasDetails ? `\n${payload.title}` : payload.title);
+	printLine(hasLeadingContext && hasDetails ? `\n${payload.title}` : payload.title);
 	for (const line of payload.summaryLines ?? []) {
 		printLine(line);
 	}
@@ -786,9 +790,9 @@ export async function executeMigrateCommand({
 	pushFlag(argv, "seed", readOptionalLooseStringFlag(flags, "seed"));
 
 	const parsed = parseMigrationArgs(argv);
-	const lines: string[] = [];
+	const lines: string[] | null = renderLine ? [] : null;
 	const captureLine = (line: string) => {
-		lines.push(line);
+		lines?.push(line);
 		if (renderLine) {
 			renderLine(line);
 			return;
@@ -801,21 +805,16 @@ export async function executeMigrateCommand({
 	});
 	if (renderLine) {
 		return result && typeof result === "object" && "cancelled" in result && result.cancelled === true
-			? undefined
-			: buildMigrationCompletionPayload({
-					command,
-					lines,
+				? undefined
+				: buildMigrationCompletionPayload({
+					command: parsed.command ?? "plan",
+					lines: lines ?? [],
 				});
 	}
 
 	if (result && typeof result === "object" && "cancelled" in result && result.cancelled === true) {
 		return;
 	}
-
-	return buildMigrationCompletionPayload({
-		command,
-		lines,
-	});
 }
 
 export { listTemplates };

--- a/packages/wp-typia/src/runtime-bridge.ts
+++ b/packages/wp-typia/src/runtime-bridge.ts
@@ -12,20 +12,26 @@ import {
 import { formatRunScript } from "@wp-typia/project-tools/package-managers";
 import { tryResolveWorkspaceProject } from "@wp-typia/project-tools/workspace-project";
 import type { ReadlinePrompt } from "@wp-typia/project-tools/cli-prompt";
+import type { AlternateBufferCompletionPayload } from "./ui/alternate-buffer-lifecycle";
 
 type CreateExecutionInput = {
 	projectDir: string;
 	cwd: string;
+	emitOutput?: boolean;
 	flags: Record<string, unknown>;
 	interactive?: boolean;
+	printLine?: PrintLine;
 	prompt?: ReadlinePrompt;
+	warnLine?: PrintLine;
 };
 
 type AddExecutionInput = {
 	cwd: string;
+	emitOutput?: boolean;
 	flags: Record<string, unknown>;
 	kind?: string;
 	name?: string;
+	printLine?: PrintLine;
 };
 
 type TemplatesExecutionInput = {
@@ -68,6 +74,147 @@ const loadMigrationsRuntime = () => import("@wp-typia/project-tools/migrations")
 function printBlock(lines: string[], printLine: PrintLine): void {
 	for (const line of lines) {
 		printLine(line);
+	}
+}
+
+export function printCompletionPayload(
+	payload: AlternateBufferCompletionPayload,
+	options: {
+		printLine?: PrintLine;
+		warnLine?: PrintLine;
+	} = {},
+): void {
+	const { printLine = console.log as PrintLine, warnLine = console.warn as PrintLine } = options;
+
+	for (const line of payload.preambleLines ?? []) {
+		printLine(line);
+	}
+	for (const warning of payload.warningLines ?? []) {
+		warnLine(`⚠️ ${warning}`);
+	}
+
+	const hasDetails =
+		(payload.summaryLines?.length ?? 0) > 0 ||
+		(payload.nextSteps?.length ?? 0) > 0 ||
+		(payload.optionalLines?.length ?? 0) > 0 ||
+		Boolean(payload.optionalNote);
+
+	printLine(hasDetails ? `\n${payload.title}` : payload.title);
+	for (const line of payload.summaryLines ?? []) {
+		printLine(line);
+	}
+	if ((payload.nextSteps?.length ?? 0) > 0) {
+		printLine("Next steps:");
+		for (const step of payload.nextSteps ?? []) {
+			printLine(`  ${step}`);
+		}
+	}
+	if ((payload.optionalLines?.length ?? 0) > 0) {
+		printLine(`\n${payload.optionalTitle ?? "Optional:"}`);
+		for (const step of payload.optionalLines ?? []) {
+			printLine(`  ${step}`);
+		}
+	}
+	if (payload.optionalNote) {
+		printLine(`Note: ${payload.optionalNote}`);
+	}
+}
+
+export function buildCreateCompletionPayload(flow: {
+	nextSteps: string[];
+	optionalOnboarding: {
+		note: string;
+		steps: string[];
+	};
+	projectDir: string;
+	result: {
+		selectedVariant?: string | null;
+		variables: {
+			title: string;
+		};
+		warnings: string[];
+	};
+}): AlternateBufferCompletionPayload {
+	return {
+		nextSteps: flow.nextSteps,
+		optionalLines:
+			flow.optionalOnboarding.steps.length > 0 ? flow.optionalOnboarding.steps : undefined,
+		optionalNote:
+			flow.optionalOnboarding.steps.length > 0 ? flow.optionalOnboarding.note : undefined,
+		optionalTitle:
+			flow.optionalOnboarding.steps.length > 0 ? "Optional before first commit:" : undefined,
+		preambleLines: flow.result.selectedVariant
+			? [`Template variant: ${flow.result.selectedVariant}`]
+			: undefined,
+		summaryLines: [`Project directory: ${flow.projectDir}`],
+		title: `✅ Created ${flow.result.variables.title} in ${flow.projectDir}`,
+		warningLines: flow.result.warnings,
+	};
+}
+
+export function buildMigrationCompletionPayload(options: {
+	command: string;
+	lines: string[];
+}): AlternateBufferCompletionPayload {
+	const summaryLines = options.lines.filter((line) => line.trim().length > 0);
+
+	return {
+		summaryLines,
+		title: `✅ Completed wp-typia migrate ${options.command}`,
+	};
+}
+
+function buildAddCompletionPayload(options: {
+	kind: "binding-source" | "block" | "hooked-block" | "pattern" | "variation";
+	projectDir: string;
+	values: Record<string, string>;
+}): AlternateBufferCompletionPayload {
+	switch (options.kind) {
+		case "variation":
+			return {
+				summaryLines: [
+					`Variation: ${options.values.variationSlug}`,
+					`Target block: ${options.values.blockSlug}`,
+					`Project directory: ${options.projectDir}`,
+				],
+				title: "✅ Added workspace variation",
+			};
+		case "pattern":
+			return {
+				summaryLines: [
+					`Pattern: ${options.values.patternSlug}`,
+					`Project directory: ${options.projectDir}`,
+				],
+				title: "✅ Added workspace pattern",
+			};
+		case "binding-source":
+			return {
+				summaryLines: [
+					`Binding source: ${options.values.bindingSourceSlug}`,
+					`Project directory: ${options.projectDir}`,
+				],
+				title: "✅ Added binding source",
+			};
+		case "hooked-block":
+			return {
+				summaryLines: [
+					`Block: ${options.values.blockSlug}`,
+					`Anchor: ${options.values.anchorBlockName}`,
+					`Position: ${options.values.position}`,
+					`Project directory: ${options.projectDir}`,
+				],
+				title: "✅ Added blockHooks metadata",
+			};
+		case "block":
+		default:
+			return {
+				summaryLines: [
+					`Blocks: ${options.values.blockSlugs}`,
+					`Template family: ${options.values.templateId}`,
+					`Project directory: ${options.projectDir}`,
+				],
+				title: "✅ Added workspace block",
+			};
 	}
 }
 
@@ -261,10 +408,13 @@ const BOOLEAN_PROMPT_OPTIONS = [
 export async function executeCreateCommand({
 	projectDir,
 	cwd,
+	emitOutput = true,
 	flags,
 	interactive,
+	printLine = console.log as PrintLine,
 	prompt,
-}: CreateExecutionInput): Promise<void> {
+	warnLine = console.warn as PrintLine,
+}: CreateExecutionInput): Promise<AlternateBufferCompletionPayload> {
 	const [
 		{ createReadlinePrompt },
 		{ runScaffoldFlow },
@@ -333,25 +483,14 @@ export async function executeCreateCommand({
 			yes: Boolean(flags.yes),
 		});
 
-		if (flow.result.selectedVariant) {
-			console.log(`Template variant: ${flow.result.selectedVariant}`);
+		const payload = buildCreateCompletionPayload(flow);
+		if (emitOutput) {
+			printCompletionPayload(payload, {
+				printLine,
+				warnLine,
+			});
 		}
-		for (const warning of flow.result.warnings) {
-			console.warn(`⚠️ ${warning}`);
-		}
-
-		console.log(`\n✅ Created ${flow.result.variables.title} in ${flow.projectDir}`);
-		console.log("Next steps:");
-		for (const step of flow.nextSteps) {
-			console.log(`  ${step}`);
-		}
-		if (flow.optionalOnboarding.steps.length > 0) {
-			console.log("\nOptional before first commit:");
-			for (const step of flow.optionalOnboarding.steps) {
-				console.log(`  ${step}`);
-			}
-			console.log(`Note: ${flow.optionalOnboarding.note}`);
-		}
+		return payload;
 	} finally {
 		if (activePrompt && activePrompt !== prompt) {
 			activePrompt.close();
@@ -361,13 +500,15 @@ export async function executeCreateCommand({
 
 export async function executeAddCommand({
 	cwd,
+	emitOutput = true,
 	flags,
 	kind,
 	name,
-}: AddExecutionInput): Promise<void> {
+	printLine = console.log as PrintLine,
+}: AddExecutionInput): Promise<AlternateBufferCompletionPayload | void> {
 	if (!kind) {
 		const { formatAddHelpText } = await loadCliAddRuntime();
-		console.log(formatAddHelpText());
+		printLine(formatAddHelpText());
 		return;
 	}
 
@@ -390,8 +531,18 @@ export async function executeAddCommand({
 			cwd,
 			variationName: name,
 		});
-		console.log(`✅ Added variation ${result.variationSlug} to ${result.blockSlug} in ${result.projectDir}.`);
-		return;
+		const payload = buildAddCompletionPayload({
+			kind: "variation",
+			projectDir: result.projectDir,
+			values: {
+				blockSlug: result.blockSlug,
+				variationSlug: result.variationSlug,
+			},
+		});
+		if (emitOutput) {
+			printCompletionPayload(payload, { printLine });
+		}
+		return payload;
 	}
 
 	if (kind === "pattern") {
@@ -405,8 +556,17 @@ export async function executeAddCommand({
 			cwd,
 			patternName: name,
 		});
-		console.log(`✅ Added pattern ${result.patternSlug} in ${result.projectDir}.`);
-		return;
+		const payload = buildAddCompletionPayload({
+			kind: "pattern",
+			projectDir: result.projectDir,
+			values: {
+				patternSlug: result.patternSlug,
+			},
+		});
+		if (emitOutput) {
+			printCompletionPayload(payload, { printLine });
+		}
+		return payload;
 	}
 
 	if (kind === "binding-source") {
@@ -420,8 +580,17 @@ export async function executeAddCommand({
 			bindingSourceName: name,
 			cwd,
 		});
-		console.log(`✅ Added binding source ${result.bindingSourceSlug} in ${result.projectDir}.`);
-		return;
+		const payload = buildAddCompletionPayload({
+			kind: "binding-source",
+			projectDir: result.projectDir,
+			values: {
+				bindingSourceSlug: result.bindingSourceSlug,
+			},
+		});
+		if (emitOutput) {
+			printCompletionPayload(payload, { printLine });
+		}
+		return payload;
 	}
 
 	if (kind === "hooked-block") {
@@ -449,10 +618,19 @@ export async function executeAddCommand({
 			cwd,
 			position,
 		});
-		console.log(
-			`✅ Added blockHooks metadata for ${result.blockSlug} relative to ${result.anchorBlockName} (${result.position}) in ${result.projectDir}.`,
-		);
-		return;
+		const payload = buildAddCompletionPayload({
+			kind: "hooked-block",
+			projectDir: result.projectDir,
+			values: {
+				anchorBlockName: result.anchorBlockName,
+				blockSlug: result.blockSlug,
+				position: result.position,
+			},
+		});
+		if (emitOutput) {
+			printCompletionPayload(payload, { printLine });
+		}
+		return payload;
 	}
 
 	if (kind !== "block") {
@@ -485,9 +663,18 @@ export async function executeAddCommand({
 			| "compound",
 	});
 
-	console.log(
-		`✅ Added ${result.blockSlugs.join(", ")} to ${result.projectDir} using the ${result.templateId} family.`,
-	);
+	const payload = buildAddCompletionPayload({
+		kind: "block",
+		projectDir: result.projectDir,
+		values: {
+			blockSlugs: result.blockSlugs.join(", "),
+			templateId: result.templateId,
+		},
+	});
+	if (emitOutput) {
+		printCompletionPayload(payload, { printLine });
+	}
+	return payload;
 }
 
 export async function executeTemplatesCommand(
@@ -568,7 +755,7 @@ export async function executeMigrateCommand({
 	flags,
 	prompt,
 	renderLine,
-}: MigrateExecutionInput): Promise<void> {
+}: MigrateExecutionInput): Promise<AlternateBufferCompletionPayload | void> {
 	const { formatMigrationHelpText, parseMigrationArgs, runMigrationCommand } =
 		await loadMigrationsRuntime();
 	if (!command) {
@@ -599,9 +786,35 @@ export async function executeMigrateCommand({
 	pushFlag(argv, "seed", readOptionalLooseStringFlag(flags, "seed"));
 
 	const parsed = parseMigrationArgs(argv);
-	await runMigrationCommand(parsed, cwd, {
+	const lines: string[] = [];
+	const captureLine = (line: string) => {
+		lines.push(line);
+		if (renderLine) {
+			renderLine(line);
+			return;
+		}
+		console.log(line);
+	};
+	const result = await runMigrationCommand(parsed, cwd, {
 		prompt,
-		renderLine,
+		renderLine: captureLine,
+	});
+	if (renderLine) {
+		return result && typeof result === "object" && "cancelled" in result && result.cancelled === true
+			? undefined
+			: buildMigrationCompletionPayload({
+					command,
+					lines,
+				});
+	}
+
+	if (result && typeof result === "object" && "cancelled" in result && result.cancelled === true) {
+		return;
+	}
+
+	return buildMigrationCompletionPayload({
+		command,
+		lines,
 	});
 }
 

--- a/packages/wp-typia/src/ui/add-flow.tsx
+++ b/packages/wp-typia/src/ui/add-flow.tsx
@@ -20,6 +20,7 @@ import {
 	sanitizeAddSubmitValues,
 } from "./add-flow-model";
 import {
+	FirstPartyCompletionViewport,
 	FirstPartyFormViewport,
 	FirstPartySelectField,
 	FirstPartyTextField,
@@ -263,9 +264,11 @@ function AddFlowFields({
 }
 
 export function AddFlow({ cwd, initialValues }: AddFlowProps) {
-	const { handleCancel, handleFailure, handleSubmit } = useAlternateBufferLifecycle(
+	const { completion, handleCancel, handleFailure, handleSubmit, status } =
+		useAlternateBufferLifecycle(
 		"wp-typia add failed",
-	);
+		);
+	const { height: terminalHeight = 24 } = useTerminalDimensions();
 	const [workspaceBlockOptions, setWorkspaceBlockOptions] = useState<WorkspaceBlockOption[]>([]);
 
 	useEffect(() => {
@@ -289,6 +292,13 @@ export function AddFlow({ cwd, initialValues }: AddFlowProps) {
 		};
 	}, [cwd, handleFailure]);
 
+	if (status === "completed" && completion) {
+		return createElement(FirstPartyCompletionViewport, {
+			completion,
+			viewportHeight: getAddViewportHeight(terminalHeight),
+		});
+	}
+
 	return (
 		<Form
 			initialValues={initialValues}
@@ -296,8 +306,9 @@ export function AddFlow({ cwd, initialValues }: AddFlowProps) {
 			onSubmit={async (values) =>
 				handleSubmit(async () => {
 					const flags = sanitizeAddSubmitValues(values);
-					await executeAddCommand({
+					return executeAddCommand({
 						cwd,
+						emitOutput: false,
 						flags,
 						kind: values.kind,
 						name: typeof flags.name === "string" ? flags.name : undefined,

--- a/packages/wp-typia/src/ui/alternate-buffer-lifecycle.ts
+++ b/packages/wp-typia/src/ui/alternate-buffer-lifecycle.ts
@@ -1,11 +1,23 @@
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 
 import { useRuntime } from "@bunli/runtime/app";
 import { useKeyboard } from "@bunli/tui";
 
 type AlternateBufferKeyEvent = {
 	ctrl?: boolean;
+	sequence?: string;
 	name?: string;
+};
+
+export type AlternateBufferCompletionPayload = {
+	title: string;
+	preambleLines?: string[];
+	summaryLines?: string[];
+	nextSteps?: string[];
+	optionalTitle?: string;
+	optionalLines?: string[];
+	optionalNote?: string;
+	warningLines?: string[];
 };
 
 type AlternateBufferFailureOptions = {
@@ -16,11 +28,15 @@ type AlternateBufferFailureOptions = {
 };
 
 type RunAlternateBufferActionOptions = {
-	action: () => Promise<void>;
+	action: () => Promise<unknown>;
 	context: string;
 	exit: () => void;
+	exitOnSuccess?: boolean;
 	log?: (message: string) => void;
+	onSuccess?: (result: unknown) => void;
 };
+
+type AlternateBufferLifecycleStatus = "editing" | "submitting" | "completed";
 
 export function describeAlternateBufferFailure(context: string, error: unknown): string {
 	const message = error instanceof Error ? error.message : String(error);
@@ -29,6 +45,10 @@ export function describeAlternateBufferFailure(context: string, error: unknown):
 
 export function isAlternateBufferExitKey(key: AlternateBufferKeyEvent): boolean {
 	return key.name === "q" || (key.ctrl === true && key.name === "c");
+}
+
+export function isAlternateBufferCompletionKey(key: AlternateBufferKeyEvent): boolean {
+	return key.name === "enter" || key.sequence === "\r" || key.sequence === "\n";
 }
 
 export function reportAlternateBufferFailure({
@@ -46,11 +66,16 @@ export async function runAlternateBufferAction({
 	action,
 	context,
 	exit,
+	exitOnSuccess = true,
 	log = console.error,
+	onSuccess,
 }: RunAlternateBufferActionOptions): Promise<void> {
 	try {
-		await action();
-		exit();
+		const result = await action();
+		onSuccess?.(result);
+		if (exitOnSuccess) {
+			exit();
+		}
 	} catch (error) {
 		reportAlternateBufferFailure({ context, error, exit, log });
 	}
@@ -98,32 +123,75 @@ export function useAlternateBufferExitKeys(options: {
 	});
 }
 
+export function useAlternateBufferCompletionKeys(options: {
+	enabled?: boolean;
+	exit?: () => void;
+} = {}): void {
+	const runtime = useRuntime();
+	const exit = options.exit ?? (() => runtime.exit());
+	const enabled = options.enabled ?? false;
+
+	useKeyboard((key: AlternateBufferKeyEvent) => {
+		if (!enabled) {
+			return;
+		}
+
+		if (isAlternateBufferCompletionKey(key) || isAlternateBufferExitKey(key)) {
+			exit();
+		}
+	});
+}
+
+function isAlternateBufferCompletionPayload(
+	value: unknown,
+): value is AlternateBufferCompletionPayload {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		return false;
+	}
+
+	const candidate = value as { title?: unknown };
+	return typeof candidate.title === "string" && candidate.title.trim().length > 0;
+}
+
 export function useAlternateBufferLifecycle(
 	context: string,
 	options: {
 		enableExitKeys?: boolean;
 	} = {},
 ): {
+	completion: AlternateBufferCompletionPayload | null;
 	handleCancel: () => void;
 	handleFailure: (error: unknown) => void;
-	handleSubmit: (action: () => Promise<void>) => Promise<void>;
+	handleSubmit: (action: () => Promise<AlternateBufferCompletionPayload | void>) => Promise<void>;
+	status: AlternateBufferLifecycleStatus;
 } {
 	const runtime = useRuntime();
+	const [completion, setCompletion] = useState<AlternateBufferCompletionPayload | null>(null);
+	const [status, setStatus] = useState<AlternateBufferLifecycleStatus>("editing");
 	const exit = useCallback(() => {
 		runtime.exit();
 	}, [runtime]);
 
 	useAlternateBufferExitKeys({
-		enabled: options.enableExitKeys ?? true,
+		enabled: (options.enableExitKeys ?? true) && status !== "completed",
+		exit,
+	});
+
+	useAlternateBufferCompletionKeys({
+		enabled: status === "completed",
 		exit,
 	});
 
 	const handleCancel = useCallback(() => {
+		setCompletion(null);
+		setStatus("editing");
 		exit();
 	}, [exit]);
 
 	const handleFailure = useCallback(
 		(error: unknown) => {
+			setCompletion(null);
+			setStatus("editing");
 			reportAlternateBufferFailure({
 				context,
 				error,
@@ -134,19 +202,37 @@ export function useAlternateBufferLifecycle(
 	);
 
 	const handleSubmit = useCallback(
-		async (action: () => Promise<void>) => {
-			await runAlternateBufferAction({
-				action,
-				context,
-				exit,
-			});
+		async (action: () => Promise<AlternateBufferCompletionPayload | void>) => {
+			setCompletion(null);
+			setStatus("submitting");
+
+			try {
+				const result = await action();
+				if (isAlternateBufferCompletionPayload(result)) {
+					setCompletion(result);
+					setStatus("completed");
+					return;
+				}
+
+				exit();
+			} catch (error) {
+				setCompletion(null);
+				setStatus("editing");
+				reportAlternateBufferFailure({
+					context,
+					error,
+					exit,
+				});
+			}
 		},
 		[context, exit],
 	);
 
 	return {
+		completion,
 		handleCancel,
 		handleFailure,
 		handleSubmit,
+		status,
 	};
 }

--- a/packages/wp-typia/src/ui/create-flow.tsx
+++ b/packages/wp-typia/src/ui/create-flow.tsx
@@ -21,6 +21,7 @@ import {
 } from "./create-flow-model";
 import {
 	FirstPartyCheckboxField,
+	FirstPartyCompletionViewport,
 	FirstPartyFormViewport,
 	FirstPartySelectField,
 	FirstPartyTextField,
@@ -167,7 +168,10 @@ function CreateFlowFields() {
 }
 
 export function CreateFlow({ cwd, initialValues }: CreateFlowProps) {
-	const { handleCancel, handleSubmit } = useAlternateBufferLifecycle("wp-typia create failed");
+	const { completion, handleCancel, handleSubmit, status } = useAlternateBufferLifecycle(
+		"wp-typia create failed",
+	);
+	const { height: terminalHeight = 24 } = useTerminalDimensions();
 	const defaultPrompt = {
 		close() {},
 		select<T extends string>(_message: string, options: Array<{ value: T }>, defaultValue = 1) {
@@ -179,6 +183,13 @@ export function CreateFlow({ cwd, initialValues }: CreateFlowProps) {
 		},
 	};
 
+	if (status === "completed" && completion) {
+		return createElement(FirstPartyCompletionViewport, {
+			completion,
+			viewportHeight: getCreateViewportHeight(terminalHeight),
+		});
+	}
+
 	return (
 		<Form
 			initialValues={initialValues}
@@ -186,8 +197,9 @@ export function CreateFlow({ cwd, initialValues }: CreateFlowProps) {
 			onSubmit={async (values) =>
 				handleSubmit(async () => {
 					const flags = sanitizeCreateSubmitValues(values);
-					await executeCreateCommand({
+					return executeCreateCommand({
 						cwd,
+						emitOutput: false,
 						flags,
 						interactive: true,
 						projectDir: values["project-dir"],

--- a/packages/wp-typia/src/ui/first-party-form.tsx
+++ b/packages/wp-typia/src/ui/first-party-form.tsx
@@ -98,6 +98,30 @@ function isCheckboxToggleKey(key: Parameters<typeof checkboxKeymap.match>[1]) {
 	);
 }
 
+function isCompletionLineDownKey(key: Parameters<typeof checkboxKeymap.match>[1]) {
+	return key.name === "down" || key.sequence === "\x1b[B";
+}
+
+function isCompletionLineUpKey(key: Parameters<typeof checkboxKeymap.match>[1]) {
+	return key.name === "up" || key.sequence === "\x1b[A";
+}
+
+function isCompletionPageDownKey(key: Parameters<typeof checkboxKeymap.match>[1]) {
+	return key.name === "pagedown" || key.sequence === "\x1b[6~" || key.sequence === " ";
+}
+
+function isCompletionPageUpKey(key: Parameters<typeof checkboxKeymap.match>[1]) {
+	return key.name === "pageup" || key.sequence === "\x1b[5~";
+}
+
+function isCompletionHomeKey(key: Parameters<typeof checkboxKeymap.match>[1]) {
+	return key.name === "home" || key.sequence === "\x1b[H" || key.sequence === "\x1bOH";
+}
+
+function isCompletionEndKey(key: Parameters<typeof checkboxKeymap.match>[1]) {
+	return key.name === "end" || key.sequence === "\x1b[F" || key.sequence === "\x1bOF";
+}
+
 function useFirstPartyFieldNavigation(options: {
 	focused: boolean;
 	keyboardScopeId: string;
@@ -536,7 +560,58 @@ export function FirstPartyCompletionViewport({
 	viewportHeight: number;
 }) {
 	const { tokens } = useTuiTheme();
+	const reactScopeId = useId();
+	const keyboardScopeId = `first-party-completion:${reactScopeId}`;
 	const bodyHeight = Math.max(4, viewportHeight - 3);
+	const bodyRef = useRef<{ scrollTop: number } | null>(null);
+
+	const setCompletionScrollTop = useCallback((nextScrollTop: number) => {
+		if (!bodyRef.current) {
+			return false;
+		}
+
+		bodyRef.current.scrollTop = Math.max(0, nextScrollTop);
+		return true;
+	}, []);
+
+	const adjustCompletionScrollTop = useCallback(
+		(delta: number) => {
+			if (!bodyRef.current) {
+				return false;
+			}
+
+			bodyRef.current.scrollTop = Math.max(0, bodyRef.current.scrollTop + delta);
+			return true;
+		},
+		[],
+	);
+
+	useScopedKeyboard(
+		keyboardScopeId,
+		(key) => {
+			if (isCompletionLineDownKey(key)) {
+				return adjustCompletionScrollTop(1);
+			}
+			if (isCompletionLineUpKey(key)) {
+				return adjustCompletionScrollTop(-1);
+			}
+			if (isCompletionPageDownKey(key)) {
+				return adjustCompletionScrollTop(Math.max(1, bodyHeight - 1));
+			}
+			if (isCompletionPageUpKey(key)) {
+				return adjustCompletionScrollTop(-Math.max(1, bodyHeight - 1));
+			}
+			if (isCompletionHomeKey(key)) {
+				return setCompletionScrollTop(0);
+			}
+			if (isCompletionEndKey(key)) {
+				return setCompletionScrollTop(Number.MAX_SAFE_INTEGER);
+			}
+
+			return false;
+		},
+		{ active: true },
+	);
 
 	return createElement(
 		"box",
@@ -553,6 +628,7 @@ export function FirstPartyCompletionViewport({
 		createElement(
 			"scrollbox",
 			{
+				ref: bodyRef,
 				height: bodyHeight,
 				scrollY: true,
 				scrollbarOptions: {
@@ -637,7 +713,7 @@ export function FirstPartyCompletionViewport({
 			),
 		),
 		createElement("text", {
-			content: "Enter: close | q: exit | Ctrl+C: quit",
+			content: "PgUp/PgDn | ↑/↓ | Home/End | Enter: close | q: exit | Ctrl+C: quit",
 			fg: tokens.textMuted,
 		}),
 	);

--- a/packages/wp-typia/src/ui/first-party-form.tsx
+++ b/packages/wp-typia/src/ui/first-party-form.tsx
@@ -24,6 +24,7 @@ import {
 	FIRST_PARTY_SELECT_FIELD_CONTROL_HEIGHT,
 	FIRST_PARTY_SELECT_FIELD_LABEL_GAP,
 } from "./first-party-form-model";
+import type { AlternateBufferCompletionPayload } from "./alternate-buffer-lifecycle";
 
 const checkboxKeymap = createKeyMatcher({
 	toggle: ["space", "enter"],
@@ -525,4 +526,119 @@ export function FirstPartyFormViewport({
 		viewportHeight,
 		children,
 	});
+}
+
+export function FirstPartyCompletionViewport({
+	completion,
+	viewportHeight,
+}: {
+	completion: AlternateBufferCompletionPayload;
+	viewportHeight: number;
+}) {
+	const { tokens } = useTuiTheme();
+	const bodyHeight = Math.max(4, viewportHeight - 3);
+
+	return createElement(
+		"box",
+		{
+			border: true,
+			height: viewportHeight,
+			width: "100%",
+			"data-form-surface": "completed",
+			style: {
+				borderColor: tokens.borderMuted,
+				flexDirection: "column",
+			},
+		},
+		createElement(
+			"scrollbox",
+			{
+				height: bodyHeight,
+				scrollY: true,
+				scrollbarOptions: {
+					visible: true,
+					trackOptions: {
+						backgroundColor: tokens.backgroundMuted,
+						foregroundColor: tokens.borderMuted,
+					},
+				},
+				viewportOptions: { width: "100%" },
+				contentOptions: { width: "100%" },
+			},
+			createElement(
+				"box",
+				{
+					width: "100%",
+					style: {
+						flexDirection: "column",
+						gap: 1,
+					},
+				},
+				createElement("text", {
+					content: completion.title,
+					fg: tokens.accent,
+				}),
+				...(completion.preambleLines ?? []).map((line, index) =>
+					createElement("text", {
+						content: line,
+						fg: tokens.textMuted,
+						key: `preamble:${index}`,
+					}),
+				),
+				...(completion.warningLines ?? []).map((line, index) =>
+					createElement("text", {
+						content: `⚠️ ${line}`,
+						fg: tokens.textWarning,
+						key: `warning:${index}`,
+					}),
+				),
+				...(completion.summaryLines ?? []).map((line, index) =>
+					createElement("text", {
+						content: line,
+						fg: tokens.textPrimary,
+						key: `summary:${index}`,
+					}),
+				),
+				(completion.nextSteps?.length ?? 0) > 0
+					? createElement("text", {
+							content: "Next steps:",
+							fg: tokens.textPrimary,
+							key: "next-steps:title",
+						})
+					: null,
+				...(completion.nextSteps ?? []).map((line, index) =>
+					createElement("text", {
+						content: `  ${line}`,
+						fg: tokens.textPrimary,
+						key: `next-step:${index}`,
+					}),
+				),
+				(completion.optionalLines?.length ?? 0) > 0
+					? createElement("text", {
+							content: completion.optionalTitle ?? "Optional:",
+							fg: tokens.textPrimary,
+							key: "optional:title",
+						})
+					: null,
+				...(completion.optionalLines ?? []).map((line, index) =>
+					createElement("text", {
+						content: `  ${line}`,
+						fg: tokens.textMuted,
+						key: `optional:${index}`,
+					}),
+				),
+				completion.optionalNote
+					? createElement("text", {
+							content: `Note: ${completion.optionalNote}`,
+							fg: tokens.textMuted,
+							key: "optional:note",
+						})
+					: null,
+			),
+		),
+		createElement("text", {
+			content: "Enter: close | q: exit | Ctrl+C: quit",
+			fg: tokens.textMuted,
+		}),
+	);
 }

--- a/packages/wp-typia/src/ui/migrate-flow.tsx
+++ b/packages/wp-typia/src/ui/migrate-flow.tsx
@@ -19,6 +19,7 @@ import {
 } from "./migrate-flow-model";
 import {
 	FirstPartyCheckboxField,
+	FirstPartyCompletionViewport,
 	FirstPartyFormViewport,
 	FirstPartySelectField,
 	FirstPartyTextField,
@@ -186,7 +187,17 @@ function MigrateFlowFields() {
 }
 
 export function MigrateFlow({ cwd, initialValues }: MigrateFlowProps) {
-	const { handleCancel, handleSubmit } = useAlternateBufferLifecycle("wp-typia migrate failed");
+	const { completion, handleCancel, handleSubmit, status } = useAlternateBufferLifecycle(
+		"wp-typia migrate failed",
+	);
+	const { height: terminalHeight = 24 } = useTerminalDimensions();
+
+	if (status === "completed" && completion) {
+		return createElement(FirstPartyCompletionViewport, {
+			completion,
+			viewportHeight: getMigrateViewportHeight(terminalHeight),
+		});
+	}
 
 	return (
 		<Form
@@ -195,10 +206,11 @@ export function MigrateFlow({ cwd, initialValues }: MigrateFlowProps) {
 			onSubmit={async (values) =>
 				handleSubmit(async () => {
 					const flags = sanitizeMigrateSubmitValues(values);
-					await executeMigrateCommand({
+					return executeMigrateCommand({
 						command: values.command,
 						cwd,
 						flags,
+						renderLine: () => undefined,
 					});
 				})
 			}

--- a/packages/wp-typia/tests/completion-output.test.ts
+++ b/packages/wp-typia/tests/completion-output.test.ts
@@ -68,6 +68,46 @@ describe("alternate-buffer completion output helpers", () => {
 		]);
 	});
 
+	test("completion printer keeps warnings on the same stream by default", () => {
+		const printed: string[] = [];
+
+		printCompletionPayload(
+			{
+				summaryLines: ["Project directory: /tmp/demo-block"],
+				title: "✅ Created Demo Block in /tmp/demo-block",
+				warningLines: ["This template enables optional migration UI."],
+			},
+			{
+				printLine: (line) => printed.push(line),
+			},
+		);
+
+		expect(printed).toEqual([
+			"⚠️ This template enables optional migration UI.",
+			"\n✅ Created Demo Block in /tmp/demo-block",
+			"Project directory: /tmp/demo-block",
+		]);
+	});
+
+	test("completion printer avoids a leading blank line when no preamble or warnings were emitted", () => {
+		const printed: string[] = [];
+
+		printCompletionPayload(
+			{
+				summaryLines: ["Project directory: /tmp/demo-block"],
+				title: "✅ Created Demo Block in /tmp/demo-block",
+			},
+			{
+				printLine: (line) => printed.push(line),
+			},
+		);
+
+		expect(printed).toEqual([
+			"✅ Created Demo Block in /tmp/demo-block",
+			"Project directory: /tmp/demo-block",
+		]);
+	});
+
 	test("migration completion payload keeps rendered lines reviewable in order", () => {
 		const payload = buildMigrationCompletionPayload({
 			command: "plan",

--- a/packages/wp-typia/tests/completion-output.test.ts
+++ b/packages/wp-typia/tests/completion-output.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+	buildCreateCompletionPayload,
+	buildMigrationCompletionPayload,
+	printCompletionPayload,
+} from "../src/runtime-bridge";
+
+describe("alternate-buffer completion output helpers", () => {
+	test("create completion payload preserves reviewable next steps and optional onboarding", () => {
+		const payload = buildCreateCompletionPayload({
+			nextSteps: ["cd demo-block", "npm install", "npm run dev"],
+			optionalOnboarding: {
+				note: "Run npm run sync before your first commit if you edited types.",
+				steps: ["npm run sync"],
+			},
+			projectDir: "/tmp/demo-block",
+			result: {
+				selectedVariant: "hero",
+				variables: {
+					title: "Demo Block",
+				},
+				warnings: ["This template enables optional migration UI."],
+			},
+		});
+
+		expect(payload.title).toBe("✅ Created Demo Block in /tmp/demo-block");
+		expect(payload.preambleLines).toEqual(["Template variant: hero"]);
+		expect(payload.warningLines).toEqual(["This template enables optional migration UI."]);
+		expect(payload.nextSteps).toEqual(["cd demo-block", "npm install", "npm run dev"]);
+		expect(payload.optionalTitle).toBe("Optional before first commit:");
+		expect(payload.optionalLines).toEqual(["npm run sync"]);
+		expect(payload.optionalNote).toContain("npm run sync");
+	});
+
+	test("completion printer keeps warning and next-step ordering stable", () => {
+		const printed: string[] = [];
+		const warned: string[] = [];
+
+		printCompletionPayload(
+			{
+				nextSteps: ["cd demo-block", "npm install"],
+				optionalLines: ["npm run sync"],
+				optionalNote: "Review the generated metadata before first commit.",
+				optionalTitle: "Optional before first commit:",
+				preambleLines: ["Template variant: hero"],
+				summaryLines: ["Project directory: /tmp/demo-block"],
+				title: "✅ Created Demo Block in /tmp/demo-block",
+				warningLines: ["This template enables optional migration UI."],
+			},
+			{
+				printLine: (line) => printed.push(line),
+				warnLine: (line) => warned.push(line),
+			},
+		);
+
+		expect(warned).toEqual(["⚠️ This template enables optional migration UI."]);
+		expect(printed).toEqual([
+			"Template variant: hero",
+			"\n✅ Created Demo Block in /tmp/demo-block",
+			"Project directory: /tmp/demo-block",
+			"Next steps:",
+			"  cd demo-block",
+			"  npm install",
+			"\nOptional before first commit:",
+			"  npm run sync",
+			"Note: Review the generated metadata before first commit.",
+		]);
+	});
+
+	test("migration completion payload keeps rendered lines reviewable in order", () => {
+		const payload = buildMigrationCompletionPayload({
+			command: "plan",
+			lines: [
+				"Current migration version: v3",
+				"Selected migration edge: v1 -> v3",
+				"Next steps:",
+				"  wp-typia migrate scaffold --from-migration-version v1",
+			],
+		});
+
+		expect(payload.title).toBe("✅ Completed wp-typia migrate plan");
+		expect(payload.summaryLines).toEqual([
+			"Current migration version: v3",
+			"Selected migration edge: v1 -> v3",
+			"Next steps:",
+			"  wp-typia migrate scaffold --from-migration-version v1",
+		]);
+	});
+});

--- a/packages/wp-typia/tests/tui-lifecycle.test.ts
+++ b/packages/wp-typia/tests/tui-lifecycle.test.ts
@@ -285,6 +285,8 @@ describe("alternate-buffer TUI lifecycle", () => {
 		expect(rendered).toContain("cd demo-block");
 		expect(rendered).toContain("Optional before first commit:");
 		expect(rendered).toContain("Review the generated metadata before first commit.");
+		expect(rendered).toContain("PgUp/PgDn");
+		expect(rendered).toContain("Home/End");
 		expect(rendered).toContain("Enter: close | q: exit | Ctrl+C: quit");
 	});
 });

--- a/packages/wp-typia/tests/tui-lifecycle.test.ts
+++ b/packages/wp-typia/tests/tui-lifecycle.test.ts
@@ -6,13 +6,17 @@ import { addCommand } from "../src/commands/add";
 import { createCommand } from "../src/commands/create";
 import { migrateCommand } from "../src/commands/migrate";
 import {
+	isAlternateBufferCompletionKey,
 	describeAlternateBufferFailure,
 	isAlternateBufferExitKey,
 	reportAlternateBufferFailure,
 	resolveLazyFlowComponent,
 	runAlternateBufferAction,
 } from "../src/ui/alternate-buffer-lifecycle";
-import { FirstPartyFormViewport } from "../src/ui/first-party-form";
+import {
+	FirstPartyCompletionViewport,
+	FirstPartyFormViewport,
+} from "../src/ui/first-party-form";
 
 function renderStaticMarkupSilently(element: ReturnType<typeof createElement>): string {
 	const originalError = console.error;
@@ -31,6 +35,13 @@ describe("alternate-buffer TUI lifecycle", () => {
 		expect(isAlternateBufferExitKey({ ctrl: true, name: "c" })).toBe(true);
 		expect(isAlternateBufferExitKey({ name: "escape" })).toBe(false);
 		expect(isAlternateBufferExitKey({ ctrl: true, name: "x" })).toBe(false);
+	});
+
+	test("matches the completion confirmation keys", () => {
+		expect(isAlternateBufferCompletionKey({ name: "enter" })).toBe(true);
+		expect(isAlternateBufferCompletionKey({ sequence: "\r" })).toBe(true);
+		expect(isAlternateBufferCompletionKey({ sequence: "\n" })).toBe(true);
+		expect(isAlternateBufferCompletionKey({ name: "space" })).toBe(false);
 	});
 
 	test("describes failures with context", () => {
@@ -86,6 +97,30 @@ describe("alternate-buffer TUI lifecycle", () => {
 		expect(ran).toBe(true);
 		expect(messages).toEqual([]);
 		expect(exited).toBe(1);
+	});
+
+	test("run helper can defer exit while completion state takes over", async () => {
+		const completion = {
+			nextSteps: ["cd demo", "npm install"],
+			title: "✅ Created Demo Block",
+		};
+		let exited = 0;
+		let received: unknown;
+
+		await runAlternateBufferAction({
+			action: async () => completion,
+			context: "wp-typia create failed",
+			exit: () => {
+				exited += 1;
+			},
+			exitOnSuccess: false,
+			onSuccess: (result) => {
+				received = result;
+			},
+		});
+
+		expect(received).toEqual(completion);
+		expect(exited).toBe(0);
 	});
 
 	test("run helper reports failure and exits", async () => {
@@ -225,5 +260,31 @@ describe("alternate-buffer TUI lifecycle", () => {
 		expect(rendered).toContain("<scrollbox");
 		expect(rendered).toContain("Project directory");
 		expect(rendered).not.toContain('data-form-surface="submitting"');
+	});
+
+	test("shared first-party completion surface renders next steps and close hints", () => {
+		const rendered = renderStaticMarkupSilently(
+			createElement(FirstPartyCompletionViewport, {
+				completion: {
+					nextSteps: ["cd demo-block", "npm install", "npm run dev"],
+					optionalLines: ["npm run sync"],
+					optionalNote: "Review the generated metadata before first commit.",
+					optionalTitle: "Optional before first commit:",
+					preambleLines: ["Template variant: hero"],
+					summaryLines: ["Project directory: /tmp/demo-block"],
+					title: "✅ Created Demo Block in /tmp/demo-block",
+					warningLines: ["This template enables optional migration UI."],
+				},
+				viewportHeight: 10,
+			}),
+		);
+
+		expect(rendered).toContain('data-form-surface="completed"');
+		expect(rendered).toContain("✅ Created Demo Block in /tmp/demo-block");
+		expect(rendered).toContain("Next steps:");
+		expect(rendered).toContain("cd demo-block");
+		expect(rendered).toContain("Optional before first commit:");
+		expect(rendered).toContain("Review the generated metadata before first commit.");
+		expect(rendered).toContain("Enter: close | q: exit | Ctrl+C: quit");
 	});
 });


### PR DESCRIPTION
## Summary
- keep successful first-party TUI flows inside the alternate buffer until the user confirms exit
- add a shared completion surface for create, add, and migrate success handoff
- add regression coverage for completion payload rendering and lifecycle helpers

Closes #232.

## Validation
- bun run --filter wp-typia test
- bun run typecheck
- bun run ci:local

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create, add, and migrate commands show a structured, reviewable completion surface before exiting.
  * Completion view includes title, warnings, summary lines, next steps, and optional notes.
  * Terminal-aware viewport with keyboard-driven scrolling and common shortcuts for navigation and closing.
  * Consistent completion surfaces across workflows for a unified experience.

* **Tests**
  * Added tests covering completion payload construction, printing behavior, lifecycle handling, and the completion viewport.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->