### PR TITLE
fix: trim dead interactivity scaffold surface

### DIFF
--- a/.sampo/changesets/issue-227-interactivity-scaffold-trim.md
+++ b/.sampo/changesets/issue-227-interactivity-scaffold-trim.md
@@ -3,4 +3,4 @@ npm/@wp-typia/project-tools: patch
 npm/wp-typia: patch
 ---
 
-Trim the default interactivity scaffold down to the runtime surface it actually uses by removing dead context fields, unbound actions, and unused editor attributes like `uniqueId` and `autoPlayInterval`.
+Trim the default interactivity scaffold down to the runtime surface it actually uses by removing dead context fields, unbound actions, unused editor attributes like `uniqueId` and `autoPlayInterval`, and the unused `interactiveMode: "auto"` scaffold option.

--- a/.sampo/changesets/issue-227-interactivity-scaffold-trim.md
+++ b/.sampo/changesets/issue-227-interactivity-scaffold-trim.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Trim the default interactivity scaffold down to the runtime surface it actually uses by removing dead context fields, unbound actions, and unused editor attributes like `uniqueId` and `autoPlayInterval`.

--- a/packages/wp-typia-project-tools/src/runtime/starter-manifests.ts
+++ b/packages/wp-typia-project-tools/src/runtime/starter-manifests.ts
@@ -22,7 +22,7 @@ interface StarterAttributeDefinition {
 }
 
 const ALIGNMENT_VALUES = ["left", "center", "right", "justify"] as const;
-const INTERACTIVE_MODE_VALUES = ["click", "hover", "auto"] as const;
+const INTERACTIVE_MODE_VALUES = ["click", "hover"] as const;
 const ANIMATION_VALUES = ["none", "bounce", "pulse", "shake", "flip"] as const;
 const DEFAULT_COMPOUND_CHILD_BODY_PLACEHOLDER =
 	"Add supporting details for this internal item.";
@@ -163,16 +163,6 @@ function buildInteractivityStarterManifest(
 			required: false,
 			sourceType: "string",
 		}),
-		autoPlayInterval: createAttribute({
-			constraints: {
-				minimum: 0,
-				typeTag: "uint32",
-			},
-			defaultValue: 0,
-			kind: "number",
-			required: false,
-			sourceType: "number",
-		}),
 		clickCount: createAttribute({
 			constraints: {
 				minimum: 0,
@@ -226,12 +216,6 @@ function buildInteractivityStarterManifest(
 			kind: "boolean",
 			required: false,
 			sourceType: "boolean",
-		}),
-		uniqueId: createAttribute({
-			defaultValue: "",
-			kind: "string",
-			required: false,
-			sourceType: "string",
 		}),
 	});
 }

--- a/packages/wp-typia-project-tools/templates/interactivity/src/block.json.mustache
+++ b/packages/wp-typia-project-tools/templates/interactivity/src/block.json.mustache
@@ -33,7 +33,7 @@
 		},
 		"interactiveMode": {
 			"type": "string",
-			"enum": ["click", "hover", "auto"],
+			"enum": ["click", "hover"],
 			"default": "click"
 		},
 		"animation": {
@@ -56,14 +56,6 @@
 		"maxClicks": {
 			"type": "number",
 			"default": 10
-		},
-		"autoPlayInterval": {
-			"type": "number",
-			"default": 0
-		},
-		"uniqueId": {
-			"type": "string",
-			"default": ""
 		}
 	},
 	"textdomain": "{{textDomain}}",

--- a/packages/wp-typia-project-tools/templates/interactivity/src/edit.tsx.mustache
+++ b/packages/wp-typia-project-tools/templates/interactivity/src/edit.tsx.mustache
@@ -1,6 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import { useBlockProps, InspectorControls, RichText, BlockControls, AlignmentToolbar } from '@wordpress/block-editor';
-import { PanelBody, RangeControl, TextControl, Button, Notice } from '@wordpress/components';
+import { PanelBody, RangeControl, Button, Notice } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import currentManifest from './typia.manifest.json';
 import {
@@ -23,7 +23,7 @@ export default function Edit({ attributes, setAttributes, isSelected }: {
 }) {
   const [isPreviewing, setIsPreviewing] = useState(false);
   const editorFields = useEditorFields(currentManifest as ManifestDocument, {
-    manual: ['content', 'clickCount', 'maxClicks', 'autoPlayInterval', 'uniqueId'],
+    manual: ['content', 'clickCount', 'maxClicks'],
     labels: {
       alignment: __('Alignment', '{{textDomain}}'),
       animation: __('Animation', '{{textDomain}}'),
@@ -57,7 +57,6 @@ export default function Edit({ attributes, setAttributes, isSelected }: {
     'alignment',
     'left'
   ) as NonNullable<{{pascalCase}}Attributes['alignment']>;
-  const autoPlayInterval = attributes.autoPlayInterval ?? 0;
   const clickCount = attributes.clickCount ?? 0;
   const isVisible = editorFields.getBooleanValue(
     attributes,
@@ -81,7 +80,6 @@ export default function Edit({ attributes, setAttributes, isSelected }: {
     'animation',
     'none'
   ) as NonNullable<{{pascalCase}}Attributes['animation']>;
-  const uniqueId = attributes.uniqueId ?? '';
 
   const blockProps = useBlockProps({
     className: `{{cssClassName}} {{cssClassName}}--${interactiveMode}`,
@@ -90,11 +88,8 @@ export default function Edit({ attributes, setAttributes, isSelected }: {
       clicks: clickCount,
       isAnimating,
       isVisible,
-      lastInteraction: '',
       animation,
-      interactiveMode,
       maxClicks,
-      autoPlayInterval
     })
   });
 
@@ -138,18 +133,6 @@ export default function Edit({ attributes, setAttributes, isSelected }: {
             help={__('Set to 0 for unlimited clicks', '{{textDomain}}')}
           />
 
-          {interactiveMode === 'auto' && (
-            <RangeControl
-              label={__('Auto Play Interval (ms)', '{{textDomain}}')}
-              value={autoPlayInterval}
-              onChange={(value) => updateField('autoPlayInterval', value ?? autoPlayInterval)}
-              min={100}
-              max={5000}
-              step={100}
-              help={__('Interval between automatic animations', '{{textDomain}}')}
-            />
-          )}
-
           <div style={{ display: 'flex', gap: '8px', marginTop: '16px' }}>
             <Button
               variant="secondary"
@@ -166,13 +149,6 @@ export default function Edit({ attributes, setAttributes, isSelected }: {
               {__('Test Animation', '{{textDomain}}')}
             </Button>
           </div>
-
-          <TextControl
-            label={__('Unique ID', '{{textDomain}}')}
-            value={uniqueId}
-            onChange={(value) => updateField('uniqueId', value)}
-            help={__('Optional unique identifier for this block instance', '{{textDomain}}')}
-          />
         </PanelBody>
 
         {!isValid && (

--- a/packages/wp-typia-project-tools/templates/interactivity/src/interactivity.ts.mustache
+++ b/packages/wp-typia-project-tools/templates/interactivity/src/interactivity.ts.mustache
@@ -21,23 +21,6 @@ store('{{slugKebabCase}}', {
     get isVisible() {
       return getBlockContext().isVisible;
     },
-    get animationClass() {
-      const context = getBlockContext();
-      if (!context.isAnimating) return '';
-
-      switch (context.animation) {
-        case 'bounce':
-          return 'animate-bounce';
-        case 'pulse':
-          return 'animate-pulse';
-        case 'shake':
-          return 'animate-shake';
-        case 'flip':
-          return 'animate-flip';
-        default:
-          return '';
-      }
-    },
     get progress() {
       const context = getBlockContext();
       return context.maxClicks > 0 ? (context.clicks / context.maxClicks) * 100 : 0;
@@ -67,7 +50,6 @@ store('{{slugKebabCase}}', {
 
       // Increment click counter
       context.clicks += 1;
-      context.lastInteraction = 'click';
 
       // Trigger animation
       if (context.animation !== 'none') {
@@ -93,23 +75,12 @@ store('{{slugKebabCase}}', {
     // Handle hover events
     handleMouseEnter: () => {
       const context = getBlockContext();
-      if (context.interactiveMode === 'hover') {
-        context.isAnimating = true;
-        context.lastInteraction = 'hover';
-      }
+      context.isAnimating = true;
     },
 
     handleMouseLeave: () => {
       const context = getBlockContext();
-      if (context.interactiveMode === 'hover') {
-        context.isAnimating = false;
-      }
-    },
-
-    // Toggle visibility
-    toggleVisibility: () => {
-      const context = getBlockContext();
-      context.isVisible = !context.isVisible;
+      context.isAnimating = false;
     },
 
     // Reset counter
@@ -117,26 +88,6 @@ store('{{slugKebabCase}}', {
       const context = getBlockContext();
       context.clicks = 0;
       context.isAnimating = false;
-      context.lastInteraction = 'reset';
-    },
-
-    // Start/stop auto play
-    toggleAutoPlay: () => {
-      const context = getBlockContext();
-      if (context.autoPlayInterval > 0) {
-        if (context.autoPlayTimer) {
-          clearInterval(context.autoPlayTimer);
-          context.autoPlayTimer = null;
-        } else {
-          context.autoPlayTimer = setInterval(() => {
-            context.clicks += 1;
-            context.isAnimating = true;
-            setTimeout(() => {
-              context.isAnimating = false;
-            }, 500);
-          }, context.autoPlayInterval);
-        }
-      }
     }
   }
 });

--- a/packages/wp-typia-project-tools/templates/interactivity/src/interactivity.ts.mustache
+++ b/packages/wp-typia-project-tools/templates/interactivity/src/interactivity.ts.mustache
@@ -75,11 +75,13 @@ store('{{slugKebabCase}}', {
     // Handle hover events
     handleMouseEnter: () => {
       const context = getBlockContext();
+      if (context.animation === 'none') return;
       context.isAnimating = true;
     },
 
     handleMouseLeave: () => {
       const context = getBlockContext();
+      if (context.animation === 'none') return;
       context.isAnimating = false;
     },
 

--- a/packages/wp-typia-project-tools/templates/interactivity/src/save.tsx.mustache
+++ b/packages/wp-typia-project-tools/templates/interactivity/src/save.tsx.mustache
@@ -2,7 +2,6 @@ import { useBlockProps, RichText } from '@wordpress/block-editor';
 import type { {{pascalCase}}Attributes } from './types';
 
 export default function Save({ attributes }: { attributes: {{pascalCase}}Attributes }) {
-  const autoPlayInterval = attributes.autoPlayInterval ?? 0;
   const clickCount = attributes.clickCount ?? 0;
   const interactiveMode = attributes.interactiveMode ?? 'click';
   const animation = attributes.animation ?? 'none';
@@ -17,11 +16,8 @@ export default function Save({ attributes }: { attributes: {{pascalCase}}Attribu
       clicks: clickCount,
       isAnimating,
       isVisible,
-      lastInteraction: '',
       animation,
-      interactiveMode,
       maxClicks,
-      autoPlayInterval
     })
   });
 

--- a/packages/wp-typia-project-tools/templates/interactivity/src/types.ts.mustache
+++ b/packages/wp-typia-project-tools/templates/interactivity/src/types.ts.mustache
@@ -11,26 +11,20 @@ export interface {{pascalCase}}Attributes {
   content: string & tags.MinLength<1> & tags.MaxLength<1000> & tags.Default<"">;
   alignment?: TextAlignment & tags.Default<"left">;
   isVisible?: boolean & tags.Default<true>;
-  interactiveMode?: ('click' | 'hover' | 'auto') & tags.Default<"click">;
+  interactiveMode?: ('click' | 'hover') & tags.Default<"click">;
   animation?: ('none' | 'bounce' | 'pulse' | 'shake' | 'flip') & tags.Default<"none">;
   clickCount?: number & tags.Minimum<0> & tags.Type<"uint32"> & tags.Default<0>;
   isAnimating?: boolean & tags.Default<false>;
   showCounter?: boolean & tags.Default<true>;
   maxClicks?: number & tags.Minimum<0> & tags.Type<"uint32"> & tags.Default<10>;
-  autoPlayInterval?: number & tags.Minimum<0> & tags.Type<"uint32"> & tags.Default<0>;
-  uniqueId?: string & tags.Default<"">;
 }
 
 export interface {{pascalCase}}Context {
   clicks: number;
   isAnimating: boolean;
   isVisible: boolean;
-  lastInteraction: string;
   animation: 'none' | 'bounce' | 'pulse' | 'shake' | 'flip';
-  interactiveMode: 'click' | 'hover' | 'auto';
   maxClicks: number;
-  autoPlayInterval: number;
-  autoPlayTimer?: ReturnType<typeof setInterval> | null;
 }
 
 export type {{pascalCase}}ValidationResult = ValidationResult<{{pascalCase}}Attributes>;

--- a/packages/wp-typia-project-tools/templates/interactivity/src/validators.ts.mustache
+++ b/packages/wp-typia-project-tools/templates/interactivity/src/validators.ts.mustache
@@ -1,7 +1,6 @@
 import typia from 'typia';
 import currentManifest from "./typia.manifest.json";
 import { {{pascalCase}}Attributes, {{pascalCase}}ValidationResult } from "./types";
-import { generateScopedClientId } from "@wp-typia/block-runtime/identifiers";
 import { createTemplateValidatorToolkit } from "./validator-toolkit";
 
 const scaffoldValidators = createTemplateValidatorToolkit<{{pascalCase}}Attributes>({
@@ -15,13 +14,6 @@ const scaffoldValidators = createTemplateValidatorToolkit<{{pascalCase}}Attribut
   random: typia.createRandom<{{pascalCase}}Attributes>() as (
     ...args: unknown[]
   ) => {{pascalCase}}Attributes,
-  finalize: (normalized) => ({
-    ...normalized,
-    uniqueId:
-      normalized.uniqueId && normalized.uniqueId.length > 0
-        ? normalized.uniqueId
-        : generateScopedClientId("{{slugKebabCase}}"),
-  }),
   validate: typia.createValidate<{{pascalCase}}Attributes>(),
 });
 

--- a/packages/wp-typia-project-tools/tests/scaffold-basic.test.ts
+++ b/packages/wp-typia-project-tools/tests/scaffold-basic.test.ts
@@ -568,13 +568,20 @@ test(
   expect(blockJson.category).toBe("widgets");
   expect(blockJson.icon).toBe("smiley");
   expect(blockJson.editorStyle).toBe("file:./index.css");
+  expect(blockJson.attributes.interactiveMode.enum).toEqual([
+    "click",
+    "hover",
+  ]);
+  expect(blockJson.attributes.autoPlayInterval).toBeUndefined();
+  expect(blockJson.attributes.uniqueId).toBeUndefined();
   expect(generatedManifest.manifestVersion).toBe(2);
   expect(generatedManifest.sourceType).toBe("DemoInteractivityAttributes");
   expect(generatedManifest.attributes.interactiveMode.wp.enum).toEqual([
     "click",
     "hover",
-    "auto",
   ]);
+  expect(generatedManifest.attributes.autoPlayInterval).toBeUndefined();
+  expect(generatedManifest.attributes.uniqueId).toBeUndefined();
   expect(
     generatedManifest.attributes.clickCount.typia.constraints.typeTag
   ).toBe("uint32");
@@ -582,10 +589,10 @@ test(
   expect(generatedHooks).toContain("useTypiaValidation");
   expect(generatedHooks).toContain("createUseTypiaValidationHook");
   expect(generatedValidators).toContain('from "./validator-toolkit"');
-  expect(generatedValidators).toContain(
+  expect(generatedValidators).not.toContain(
     "@wp-typia/block-runtime/identifiers"
   );
-  expect(generatedValidators).toContain("generateScopedClientId");
+  expect(generatedValidators).not.toContain("generateScopedClientId");
   expect(generatedValidators).not.toContain("createScaffoldValidatorToolkit");
   expect(generatedValidators).not.toContain("generateUniqueId");
   expect(generatedEdit).toContain("@wp-typia/block-runtime/inspector");
@@ -595,6 +602,12 @@ test(
   expect(generatedEdit).toContain("useTypiaValidation");
   expect(generatedEdit).toContain("useTypedAttributeUpdater");
   expect(generatedEdit).toContain("aria-pressed={isPreviewing}");
+  expect(generatedEdit).not.toContain("TextControl");
+  expect(generatedEdit).not.toContain("Unique ID");
+  expect(generatedEdit).not.toContain("Auto Play Interval");
+  expect(generatedEdit).not.toContain("autoPlayInterval");
+  expect(generatedEdit).not.toContain("lastInteraction");
+  expect(generatedEdit).not.toContain("interactiveMode === 'auto'");
   expect(generatedEdit).toContain(
     "className: `wp-block-demo-space-demo-interactivity wp-block-demo-space-demo-interactivity--${interactiveMode}`"
   );
@@ -633,13 +646,25 @@ test(
   );
   expect(generatedInteractivity).not.toContain("declare global");
   expect(generatedInteractivity).toContain("get clampedClicks()");
+  expect(generatedInteractivity).not.toContain("animationClass");
+  expect(generatedInteractivity).not.toContain("toggleVisibility");
+  expect(generatedInteractivity).not.toContain("toggleAutoPlay");
+  expect(generatedInteractivity).not.toContain("lastInteraction");
+  expect(generatedInteractivity).not.toContain("autoPlayTimer");
+  expect(generatedInteractivity).not.toContain("context.interactiveMode");
   expect(generatedTypes).toContain("animation: 'none' | 'bounce'");
   expect(generatedTypes).toContain(
-    "autoPlayTimer?: ReturnType<typeof setInterval> | null;"
+    "interactiveMode?: ('click' | 'hover') & tags.Default<\"click\">;"
   );
+  expect(generatedTypes).not.toContain("autoPlayInterval");
+  expect(generatedTypes).not.toContain("uniqueId");
+  expect(generatedTypes).not.toContain("lastInteraction");
+  expect(generatedTypes).not.toContain("autoPlayTimer");
   expect(generatedSave).toContain("const clickCount = attributes.clickCount ?? 0;");
   expect(generatedSave).toContain("const maxClicks = attributes.maxClicks ?? 0;");
   expect(generatedSave).toContain("const interactiveMode = attributes.interactiveMode ?? 'click';");
+  expect(generatedSave).not.toContain("autoPlayInterval");
+  expect(generatedSave).not.toContain("lastInteraction");
   expect(generatedSave).toContain('aria-label="Reset counter"');
   expect(generatedSave).toContain('className="screen-reader-text"');
   expect(generatedSave).toContain('role="progressbar"');

--- a/packages/wp-typia-project-tools/tests/workspace-add.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-add.test.ts
@@ -240,7 +240,7 @@ test("canonical CLI can add a variation to an official workspace template", asyn
   ).toBe("pass");
 
   runCli("npm", ["run", "build"], { cwd: targetDir });
-}, 30_000);
+}, 60_000);
 
 test("variation workflow keeps registry identifiers unique for similar slugs", async () => {
   const targetDir = path.join(
@@ -304,7 +304,7 @@ test("variation workflow keeps registry identifiers unique for similar slugs", a
   );
 
   runCli("npm", ["run", "build"], { cwd: targetDir });
-}, 30_000);
+}, 60_000);
 
 test("canonical CLI can add hooked-block metadata to an official workspace block", async () => {
   const targetDir = path.join(tempRoot, "demo-workspace-add-hooked-block");
@@ -787,7 +787,7 @@ test("canonical CLI can add a compound persistence block to an official workspac
   runGeneratedScript(targetDir, "scripts/sync-rest-contracts.ts", [
     "--check",
   ]);
-}, 30_000);
+}, 60_000);
 
 test("add compound block repairs a legacy shared validator toolkit in an official workspace template", async () => {
   const targetDir = path.join(
@@ -888,7 +888,7 @@ test("add compound block repairs a legacy shared validator toolkit in an officia
     "assert: typia.createAssert< FaqStackItemAttributes >()"
   );
   typecheckGeneratedProject(targetDir);
-}, 30_000);
+}, 60_000);
 
 test("add compound block does not duplicate an existing typia import during legacy validator repair", async () => {
   const targetDir = path.join(

--- a/tests/unit/starter-manifests.test.ts
+++ b/tests/unit/starter-manifests.test.ts
@@ -53,7 +53,7 @@ describe("starter manifest builders", () => {
 						interactiveMode: expect.objectContaining({
 							wp: expect.objectContaining({
 								defaultValue: "click",
-								enum: ["click", "hover", "auto"],
+								enum: ["click", "hover"],
 							}),
 						}),
 					}),


### PR DESCRIPTION
## Summary
- trim dead interactivity scaffold context, actions, and serialized payload fields
- remove unused editor and validator surface like `uniqueId` and `autoPlayInterval`
- tighten interactivity scaffold regression coverage and stabilize the heavy legacy workspace-add timeout case

Closes #227.

## Validation
- bun run --filter @wp-typia/project-tools test:scaffold-core
- bun test tests/unit/starter-manifests.test.ts
- bun run typecheck
- bun run ci:local


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Trimmed the interactivity scaffold to its runtime surface: removed dead context fields, unbound actions, editor controls, and autoplay behavior; simplified hover/click handling
  * Removed unique ID handling and limited interactive modes to "click" and "hover" only

* **Tests**
  * Updated test expectations across unit and integration suites to match the simplified scaffold

* **Chores**
  * Increased CLI test timeouts for stability
<!-- end of auto-generated comment: release notes by coderabbit.ai -->