### PR TITLE
[codex] Introduce BlockGeneratorService boundary

### DIFF
--- a/.sampo/changesets/issue-194-block-generator-service-boundary.md
+++ b/.sampo/changesets/issue-194-block-generator-service-boundary.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Add a Phase 1 typed block generation boundary to `@wp-typia/project-tools` via `BlockSpec` and `BlockGeneratorService`, while keeping built-in scaffold file bodies on their current Mustache rendering path.

--- a/docs/API.md
+++ b/docs/API.md
@@ -8,7 +8,8 @@ This repository has seven public surfaces:
   Canonical CLI package.
 - `@wp-typia/project-tools`
   Project orchestration package for scaffold, add, migrate, template, doctor,
-  package-manager, and starter-manifest helpers.
+  package-manager, starter-manifest helpers, and the phase-1 typed generator
+  boundary (`BlockSpec`, `BlockGeneratorService`).
 - `@wp-typia/project-tools/schema-core`
   Project schema/OpenAPI helpers.
 - `@wp-typia/block-runtime`
@@ -189,6 +190,11 @@ Use these packages instead:
 - `wp-typia` for the canonical CLI surface
 - `@wp-typia/project-tools` for project orchestration and programmatic runtime helpers
 - `@wp-typia/block-runtime/*` for generated-project runtime helpers
+
+For the current Phase 1 generator architecture boundary, including the
+decision to keep major scaffold file bodies on Mustache while the typed
+generator surface stabilizes, see
+[`docs/block-generator-service.md`](./block-generator-service.md).
 
 ## 3. `@wp-typia/block-types`
 

--- a/docs/block-generator-service.md
+++ b/docs/block-generator-service.md
@@ -1,0 +1,37 @@
+# Block Generator Service
+
+`BlockGeneratorService` is the Phase 1 typed generation boundary for built-in
+`wp-typia` block scaffolds.
+
+## Current responsibility split
+
+- `BlockSpec`
+  Normalized semantic source of truth for a built-in block scaffold request.
+- `BlockGeneratorService.plan`
+  Normalizes built-in scaffold inputs into a `BlockSpec`.
+- `BlockGeneratorService.validate`
+  Preserves built-in scaffold invariants before rendering.
+- `BlockGeneratorService.render`
+  Resolves the built-in template root and produces render/apply intent,
+  including template variables, README/gitignore content, and post-render hooks.
+- `BlockGeneratorService.apply`
+  Copies the built-in template, writes starter manifests, seeds persistence
+  artifacts when needed, applies migration/local-dev capabilities, normalizes
+  package-manager files, and optionally installs dependencies.
+
+## Phase 1 render policy
+
+Phase 1 does not migrate major scaffold file bodies away from Mustache.
+
+- `types.ts`, `block.json`, `edit.tsx`, and `save.tsx` remain Mustache-rendered
+  today.
+- The service boundary exists so later work can move those structural files to
+  emitters without reworking CLI and scaffold orchestration again.
+
+## Out of scope in Phase 1
+
+- external template composition
+- non-block `wp-typia add` generators such as variations, patterns,
+  binding-sources, and hooked-blocks
+- template-engine replacement
+- AST emitter migration

--- a/docs/runtime-import-policy.md
+++ b/docs/runtime-import-policy.md
@@ -43,7 +43,8 @@ Manual orchestration or repo tooling should use:
 - `@wp-typia/project-tools/schema-core`
 
 Those imports cover scaffold, add-block, migrate, template, doctor, package
-manager, starter manifest, and schema/OpenAPI project helpers.
+manager, starter manifest, schema/OpenAPI project helpers, and the phase-1
+typed generator boundary (`BlockSpec`, `BlockGeneratorService`).
 
 `@wp-typia/block-runtime/schema-core` is public and stable, but it is the
 implementation owner path rather than the preferred project-tooling import.
@@ -60,4 +61,5 @@ These areas are not covered by the generated-project compatibility promise:
 - CLI implementation internals
 - Bunli command composition
 - template rendering internals
+- Mustache-vs-emitter implementation details below the Phase 1 generator boundary
 - project-scaffold orchestration internals

--- a/docs/runtime-surface.md
+++ b/docs/runtime-surface.md
@@ -8,7 +8,8 @@ This document is descriptive, not normative. For support guarantees, see
 - `wp-typia`
   CLI package and Bunli command tree.
 - `@wp-typia/project-tools`
-  Project orchestration helpers used by the CLI and programmatic tooling.
+  Project orchestration helpers used by the CLI and programmatic tooling,
+  including the additive `BlockSpec` / `BlockGeneratorService` boundary.
 - `@wp-typia/project-tools/schema-core`
   Schema and OpenAPI helpers for project-level documents.
 - `@wp-typia/block-runtime`
@@ -45,8 +46,8 @@ This document is descriptive, not normative. For support guarantees, see
 
 - `wp-typia` owns the CLI, help, TUI, completions, skills, MCP, and bin entry.
 - `@wp-typia/project-tools` owns scaffold, add-block, migrate, template,
-  doctor, package-manager, starter-manifest, and the preferred schema project
-  imports.
+  doctor, package-manager, starter-manifest, the phase-1 typed generator
+  boundary, and the preferred schema project imports.
 - `@wp-typia/block-runtime/*` owns generated-project runtime helpers directly,
   including the canonical `schema-core` implementation.
 - `@wp-typia/create` no longer owns runtime exports or CLI behavior.

--- a/packages/wp-typia-project-tools/README.md
+++ b/packages/wp-typia-project-tools/README.md
@@ -6,6 +6,7 @@ Package roles:
 
 - `wp-typia` owns the CLI, help, TUI, completions, skills, MCP, and bin entry.
 - `@wp-typia/project-tools` owns scaffold, add-block, migrate, template, doctor, and schema project helpers.
+  It also owns the phase-1 typed generator boundary via `BlockSpec` and `BlockGeneratorService`.
 - `@wp-typia/block-runtime/*` owns generated-project runtime helpers.
 - `@wp-typia/create` is the deprecated legacy package shell.
 
@@ -24,6 +25,7 @@ Example:
 
 ```ts
 import {
+	BlockGeneratorService,
 	getTemplateById,
 	parseMigrationArgs,
 	projectJsonSchemaDocument,
@@ -34,5 +36,10 @@ import {
 ```ts
 import { normalizeEndpointAuthDefinition } from "@wp-typia/project-tools/schema-core";
 ```
+
+`BlockGeneratorService` is the additive Phase 1 orchestration boundary for built-in
+block scaffolds. It currently plans, validates, renders, and applies built-in
+block generation while Mustache file templates remain the implementation for
+rendered file bodies.
 
 If you need metadata sync, editor helpers, validation helpers, or other generated-project runtime utilities, import them directly from `@wp-typia/block-runtime/*`.

--- a/packages/wp-typia-project-tools/package.json
+++ b/packages/wp-typia-project-tools/package.json
@@ -75,7 +75,7 @@
     "prepack": "bun run build && node ./scripts/publish-manifest.mjs prepare",
     "postpack": "node ./scripts/publish-manifest.mjs restore",
     "test": "bun run build && bun test tests/*.test.ts",
-    "test:scaffold-core": "bun run build && bun test tests/scaffold-basic.test.ts tests/scaffold-persistence.test.ts tests/template-source.test.ts tests/cli-entry.test.ts tests/import-policy.test.ts",
+    "test:scaffold-core": "bun run build && bun test tests/block-generator-service.test.ts tests/scaffold-basic.test.ts tests/scaffold-persistence.test.ts tests/template-source.test.ts tests/cli-entry.test.ts tests/import-policy.test.ts",
     "test:workspace": "bun run build && bun test tests/workspace-add.test.ts tests/workspace-doctor.test.ts",
     "test:compound": "bun run build && bun test tests/scaffold-compound.test.ts",
     "test:migration-planning": "bun run build && bun test tests/migration-init.test.ts tests/migration-config.test.ts tests/migration-plan-wizard.test.ts",

--- a/packages/wp-typia-project-tools/src/runtime/block-generator-service.ts
+++ b/packages/wp-typia-project-tools/src/runtime/block-generator-service.ts
@@ -182,6 +182,8 @@ export function createBuiltInBlockSpec({
 		slug: answers.slug,
 		textDomain: answers.textDomain,
 	});
+	const resolvedDataStorageMode = dataStorageMode ?? answers.dataStorageMode;
+	const resolvedPersistencePolicy = persistencePolicy ?? answers.persistencePolicy;
 
 	return {
 		block: identifiers,
@@ -193,8 +195,8 @@ export function createBuiltInBlockSpec({
 			title: answers.title.trim(),
 		},
 		persistence: getBuiltInPersistenceSpec({
-			dataStorageMode,
-			persistencePolicy,
+			dataStorageMode: resolvedDataStorageMode,
+			persistencePolicy: resolvedPersistencePolicy,
 			templateId,
 		}),
 		project: {

--- a/packages/wp-typia-project-tools/src/runtime/block-generator-service.ts
+++ b/packages/wp-typia-project-tools/src/runtime/block-generator-service.ts
@@ -1,0 +1,430 @@
+import { getPackageVersions } from "./package-versions.js";
+import type { PackageManagerId } from "./package-managers.js";
+import {
+	BUILTIN_BLOCK_METADATA_VERSION,
+	COMPOUND_CHILD_BLOCK_METADATA_DEFAULTS,
+	getBuiltInTemplateMetadataDefaults,
+} from "./template-defaults.js";
+import {
+	getTemplateById,
+	type BuiltInTemplateId,
+} from "./template-registry.js";
+import { resolveBuiltInTemplateSource } from "./template-builtins.js";
+import {
+	toPascalCase,
+	toSnakeCase,
+} from "./string-case.js";
+import {
+	applyBuiltInScaffoldProjectFiles,
+	buildGitignore,
+	buildReadme,
+	type InstallDependenciesOptions,
+} from "./scaffold-apply-utils.js";
+import {
+	buildBlockCssClassName,
+	buildFrontendCssClassName,
+	resolveScaffoldIdentifiers,
+} from "./scaffold-identifiers.js";
+import type {
+	DataStorageMode,
+	PersistencePolicy,
+	ScaffoldAnswers,
+	ScaffoldProjectResult,
+	ScaffoldTemplateVariables,
+} from "./scaffold.js";
+
+export interface BlockSpec {
+	block: {
+		namespace: string;
+		phpPrefix: string;
+		slug: string;
+		textDomain: string;
+	};
+	metadata: {
+		category: string;
+		description: string;
+		icon: string;
+		keyword: string;
+		title: string;
+	};
+	persistence:
+		| {
+				enabled: false;
+		  }
+		| {
+				dataStorageMode: DataStorageMode;
+				enabled: true;
+				persistencePolicy: PersistencePolicy;
+				scope: "compound-parent" | "single";
+		  };
+	project: {
+		author: string;
+	};
+	runtime: {
+		withMigrationUi: boolean;
+		withTestPreset: boolean;
+		withWpEnv: boolean;
+	};
+	template: {
+		description: string;
+		family: BuiltInTemplateId;
+		features: string[];
+	};
+}
+
+export interface BlockGenerationTarget {
+	allowExistingDir: boolean;
+	cwd: string;
+	noInstall: boolean;
+	packageManager: PackageManagerId;
+	projectDir: string;
+	variant?: string;
+}
+
+export interface PlanBlockInput {
+	allowExistingDir?: boolean;
+	answers: ScaffoldAnswers;
+	cwd?: string;
+	dataStorageMode?: DataStorageMode;
+	noInstall?: boolean;
+	packageManager: PackageManagerId;
+	persistencePolicy?: PersistencePolicy;
+	projectDir: string;
+	templateId: BuiltInTemplateId;
+	variant?: string;
+	withMigrationUi?: boolean;
+	withTestPreset?: boolean;
+	withWpEnv?: boolean;
+}
+
+export interface PlanBlockResult {
+	spec: BlockSpec;
+	target: BlockGenerationTarget;
+}
+
+export interface ValidateBlockInput {
+	plan: PlanBlockResult;
+}
+
+export interface ValidateBlockResult extends PlanBlockResult {}
+
+export interface RenderBlockInput {
+	validated: ValidateBlockResult;
+}
+
+export interface RenderBlockResult extends ValidateBlockResult {
+	cleanup?: () => Promise<void>;
+	gitignoreContent: string;
+	postRender: {
+		applyLocalDevPresets: boolean;
+		applyMigrationUiCapability: boolean;
+		seedPersistenceArtifacts: boolean;
+		seedStarterManifestFiles: boolean;
+	};
+	readmeContent: string;
+	selectedVariant: null;
+	templateDir: string;
+	variables: ScaffoldTemplateVariables;
+	warnings: string[];
+}
+
+export interface ApplyBlockInput {
+	rendered: RenderBlockResult;
+	installDependencies?: ((options: InstallDependenciesOptions) => Promise<void>) | undefined;
+}
+
+function getBuiltInPersistenceSpec({
+	templateId,
+	dataStorageMode,
+	persistencePolicy,
+}: {
+	dataStorageMode?: DataStorageMode;
+	persistencePolicy?: PersistencePolicy;
+	templateId: BuiltInTemplateId;
+}): BlockSpec["persistence"] {
+	if (templateId === "persistence") {
+		return {
+			dataStorageMode: dataStorageMode ?? "custom-table",
+			enabled: true,
+			persistencePolicy: persistencePolicy ?? "authenticated",
+			scope: "single",
+		};
+	}
+
+	if (templateId === "compound" && (dataStorageMode || persistencePolicy)) {
+		return {
+			dataStorageMode: dataStorageMode ?? "custom-table",
+			enabled: true,
+			persistencePolicy: persistencePolicy ?? "authenticated",
+			scope: "compound-parent",
+		};
+	}
+
+	return {
+		enabled: false,
+	};
+}
+
+export function createBuiltInBlockSpec({
+	answers,
+	dataStorageMode,
+	persistencePolicy,
+	templateId,
+	withMigrationUi = false,
+	withTestPreset = false,
+	withWpEnv = false,
+}: Omit<PlanBlockInput, "allowExistingDir" | "cwd" | "noInstall" | "packageManager" | "projectDir" | "variant">): BlockSpec {
+	const template = getTemplateById(templateId);
+	const metadataDefaults = getBuiltInTemplateMetadataDefaults(templateId);
+	const identifiers = resolveScaffoldIdentifiers({
+		namespace: answers.namespace,
+		phpPrefix: answers.phpPrefix,
+		slug: answers.slug,
+		textDomain: answers.textDomain,
+	});
+
+	return {
+		block: identifiers,
+		metadata: {
+			category: metadataDefaults.category,
+			description: answers.description.trim(),
+			icon: metadataDefaults.icon,
+			keyword: identifiers.slug.replace(/-/g, " "),
+			title: answers.title.trim(),
+		},
+		persistence: getBuiltInPersistenceSpec({
+			dataStorageMode,
+			persistencePolicy,
+			templateId,
+		}),
+		project: {
+			author: answers.author.trim(),
+		},
+		runtime: {
+			withMigrationUi,
+			withTestPreset,
+			withWpEnv,
+		},
+		template: {
+			description: template.description,
+			family: templateId,
+			features: [...template.features],
+		},
+	};
+}
+
+export function buildTemplateVariablesFromBlockSpec(spec: BlockSpec): ScaffoldTemplateVariables {
+	const {
+		apiClientPackageVersion,
+		blockRuntimePackageVersion,
+		blockTypesPackageVersion,
+		projectToolsPackageVersion,
+		restPackageVersion,
+	} = getPackageVersions();
+	const slug = spec.block.slug;
+	const slugSnakeCase = toSnakeCase(slug);
+	const pascalCase = toPascalCase(slug);
+	const title = spec.metadata.title;
+	const namespace = spec.block.namespace;
+	const textDomain = spec.block.textDomain;
+	const phpPrefix = spec.block.phpPrefix;
+	const phpPrefixUpper = phpPrefix.toUpperCase();
+	const compoundChildTitle = `${title} Item`;
+	const cssClassName = buildBlockCssClassName(namespace, slug);
+	const compoundChildCssClassName = buildBlockCssClassName(namespace, `${slug}-item`);
+	const persistenceEnabled = spec.persistence.enabled;
+	const dataStorageMode = persistenceEnabled ? spec.persistence.dataStorageMode : "custom-table";
+	const persistencePolicy = persistenceEnabled
+		? spec.persistence.persistencePolicy
+		: "authenticated";
+
+	return {
+		apiClientPackageVersion,
+		author: spec.project.author,
+		blockRuntimePackageVersion,
+		blockMetadataVersion: BUILTIN_BLOCK_METADATA_VERSION,
+		blockTypesPackageVersion,
+		category: spec.metadata.category,
+		icon: spec.metadata.icon,
+		compoundChildTitle,
+		compoundChildCategory: COMPOUND_CHILD_BLOCK_METADATA_DEFAULTS.category,
+		compoundChildCssClassName,
+		compoundChildIcon: COMPOUND_CHILD_BLOCK_METADATA_DEFAULTS.icon,
+		compoundChildTitleJson: JSON.stringify(compoundChildTitle),
+		compoundPersistenceEnabled:
+			spec.template.family === "compound" && persistenceEnabled ? "true" : "false",
+		projectToolsPackageVersion,
+		cssClassName,
+		dashCase: slug,
+		dataStorageMode,
+		description: spec.metadata.description,
+		frontendCssClassName: buildFrontendCssClassName(cssClassName),
+		isAuthenticatedPersistencePolicy:
+			persistencePolicy === "authenticated" ? "true" : "false",
+		isPublicPersistencePolicy: persistencePolicy === "public" ? "true" : "false",
+		bootstrapCredentialDeclarations:
+			persistencePolicy === "public"
+				? "publicWriteExpiresAt?: number & tags.Type< 'uint32' >;\n\tpublicWriteToken?: string & tags.MinLength< 1 > & tags.MaxLength< 512 >;"
+				: "restNonce?: string & tags.MinLength< 1 > & tags.MaxLength< 128 >;",
+		persistencePolicyDescriptionJson: JSON.stringify(
+			persistencePolicy === "authenticated"
+				? "Writes require a logged-in user and a valid REST nonce."
+				: "Anonymous writes use signed short-lived public tokens, per-request ids, and coarse rate limiting.",
+		),
+		keyword: spec.metadata.keyword,
+		namespace,
+		needsMigration: "{{needsMigration}}",
+		pascalCase,
+		phpPrefix,
+		phpPrefixUpper,
+		restPackageVersion,
+		publicWriteRequestIdDeclaration:
+			persistencePolicy === "public"
+				? "publicWriteRequestId: string & tags.MinLength< 1 > & tags.MaxLength< 128 >;"
+				: "publicWriteRequestId?: string & tags.MinLength< 1 > & tags.MaxLength< 128 >;",
+		restWriteAuthIntent:
+			persistencePolicy === "public"
+				? "public-write-protected"
+				: "authenticated",
+		restWriteAuthMechanism:
+			persistencePolicy === "public" ? "public-signed-token" : "rest-nonce",
+		restWriteAuthMode:
+			persistencePolicy === "public" ? "public-signed-token" : "authenticated-rest-nonce",
+		slug,
+		slugCamelCase: pascalCase.charAt(0).toLowerCase() + pascalCase.slice(1),
+		slugKebabCase: slug,
+		slugSnakeCase,
+		textDomain,
+		textdomain: textDomain,
+		title,
+		titleJson: JSON.stringify(title),
+		titleCase: pascalCase,
+		persistencePolicy,
+	};
+}
+
+export class BlockGeneratorService {
+	async plan({
+		allowExistingDir = false,
+		answers,
+		cwd = process.cwd(),
+		dataStorageMode,
+		noInstall = false,
+		packageManager,
+		persistencePolicy,
+		projectDir,
+		templateId,
+		variant,
+		withMigrationUi = false,
+		withTestPreset = false,
+		withWpEnv = false,
+	}: PlanBlockInput): Promise<PlanBlockResult> {
+		return {
+			spec: createBuiltInBlockSpec({
+				answers,
+				dataStorageMode,
+				persistencePolicy,
+				templateId,
+				withMigrationUi,
+				withTestPreset,
+				withWpEnv,
+			}),
+			target: {
+				allowExistingDir,
+				cwd,
+				noInstall,
+				packageManager,
+				projectDir,
+				variant,
+			},
+		};
+	}
+
+	async validate({ plan }: ValidateBlockInput): Promise<ValidateBlockResult> {
+		if (plan.target.variant) {
+			throw new Error(
+				`--variant is only supported for official external template configs. Received variant "${plan.target.variant}" for built-in template "${plan.spec.template.family}".`,
+			);
+		}
+
+		return plan;
+	}
+
+	async render({ validated }: RenderBlockInput): Promise<RenderBlockResult> {
+		const templateSource = await resolveBuiltInTemplateSource(
+			validated.spec.template.family,
+			{
+				persistenceEnabled: validated.spec.persistence.enabled,
+				persistencePolicy:
+					validated.spec.persistence.enabled &&
+					validated.spec.persistence.persistencePolicy === "public"
+						? "public"
+						: "authenticated",
+			},
+		);
+		const variables = buildTemplateVariablesFromBlockSpec(validated.spec);
+		const persistenceEnabled = validated.spec.persistence.enabled;
+
+		return {
+			...validated,
+			cleanup: templateSource.cleanup,
+			gitignoreContent: buildGitignore(),
+			postRender: {
+				applyLocalDevPresets: true,
+				applyMigrationUiCapability: validated.spec.runtime.withMigrationUi,
+				seedPersistenceArtifacts:
+					validated.spec.template.family === "persistence" ||
+					(validated.spec.template.family === "compound" && persistenceEnabled),
+				seedStarterManifestFiles: true,
+			},
+			readmeContent: buildReadme(
+				validated.spec.template.family,
+				variables,
+				validated.target.packageManager,
+				{
+					withMigrationUi: validated.spec.runtime.withMigrationUi,
+					withTestPreset: validated.spec.runtime.withTestPreset,
+					withWpEnv: validated.spec.runtime.withWpEnv,
+				},
+			),
+			selectedVariant: null,
+			templateDir: templateSource.templateDir,
+			variables,
+			warnings: templateSource.warnings ?? [],
+		};
+	}
+
+	async apply({
+		rendered,
+		installDependencies,
+	}: ApplyBlockInput): Promise<ScaffoldProjectResult> {
+		try {
+			await applyBuiltInScaffoldProjectFiles({
+				allowExistingDir: rendered.target.allowExistingDir,
+				installDependencies,
+				noInstall: rendered.target.noInstall,
+				packageManager: rendered.target.packageManager,
+				projectDir: rendered.target.projectDir,
+				gitignoreContent: rendered.gitignoreContent,
+				readmeContent: rendered.readmeContent,
+				templateDir: rendered.templateDir,
+				templateId: rendered.spec.template.family,
+				variables: rendered.variables,
+				withMigrationUi: rendered.spec.runtime.withMigrationUi,
+				withTestPreset: rendered.spec.runtime.withTestPreset,
+				withWpEnv: rendered.spec.runtime.withWpEnv,
+			});
+		} finally {
+			await rendered.cleanup?.();
+		}
+
+		return {
+			packageManager: rendered.target.packageManager,
+			projectDir: rendered.target.projectDir,
+			selectedVariant: rendered.selectedVariant,
+			templateId: rendered.spec.template.family,
+			variables: rendered.variables,
+			warnings: rendered.warnings,
+		};
+	}
+}

--- a/packages/wp-typia-project-tools/src/runtime/index.ts
+++ b/packages/wp-typia-project-tools/src/runtime/index.ts
@@ -17,6 +17,18 @@ export {
 	resolvePackageManagerId,
 	resolveTemplateId,
 } from "./scaffold.js";
+export { BlockGeneratorService } from "./block-generator-service.js";
+export type {
+	ApplyBlockInput,
+	BlockGenerationTarget,
+	BlockSpec,
+	PlanBlockInput,
+	PlanBlockResult,
+	RenderBlockInput,
+	RenderBlockResult,
+	ValidateBlockInput,
+	ValidateBlockResult,
+} from "./block-generator-service.js";
 export {
 	formatMigrationHelpText,
 	parseMigrationArgs,

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-apply-utils.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-apply-utils.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import { promises as fsp } from "node:fs";
 import path from "node:path";
 import { execSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 
 import {
 	applyGeneratedProjectDxPackageJson,
@@ -62,6 +63,7 @@ interface GeneratedPackageJson {
 }
 
 const EPHEMERAL_NODE_MODULES_LINK_TYPE = process.platform === "win32" ? "junction" : "dir";
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const LOCKFILES: Record<PackageManagerId, string[]> = {
 	bun: ["bun.lock", "bun.lockb"],
 	npm: ["package-lock.json"],
@@ -225,7 +227,7 @@ export async function writeStarterManifestFiles(
 }
 
 function resolveScaffoldGeneratorNodeModulesPath(): string | null {
-	const projectToolsPackageRoot = path.resolve(import.meta.dir, "..", "..");
+	const projectToolsPackageRoot = path.resolve(__dirname, "..", "..");
 	const candidates = [
 		path.join(projectToolsPackageRoot, "node_modules"),
 		path.resolve(projectToolsPackageRoot, "..", ".."),

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-apply-utils.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-apply-utils.ts
@@ -1,0 +1,565 @@
+import fs from "node:fs";
+import { promises as fsp } from "node:fs";
+import path from "node:path";
+import { execSync } from "node:child_process";
+
+import {
+	applyGeneratedProjectDxPackageJson,
+	applyLocalDevPresetFiles,
+	getPrimaryDevelopmentScript,
+} from "./local-dev-presets.js";
+import { applyMigrationUiCapability } from "./migration-ui-capability.js";
+import { getPackageVersions } from "./package-versions.js";
+import {
+	ensureMigrationDirectories,
+	writeInitialMigrationScaffold,
+	writeMigrationConfig,
+} from "./migration-project.js";
+import {
+	syncPersistenceRestArtifacts,
+} from "./persistence-rest-artifacts.js";
+import {
+	getCompoundExtensionWorkflowSection,
+	getOptionalOnboardingNote,
+	getOptionalOnboardingSteps,
+	getPhpRestExtensionPointsSection,
+	getTemplateSourceOfTruthNote,
+} from "./scaffold-onboarding.js";
+import {
+	getStarterManifestFiles,
+	stringifyStarterManifest,
+} from "./starter-manifests.js";
+import {
+	OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE,
+	type BuiltInTemplateId,
+} from "./template-registry.js";
+import { copyInterpolatedDirectory } from "./template-render.js";
+import type { PackageManagerId } from "./package-managers.js";
+import {
+	formatInstallCommand,
+	formatPackageExecCommand,
+	formatRunScript,
+	getPackageManager,
+	transformPackageManagerText,
+} from "./package-managers.js";
+import type {
+	ScaffoldTemplateVariables,
+} from "./scaffold.js";
+
+export interface InstallDependenciesOptions {
+	packageManager: PackageManagerId;
+	projectDir: string;
+}
+
+interface GeneratedPackageJson {
+	dependencies?: Record<string, string>;
+	scripts?: Record<string, string>;
+	wpTypia?: {
+		projectType?: string;
+		templatePackage?: string;
+	};
+	packageManager?: string;
+}
+
+const EPHEMERAL_NODE_MODULES_LINK_TYPE = process.platform === "win32" ? "junction" : "dir";
+const LOCKFILES: Record<PackageManagerId, string[]> = {
+	bun: ["bun.lock", "bun.lockb"],
+	npm: ["package-lock.json"],
+	pnpm: ["pnpm-lock.yaml"],
+	yarn: ["yarn.lock"],
+};
+
+export async function ensureDirectory(targetDir: string, allowExisting = false): Promise<void> {
+	if (!fs.existsSync(targetDir)) {
+		await fsp.mkdir(targetDir, { recursive: true });
+		return;
+	}
+
+	if (allowExisting) {
+		return;
+	}
+
+	const entries = await fsp.readdir(targetDir);
+	if (entries.length > 0) {
+		throw new Error(`Target directory is not empty: ${targetDir}`);
+	}
+}
+
+export function buildReadme(
+	templateId: string,
+	variables: ScaffoldTemplateVariables,
+	packageManager: PackageManagerId,
+	{
+		withMigrationUi = false,
+		withTestPreset = false,
+		withWpEnv = false,
+	}: {
+		withMigrationUi?: boolean;
+		withTestPreset?: boolean;
+		withWpEnv?: boolean;
+	} = {},
+): string {
+	const optionalOnboardingSteps = getOptionalOnboardingSteps(packageManager, templateId, {
+		compoundPersistenceEnabled: variables.compoundPersistenceEnabled === "true",
+	});
+	const sourceOfTruthNote = getTemplateSourceOfTruthNote(templateId, {
+		compoundPersistenceEnabled: variables.compoundPersistenceEnabled === "true",
+	});
+	const compoundPersistenceEnabled = variables.compoundPersistenceEnabled === "true";
+	const publicPersistencePolicyNote =
+		variables.isPublicPersistencePolicy === "true"
+			? "Public persistence writes use signed short-lived tokens, per-request ids, and coarse rate limiting by default. Add application-specific abuse controls before using the same pattern for high-value metrics or experiments."
+			: null;
+	const compoundExtensionWorkflowSection = getCompoundExtensionWorkflowSection(
+		packageManager,
+		templateId,
+	);
+	const phpRestExtensionPointsSection = getPhpRestExtensionPointsSection(templateId, {
+		compoundPersistenceEnabled,
+		slug: variables.slug,
+	});
+	const developmentScript = getPrimaryDevelopmentScript(templateId);
+	const wpEnvSection = withWpEnv
+		? `## Local WordPress\n\n\`\`\`bash\n${formatRunScript(packageManager, "wp-env:start")}\n${formatRunScript(packageManager, "wp-env:stop")}\n${formatRunScript(packageManager, "wp-env:reset")}\n\`\`\``
+		: "";
+	const testPresetSection = withTestPreset
+		? `## Local Test Preset\n\n\`\`\`bash\n${formatRunScript(packageManager, "wp-env:start:test")}\n${formatRunScript(packageManager, "wp-env:wait:test")}\n${formatRunScript(packageManager, "test:e2e")}\n\`\`\`\n\nThe generated smoke test uses \`.wp-env.test.json\` and verifies that the scaffolded block registers in the WordPress editor.`
+		: "";
+	const migrationSection = withMigrationUi
+		? `## Migration UI\n\nThis scaffold already includes an initialized migration workspace at \`v1\`, generated deprecated/runtime artifacts, and an editor-embedded migration dashboard. Migration versions are schema lineage labels and are separate from your package or plugin release version. Use the existing CLI commands to snapshot, diff, scaffold, verify, and fuzz future schema changes.\n\n\`\`\`bash\n${formatRunScript(packageManager, "migration:doctor")}\n${formatRunScript(packageManager, "migration:verify")}\n${formatRunScript(packageManager, "migration:fuzz")}\n\`\`\`\n\nRun \`migration:init\` only when retrofitting migration support into an older project that was not scaffolded with \`--with-migration-ui\`.`
+		: "";
+
+	return `# ${variables.title}
+
+${variables.description}
+
+## Template
+
+${templateId}
+
+## Development
+
+\`\`\`bash
+${formatInstallCommand(packageManager)}
+${formatRunScript(packageManager, developmentScript)}
+\`\`\`
+
+## Build
+
+\`\`\`bash
+${formatRunScript(packageManager, "build")}
+\`\`\`
+
+## Optional First Sync
+
+\`\`\`bash
+${optionalOnboardingSteps.join("\n")}
+\`\`\`
+
+${getOptionalOnboardingNote(packageManager, templateId, {
+		compoundPersistenceEnabled,
+	})}
+
+${sourceOfTruthNote}${publicPersistencePolicyNote ? `\n\n${publicPersistencePolicyNote}` : ""}${migrationSection ? `\n\n${migrationSection}` : ""}${compoundExtensionWorkflowSection ? `\n\n${compoundExtensionWorkflowSection}` : ""}${wpEnvSection ? `\n\n${wpEnvSection}` : ""}${testPresetSection ? `\n\n${testPresetSection}` : ""}${phpRestExtensionPointsSection ? `\n\n${phpRestExtensionPointsSection}` : ""}
+`;
+}
+
+export function buildGitignore(): string {
+	return `# Dependencies
+node_modules/
+.yarn/
+.pnp.*
+
+# Build
+build/
+dist/
+
+# Editor
+.vscode/
+.idea/
+
+# OS
+.DS_Store
+Thumbs.db
+
+# WordPress
+*.log
+.wp-env/
+`;
+}
+
+export function mergeTextLines(primaryContent: string, existingContent: string): string {
+	const normalizedPrimary = primaryContent.replace(/\r\n/g, "\n").trimEnd();
+	const normalizedExisting = existingContent.replace(/\r\n/g, "\n").trimEnd();
+	const mergedLines: string[] = [];
+	const seen = new Set<string>();
+
+	for (const line of [...normalizedPrimary.split("\n"), ...normalizedExisting.split("\n")]) {
+		if (line.length === 0 && mergedLines[mergedLines.length - 1] === "") {
+			continue;
+		}
+		if (line.length > 0 && seen.has(line)) {
+			continue;
+		}
+		if (line.length > 0) {
+			seen.add(line);
+		}
+		mergedLines.push(line);
+	}
+
+	return `${mergedLines.join("\n").replace(/\n{3,}/g, "\n\n")}\n`;
+}
+
+export async function writeStarterManifestFiles(
+	targetDir: string,
+	templateId: string,
+	variables: ScaffoldTemplateVariables,
+): Promise<void> {
+	const manifests = getStarterManifestFiles(templateId, variables);
+
+	for (const { document, relativePath } of manifests) {
+		const destinationPath = path.join(targetDir, relativePath);
+		await fsp.mkdir(path.dirname(destinationPath), { recursive: true });
+		await fsp.writeFile(destinationPath, stringifyStarterManifest(document), "utf8");
+	}
+}
+
+function resolveScaffoldGeneratorNodeModulesPath(): string | null {
+	const projectToolsPackageRoot = path.resolve(import.meta.dir, "..", "..");
+	const candidates = [
+		path.join(projectToolsPackageRoot, "node_modules"),
+		path.resolve(projectToolsPackageRoot, "..", ".."),
+		path.resolve(projectToolsPackageRoot, "..", "..", "node_modules"),
+	];
+
+	for (const candidate of candidates) {
+		if (fs.existsSync(path.join(candidate, "typia", "package.json"))) {
+			return candidate;
+		}
+	}
+
+	return null;
+}
+
+async function withEphemeralScaffoldNodeModules(
+	targetDir: string,
+	callback: () => Promise<void>,
+): Promise<void> {
+	const targetNodeModulesPath = path.join(targetDir, "node_modules");
+	if (fs.existsSync(targetNodeModulesPath)) {
+		await callback();
+		return;
+	}
+
+	const sourceNodeModulesPath = resolveScaffoldGeneratorNodeModulesPath();
+	if (!sourceNodeModulesPath) {
+		throw new Error(
+			"Unable to resolve a node_modules directory with typia for scaffold-time REST artifact generation.",
+		);
+	}
+
+	await fsp.symlink(sourceNodeModulesPath, targetNodeModulesPath, EPHEMERAL_NODE_MODULES_LINK_TYPE);
+
+	try {
+		await callback();
+	} finally {
+		await fsp.rm(targetNodeModulesPath, { force: true, recursive: true });
+	}
+}
+
+/**
+ * Seed REST-derived persistence artifacts into a newly scaffolded built-in
+ * project before the first manual `sync-rest` run.
+ */
+export async function seedBuiltInPersistenceArtifacts(
+	targetDir: string,
+	templateId: BuiltInTemplateId,
+	variables: ScaffoldTemplateVariables,
+): Promise<void> {
+	const needsPersistenceArtifacts =
+		templateId === "persistence" ||
+		(templateId === "compound" && variables.compoundPersistenceEnabled === "true");
+
+	if (!needsPersistenceArtifacts) {
+		return;
+	}
+
+	await withEphemeralScaffoldNodeModules(targetDir, async () => {
+		if (templateId === "persistence") {
+			await syncPersistenceRestArtifacts({
+				apiTypesFile: path.join("src", "api-types.ts"),
+				outputDir: "src",
+				projectDir: targetDir,
+				variables,
+			});
+			return;
+		}
+
+		await syncPersistenceRestArtifacts({
+			apiTypesFile: path.join("src", "blocks", variables.slugKebabCase, "api-types.ts"),
+			outputDir: path.join("src", "blocks", variables.slugKebabCase),
+			projectDir: targetDir,
+			variables,
+		});
+	});
+}
+
+export async function normalizePackageManagerFiles(
+	targetDir: string,
+	packageManagerId: PackageManagerId,
+): Promise<void> {
+	const yarnRcPath = path.join(targetDir, ".yarnrc.yml");
+
+	if (packageManagerId === "yarn") {
+		await fsp.writeFile(yarnRcPath, "nodeLinker: node-modules\n", "utf8");
+		return;
+	}
+
+	if (fs.existsSync(yarnRcPath)) {
+		await fsp.rm(yarnRcPath, { force: true });
+	}
+}
+
+export async function normalizePackageJson(
+	targetDir: string,
+	packageManagerId: PackageManagerId,
+): Promise<void> {
+	const packageJsonPath = path.join(targetDir, "package.json");
+	if (!fs.existsSync(packageJsonPath)) {
+		return;
+	}
+
+	const packageManager = getPackageManager(packageManagerId);
+	const packageJson = JSON.parse(await fsp.readFile(packageJsonPath, "utf8")) as GeneratedPackageJson;
+	packageJson.packageManager = packageManager.packageManagerField;
+
+	if (packageJson.scripts) {
+		for (const [key, value] of Object.entries(packageJson.scripts)) {
+			if (typeof value === "string") {
+				packageJson.scripts[key] = transformPackageManagerText(value, packageManagerId);
+			}
+		}
+	}
+
+	await fsp.writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, "\t")}\n`, "utf8");
+}
+
+export async function removeUnexpectedLockfiles(
+	targetDir: string,
+	packageManagerId: PackageManagerId,
+): Promise<void> {
+	const keep = new Set(LOCKFILES[packageManagerId] ?? []);
+	const allLockfiles = Object.values(LOCKFILES).flat();
+
+	await Promise.all(
+		allLockfiles.map(async (filename) => {
+			if (keep.has(filename)) {
+				return;
+			}
+
+			const filePath = path.join(targetDir, filename);
+			if (fs.existsSync(filePath)) {
+				await fsp.rm(filePath, { force: true });
+			}
+		}),
+	);
+}
+
+export async function replaceTextRecursively(
+	targetDir: string,
+	packageManagerId: PackageManagerId,
+): Promise<void> {
+	const textExtensions = new Set([
+		".css",
+		".js",
+		".json",
+		".jsx",
+		".md",
+		".php",
+		".scss",
+		".ts",
+		".tsx",
+		".txt",
+	]);
+
+	async function visit(currentPath: string): Promise<void> {
+		const stats = await fsp.stat(currentPath);
+		if (stats.isDirectory()) {
+			const entries = await fsp.readdir(currentPath);
+			for (const entry of entries) {
+				await visit(path.join(currentPath, entry));
+			}
+			return;
+		}
+
+		if (path.basename(currentPath) === "package.json" || !textExtensions.has(path.extname(currentPath))) {
+			return;
+		}
+
+		const content = await fsp.readFile(currentPath, "utf8");
+		const nextContent = transformPackageManagerText(content, packageManagerId)
+			.replace(/yourusername\/wp-typia-boilerplate/g, "imjlk/wp-typia")
+			.replace(/yourusername\/wp-typia/g, "imjlk/wp-typia");
+
+		if (nextContent !== content) {
+			await fsp.writeFile(currentPath, nextContent, "utf8");
+		}
+	}
+
+	await visit(targetDir);
+}
+
+export async function defaultInstallDependencies({
+	projectDir,
+	packageManager,
+}: InstallDependenciesOptions): Promise<void> {
+	execSync(formatInstallCommand(packageManager), {
+		cwd: projectDir,
+		stdio: "inherit",
+	});
+}
+
+export function isOfficialWorkspaceProject(projectDir: string): boolean {
+	const packageJsonPath = path.join(projectDir, "package.json");
+	if (!fs.existsSync(packageJsonPath)) {
+		return false;
+	}
+
+	const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as GeneratedPackageJson;
+	return (
+		packageJson.wpTypia?.projectType === "workspace" &&
+		packageJson.wpTypia?.templatePackage === OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE
+	);
+}
+
+export async function applyWorkspaceMigrationCapability(
+	projectDir: string,
+	packageManager: PackageManagerId,
+): Promise<void> {
+	const packageJsonPath = path.join(projectDir, "package.json");
+	const packageJson = JSON.parse(
+		await fsp.readFile(packageJsonPath, "utf8"),
+	) as GeneratedPackageJson;
+	const wpTypiaPackageVersion = getPackageVersions().wpTypiaPackageVersion;
+	const canonicalCliSpecifier =
+		wpTypiaPackageVersion === "^0.0.0"
+			? "wp-typia"
+			: `wp-typia@${wpTypiaPackageVersion.replace(/^[~^]/u, "")}`;
+	const migrationCli = (args: string) =>
+		formatPackageExecCommand(packageManager, canonicalCliSpecifier, `migrate ${args}`);
+
+	packageJson.scripts = {
+		...(packageJson.scripts ?? {}),
+		"migration:init": migrationCli("init --current-migration-version v1"),
+		"migration:snapshot": migrationCli("snapshot"),
+		"migration:diff": migrationCli("diff"),
+		"migration:scaffold": migrationCli("scaffold"),
+		"migration:doctor": migrationCli("doctor --all"),
+		"migration:fixtures": migrationCli("fixtures --all"),
+		"migration:verify": migrationCli("verify --all"),
+		"migration:fuzz": migrationCli("fuzz --all"),
+	};
+
+	await fsp.writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, "\t")}\n`, "utf8");
+
+	writeMigrationConfig(projectDir, {
+		blocks: [],
+		currentMigrationVersion: "v1",
+		snapshotDir: "src/migrations/versions",
+		supportedMigrationVersions: ["v1"],
+	});
+	ensureMigrationDirectories(projectDir, []);
+	writeInitialMigrationScaffold(projectDir, "v1", []);
+}
+
+export async function applyBuiltInScaffoldProjectFiles({
+	projectDir,
+	templateDir,
+	templateId,
+	variables,
+	readmeContent,
+	gitignoreContent,
+	allowExistingDir = false,
+	packageManager,
+	withMigrationUi = false,
+	withTestPreset = false,
+	withWpEnv = false,
+	noInstall = false,
+	installDependencies,
+}: {
+	projectDir: string;
+	templateDir: string;
+	templateId: BuiltInTemplateId;
+	variables: ScaffoldTemplateVariables;
+	readmeContent?: string;
+	gitignoreContent?: string;
+	allowExistingDir?: boolean;
+	packageManager: PackageManagerId;
+	withMigrationUi?: boolean;
+	withTestPreset?: boolean;
+	withWpEnv?: boolean;
+	noInstall?: boolean;
+	installDependencies?: ((options: InstallDependenciesOptions) => Promise<void>) | undefined;
+}): Promise<void> {
+	await ensureDirectory(projectDir, allowExistingDir);
+	await copyInterpolatedDirectory(templateDir, projectDir, variables);
+	await writeStarterManifestFiles(projectDir, templateId, variables);
+	await seedBuiltInPersistenceArtifacts(projectDir, templateId, variables);
+	await applyLocalDevPresetFiles({
+		projectDir,
+		variables,
+		withTestPreset,
+		withWpEnv,
+	});
+	if (withMigrationUi) {
+		await applyMigrationUiCapability({
+			packageManager,
+			projectDir,
+			templateId,
+			variables,
+		});
+	}
+
+	const readmePath = path.join(projectDir, "README.md");
+	if (!fs.existsSync(readmePath)) {
+		await fsp.writeFile(
+			readmePath,
+			readmeContent ??
+				buildReadme(templateId, variables, packageManager, {
+					withMigrationUi,
+					withTestPreset,
+					withWpEnv,
+				}),
+			"utf8",
+		);
+	}
+	const gitignorePath = path.join(projectDir, ".gitignore");
+	const existingGitignore = fs.existsSync(gitignorePath)
+		? await fsp.readFile(gitignorePath, "utf8")
+		: "";
+	await fsp.writeFile(
+		gitignorePath,
+		mergeTextLines(gitignoreContent ?? buildGitignore(), existingGitignore),
+		"utf8",
+	);
+	await normalizePackageJson(projectDir, packageManager);
+	await applyGeneratedProjectDxPackageJson({
+		compoundPersistenceEnabled: variables.compoundPersistenceEnabled === "true",
+		packageManager,
+		projectDir,
+		templateId,
+		withTestPreset,
+		withWpEnv,
+	});
+	await normalizePackageManagerFiles(projectDir, packageManager);
+	await removeUnexpectedLockfiles(projectDir, packageManager);
+	await replaceTextRecursively(projectDir, packageManager);
+
+	if (!noInstall) {
+		const installer = installDependencies ?? defaultInstallDependencies;
+		await installer({
+			projectDir,
+			packageManager,
+		});
+	}
+}

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-identifiers.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-identifiers.ts
@@ -1,0 +1,129 @@
+import {
+	toKebabCase,
+	toSnakeCase,
+} from "./string-case.js";
+
+const BLOCK_SLUG_PATTERN = /^[a-z][a-z0-9-]*$/;
+const PHP_PREFIX_PATTERN = /^[a-z_][a-z0-9_]*$/;
+const PHP_PREFIX_MAX_LENGTH = 50;
+
+export interface ResolvedScaffoldIdentifiers {
+	namespace: string;
+	phpPrefix: string;
+	slug: string;
+	textDomain: string;
+}
+
+export function validateBlockSlug(input: string): true | string {
+	return BLOCK_SLUG_PATTERN.test(input) || "Use lowercase letters, numbers, and hyphens only";
+}
+
+export function validateNamespace(input: string): true | string {
+	return BLOCK_SLUG_PATTERN.test(toKebabCase(input))
+		? true
+		: "Use lowercase letters, numbers, and hyphens only";
+}
+
+export function validateTextDomain(input: string): true | string {
+	return BLOCK_SLUG_PATTERN.test(toKebabCase(input))
+		? true
+		: "Use lowercase letters, numbers, and hyphens only";
+}
+
+export function validatePhpPrefix(input: string): true | string {
+	const normalizedPrefix = toSnakeCase(input);
+	if (normalizedPrefix.length > PHP_PREFIX_MAX_LENGTH) {
+		return `Use ${PHP_PREFIX_MAX_LENGTH} characters or fewer to keep generated database identifiers within MySQL limits`;
+	}
+
+	return PHP_PREFIX_PATTERN.test(normalizedPrefix)
+		? true
+		: "Use letters, numbers, and underscores only, starting with a letter";
+}
+
+export function assertValidIdentifier(
+	label: string,
+	value: string,
+	validate: (value: string) => true | string,
+): string {
+	const result = validate(value);
+	if (result !== true) {
+		throw new Error(typeof result === "string" ? `${label}: ${result}` : `${label} is invalid`);
+	}
+
+	return value;
+}
+
+export function normalizeBlockSlug(input: string): string {
+	return toKebabCase(input);
+}
+
+export function resolveValidatedBlockSlug(value: string): string {
+	return assertValidIdentifier("Block slug", normalizeBlockSlug(value), validateBlockSlug);
+}
+
+export function resolveValidatedNamespace(value: string): string {
+	return assertValidIdentifier("Namespace", toKebabCase(value), validateNamespace);
+}
+
+export function resolveValidatedTextDomain(value: string): string {
+	return assertValidIdentifier("Text domain", toKebabCase(value), validateTextDomain);
+}
+
+export function resolveValidatedPhpPrefix(value: string): string {
+	return assertValidIdentifier("PHP prefix", toSnakeCase(value), validatePhpPrefix);
+}
+
+/**
+ * Builds the generated WordPress wrapper CSS class for a scaffolded block.
+ *
+ * Returns `wp-block-{namespace}-{slug}` when a non-empty namespace is present,
+ * or `wp-block-{slug}` when the namespace is empty or undefined. When the
+ * normalized namespace equals the normalized slug, appends `-block` so the
+ * generated class avoids repeated namespace segments without colliding with the
+ * default core wrapper classes. Both inputs are normalized and validated with
+ * the same scaffold identifier rules used for block names.
+ */
+export function buildBlockCssClassName(
+	namespace: string | undefined,
+	slug: string,
+): string {
+	const normalizedSlug = resolveValidatedBlockSlug(slug);
+	const normalizedNamespace =
+		typeof namespace === "string" && namespace.trim().length > 0
+			? resolveValidatedNamespace(namespace)
+			: "";
+
+	if (normalizedNamespace === normalizedSlug) {
+		return `wp-block-${normalizedSlug}-block`;
+	}
+
+	return normalizedNamespace.length > 0
+		? `wp-block-${normalizedNamespace}-${normalizedSlug}`
+		: `wp-block-${normalizedSlug}`;
+}
+
+export function buildFrontendCssClassName(blockCssClassName: string): string {
+	return `${blockCssClassName}-frontend`;
+}
+
+export function resolveScaffoldIdentifiers({
+	namespace,
+	phpPrefix,
+	slug,
+	textDomain,
+}: {
+	namespace: string;
+	phpPrefix?: string;
+	slug: string;
+	textDomain?: string;
+}): ResolvedScaffoldIdentifiers {
+	const normalizedSlug = resolveValidatedBlockSlug(slug);
+
+	return {
+		namespace: resolveValidatedNamespace(namespace),
+		phpPrefix: resolveValidatedPhpPrefix(phpPrefix ?? normalizedSlug),
+		slug: normalizedSlug,
+		textDomain: resolveValidatedTextDomain(textDomain ?? normalizedSlug),
+	};
+}

--- a/packages/wp-typia-project-tools/src/runtime/scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold.ts
@@ -55,6 +55,11 @@ import {
 } from "./template-registry.js";
 import type { BuiltInTemplateId } from "./template-registry.js";
 import { resolveTemplateSource } from "./template-source.js";
+import {
+	BlockGeneratorService,
+	buildTemplateVariablesFromBlockSpec,
+	createBuiltInBlockSpec,
+} from "./block-generator-service.js";
 
 const BLOCK_SLUG_PATTERN = /^[a-z][a-z0-9-]*$/;
 const PHP_PREFIX_PATTERN = /^[a-z_][a-z0-9_]*$/;
@@ -505,6 +510,17 @@ export function getTemplateVariables(
 	templateId: string,
 	answers: ScaffoldAnswers,
 ): ScaffoldTemplateVariables {
+	if (isBuiltInTemplateId(templateId)) {
+		return buildTemplateVariablesFromBlockSpec(
+			createBuiltInBlockSpec({
+				answers,
+				dataStorageMode: answers.dataStorageMode,
+				persistencePolicy: answers.persistencePolicy,
+				templateId,
+			}),
+		);
+	}
+
 	const {
 		apiClientPackageVersion,
 		blockRuntimePackageVersion,
@@ -1063,6 +1079,31 @@ export async function scaffoldProject({
 	const resolvedTemplateId = normalizeTemplateSelection(templateId);
 	const resolvedPackageManager = getPackageManager(packageManager).id;
 	const isBuiltInTemplate = isBuiltInTemplateId(resolvedTemplateId);
+
+	if (isBuiltInTemplate) {
+		const blockGeneratorService = new BlockGeneratorService();
+		const plan = await blockGeneratorService.plan({
+			allowExistingDir,
+			answers,
+			cwd,
+			dataStorageMode: dataStorageMode ?? answers.dataStorageMode,
+			noInstall,
+			packageManager: resolvedPackageManager,
+			persistencePolicy: persistencePolicy ?? answers.persistencePolicy,
+			projectDir,
+			templateId: resolvedTemplateId,
+			variant,
+			withMigrationUi,
+			withTestPreset,
+			withWpEnv,
+		});
+		const validated = await blockGeneratorService.validate({ plan });
+		const rendered = await blockGeneratorService.render({ validated });
+		return blockGeneratorService.apply({
+			installDependencies,
+			rendered,
+		});
+	}
 
 	const variables = getTemplateVariables(resolvedTemplateId, {
 		...answers,

--- a/packages/wp-typia-project-tools/tests/block-generator-service.test.ts
+++ b/packages/wp-typia-project-tools/tests/block-generator-service.test.ts
@@ -1,0 +1,142 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import {
+	cleanupScaffoldTempRoot,
+	createScaffoldTempRoot,
+	typecheckGeneratedProject,
+} from "./helpers/scaffold-test-harness.js";
+import { BlockGeneratorService } from "../src/runtime/index.js";
+import { getDefaultAnswers } from "../src/runtime/scaffold.js";
+import type { BuiltInTemplateId } from "../src/runtime/template-registry.js";
+
+function buildAnswers(templateId: BuiltInTemplateId) {
+	return {
+		...getDefaultAnswers("demo-generator-service", templateId),
+		author: "Test Runner",
+		description: `Demo ${templateId} block`,
+		namespace: "demo-space",
+		phpPrefix: "demo_space",
+		slug: "demo-generator-service",
+		textDomain: "demo-space",
+		title: "Demo Generator Service",
+	};
+}
+
+describe("BlockGeneratorService", () => {
+	const tempRoot = createScaffoldTempRoot("wp-typia-block-generator-service-");
+
+	afterAll(() => {
+		cleanupScaffoldTempRoot(tempRoot);
+	});
+
+	test.each([
+		["basic", false],
+		["interactivity", false],
+		["persistence", true],
+		["compound", true],
+	] as const)(
+		"plan normalizes %s into a typed block spec",
+		async (templateId, expectPersistence) => {
+			const service = new BlockGeneratorService();
+			const plan = await service.plan({
+				answers: buildAnswers(templateId),
+				dataStorageMode: expectPersistence ? "custom-table" : undefined,
+				noInstall: true,
+				packageManager: "npm",
+				persistencePolicy: expectPersistence ? "authenticated" : undefined,
+				projectDir: path.join(tempRoot, `plan-${templateId}`),
+				templateId,
+			});
+
+			expect(plan.spec.template.family).toBe(templateId);
+			expect(plan.spec.block.slug).toBe("demo-generator-service");
+			expect(plan.spec.block.namespace).toBe("demo-space");
+			expect(plan.spec.block.textDomain).toBe("demo-space");
+			expect(plan.spec.project.author).toBe("Test Runner");
+			expect(plan.target.packageManager).toBe("npm");
+			expect(plan.target.noInstall).toBe(true);
+			expect(plan.spec.persistence.enabled).toBe(expectPersistence);
+
+			if (plan.spec.persistence.enabled) {
+				expect(plan.spec.persistence.dataStorageMode).toBe("custom-table");
+				expect(plan.spec.persistence.persistencePolicy).toBe("authenticated");
+			}
+		},
+	);
+
+	test("validate preserves built-in behavior for unsupported variants", async () => {
+		const service = new BlockGeneratorService();
+		const plan = await service.plan({
+			answers: buildAnswers("basic"),
+			noInstall: true,
+			packageManager: "npm",
+			projectDir: path.join(tempRoot, "variant-rejection"),
+			templateId: "basic",
+			variant: "hero",
+		});
+
+		await expect(service.validate({ plan })).rejects.toThrow(
+			'--variant is only supported for official external template configs. Received variant "hero" for built-in template "basic".',
+		);
+	});
+
+	test("render exposes explicit stage intent for compound persistence scaffolds", async () => {
+		const service = new BlockGeneratorService();
+		const plan = await service.plan({
+			answers: buildAnswers("compound"),
+			dataStorageMode: "post-meta",
+			noInstall: true,
+			packageManager: "npm",
+			persistencePolicy: "public",
+			projectDir: path.join(tempRoot, "render-compound"),
+			templateId: "compound",
+			withMigrationUi: true,
+			withTestPreset: true,
+			withWpEnv: true,
+		});
+		const validated = await service.validate({ plan });
+		const rendered = await service.render({ validated });
+
+		expect(path.basename(rendered.templateDir)).toBe("compound");
+		expect(rendered.cleanup).toBeFunction();
+		expect(rendered.variables.compoundPersistenceEnabled).toBe("true");
+		expect(rendered.variables.persistencePolicy).toBe("public");
+		expect(rendered.variables.dataStorageMode).toBe("post-meta");
+		expect(rendered.variables.blockMetadataVersion).toBe("0.1.0");
+		expect(rendered.readmeContent).toContain("## Template");
+		expect(rendered.gitignoreContent).toContain("node_modules/");
+		expect(rendered.postRender.seedStarterManifestFiles).toBe(true);
+		expect(rendered.postRender.seedPersistenceArtifacts).toBe(true);
+		expect(rendered.postRender.applyLocalDevPresets).toBe(true);
+		expect(rendered.postRender.applyMigrationUiCapability).toBe(true);
+	});
+
+	test("apply writes a built-in scaffold through the service boundary", async () => {
+		const service = new BlockGeneratorService();
+		const projectDir = path.join(tempRoot, "apply-basic");
+		const plan = await service.plan({
+			answers: buildAnswers("basic"),
+			noInstall: true,
+			packageManager: "npm",
+			projectDir,
+			templateId: "basic",
+		});
+		const validated = await service.validate({ plan });
+		const rendered = await service.render({ validated });
+		const result = await service.apply({ rendered });
+
+		expect(result.templateId).toBe("basic");
+		expect(result.selectedVariant).toBeNull();
+		expect(fs.existsSync(path.join(projectDir, "src", "block.json"))).toBe(true);
+		expect(fs.existsSync(path.join(projectDir, "src", "typia.manifest.json"))).toBe(
+			true,
+		);
+		expect(fs.readFileSync(path.join(projectDir, "README.md"), "utf8")).toContain(
+			"Demo Generator Service",
+		);
+
+		typecheckGeneratedProject(projectDir);
+	});
+});

--- a/packages/wp-typia-project-tools/tests/block-generator-service.test.ts
+++ b/packages/wp-typia-project-tools/tests/block-generator-service.test.ts
@@ -102,7 +102,8 @@ describe("BlockGeneratorService", () => {
 		expect(path.basename(rendered.templateDir)).toBe("compound");
 		expect(rendered.cleanup).toBeFunction();
 		expect(rendered.variables.compoundPersistenceEnabled).toBe("true");
-		expect(rendered.variables.persistencePolicy).toBe("public");
+		expect(rendered.variables.isPublicPersistencePolicy).toBe("true");
+		expect(rendered.variables.isAuthenticatedPersistencePolicy).toBe("false");
 		expect(rendered.variables.dataStorageMode).toBe("post-meta");
 		expect(rendered.variables.blockMetadataVersion).toBe("0.1.0");
 		expect(rendered.readmeContent).toContain("## Template");

--- a/packages/wp-typia-project-tools/tests/block-generator-service.test.ts
+++ b/packages/wp-typia-project-tools/tests/block-generator-service.test.ts
@@ -113,6 +113,28 @@ describe("BlockGeneratorService", () => {
 		expect(rendered.postRender.applyMigrationUiCapability).toBe(true);
 	});
 
+	test("plan preserves compound persistence settings from scaffold answers", async () => {
+		const service = new BlockGeneratorService();
+		const plan = await service.plan({
+			answers: {
+				...buildAnswers("compound"),
+				dataStorageMode: "post-meta",
+				persistencePolicy: "public",
+			},
+			noInstall: true,
+			packageManager: "npm",
+			projectDir: path.join(tempRoot, "plan-compound-from-answers"),
+			templateId: "compound",
+		});
+
+		expect(plan.spec.persistence.enabled).toBe(true);
+		if (plan.spec.persistence.enabled) {
+			expect(plan.spec.persistence.scope).toBe("compound-parent");
+			expect(plan.spec.persistence.dataStorageMode).toBe("post-meta");
+			expect(plan.spec.persistence.persistencePolicy).toBe("public");
+		}
+	});
+
 	test("apply writes a built-in scaffold through the service boundary", async () => {
 		const service = new BlockGeneratorService();
 		const projectDir = path.join(tempRoot, "apply-basic");

--- a/packages/wp-typia-project-tools/tests/import-policy.test.ts
+++ b/packages/wp-typia-project-tools/tests/import-policy.test.ts
@@ -14,6 +14,7 @@ describe("@wp-typia/project-tools import policy", () => {
 		]);
 
 		expect(typeof rootModule.collectScaffoldAnswers).toBe("function");
+		expect(typeof rootModule.BlockGeneratorService).toBe("function");
 		expect(typeof rootModule.formatAddHelpText).toBe("function");
 		expect(typeof rootModule.formatMigrationHelpText).toBe("function");
 		expect(typeof rootModule.getDoctorChecks).toBe("function");
@@ -81,19 +82,23 @@ describe("@wp-typia/project-tools import policy", () => {
 
 		expect(projectToolsReadme).toContain("@wp-typia/project-tools");
 		expect(projectToolsReadme).toContain("@wp-typia/project-tools/schema-core");
+		expect(projectToolsReadme).toContain("BlockGeneratorService");
 		expect(projectToolsReadme).toContain("@wp-typia/block-runtime/*");
 		expect(projectToolsReadme).toContain("@wp-typia/block-runtime/schema-core");
 		expect(createReadme).toContain("deprecated legacy package shell");
 		expect(createReadme).toContain("@wp-typia/project-tools");
 		expect(createReadme).toContain("@wp-typia/project-tools/schema-core");
 		expect(apiGuide).toContain("@wp-typia/project-tools");
+		expect(apiGuide).toContain("BlockGeneratorService");
 		expect(apiGuide).toContain("@wp-typia/project-tools/schema-core");
 		expect(apiGuide).toContain("@wp-typia/block-runtime/metadata-core");
 		expect(runtimeSurfaceDoc).toContain("@wp-typia/project-tools");
+		expect(runtimeSurfaceDoc).toContain("BlockGeneratorService");
 		expect(runtimeSurfaceDoc).toContain("@wp-typia/project-tools/schema-core");
 		expect(runtimeSurfaceDoc).toContain("@wp-typia/block-runtime/schema-core");
 		expect(runtimeSurfaceDoc).not.toContain("@wp-typia/project-tools/runtime/*");
 		expect(importPolicyDoc).toContain("@wp-typia/project-tools");
+		expect(importPolicyDoc).toContain("BlockGeneratorService");
 		expect(importPolicyDoc).toContain("@wp-typia/project-tools/schema-core");
 		expect(importPolicyDoc).toContain("@wp-typia/block-runtime/schema-core");
 		expect(importPolicyDoc).not.toContain("@wp-typia/project-tools/runtime/*");


### PR DESCRIPTION
## Summary

Closes #194.

Introduce a Phase 1 typed generation boundary for built-in block scaffolds in `@wp-typia/project-tools`.

This keeps the existing Mustache-based file bodies and scaffold behavior, but splits the orchestration path into explicit `plan`, `validate`, `render`, and `apply` stages through a new `BlockGeneratorService` and `BlockSpec` model.

## What Changed

- added `BlockSpec` and related stage input/output types to the `@wp-typia/project-tools` root surface
- introduced `BlockGeneratorService` with explicit `plan`, `validate`, `render`, and `apply` stages for built-in block templates
- routed built-in `scaffoldProject` flows through the new typed boundary while keeping external template paths on the existing flow
- kept `runAddBlockCommand` on its current temp-scaffold strategy so workspace block creation still reuses the built-in scaffold path indirectly
- documented the Phase 1 Mustache-vs-emitter boundary in the project tools docs
- added direct service tests plus import-policy/doc assertions for the new root exports

## Why

`scaffold.ts` had accumulated planning, validation, render, and apply responsibilities in one place. This PR introduces an explicit typed orchestration boundary that later work can build on without changing current scaffold behavior or forcing a template migration in the same step.

## Validation

- `bun run --filter @wp-typia/project-tools test:scaffold-core`
- `bun run --filter @wp-typia/project-tools test:workspace`
- `bun run --filter wp-typia test`
- `bun run typecheck`
- `bun run docs:build`
- `bun run ci:local`

## Release Notes

- `npm/@wp-typia/project-tools`: patch
- `npm/wp-typia`: patch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a typed block generation boundary (BlockGeneratorService) to plan, validate, render, and apply built-in block scaffolds; built-in scaffold file bodies remain Mustache-rendered. Scaffolding now applies templates, normalizes package-manager files, and can seed persistence/migration artifacts.

* **Documentation**
  * New doc and updated guides describing the block generator boundary and updated runtime import surface.

* **Tests**
  * Added end-to-end tests covering plan → validate → render → apply flows.

* **Chores**
  * Updated test script to include the new block-generator-service tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->