### PR TITLE
feat: clarify repository error and export contracts

### DIFF
--- a/.sampo/changesets/issue-248-error-export-contract-clarification.md
+++ b/.sampo/changesets/issue-248-error-export-contract-clarification.md
@@ -5,6 +5,6 @@ npm/@wp-typia/rest: patch
 
 Clarify the public runtime error contract and `@wp-typia/rest` export semantics
 by documenting validation-vs-throw behavior, introducing named configuration and
-assertion errors for the runtime client packages, and making the `./http`
-subpath a distinct decoder-only export while keeping `./client` as a documented
-compatibility alias.
+assertion errors for the runtime client packages, and explicitly documenting
+that `./client` and `./http` remain compatibility aliases in the current major
+line instead of introducing a breaking export split.

--- a/.sampo/changesets/issue-248-error-export-contract-clarification.md
+++ b/.sampo/changesets/issue-248-error-export-contract-clarification.md
@@ -1,0 +1,10 @@
+---
+npm/@wp-typia/api-client: patch
+npm/@wp-typia/rest: patch
+---
+
+Clarify the public runtime error contract and `@wp-typia/rest` export semantics
+by documenting validation-vs-throw behavior, introducing named configuration and
+assertion errors for the runtime client packages, and making the `./http`
+subpath a distinct decoder-only export while keeping `./client` as a documented
+compatibility alias.

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ npx wp-typia create my-block --template @scope/create-block-template --variant h
 - [Architecture Guide](docs/architecture.md)
 - [API Guide](docs/API.md)
 - [Migration Guide](docs/migrations.md)
+- [Error and Export Contract Guide](docs/error-export-contracts.md)
 - [Package Manifest Policy](docs/package-manifest-policy.md)
 - [TypeScript Strictness Policy](docs/typescript-strictness-policy.md)
 - [Upgrade Guide](UPGRADE.md)

--- a/docs/API.md
+++ b/docs/API.md
@@ -234,7 +234,8 @@ Export semantics:
 - `@wp-typia/rest` is the canonical convenience surface
 - `@wp-typia/rest/client` is a backward-compatible alias, not a distinct
   semantic contract
-- `@wp-typia/rest/http` is the decoder-only helper surface
+- `@wp-typia/rest/http` is currently a backward-compatible alias of the root
+  surface, not a distinct decoder-only contract
 - `@wp-typia/rest/react` is the React cache/hook layer
 
 The root package stays transport-only. React/data helpers live under the

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # API Guide
 
-This repository has seven public surfaces:
+This repository has multiple public surfaces:
 
 ## Package Map
 
@@ -229,6 +229,14 @@ The package stays TypeScript-side only. WordPress/PHP route registration and sch
 Use it when the consumer should understand WordPress REST root discovery and
 nonce-aware request wiring.
 
+Export semantics:
+
+- `@wp-typia/rest` is the canonical convenience surface
+- `@wp-typia/rest/client` is a backward-compatible alias, not a distinct
+  semantic contract
+- `@wp-typia/rest/http` is the decoder-only helper surface
+- `@wp-typia/rest/react` is the React cache/hook layer
+
 The root package stays transport-only. React/data helpers live under the
 separate `@wp-typia/rest/react` subpath:
 
@@ -252,12 +260,26 @@ Refresh-sensitive auth remains explicit there:
 - there is no built-in automatic retry when nonce or token state is stale; the
   caller refreshes state and then invokes `refetch()` or `mutate()` again
 
+Error contract:
+
+- validation failures stay in `EndpointValidationResult<Req, Res>`
+- caller/configuration faults throw `RestConfigurationError`,
+  `RestRootResolutionError`, or `RestQueryHookUsageError`
+- assertion APIs may throw `RestValidationAssertionError`
+
 ## 5. `@wp-typia/api-client`
 
 `@wp-typia/api-client` is the transport-neutral sibling to `@wp-typia/rest`.
 
 - `createEndpoint<Req, Res>()`
 - `callEndpoint<Req, Res>()`
+- `WpTypiaContractError`
+- `ApiClientConfigurationError`
+- `WpTypiaValidationAssertionError`
+
+For the repo-level contract that explains when runtime APIs should return
+validation unions vs. throw named errors, and how `@wp-typia/rest` subpaths are
+classified, see [`docs/error-export-contracts.md`](./error-export-contracts.md).
 - `createFetchTransport({ baseUrl })`
 - `withHeaders(transport, headers)`
 - `withComputedHeaders(transport, resolveHeaders)`

--- a/docs/error-export-contracts.md
+++ b/docs/error-export-contracts.md
@@ -1,0 +1,123 @@
+# Error and Export Contracts
+
+This document is the normative contract for two repository-wide areas that need
+stable downstream expectations:
+
+- public runtime error semantics
+- package export-surface semantics where overlapping subpaths can imply
+  misleading meaning
+
+## Error contract
+
+### 1. Validation failures stay in result unions
+
+When a public runtime API already exposes a validation result type, invalid
+request or response payloads should remain in that value contract instead of
+throwing generic exceptions.
+
+Current canonical examples:
+
+- `ValidationResult<T>`
+- `EndpointValidationResult<Req, Res>`
+
+That means:
+
+- `callEndpoint(...)` should return request/response validation failures
+- `createValidatedFetch(...).fetch(...)` should return validation failures
+- validation failure is not itself a reason to introduce a new thrown error path
+
+### 2. Public runtime misconfiguration uses named error classes
+
+When a public runtime API must throw because the caller violated a usage or
+configuration contract, it should prefer a named domain-specific error class
+over a generic `Error`.
+
+Current baseline:
+
+- `WpTypiaContractError`
+  Shared base for catch-worthy public runtime contract failures.
+- `ApiClientConfigurationError`
+  Transport-neutral client misuse or missing transport configuration.
+- `RestConfigurationError`
+  WordPress REST helper misconfiguration.
+- `RestRootResolutionError`
+  Automatic REST root discovery failed.
+- `RestQueryHookUsageError`
+  React hook misuse such as calling `useEndpointQuery(...)` on a non-GET
+  endpoint.
+
+### 3. Assertion helpers may throw typed validation assertion errors
+
+Some helper APIs intentionally convert validation failures into thrown
+exceptions because the caller explicitly opted into an assertion path.
+
+Current baseline:
+
+- `WpTypiaValidationAssertionError`
+- `RestValidationAssertionError`
+
+Those errors should carry the normalized validation payload so callers can
+inspect the failure programmatically.
+
+### 4. Internal authoring and invariant failures may stay generic
+
+The repository still contains many internal parser, generator, migration,
+metadata, and test-helper paths that throw generic `Error`.
+
+That is acceptable when the throw site is:
+
+- an internal invariant breach
+- authoring/build-time drift
+- generator/template failure
+- a repo-local test helper or fixture failure
+
+In other words, the repo is not adopting domain-specific classes for every
+throw site immediately. The current contract is narrower:
+
+- public runtime boundaries should be typed
+- internal authoring/invariant paths may remain generic until there is a real
+  downstream need to catch them programmatically
+
+## Export-surface contract
+
+### `@wp-typia/api-client`
+
+- `@wp-typia/api-client`
+  Canonical transport-neutral runtime surface.
+- `@wp-typia/api-client/client-utils`
+  Distinct low-level request/response helpers.
+- `@wp-typia/api-client/runtime-primitives`
+  Distinct validation/runtime primitive helpers.
+
+These subpaths are semantically distinct and should remain documented that way.
+
+### `@wp-typia/rest`
+
+- `@wp-typia/rest`
+  Canonical convenience surface. It intentionally combines the transport helper
+  layer and the HTTP decoder helpers.
+- `@wp-typia/rest/client`
+  Compatibility alias of the root surface. It is public, but it is not a
+  distinct semantic contract.
+- `@wp-typia/rest/http`
+  Decoder-only helper surface.
+- `@wp-typia/rest/react`
+  React cache and hook surface.
+
+Implications:
+
+- prefer `@wp-typia/rest` for transport-oriented imports
+- prefer `@wp-typia/rest/http` when a consumer only needs decoder helpers
+- prefer `@wp-typia/rest/react` for hook imports
+- treat `@wp-typia/rest/client` as compatibility-only, not as the recommended
+  canonical import
+
+## Future direction
+
+Future work may:
+
+- expand named public runtime error classes into more subsystems
+- remove compatibility aliases such as `@wp-typia/rest/client` in a major
+  release if downstream usage is low enough
+- keep tightening docs/tests so export semantics and catch-worthy error
+  contracts remain explicit instead of ad hoc

--- a/docs/error-export-contracts.md
+++ b/docs/error-export-contracts.md
@@ -100,14 +100,17 @@ These subpaths are semantically distinct and should remain documented that way.
   Compatibility alias of the root surface. It is public, but it is not a
   distinct semantic contract.
 - `@wp-typia/rest/http`
-  Decoder-only helper surface.
+  Compatibility alias of the root surface. It remains available for historical
+  imports, but it is not yet a distinct decoder-only contract in the current
+  major line.
 - `@wp-typia/rest/react`
   React cache and hook surface.
 
 Implications:
 
 - prefer `@wp-typia/rest` for transport-oriented imports
-- prefer `@wp-typia/rest/http` when a consumer only needs decoder helpers
+- treat `@wp-typia/rest/http` as compatibility-only until a future major
+  release can safely narrow it
 - prefer `@wp-typia/rest/react` for hook imports
 - treat `@wp-typia/rest/client` as compatibility-only, not as the recommended
   canonical import

--- a/docs/runtime-import-policy.md
+++ b/docs/runtime-import-policy.md
@@ -7,6 +7,21 @@ surfaces.
 
 - `wp-typia`
   CLI only.
+- `@wp-typia/api-client`
+  Transport-neutral runtime surface.
+- `@wp-typia/api-client/client-utils`
+  Distinct low-level request/response helper surface.
+- `@wp-typia/api-client/runtime-primitives`
+  Distinct validation/runtime primitive helper surface.
+- `@wp-typia/rest`
+  Canonical WordPress REST runtime surface.
+- `@wp-typia/rest/client`
+  Compatibility alias of the root `@wp-typia/rest` surface, not a distinct
+  semantic contract.
+- `@wp-typia/rest/http`
+  Decoder-only helper surface.
+- `@wp-typia/rest/react`
+  React cache and hook surface.
 - `@wp-typia/project-tools`
   Project orchestration and programmatic tooling.
 - `@wp-typia/project-tools/schema-core`
@@ -52,6 +67,25 @@ TS/TSX, style, or block-local `render.php` Mustache files.
 
 `@wp-typia/block-runtime/schema-core` is public and stable, but it is the
 implementation owner path rather than the preferred project-tooling import.
+
+## Error contract baseline
+
+Validation failures should stay in result unions such as `ValidationResult<T>`
+or `EndpointValidationResult<Req, Res>`.
+
+Public runtime throws should prefer named contract errors:
+
+- `WpTypiaContractError`
+- `ApiClientConfigurationError`
+- `RestConfigurationError`
+- `RestRootResolutionError`
+- `RestQueryHookUsageError`
+- `WpTypiaValidationAssertionError`
+- `RestValidationAssertionError`
+
+Internal generator, parser, migration, and build invariants may still use
+generic `Error` until there is a concrete downstream need for a typed public
+catch contract.
 
 ## Deprecated surface
 

--- a/docs/runtime-import-policy.md
+++ b/docs/runtime-import-policy.md
@@ -19,7 +19,8 @@ surfaces.
   Compatibility alias of the root `@wp-typia/rest` surface, not a distinct
   semantic contract.
 - `@wp-typia/rest/http`
-  Decoder-only helper surface.
+  Compatibility alias of the root `@wp-typia/rest` surface in the current
+  major line. It is not yet a distinct decoder-only contract.
 - `@wp-typia/rest/react`
   React cache and hook surface.
 - `@wp-typia/project-tools`

--- a/docs/runtime-surface.md
+++ b/docs/runtime-surface.md
@@ -7,6 +7,13 @@ This document is descriptive, not normative. For support guarantees, see
 
 - `wp-typia`
   CLI package and Bunli command tree.
+- `@wp-typia/api-client`
+- `@wp-typia/api-client/client-utils`
+- `@wp-typia/api-client/runtime-primitives`
+- `@wp-typia/rest`
+- `@wp-typia/rest/client`
+- `@wp-typia/rest/http`
+- `@wp-typia/rest/react`
 - `@wp-typia/project-tools`
   Project orchestration helpers used by the CLI and programmatic tooling,
   including the additive `BlockSpec` / `BlockGeneratorService` boundary and
@@ -33,6 +40,13 @@ This document is descriptive, not normative. For support guarantees, see
 ### Stable public
 
 - `wp-typia`
+- `@wp-typia/api-client`
+- `@wp-typia/api-client/client-utils`
+- `@wp-typia/api-client/runtime-primitives`
+- `@wp-typia/rest`
+- `@wp-typia/rest/client`
+- `@wp-typia/rest/http`
+- `@wp-typia/rest/react`
 - `@wp-typia/project-tools`
 - `@wp-typia/project-tools/schema-core`
 - `@wp-typia/block-runtime/migration-types`
@@ -48,6 +62,13 @@ This document is descriptive, not normative. For support guarantees, see
 
 ## Ownership notes
 
+- `@wp-typia/api-client` owns the transport-neutral endpoint contract, runtime
+  validation primitives, and the shared public runtime error base
+  (`WpTypiaContractError`, `WpTypiaValidationAssertionError`).
+- `@wp-typia/rest` owns WordPress-specific route discovery, `apiFetch`
+  integration, decoder helpers, and the React cache/hook layer. The root
+  surface is canonical, `./client` is compatibility-only, `./http` is the
+  decoder-only surface, and `./react` owns hooks.
 - `wp-typia` owns the CLI, help, TUI, completions, skills, MCP, and bin entry.
 - `@wp-typia/project-tools` owns scaffold, add-block, migrate, template,
   doctor, package-manager, starter-manifest, the typed generator boundary, the

--- a/docs/runtime-surface.md
+++ b/docs/runtime-surface.md
@@ -67,8 +67,8 @@ This document is descriptive, not normative. For support guarantees, see
   (`WpTypiaContractError`, `WpTypiaValidationAssertionError`).
 - `@wp-typia/rest` owns WordPress-specific route discovery, `apiFetch`
   integration, decoder helpers, and the React cache/hook layer. The root
-  surface is canonical, `./client` is compatibility-only, `./http` is the
-  decoder-only surface, and `./react` owns hooks.
+  surface is canonical, `./client` and `./http` are compatibility-only aliases
+  in the current major line, and `./react` owns hooks.
 - `wp-typia` owns the CLI, help, TUI, completions, skills, MCP, and bin entry.
 - `@wp-typia/project-tools` owns scaffold, add-block, migrate, template,
   doctor, package-manager, starter-manifest, the typed generator boundary, the

--- a/examples/my-typia-block/webpack.config.js
+++ b/examples/my-typia-block/webpack.config.js
@@ -235,6 +235,10 @@ module.exports = async () => {
 						process.cwd(),
 						'../../packages/wp-typia-api-client/src/client-utils.ts'
 					),
+					'@wp-typia/api-client': path.resolve(
+						process.cwd(),
+						'../../packages/wp-typia-api-client/src/index.ts'
+					),
 					'@wp-typia/rest': path.resolve(
 						process.cwd(),
 						'../../packages/wp-typia-rest/src'

--- a/examples/my-typia-block/webpack.config.js
+++ b/examples/my-typia-block/webpack.config.js
@@ -235,7 +235,7 @@ module.exports = async () => {
 						process.cwd(),
 						'../../packages/wp-typia-api-client/src/client-utils.ts'
 					),
-					'@wp-typia/api-client': path.resolve(
+					'@wp-typia/api-client$': path.resolve(
 						process.cwd(),
 						'../../packages/wp-typia-api-client/src/index.ts'
 					),

--- a/examples/persistence-examples/webpack.config.js
+++ b/examples/persistence-examples/webpack.config.js
@@ -270,7 +270,7 @@ module.exports = async () => {
 						process.cwd(),
 						'../../packages/wp-typia-api-client/src/client-utils.ts'
 					),
-					'@wp-typia/api-client': path.resolve(
+					'@wp-typia/api-client$': path.resolve(
 						process.cwd(),
 						'../../packages/wp-typia-api-client/src/index.ts'
 					),

--- a/examples/persistence-examples/webpack.config.js
+++ b/examples/persistence-examples/webpack.config.js
@@ -270,6 +270,10 @@ module.exports = async () => {
 						process.cwd(),
 						'../../packages/wp-typia-api-client/src/client-utils.ts'
 					),
+					'@wp-typia/api-client': path.resolve(
+						process.cwd(),
+						'../../packages/wp-typia-api-client/src/index.ts'
+					),
 					'@wp-typia/rest': path.resolve(
 						process.cwd(),
 						'../../packages/wp-typia-rest/src'

--- a/packages/wp-typia-api-client/README.md
+++ b/packages/wp-typia-api-client/README.md
@@ -101,6 +101,13 @@ validation failures are surfaced honestly with
 `validationTarget: "request"`, while post-transport response validation uses
 `validationTarget: "response"`.
 
+That result union is the canonical validation contract. Public thrown errors are
+reserved for caller/configuration faults rather than validation failure:
+
+- `WpTypiaContractError`
+- `ApiClientConfigurationError`
+- `WpTypiaValidationAssertionError`
+
 Use `@wp-typia/rest` when you want WordPress-specific helpers such as canonical
 REST route URL resolution and `@wordpress/api-fetch` integration. Manifest
 `authIntent` is the primary portable metadata surface, while legacy

--- a/packages/wp-typia-api-client/src/client.ts
+++ b/packages/wp-typia-api-client/src/client.ts
@@ -10,6 +10,7 @@ import {
 	mergeHeaderInputs,
 	parseResponsePayload,
 } from "./client-utils.js";
+import { ApiClientConfigurationError } from "./errors.js";
 
 export type EndpointMethod = "DELETE" | "GET" | "PATCH" | "POST" | "PUT";
 export type EndpointAuthIntent =
@@ -96,7 +97,9 @@ function resolveRequestUrl(options: EndpointTransportRequest, baseUrl: string): 
 		return new URL(options.path.replace(/^\/+/, ""), baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`).toString();
 	}
 
-	throw new Error("Transport requests must include either a path or a url.");
+	throw new ApiClientConfigurationError(
+		"Transport requests must include either a path or a url.",
+	);
 }
 
 function createReadonlyTransportRequest(
@@ -156,7 +159,7 @@ function resolveCombinedRequest(
 		!Object.prototype.hasOwnProperty.call(request, "body") ||
 		!Object.prototype.hasOwnProperty.call(request, "query")
 	) {
-		throw new Error(
+		throw new ApiClientConfigurationError(
 			`Endpoints with requestLocation "query-and-body" require requests shaped like { query, body }.`,
 		);
 	}
@@ -181,7 +184,7 @@ function buildEndpointRequestOptions<Req>(
 
 	if (requestLocation === "query-and-body") {
 		if (endpoint.method === "GET") {
-			throw new Error(
+			throw new ApiClientConfigurationError(
 				'requestLocation "query-and-body" is not supported for GET endpoints.',
 			);
 		}
@@ -334,7 +337,7 @@ export async function callEndpoint<Req, Res>(
 	}
 
 	if (!transport) {
-		throw new Error(
+		throw new ApiClientConfigurationError(
 			"A transport is required. Create one with createFetchTransport({ baseUrl }) or supply a custom EndpointTransport.",
 		);
 	}

--- a/packages/wp-typia-api-client/src/errors.ts
+++ b/packages/wp-typia-api-client/src/errors.ts
@@ -1,0 +1,31 @@
+import type { ValidationResult } from "./runtime-primitives.js";
+
+export class WpTypiaContractError extends Error {
+	readonly code: string;
+
+	constructor(message: string, code = "WP_TYPIA_CONTRACT_ERROR") {
+		super(message);
+		this.name = new.target.name;
+		this.code = code;
+	}
+}
+
+export class ApiClientConfigurationError extends WpTypiaContractError {
+	constructor(message: string) {
+		super(message, "API_CLIENT_CONFIGURATION_ERROR");
+	}
+}
+
+export class WpTypiaValidationAssertionError<T = unknown> extends Error {
+	readonly code = "WP_TYPIA_VALIDATION_ASSERTION_ERROR";
+	readonly validation: ValidationResult<T>;
+
+	constructor(
+		validation: ValidationResult<T>,
+		message: string,
+	) {
+		super(message);
+		this.name = new.target.name;
+		this.validation = validation;
+	}
+}

--- a/packages/wp-typia-api-client/src/index.ts
+++ b/packages/wp-typia-api-client/src/index.ts
@@ -20,3 +20,8 @@ export {
 	type ValidationLike,
 	type ValidationResult,
 } from "./client.js";
+export {
+	ApiClientConfigurationError,
+	WpTypiaContractError,
+	WpTypiaValidationAssertionError,
+} from "./errors.js";

--- a/packages/wp-typia-api-client/tests/error-contracts.test.ts
+++ b/packages/wp-typia-api-client/tests/error-contracts.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+	ApiClientConfigurationError,
+	createEndpoint,
+	createFetchTransport,
+	callEndpoint,
+	toValidationResult,
+	WpTypiaContractError,
+} from "../src/index";
+
+describe("@wp-typia/api-client error contracts", () => {
+	test("exports a named contract error baseline from the root surface", () => {
+		const error = new ApiClientConfigurationError("boom");
+
+		expect(error).toBeInstanceOf(Error);
+		expect(error).toBeInstanceOf(WpTypiaContractError);
+		expect(error.code).toBe("API_CLIENT_CONFIGURATION_ERROR");
+	});
+
+	test("throws ApiClientConfigurationError for public configuration faults", async () => {
+		const transport = createFetchTransport({
+			baseUrl: "https://example.test",
+			fetchFn: async () => new Response("{}"),
+		});
+		const endpoint = createEndpoint<{ title: string }, { ok: boolean }>({
+			method: "POST",
+			path: "/demo",
+			validateRequest: (input: unknown) =>
+				toValidationResult(
+					typeof input === "object" &&
+						input !== null &&
+						typeof (input as { title?: unknown }).title === "string"
+						? {
+								data: input as { title: string },
+								errors: [],
+								success: true,
+							}
+						: {
+								errors: [
+									{
+										expected: "{ title: string }",
+										path: "$.title",
+										value: undefined,
+									},
+								],
+								success: false,
+							},
+				),
+			validateResponse: (input: unknown) =>
+				toValidationResult(
+					typeof input === "object" &&
+						input !== null &&
+						(input as { ok?: unknown }).ok === true
+						? {
+								data: input as { ok: boolean },
+								errors: [],
+								success: true,
+							}
+						: {
+								errors: [{ expected: "{ ok: true }", path: "$.ok", value: undefined }],
+								success: false,
+							},
+				),
+		});
+
+		await expect(transport({})).rejects.toBeInstanceOf(ApiClientConfigurationError);
+		await expect(callEndpoint(endpoint, { title: "Hello" })).rejects.toBeInstanceOf(
+			ApiClientConfigurationError,
+		);
+	});
+});

--- a/packages/wp-typia-rest/README.md
+++ b/packages/wp-typia-rest/README.md
@@ -15,6 +15,18 @@ It does not include any WordPress PHP bridge logic. Generated PHP route code sta
 If you need a backend-neutral consumer instead of WordPress-specific route
 resolution, use `@wp-typia/api-client`.
 
+## Export contract
+
+- `@wp-typia/rest`
+  Canonical convenience surface for transport helpers plus HTTP decoder helpers.
+- `@wp-typia/rest/client`
+  Backward-compatible alias of the root surface. It is not a distinct semantic
+  contract and may be removed in a future major once downstream imports settle.
+- `@wp-typia/rest/http`
+  Decoder-only helper surface for query/header/parameter decoders.
+- `@wp-typia/rest/react`
+  React-only cache and hook layer.
+
 The root `@wp-typia/rest` entry stays transport-oriented. If you want query and
 mutation hooks on top of those WordPress helpers, use the React-only subpath:
 
@@ -41,6 +53,16 @@ const result = await callEndpoint(endpoint, { title: "Hello" });
 validation fails before transport execution, the result keeps
 `validationTarget: "request"`. Response validation runs after transport and uses
 `validationTarget: "response"`.
+
+Invalid request/response payloads stay in that result union. Thrown exceptions
+are reserved for public runtime misconfiguration or assertion APIs:
+
+- `RestConfigurationError`
+- `RestRootResolutionError`
+- `RestQueryHookUsageError`
+- `RestValidationAssertionError`
+- shared base classes re-exported from `@wp-typia/api-client`:
+  `WpTypiaContractError` and `WpTypiaValidationAssertionError`
 
 If you need a canonical REST URL for a route path, use:
 

--- a/packages/wp-typia-rest/README.md
+++ b/packages/wp-typia-rest/README.md
@@ -23,7 +23,9 @@ resolution, use `@wp-typia/api-client`.
   Backward-compatible alias of the root surface. It is not a distinct semantic
   contract and may be removed in a future major once downstream imports settle.
 - `@wp-typia/rest/http`
-  Decoder-only helper surface for query/header/parameter decoders.
+  Backward-compatible alias of the root surface. It remains publishable for
+  existing imports, but it is not a distinct decoder-only contract in the
+  current major line.
 - `@wp-typia/rest/react`
   React-only cache and hook layer.
 

--- a/packages/wp-typia-rest/package.json
+++ b/packages/wp-typia-rest/package.json
@@ -17,9 +17,9 @@
       "default": "./dist/index.js"
     },
     "./http": {
-      "types": "./dist/http.d.ts",
-      "import": "./dist/http.js",
-      "default": "./dist/http.js"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./react": {
       "types": "./dist/react.d.ts",

--- a/packages/wp-typia-rest/package.json
+++ b/packages/wp-typia-rest/package.json
@@ -17,9 +17,9 @@
       "default": "./dist/index.js"
     },
     "./http": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "default": "./dist/index.js"
+      "types": "./dist/http.d.ts",
+      "import": "./dist/http.js",
+      "default": "./dist/http.js"
     },
     "./react": {
       "types": "./dist/react.d.ts",

--- a/packages/wp-typia-rest/src/client.ts
+++ b/packages/wp-typia-rest/src/client.ts
@@ -17,6 +17,11 @@ import {
 	type ValidationLike,
 	type ValidationResult,
 } from "./internal/runtime-primitives.js";
+import {
+	RestConfigurationError,
+	RestRootResolutionError,
+	RestValidationAssertionError,
+} from "./errors.js";
 
 export type { ValidationError, ValidationLike, ValidationResult } from "./internal/runtime-primitives.js";
 export { isValidationResult, normalizeValidationError, toValidationResult } from "./internal/runtime-primitives.js";
@@ -69,7 +74,7 @@ function getDefaultRestRoot(): string {
 		}
 	}
 
-	throw new Error(
+	throw new RestRootResolutionError(
 		"Unable to resolve the WordPress REST root automatically. Provide wpApiSettings.root, an api.w.org discovery link, or an explicit url.",
 	);
 }
@@ -112,7 +117,9 @@ function resolveFetchUrl(options: APIFetchOptions): string {
 		return resolveRestRouteUrl(options.path);
 	}
 
-	throw new Error("API fetch options must include either a path or a url.");
+	throw new RestConfigurationError(
+		"API fetch options must include either a path or a url.",
+	);
 }
 
 async function defaultFetch<T = unknown, Parse extends boolean = true>(
@@ -243,7 +250,8 @@ export function createValidatedFetch<T>(
 		async assertFetch(options: APIFetchOptions) {
 			const result = await this.fetch(options);
 			if (!result.isValid) {
-				throw new Error(
+				throw new RestValidationAssertionError(
+					result,
 					result.errors[0]
 						? `${result.errors[0].path}: ${result.errors[0].expected}`
 						: "REST response validation failed.",

--- a/packages/wp-typia-rest/src/errors.ts
+++ b/packages/wp-typia-rest/src/errors.ts
@@ -1,0 +1,41 @@
+import {
+	WpTypiaContractError,
+	WpTypiaValidationAssertionError,
+	type ValidationResult,
+} from "@wp-typia/api-client";
+
+export {
+	ApiClientConfigurationError,
+	WpTypiaContractError,
+	WpTypiaValidationAssertionError,
+} from "@wp-typia/api-client";
+
+export class RestConfigurationError extends WpTypiaContractError {
+	constructor(message: string) {
+		super(message, "REST_CONFIGURATION_ERROR");
+	}
+}
+
+export class RestRootResolutionError extends RestConfigurationError {
+	constructor(message: string) {
+		super(message);
+		this.name = new.target.name;
+	}
+}
+
+export class RestQueryHookUsageError extends RestConfigurationError {
+	constructor(message: string) {
+		super(message);
+		this.name = new.target.name;
+	}
+}
+
+export class RestValidationAssertionError<T = unknown> extends WpTypiaValidationAssertionError<T> {
+	constructor(
+		validation: ValidationResult<T>,
+		message: string,
+	) {
+		super(validation, message);
+		this.name = new.target.name;
+	}
+}

--- a/packages/wp-typia-rest/src/index.ts
+++ b/packages/wp-typia-rest/src/index.ts
@@ -18,6 +18,15 @@ export {
 	type ValidationLike,
 } from "./client";
 export {
+	ApiClientConfigurationError,
+	RestConfigurationError,
+	RestQueryHookUsageError,
+	RestRootResolutionError,
+	RestValidationAssertionError,
+	WpTypiaContractError,
+	WpTypiaValidationAssertionError,
+} from "./errors";
+export {
 	createHeadersDecoder,
 	createParameterDecoder,
 	createQueryDecoder,

--- a/packages/wp-typia-rest/src/index.ts
+++ b/packages/wp-typia-rest/src/index.ts
@@ -25,7 +25,7 @@ export {
 	RestValidationAssertionError,
 	WpTypiaContractError,
 	WpTypiaValidationAssertionError,
-} from "./errors";
+} from "./errors.js";
 export {
 	createHeadersDecoder,
 	createParameterDecoder,

--- a/packages/wp-typia-rest/src/react.ts
+++ b/packages/wp-typia-rest/src/react.ts
@@ -19,6 +19,7 @@ import {
 	type EndpointValidationResult,
 	type ValidationResult,
 } from "./client";
+import { RestQueryHookUsageError } from "./errors.js";
 import { isPlainObject } from "./internal/runtime-primitives.js";
 
 type CacheKey = string;
@@ -576,7 +577,9 @@ export function useEndpointQuery<Req, Res, Selected = Res>(
 	options: UseEndpointQueryOptions<Req, Res, Selected> = {},
 ): UseEndpointQueryResult<Res, Selected, Req> {
 	if (endpoint.method !== "GET") {
-		throw new Error("useEndpointQuery only supports GET endpoints in v1.");
+		throw new RestQueryHookUsageError(
+			"useEndpointQuery only supports GET endpoints in v1.",
+		);
 	}
 
 	const defaultClient = useEndpointDataClient();

--- a/packages/wp-typia-rest/tests/package-contracts.test.ts
+++ b/packages/wp-typia-rest/tests/package-contracts.test.ts
@@ -28,10 +28,13 @@ describe("@wp-typia/rest export contracts", () => {
 		const importRestClient = new Function(
 			'return import("@wp-typia/rest/client");',
 		) as () => Promise<Record<string, unknown>>;
+		const importRestHttp = new Function(
+			'return import("@wp-typia/rest/http");',
+		) as () => Promise<Record<string, unknown>>;
 		const [restRoot, restClient, restHttp, restReact] = await Promise.all([
 			import("@wp-typia/rest"),
 			importRestClient(),
-			import("@wp-typia/rest/http"),
+			importRestHttp(),
 			import("@wp-typia/rest/react"),
 		]);
 

--- a/packages/wp-typia-rest/tests/package-contracts.test.ts
+++ b/packages/wp-typia-rest/tests/package-contracts.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { describe, expect, test } from "bun:test";
 
 describe("@wp-typia/rest export contracts", () => {
-	test("publishes distinct decoder and react subpaths while keeping ./client as a compatibility alias", async () => {
+	test("publishes legacy root aliases for ./client and ./http while keeping ./react distinct", async () => {
 		const packageJson = JSON.parse(
 			readFileSync(new URL("../package.json", import.meta.url), "utf8"),
 		) as {
@@ -15,9 +15,9 @@ describe("@wp-typia/rest export contracts", () => {
 			types: "./dist/index.d.ts",
 		});
 		expect(packageJson.exports?.["./http"]).toEqual({
-			default: "./dist/http.js",
-			import: "./dist/http.js",
-			types: "./dist/http.d.ts",
+			default: "./dist/index.js",
+			import: "./dist/index.js",
+			types: "./dist/index.d.ts",
 		});
 		expect(packageJson.exports?.["./react"]).toEqual({
 			default: "./dist/react.js",
@@ -39,8 +39,8 @@ describe("@wp-typia/rest export contracts", () => {
 		expect(typeof restRoot.createHeadersDecoder).toBe("function");
 		expect(typeof restClient.callEndpoint).toBe("function");
 		expect(typeof restClient.createHeadersDecoder).toBe("function");
+		expect(typeof restHttp.callEndpoint).toBe("function");
 		expect(typeof restHttp.createHeadersDecoder).toBe("function");
-		expect("callEndpoint" in restHttp).toBe(false);
 		expect(typeof restReact.useEndpointQuery).toBe("function");
 		expect("callEndpoint" in restReact).toBe(false);
 	});

--- a/packages/wp-typia-rest/tests/package-contracts.test.ts
+++ b/packages/wp-typia-rest/tests/package-contracts.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, test } from "bun:test";
+
+describe("@wp-typia/rest export contracts", () => {
+	test("publishes distinct decoder and react subpaths while keeping ./client as a compatibility alias", async () => {
+		const packageJson = JSON.parse(
+			readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+		) as {
+			exports?: Record<string, unknown>;
+		};
+
+		expect(packageJson.exports?.["./client"]).toEqual({
+			default: "./dist/index.js",
+			import: "./dist/index.js",
+			types: "./dist/index.d.ts",
+		});
+		expect(packageJson.exports?.["./http"]).toEqual({
+			default: "./dist/http.js",
+			import: "./dist/http.js",
+			types: "./dist/http.d.ts",
+		});
+		expect(packageJson.exports?.["./react"]).toEqual({
+			default: "./dist/react.js",
+			import: "./dist/react.js",
+			types: "./dist/react.d.ts",
+		});
+
+		const importRestClient = new Function(
+			'return import("@wp-typia/rest/client");',
+		) as () => Promise<Record<string, unknown>>;
+		const [restRoot, restClient, restHttp, restReact] = await Promise.all([
+			import("@wp-typia/rest"),
+			importRestClient(),
+			import("@wp-typia/rest/http"),
+			import("@wp-typia/rest/react"),
+		]);
+
+		expect(typeof restRoot.callEndpoint).toBe("function");
+		expect(typeof restRoot.createHeadersDecoder).toBe("function");
+		expect(typeof restClient.callEndpoint).toBe("function");
+		expect(typeof restClient.createHeadersDecoder).toBe("function");
+		expect(typeof restHttp.createHeadersDecoder).toBe("function");
+		expect("callEndpoint" in restHttp).toBe(false);
+		expect(typeof restReact.useEndpointQuery).toBe("function");
+		expect("callEndpoint" in restReact).toBe(false);
+	});
+});

--- a/packages/wp-typia-rest/tests/package-contracts.test.ts
+++ b/packages/wp-typia-rest/tests/package-contracts.test.ts
@@ -44,4 +44,22 @@ describe("@wp-typia/rest export contracts", () => {
 		expect(typeof restReact.useEndpointQuery).toBe("function");
 		expect("callEndpoint" in restReact).toBe(false);
 	});
+
+	test("built root entry preserves ESM-safe .js re-export specifiers", () => {
+		const builtIndexJs = readFileSync(
+			new URL("../dist/index.js", import.meta.url),
+			"utf8",
+		);
+		const builtIndexDts = readFileSync(
+			new URL("../dist/index.d.ts", import.meta.url),
+			"utf8",
+		);
+
+		expect(builtIndexJs).toContain('from "./client.js"');
+		expect(builtIndexJs).toContain('from "./errors.js"');
+		expect(builtIndexJs).toContain('from "./http.js"');
+		expect(builtIndexDts).toContain('from "./client.js"');
+		expect(builtIndexDts).toContain('from "./errors.js"');
+		expect(builtIndexDts).toContain('from "./http.js"');
+	});
 });

--- a/packages/wp-typia-rest/tests/react.test.tsx
+++ b/packages/wp-typia-rest/tests/react.test.tsx
@@ -9,6 +9,7 @@ import {
 
 import {
 	createEndpoint,
+	RestQueryHookUsageError,
 	toValidationResult,
 	type ValidationLike,
 } from "../src/index";
@@ -155,6 +156,29 @@ afterEach(() => {
 });
 
 describe("@wp-typia/rest/react", () => {
+	test("useEndpointQuery throws a named usage error for non-GET endpoints", async () => {
+		const endpoint = createEndpoint<{ title: string }, { ok: boolean }>({
+			method: "POST",
+			path: "/demo/v1/items",
+			validateRequest: (input: unknown) =>
+				typeof input === "object" &&
+				input !== null &&
+				typeof (input as { title?: unknown }).title === "string"
+					? toValidationResult(success(input as { title: string }))
+					: toValidationResult(failure<{ title: string }>("{ title: string }", "$.title")),
+			validateResponse: (input: unknown) =>
+				typeof input === "object" &&
+				input !== null &&
+				(input as { ok?: unknown }).ok === true
+					? toValidationResult(success(input as { ok: boolean }))
+					: toValidationResult(failure<{ ok: boolean }>("{ ok: true }", "$.ok")),
+		});
+
+		await expect(
+			createHookRenderer(() => useEndpointQuery(endpoint, { title: "Hello" })),
+		).rejects.toBeInstanceOf(RestQueryHookUsageError);
+	});
+
 	test("useEndpointQuery performs the initial fetch and reuses cached data across consumers", async () => {
 		let fetchCount = 0;
 		const endpoint = createEndpoint<{ page: number }, { count: number }>({
@@ -261,7 +285,7 @@ describe("@wp-typia/rest/react", () => {
 		await renderer.unmount();
 	});
 
-	test("useEndpointQuery throws for non-GET endpoints", () => {
+	test("renderToString also surfaces the named usage error for non-GET endpoints", () => {
 		const endpoint = createEndpoint<{ title: string }, { ok: boolean }>({
 			method: "POST",
 			path: "/demo/v1/items",
@@ -286,7 +310,7 @@ describe("@wp-typia/rest/react", () => {
 					return null;
 				}),
 			),
-		).toThrow("useEndpointQuery only supports GET endpoints in v1.");
+		).toThrow(RestQueryHookUsageError);
 	});
 
 	test("invalidate and refetch trigger fresh query execution", async () => {

--- a/packages/wp-typia-rest/tests/rest.test.ts
+++ b/packages/wp-typia-rest/tests/rest.test.ts
@@ -7,6 +7,9 @@ import {
 } from "../../wp-typia-api-client/src/index";
 
 import {
+	RestConfigurationError,
+	RestRootResolutionError,
+	RestValidationAssertionError,
 	callEndpoint,
 	createEndpoint,
 	createHeadersDecoder,
@@ -38,6 +41,28 @@ function asApiFetch(fn: (...args: any[]) => Promise<unknown>): ApiFetch {
 }
 
 describe("@wp-typia/rest", () => {
+	test("throws named public runtime errors for configuration and assertion faults", async () => {
+		const fetcher = createValidatedFetch<{ count: number }>((input: unknown) =>
+			typeof input === "object" &&
+			input !== null &&
+			typeof (input as { count?: unknown }).count === "number"
+				? success(input as { count: number })
+				: failure<{ count: number }>("{ count: number }", "$.count"),
+		);
+		const rejectingAssertionFetcher = createValidatedFetch<{ count: number }>(
+			() => failure<{ count: number }>("{ count: number }", "$.count"),
+			asApiFetch(async () => ({ ok: false }) as never),
+		);
+
+		expect(() => resolveRestRouteUrl("/demo")).toThrow(RestRootResolutionError);
+		await expect(fetcher.fetch({} as never)).rejects.toBeInstanceOf(
+			RestConfigurationError,
+		);
+		await expect(
+			rejectingAssertionFetcher.assertFetch({ path: "/demo" }),
+		).rejects.toBeInstanceOf(RestValidationAssertionError);
+	});
+
 	test("createValidatedFetch validates parsed responses", async () => {
 		const fetcher = createValidatedFetch<{ count: number }>(
 			(input: unknown) =>

--- a/tests/unit/error-export-contracts.test.ts
+++ b/tests/unit/error-export-contracts.test.ts
@@ -29,10 +29,13 @@ describe("repository error and export contracts", () => {
 		expect(contractGuide).toContain("RestRootResolutionError");
 		expect(contractGuide).toContain("@wp-typia/rest/client");
 		expect(contractGuide).toContain("@wp-typia/rest/http");
+		expect(contractGuide).toContain("compatibility alias");
 		expect(importPolicy).toContain("@wp-typia/api-client");
 		expect(importPolicy).toContain("@wp-typia/rest/http");
+		expect(importPolicy).toContain("Compatibility alias of the root");
 		expect(importPolicy).toContain("RestQueryHookUsageError");
 		expect(runtimeSurface).toContain("@wp-typia/rest/client");
+		expect(runtimeSurface).toContain("`./client` and `./http` are compatibility-only aliases");
 		expect(runtimeSurface).toContain("@wp-typia/api-client/runtime-primitives");
 	});
 });

--- a/tests/unit/error-export-contracts.test.ts
+++ b/tests/unit/error-export-contracts.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, test } from "bun:test";
+
+describe("repository error and export contracts", () => {
+	test("documents the chosen error taxonomy and runtime subpath semantics", () => {
+		const readme = readFileSync(new URL("../../README.md", import.meta.url), "utf8");
+		const apiGuide = readFileSync(new URL("../../docs/API.md", import.meta.url), "utf8");
+		const contractGuide = readFileSync(
+			new URL("../../docs/error-export-contracts.md", import.meta.url),
+			"utf8",
+		);
+		const importPolicy = readFileSync(
+			new URL("../../docs/runtime-import-policy.md", import.meta.url),
+			"utf8",
+		);
+		const runtimeSurface = readFileSync(
+			new URL("../../docs/runtime-surface.md", import.meta.url),
+			"utf8",
+		);
+
+		expect(readme).toContain("Error and Export Contract Guide");
+		expect(apiGuide).toContain("@wp-typia/rest/http");
+		expect(apiGuide).toContain("@wp-typia/rest/client");
+		expect(apiGuide).toContain("WpTypiaContractError");
+		expect(contractGuide).toContain("ValidationResult<T>");
+		expect(contractGuide).toContain("EndpointValidationResult<Req, Res>");
+		expect(contractGuide).toContain("WpTypiaContractError");
+		expect(contractGuide).toContain("ApiClientConfigurationError");
+		expect(contractGuide).toContain("RestRootResolutionError");
+		expect(contractGuide).toContain("@wp-typia/rest/client");
+		expect(contractGuide).toContain("@wp-typia/rest/http");
+		expect(importPolicy).toContain("@wp-typia/api-client");
+		expect(importPolicy).toContain("@wp-typia/rest/http");
+		expect(importPolicy).toContain("RestQueryHookUsageError");
+		expect(runtimeSurface).toContain("@wp-typia/rest/client");
+		expect(runtimeSurface).toContain("@wp-typia/api-client/runtime-primitives");
+	});
+});


### PR DESCRIPTION
## Summary
- add explicit runtime error classes for api-client and rest configuration/assertion paths
- clarify `@wp-typia/rest` root/client/http/react export semantics and document the contract
- add regression tests and changeset coverage for repository-wide error/export guidance

Closes #248

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guides clarifying error handling contracts and export surface semantics for public APIs.
  * Updated package documentation with runtime error types and subpath export aliases.

* **New Features**
  * Introduced named error classes for configuration failures, validation assertions, and runtime errors, enabling precise error handling across packages.

* **Tests**
  * Added contract verification tests for error types and export surfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->