### PR TITLE
docs: formalize AI-friendly block generator architecture

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,7 @@ bun run docs:build
 - [`README.md`](./README.md) is the main product/audience entry point
 - [`UPGRADE.md`](./UPGRADE.md) collects high-signal maintainer upgrade notes
 - [`SECURITY.md`](./SECURITY.md) explains private vulnerability reporting
+- [`docs/block-generator-architecture.md`](./docs/block-generator-architecture.md) records the typed generator architecture and phase map
 - [`docs/formatting-toolchain-policy.md`](./docs/formatting-toolchain-policy.md) records the formatter baseline and CI gate
 - [`docs/maintenance-automation-policy.md`](./docs/maintenance-automation-policy.md) records the dependency update and audit baseline
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ npx wp-typia create my-block --template @scope/create-block-template --variant h
 ## Documentation
 
 - [Architecture Guide](docs/architecture.md)
+- [Block Generator Architecture](docs/block-generator-architecture.md)
 - [API Guide](docs/API.md)
 - [Migration Guide](docs/migrations.md)
 - [Error and Export Contract Guide](docs/error-export-contracts.md)

--- a/docs/API.md
+++ b/docs/API.md
@@ -195,11 +195,13 @@ Use these packages instead:
 - `@wp-typia/project-tools` for project orchestration and programmatic runtime helpers
 - `@wp-typia/block-runtime/*` for generated-project runtime helpers
 
-For the current generator architecture boundary, including the split between
-emitter-owned built-in structural/source files and Mustache-owned shared
-project/bootstrap assets, and the fact that built-in templates no longer ship
-structural, TS/TSX, style, or block-local `render.php` Mustache files, see
-[`docs/block-generator-service.md`](./block-generator-service.md).
+For the current generator architecture boundary, including the staged
+`BlockSpec` / `BlockGeneratorService` contract, the current phase status, and
+the split between emitter-owned built-in artifacts and Mustache-owned shared
+project/bootstrap assets, see:
+
+- [`docs/block-generator-architecture.md`](./block-generator-architecture.md)
+- [`docs/block-generator-service.md`](./block-generator-service.md)
 
 ## 3. `@wp-typia/block-types`
 

--- a/docs/block-generator-architecture.md
+++ b/docs/block-generator-architecture.md
@@ -106,6 +106,9 @@ Agentica-, MCP-, or other structured tool controllers.
 import { BlockGeneratorService } from '@wp-typia/project-tools';
 
 const service = new BlockGeneratorService();
+const answers = {
+  // minimal scaffold answers for demonstration
+};
 
 const plan = await service.plan({
   answers,

--- a/docs/block-generator-architecture.md
+++ b/docs/block-generator-architecture.md
@@ -1,0 +1,173 @@
+# AI-Friendly Block Generator Architecture
+
+This document is the architecture record for the typed built-in block generator
+that now powers `wp-typia`.
+
+It closes the design thread from issue `#193`: block generation is no longer a
+string-template-only pipeline, but it is also not an AST-first rewrite. The
+current architecture is intentionally hybrid.
+
+## Design goals
+
+- keep generation centered on typed semantic input instead of ad-hoc template
+  variables
+- preserve Typia-first validation and metadata projection as first-class
+  concerns
+- support AI/tool-driven generation through structured non-mutating stages
+- keep scaffold behavior backward-compatible while the generator evolves
+- use the simplest emitter strategy that is safe for each file type
+
+## Current architecture contract
+
+### `BlockSpec` is the semantic source of truth
+
+`BlockSpec` is the normalized semantic model for built-in block generation.
+
+It owns the parts of generation that matter structurally:
+
+- block identity: namespace, slug, text domain, PHP prefix
+- block metadata: title, description, keyword, icon, category
+- persistence intent: enabled/disabled, policy, storage mode, scope
+- runtime intent: migration UI and local-dev presets
+- built-in template family metadata
+
+Structural rules no longer live primarily in Mustache templates. Built-in
+generation now starts from a typed spec and only later renders files from that
+spec.
+
+### `BlockGeneratorService` is the orchestration boundary
+
+`BlockGeneratorService` is the stable internal service boundary for built-in
+block generation.
+
+It exposes four explicit stages:
+
+- `plan`
+  Normalize scaffold answers and built-in flags into a `BlockSpec`.
+- `validate`
+  Preserve invariants before rendering or workspace mutation.
+- `render`
+  Produce file-generation intent, emitter-owned artifacts, template variables,
+  and post-render hooks without mutating the workspace.
+- `apply`
+  Copy templates, write emitter-owned files, seed starter manifests, apply
+  migration/local-dev capabilities, normalize package-manager files, and
+  optionally install dependencies.
+
+That split is what makes the generator AI-friendly. Tooling can stop at
+`plan`, `validate`, or `render` and inspect a structured result before deciding
+whether to mutate the workspace.
+
+### Typia remains first-class
+
+The generator architecture is not a replacement for Typia. It is the layer that
+feeds Typia-driven metadata, schema, OpenAPI, PHP validator, and starter
+manifest flows from a better structural model.
+
+The contract is:
+
+- `src/types.ts` remains the authoring source of truth inside generated projects
+- built-in generation derives starter artifacts from the same semantic model
+- schema/OpenAPI/manifest/validator flows stay compatible with the existing
+  sync pipeline
+
+### Hybrid rendering stays intentional
+
+The generator is deliberately hybrid.
+
+Emitter-owned built-in artifacts:
+
+- `types.ts`
+- `block.json`
+- built-in TS/TSX scaffold bodies such as `edit.tsx`, `save.tsx`, `index.tsx`,
+  `hooks.ts`, `validators.ts`, `interactivity.ts`, and `children.ts`
+- built-in style assets and block-local `render.php`
+- starter `typia.manifest.json`
+
+Mustache-backed or copied/shared assets that still stay outside the typed
+emitter path:
+
+- project bootstrap and package-manager scaffolding
+- sync scripts and shared REST helpers
+- shared `_shared` project layers that are still copied/interpolated
+- external template composition
+- non-block `wp-typia add` generators such as variation, pattern,
+  binding-source, and hooked-block flows
+
+This keeps the architecture explicit without turning the migration into a
+template-engine replacement project.
+
+## Tool-facing usage model
+
+The current non-mutating service surface is already suitable for future
+Agentica-, MCP-, or other structured tool controllers.
+
+```ts
+import { BlockGeneratorService } from '@wp-typia/project-tools';
+
+const service = new BlockGeneratorService();
+
+const plan = await service.plan({
+  answers,
+  packageManager: 'bun',
+  projectDir: 'demo-block',
+  templateId: 'basic',
+});
+
+const validated = await service.validate({ plan });
+const rendered = await service.render({ validated });
+
+// Tooling can inspect rendered.spec, rendered.variables, rendered.warnings,
+// rendered.templateDir, and the planned post-render hooks here.
+
+await service.apply({ rendered });
+```
+
+That means the future AI/tool contract does not need a second generator. It
+only needs to expose the same staged boundary in a more formal controller
+interface.
+
+## Phase status
+
+The architecture in issue `#193` was implemented incrementally.
+
+- Phase 1: complete
+  `BlockSpec` and `BlockGeneratorService` were introduced as the typed
+  planning/validation/render/apply boundary.
+- Phase 2: complete
+  Built-in `types.ts` and `block.json` moved to typed emitters.
+- Phase 2.5: complete
+  Stale built-in structural Mustache files were removed and ownership
+  guardrails were added.
+- Phase 3: complete
+  Built-in TS/TSX scaffold bodies, built-in style assets, and block-local
+  `render.php` moved to emitter ownership for all built-in block families.
+- Phase 4: still open
+  The remaining follow-through is a formal tool/controller contract for
+  non-mutating generator usage plus architecture for external layer
+  composition, which now belongs with issue `#198`.
+
+## What this architecture does not do
+
+This design intentionally does not promise:
+
+- a full Mustache removal across every scaffold asset
+- AST-first emission or `ts-morph` as a baseline dependency
+- external `_shared` layer composition in the current built-in generator phase
+- a commitment that every internal helper becomes public API
+
+The public compatibility promise is still the root
+`@wp-typia/project-tools` orchestration surface plus the generated-project
+runtime surfaces under `@wp-typia/block-runtime/*`.
+
+## Relationship to the rest of the repo
+
+- [`docs/block-generator-service.md`](./block-generator-service.md)
+  describes the current concrete responsibility split inside the generator.
+- [`docs/API.md`](./API.md)
+  maps the public package surfaces that expose the generator boundary.
+- [`docs/runtime-import-policy.md`](./runtime-import-policy.md)
+  defines which imports are stable and which details stay internal.
+- Issue `#198`
+  remains the separate RFC for external template-layer composition on top of the
+  built-in shared scaffold model.

--- a/docs/block-generator-service.md
+++ b/docs/block-generator-service.md
@@ -3,6 +3,10 @@
 `BlockGeneratorService` is the typed generation boundary for built-in
 `wp-typia` block scaffolds.
 
+For the higher-level architecture record, phase map, and AI/tool-facing staged
+usage model, see
+[`docs/block-generator-architecture.md`](./block-generator-architecture.md).
+
 ## Current responsibility split
 
 - `BlockSpec`

--- a/docs/runtime-import-policy.md
+++ b/docs/runtime-import-policy.md
@@ -66,6 +66,10 @@ manager, starter manifest, schema/OpenAPI project helpers, the `BlockSpec` /
 structural/source path where built-in templates no longer ship structural,
 TS/TSX, style, or block-local `render.php` Mustache files.
 
+For the architecture record behind that boundary, including the staged
+non-mutating tool-facing contract and current phase map, see
+[`docs/block-generator-architecture.md`](./block-generator-architecture.md).
+
 `@wp-typia/block-runtime/schema-core` is public and stable, but it is the
 implementation owner path rather than the preferred project-tooling import.
 

--- a/docs/runtime-surface.md
+++ b/docs/runtime-surface.md
@@ -74,7 +74,9 @@ This document is descriptive, not normative. For support guarantees, see
   doctor, package-manager, starter-manifest, the typed generator boundary, the
   built-in structural/code emitters, and the preferred schema project imports.
   Built-in templates no longer ship structural, TS/TSX, style, or block-local
-  `render.php` Mustache files for those generated artifacts.
+  `render.php` Mustache files for those generated artifacts. The higher-level
+  generator architecture record lives in
+  [`docs/block-generator-architecture.md`](./block-generator-architecture.md).
 - `@wp-typia/block-runtime/*` owns generated-project runtime helpers directly,
   including the canonical `schema-core` implementation and shared
   manifest/migration contract types.

--- a/packages/wp-typia-project-tools/README.md
+++ b/packages/wp-typia-project-tools/README.md
@@ -50,4 +50,9 @@ files and starter `typia.manifest.json` now come from the emitter path, while
 project bootstrap/package-manager files, sync scripts, shared REST helpers, and
 the remaining non-block assets still come from Mustache-backed template copy.
 
+The higher-level generator architecture record, including the current phase map
+and the non-mutating `plan -> validate -> render -> apply` tool-facing usage
+model, lives in
+[`docs/block-generator-architecture.md`](../../docs/block-generator-architecture.md).
+
 If you need metadata sync, editor helpers, validation helpers, or other generated-project runtime utilities, import them directly from `@wp-typia/block-runtime/*`.

--- a/packages/wp-typia-project-tools/tests/import-policy.test.ts
+++ b/packages/wp-typia-project-tools/tests/import-policy.test.ts
@@ -196,20 +196,20 @@ describe('@wp-typia/project-tools import policy', () => {
     expect(
       blockRuntimePackageManifest.exports?.['./migration-types'],
     ).toBeDefined();
-    expect(migrationTypesSource).toContain(
-      'from "@wp-typia/block-runtime/migration-types"',
+    expect(migrationTypesSource).toMatch(
+      /from\s+['"]@wp-typia\/block-runtime\/migration-types['"]/,
     );
-    expect(templateRegistrySource).toContain(
-      'export const OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE = "@wp-typia/create-workspace-template";',
+    expect(templateRegistrySource).toMatch(
+      /export\s+const\s+OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE\s*=\s*['"]@wp-typia\/create-workspace-template['"]/,
     );
-    expect(templateSourceSource).not.toContain(
-      'const OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE = "@wp-typia/create-workspace-template";',
+    expect(templateSourceSource).not.toMatch(
+      /\bconst\s+OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE\b/,
     );
-    expect(cliScaffoldSource).not.toContain(
-      'const OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE = "@wp-typia/create-workspace-template";',
+    expect(cliScaffoldSource).not.toMatch(
+      /\bconst\s+OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE\b/,
     );
-    expect(scaffoldSource).not.toContain(
-      'const OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE = "@wp-typia/create-workspace-template";',
+    expect(scaffoldSource).not.toMatch(
+      /\bconst\s+OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE\b/,
     );
   });
 });

--- a/packages/wp-typia-project-tools/tests/import-policy.test.ts
+++ b/packages/wp-typia-project-tools/tests/import-policy.test.ts
@@ -1,176 +1,215 @@
-import { describe, expect, test } from "bun:test";
-import * as fs from "node:fs";
-import * as path from "node:path";
+import { describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
-const packageRoot = path.resolve(import.meta.dir, "..");
-const repoRoot = path.resolve(packageRoot, "..", "..");
+const packageRoot = path.resolve(import.meta.dir, '..');
+const repoRoot = path.resolve(packageRoot, '..', '..');
 
-describe("@wp-typia/project-tools import policy", () => {
-	test("exports project orchestration helpers without re-exporting generated runtime helpers", async () => {
-		const [
-			rootModule,
-			schemaCoreModule,
-			migrationTypesModule,
-			metadataCoreModule,
-		] = await Promise.all([
-			import("@wp-typia/project-tools"),
-			import("@wp-typia/project-tools/schema-core"),
-			import("@wp-typia/block-runtime/migration-types"),
-			import("@wp-typia/block-runtime/metadata-core"),
-		]);
+describe('@wp-typia/project-tools import policy', () => {
+  test('exports project orchestration helpers without re-exporting generated runtime helpers', async () => {
+    const [
+      rootModule,
+      schemaCoreModule,
+      migrationTypesModule,
+      metadataCoreModule,
+    ] = await Promise.all([
+      import('@wp-typia/project-tools'),
+      import('@wp-typia/project-tools/schema-core'),
+      import('@wp-typia/block-runtime/migration-types'),
+      import('@wp-typia/block-runtime/metadata-core'),
+    ]);
 
-		expect(typeof rootModule.collectScaffoldAnswers).toBe("function");
-		expect(typeof rootModule.BlockGeneratorService).toBe("function");
-		expect(typeof rootModule.formatAddHelpText).toBe("function");
-		expect(typeof rootModule.formatMigrationHelpText).toBe("function");
-		expect(typeof rootModule.getDoctorChecks).toBe("function");
-		expect(typeof rootModule.getTemplateById).toBe("function");
-		expect(typeof rootModule.listTemplates).toBe("function");
-		expect(typeof rootModule.parseMigrationArgs).toBe("function");
-		expect(typeof rootModule.projectJsonSchemaDocument).toBe("function");
-		expect(typeof rootModule.resolvePackageManagerId).toBe("function");
-		expect(typeof rootModule.runAddBlockCommand).toBe("function");
-		expect(typeof rootModule.runMigrationCommand).toBe("function");
-		expect(typeof rootModule.runScaffoldFlow).toBe("function");
-		expect(typeof schemaCoreModule.normalizeEndpointAuthDefinition).toBe("function");
-		expect(Object.keys(migrationTypesModule)).toEqual([]);
-		expect(typeof metadataCoreModule.defineEndpointManifest).toBe("function");
+    expect(typeof rootModule.collectScaffoldAnswers).toBe('function');
+    expect(typeof rootModule.BlockGeneratorService).toBe('function');
+    expect(typeof rootModule.formatAddHelpText).toBe('function');
+    expect(typeof rootModule.formatMigrationHelpText).toBe('function');
+    expect(typeof rootModule.getDoctorChecks).toBe('function');
+    expect(typeof rootModule.getTemplateById).toBe('function');
+    expect(typeof rootModule.listTemplates).toBe('function');
+    expect(typeof rootModule.parseMigrationArgs).toBe('function');
+    expect(typeof rootModule.projectJsonSchemaDocument).toBe('function');
+    expect(typeof rootModule.resolvePackageManagerId).toBe('function');
+    expect(typeof rootModule.runAddBlockCommand).toBe('function');
+    expect(typeof rootModule.runMigrationCommand).toBe('function');
+    expect(typeof rootModule.runScaffoldFlow).toBe('function');
+    expect(typeof schemaCoreModule.normalizeEndpointAuthDefinition).toBe(
+      'function',
+    );
+    expect(Object.keys(migrationTypesModule)).toEqual([]);
+    expect(typeof metadataCoreModule.defineEndpointManifest).toBe('function');
 
-		expect("applyTemplateDefaultsFromManifest" in rootModule).toBe(false);
-		expect("buildScaffoldBlockRegistration" in rootModule).toBe(false);
-		expect("createAttributeUpdater" in rootModule).toBe(false);
-		expect("createEditorModel" in rootModule).toBe(false);
-		expect("runSyncBlockMetadata" in rootModule).toBe(false);
-	});
+    expect('applyTemplateDefaultsFromManifest' in rootModule).toBe(false);
+    expect('buildScaffoldBlockRegistration' in rootModule).toBe(false);
+    expect('createAttributeUpdater' in rootModule).toBe(false);
+    expect('createEditorModel' in rootModule).toBe(false);
+    expect('runSyncBlockMetadata' in rootModule).toBe(false);
+  });
 
-	test("does not expose legacy runtime compatibility subpaths", async () => {
-		const packageManifest = JSON.parse(
-			fs.readFileSync(path.join(packageRoot, "package.json"), "utf8"),
-		) as {
-			bin?: Record<string, string>;
-			exports?: Record<string, unknown>;
-		};
+  test('does not expose legacy runtime compatibility subpaths', async () => {
+    const packageManifest = JSON.parse(
+      fs.readFileSync(path.join(packageRoot, 'package.json'), 'utf8'),
+    ) as {
+      bin?: Record<string, string>;
+      exports?: Record<string, unknown>;
+    };
 
-		expect(packageManifest.bin).toBeUndefined();
-		expect(packageManifest.exports?.["./cli"]).toBeUndefined();
-		expect(packageManifest.exports?.["./metadata-core"]).toBeUndefined();
-		expect(packageManifest.exports?.["./runtime/cli-core"]).toBeUndefined();
-		expect(packageManifest.exports?.["./runtime/schema-core"]).toBeUndefined();
+    expect(packageManifest.bin).toBeUndefined();
+    expect(packageManifest.exports?.['./cli']).toBeUndefined();
+    expect(packageManifest.exports?.['./metadata-core']).toBeUndefined();
+    expect(packageManifest.exports?.['./runtime/cli-core']).toBeUndefined();
+    expect(packageManifest.exports?.['./runtime/schema-core']).toBeUndefined();
 
-		const importRemovedCli = new Function(
-			"return import('@wp-typia/project-tools/cli');",
-		) as () => Promise<unknown>;
-		const importRemovedRuntime = new Function(
-			"return import('@wp-typia/project-tools/runtime/blocks');",
-		) as () => Promise<unknown>;
+    const importRemovedCli = new Function(
+      "return import('@wp-typia/project-tools/cli');",
+    ) as () => Promise<unknown>;
+    const importRemovedRuntime = new Function(
+      "return import('@wp-typia/project-tools/runtime/blocks');",
+    ) as () => Promise<unknown>;
 
-		await expect(importRemovedCli()).rejects.toThrow();
-		await expect(importRemovedRuntime()).rejects.toThrow();
-	});
+    await expect(importRemovedCli()).rejects.toThrow();
+    await expect(importRemovedRuntime()).rejects.toThrow();
+  });
 
-	test("public docs point to the new canonical package map", () => {
-		const projectToolsReadme = fs.readFileSync(
-			path.join(packageRoot, "README.md"),
-			"utf8",
-		);
-		const createReadme = fs.readFileSync(
-			path.join(repoRoot, "packages", "create", "README.md"),
-			"utf8",
-		);
-		const apiGuide = fs.readFileSync(path.join(repoRoot, "docs", "API.md"), "utf8");
-		const runtimeSurfaceDoc = fs.readFileSync(
-			path.join(repoRoot, "docs", "runtime-surface.md"),
-			"utf8",
-		);
-		const blockGeneratorDoc = fs.readFileSync(
-			path.join(repoRoot, "docs", "block-generator-service.md"),
-			"utf8",
-		);
-		const importPolicyDoc = fs.readFileSync(
-			path.join(repoRoot, "docs", "runtime-import-policy.md"),
-			"utf8",
-		);
+  test('public docs point to the new canonical package map', () => {
+    const projectToolsReadme = fs.readFileSync(
+      path.join(packageRoot, 'README.md'),
+      'utf8',
+    );
+    const createReadme = fs.readFileSync(
+      path.join(repoRoot, 'packages', 'create', 'README.md'),
+      'utf8',
+    );
+    const apiGuide = fs.readFileSync(
+      path.join(repoRoot, 'docs', 'API.md'),
+      'utf8',
+    );
+    const runtimeSurfaceDoc = fs.readFileSync(
+      path.join(repoRoot, 'docs', 'runtime-surface.md'),
+      'utf8',
+    );
+    const blockGeneratorDoc = fs.readFileSync(
+      path.join(repoRoot, 'docs', 'block-generator-service.md'),
+      'utf8',
+    );
+    const blockGeneratorArchitectureDoc = fs.readFileSync(
+      path.join(repoRoot, 'docs', 'block-generator-architecture.md'),
+      'utf8',
+    );
+    const importPolicyDoc = fs.readFileSync(
+      path.join(repoRoot, 'docs', 'runtime-import-policy.md'),
+      'utf8',
+    );
 
-		expect(projectToolsReadme).toContain("@wp-typia/project-tools");
-		expect(projectToolsReadme).toContain("@wp-typia/project-tools/schema-core");
-		expect(projectToolsReadme).toContain("BlockGeneratorService");
-		expect(projectToolsReadme).toContain("@wp-typia/block-runtime/*");
-		expect(projectToolsReadme).toContain("@wp-typia/block-runtime/migration-types");
-		expect(projectToolsReadme).toContain("@wp-typia/block-runtime/schema-core");
-		expect(createReadme).toContain("deprecated legacy package shell");
-		expect(createReadme).toContain("@wp-typia/project-tools");
-		expect(createReadme).toContain("@wp-typia/project-tools/schema-core");
-		expect(apiGuide).toContain("@wp-typia/project-tools");
-		expect(apiGuide).toContain("BlockGeneratorService");
-		expect(apiGuide).toContain("@wp-typia/project-tools/schema-core");
-		expect(apiGuide).toContain("@wp-typia/block-runtime/metadata-core");
-		expect(runtimeSurfaceDoc).toContain("@wp-typia/project-tools");
-		expect(runtimeSurfaceDoc).toContain("BlockGeneratorService");
-		expect(runtimeSurfaceDoc).toContain("@wp-typia/project-tools/schema-core");
-		expect(runtimeSurfaceDoc).toContain("@wp-typia/block-runtime/migration-types");
-		expect(runtimeSurfaceDoc).toContain("@wp-typia/block-runtime/schema-core");
-		expect(runtimeSurfaceDoc).toContain(
-			"no longer ship structural, TS/TSX, style, or block-local",
-		);
-		expect(runtimeSurfaceDoc).toContain("render.php` Mustache files");
-		expect(blockGeneratorDoc).toContain(
-			"built-in templates no longer ship structural, TS/TSX, style, or block-local",
-		);
-		expect(runtimeSurfaceDoc).not.toContain("@wp-typia/project-tools/runtime/*");
-		expect(importPolicyDoc).toContain("@wp-typia/project-tools");
-		expect(importPolicyDoc).toContain("BlockGeneratorService");
-		expect(importPolicyDoc).toContain("@wp-typia/project-tools/schema-core");
-		expect(importPolicyDoc).toContain("@wp-typia/block-runtime/migration-types");
-		expect(importPolicyDoc).toContain("@wp-typia/block-runtime/schema-core");
-		expect(importPolicyDoc).toContain("built-in templates no longer ship");
-		expect(importPolicyDoc).toContain("structural,");
-		expect(importPolicyDoc).toContain("render.php` Mustache files");
-		expect(importPolicyDoc).not.toContain("@wp-typia/project-tools/runtime/*");
-	});
+    expect(projectToolsReadme).toContain('@wp-typia/project-tools');
+    expect(projectToolsReadme).toContain('@wp-typia/project-tools/schema-core');
+    expect(projectToolsReadme).toContain('BlockGeneratorService');
+    expect(projectToolsReadme).toContain('@wp-typia/block-runtime/*');
+    expect(projectToolsReadme).toContain(
+      '@wp-typia/block-runtime/migration-types',
+    );
+    expect(projectToolsReadme).toContain('@wp-typia/block-runtime/schema-core');
+    expect(createReadme).toContain('deprecated legacy package shell');
+    expect(createReadme).toContain('@wp-typia/project-tools');
+    expect(createReadme).toContain('@wp-typia/project-tools/schema-core');
+    expect(apiGuide).toContain('@wp-typia/project-tools');
+    expect(apiGuide).toContain('BlockGeneratorService');
+    expect(apiGuide).toContain('docs/block-generator-architecture.md');
+    expect(apiGuide).toContain('@wp-typia/project-tools/schema-core');
+    expect(apiGuide).toContain('@wp-typia/block-runtime/metadata-core');
+    expect(runtimeSurfaceDoc).toContain('@wp-typia/project-tools');
+    expect(runtimeSurfaceDoc).toContain('BlockGeneratorService');
+    expect(runtimeSurfaceDoc).toContain('docs/block-generator-architecture.md');
+    expect(runtimeSurfaceDoc).toContain('@wp-typia/project-tools/schema-core');
+    expect(runtimeSurfaceDoc).toContain(
+      '@wp-typia/block-runtime/migration-types',
+    );
+    expect(runtimeSurfaceDoc).toContain('@wp-typia/block-runtime/schema-core');
+    expect(runtimeSurfaceDoc).toContain(
+      'no longer ship structural, TS/TSX, style, or block-local',
+    );
+    expect(runtimeSurfaceDoc).toContain('render.php` Mustache files');
+    expect(blockGeneratorDoc).toContain(
+      'built-in templates no longer ship structural, TS/TSX, style, or block-local',
+    );
+    expect(blockGeneratorDoc).toContain('docs/block-generator-architecture.md');
+    expect(blockGeneratorArchitectureDoc).toContain('BlockSpec');
+    expect(blockGeneratorArchitectureDoc).toContain('BlockGeneratorService');
+    expect(blockGeneratorArchitectureDoc).toContain('Agentica');
+    expect(blockGeneratorArchitectureDoc).toContain('MCP');
+    expect(blockGeneratorArchitectureDoc).toContain('plan');
+    expect(blockGeneratorArchitectureDoc).toContain('validate');
+    expect(blockGeneratorArchitectureDoc).toContain('render');
+    expect(blockGeneratorArchitectureDoc).toContain('apply');
+    expect(blockGeneratorArchitectureDoc).toContain('Phase 1: complete');
+    expect(blockGeneratorArchitectureDoc).toContain('Phase 3: complete');
+    expect(blockGeneratorArchitectureDoc).toContain('Phase 4: still open');
+    expect(runtimeSurfaceDoc).not.toContain(
+      '@wp-typia/project-tools/runtime/*',
+    );
+    expect(importPolicyDoc).toContain('@wp-typia/project-tools');
+    expect(importPolicyDoc).toContain('BlockGeneratorService');
+    expect(importPolicyDoc).toContain('docs/block-generator-architecture.md');
+    expect(importPolicyDoc).toContain('@wp-typia/project-tools/schema-core');
+    expect(importPolicyDoc).toContain(
+      '@wp-typia/block-runtime/migration-types',
+    );
+    expect(importPolicyDoc).toContain('@wp-typia/block-runtime/schema-core');
+    expect(importPolicyDoc).toContain('built-in templates no longer ship');
+    expect(importPolicyDoc).toContain('structural,');
+    expect(importPolicyDoc).toContain('render.php` Mustache files');
+    expect(importPolicyDoc).not.toContain('@wp-typia/project-tools/runtime/*');
+  });
 
-	test("shared migration contracts and workspace template identity have a single owner", () => {
-		const blockRuntimePackageManifest = JSON.parse(
-			fs.readFileSync(
-				path.join(repoRoot, "packages", "wp-typia-block-runtime", "package.json"),
-				"utf8",
-			),
-		) as { exports?: Record<string, unknown> };
-		const migrationTypesSource = fs.readFileSync(
-			path.join(packageRoot, "src", "runtime", "migration-types.ts"),
-			"utf8",
-		);
-		const templateRegistrySource = fs.readFileSync(
-			path.join(packageRoot, "src", "runtime", "template-registry.ts"),
-			"utf8",
-		);
-		const templateSourceSource = fs.readFileSync(
-			path.join(packageRoot, "src", "runtime", "template-source.ts"),
-			"utf8",
-		);
-		const cliScaffoldSource = fs.readFileSync(
-			path.join(packageRoot, "src", "runtime", "cli-scaffold.ts"),
-			"utf8",
-		);
-		const scaffoldSource = fs.readFileSync(
-			path.join(packageRoot, "src", "runtime", "scaffold.ts"),
-			"utf8",
-		);
+  test('shared migration contracts and workspace template identity have a single owner', () => {
+    const blockRuntimePackageManifest = JSON.parse(
+      fs.readFileSync(
+        path.join(
+          repoRoot,
+          'packages',
+          'wp-typia-block-runtime',
+          'package.json',
+        ),
+        'utf8',
+      ),
+    ) as { exports?: Record<string, unknown> };
+    const migrationTypesSource = fs.readFileSync(
+      path.join(packageRoot, 'src', 'runtime', 'migration-types.ts'),
+      'utf8',
+    );
+    const templateRegistrySource = fs.readFileSync(
+      path.join(packageRoot, 'src', 'runtime', 'template-registry.ts'),
+      'utf8',
+    );
+    const templateSourceSource = fs.readFileSync(
+      path.join(packageRoot, 'src', 'runtime', 'template-source.ts'),
+      'utf8',
+    );
+    const cliScaffoldSource = fs.readFileSync(
+      path.join(packageRoot, 'src', 'runtime', 'cli-scaffold.ts'),
+      'utf8',
+    );
+    const scaffoldSource = fs.readFileSync(
+      path.join(packageRoot, 'src', 'runtime', 'scaffold.ts'),
+      'utf8',
+    );
 
-		expect(blockRuntimePackageManifest.exports?.["./migration-types"]).toBeDefined();
-		expect(migrationTypesSource).toContain(
-			'from "@wp-typia/block-runtime/migration-types"',
-		);
-		expect(templateRegistrySource).toContain(
-			'export const OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE = "@wp-typia/create-workspace-template";',
-		);
-		expect(templateSourceSource).not.toContain(
-			'const OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE = "@wp-typia/create-workspace-template";',
-		);
-		expect(cliScaffoldSource).not.toContain(
-			'const OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE = "@wp-typia/create-workspace-template";',
-		);
-		expect(scaffoldSource).not.toContain(
-			'const OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE = "@wp-typia/create-workspace-template";',
-		);
-	});
+    expect(
+      blockRuntimePackageManifest.exports?.['./migration-types'],
+    ).toBeDefined();
+    expect(migrationTypesSource).toContain(
+      'from "@wp-typia/block-runtime/migration-types"',
+    );
+    expect(templateRegistrySource).toContain(
+      'export const OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE = "@wp-typia/create-workspace-template";',
+    );
+    expect(templateSourceSource).not.toContain(
+      'const OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE = "@wp-typia/create-workspace-template";',
+    );
+    expect(cliScaffoldSource).not.toContain(
+      'const OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE = "@wp-typia/create-workspace-template";',
+    );
+    expect(scaffoldSource).not.toContain(
+      'const OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE = "@wp-typia/create-workspace-template";',
+    );
+  });
 });

--- a/tests/unit/repo-dx-baseline.test.ts
+++ b/tests/unit/repo-dx-baseline.test.ts
@@ -5,139 +5,208 @@ import path from 'node:path';
 const repoRoot = path.resolve(import.meta.dir, '..', '..');
 
 function readJson(relativePath: string): Record<string, unknown> {
-	return JSON.parse(fs.readFileSync(path.join(repoRoot, relativePath), 'utf8')) as Record<string, unknown>;
+  return JSON.parse(
+    fs.readFileSync(path.join(repoRoot, relativePath), 'utf8'),
+  ) as Record<string, unknown>;
 }
 
 describe('repository DX baseline', () => {
-	test('root package scripts expose maintainer aggregate commands', () => {
-		const packageJson = readJson('package.json');
-		const scripts = packageJson.scripts as Record<string, string>;
+  test('root package scripts expose maintainer aggregate commands', () => {
+    const packageJson = readJson('package.json');
+    const scripts = packageJson.scripts as Record<string, string>;
 
-		expect(scripts['lint:repo']).toBeDefined();
-		expect(scripts['lint:all']).toBeDefined();
-		expect(scripts['format:check']).toBeDefined();
-		expect(scripts['maintenance-automation:validate']).toBe(
-			'node scripts/validate-maintenance-automation-policy.mjs',
-		);
-		expect(scripts['formatting-policy:validate']).toBe(
-			'node scripts/validate-formatting-toolchain-policy.mjs',
-		);
-		expect(scripts['test:all']).toBeDefined();
-		expect(scripts['ci:local']).toBeDefined();
-		expect(scripts['ci:local']).toContain('bun run maintenance-automation:validate');
-		expect(scripts['ci:local']).toContain('bun run formatting-policy:validate');
-		expect(scripts['ci:local']).toContain('bun run format:check');
-		expect(scripts['typescript-runtime:validate']).toBe(
-			'node scripts/validate-typescript-runtime-dependency-placement.mjs',
-		);
-		expect(scripts['examples:build']).toBe('node scripts/run-clean-examples-build.mjs');
-	});
+    expect(scripts['lint:repo']).toBeDefined();
+    expect(scripts['lint:all']).toBeDefined();
+    expect(scripts['format:check']).toBeDefined();
+    expect(scripts['maintenance-automation:validate']).toBe(
+      'node scripts/validate-maintenance-automation-policy.mjs',
+    );
+    expect(scripts['formatting-policy:validate']).toBe(
+      'node scripts/validate-formatting-toolchain-policy.mjs',
+    );
+    expect(scripts['test:all']).toBeDefined();
+    expect(scripts['ci:local']).toBeDefined();
+    expect(scripts['ci:local']).toContain(
+      'bun run maintenance-automation:validate',
+    );
+    expect(scripts['ci:local']).toContain('bun run formatting-policy:validate');
+    expect(scripts['ci:local']).toContain('bun run format:check');
+    expect(scripts['typescript-runtime:validate']).toBe(
+      'node scripts/validate-typescript-runtime-dependency-placement.mjs',
+    );
+    expect(scripts['examples:build']).toBe(
+      'node scripts/run-clean-examples-build.mjs',
+    );
+  });
 
-	test('root ESLint scope stays on repo infrastructure while examples keep wp-scripts ownership', () => {
-		const packageJson = readJson('package.json');
-		const scripts = packageJson.scripts as Record<string, string>;
-		const eslintConfig = fs.readFileSync(path.join(repoRoot, 'eslint.config.mjs'), 'utf8');
+  test('root ESLint scope stays on repo infrastructure while examples keep wp-scripts ownership', () => {
+    const packageJson = readJson('package.json');
+    const scripts = packageJson.scripts as Record<string, string>;
+    const eslintConfig = fs.readFileSync(
+      path.join(repoRoot, 'eslint.config.mjs'),
+      'utf8',
+    );
 
-		expect(eslintConfig).toContain('scripts/**/*');
-		expect(eslintConfig).toContain('tests/**/*');
-		expect(eslintConfig).toMatch(/const repoIgnores = \[[\s\S]*["']examples\/\*\*["']/);
-		expect(scripts).toHaveProperty('examples:lint');
-		expect(scripts['examples:lint']).toContain('ESLINT_USE_FLAT_CONFIG=false');
-	});
+    expect(eslintConfig).toContain('scripts/**/*');
+    expect(eslintConfig).toContain('tests/**/*');
+    expect(eslintConfig).toMatch(
+      /const repoIgnores = \[[\s\S]*["']examples\/\*\*["']/,
+    );
+    expect(scripts).toHaveProperty('examples:lint');
+    expect(scripts['examples:lint']).toContain('ESLINT_USE_FLAT_CONFIG=false');
+  });
 
-	test('.vscode workspace baseline exists', () => {
-		expect(fs.existsSync(path.join(repoRoot, '.vscode', 'extensions.json'))).toBe(true);
-		expect(fs.existsSync(path.join(repoRoot, '.vscode', 'settings.json'))).toBe(true);
-	});
+  test('.vscode workspace baseline exists', () => {
+    expect(
+      fs.existsSync(path.join(repoRoot, '.vscode', 'extensions.json')),
+    ).toBe(true);
+    expect(fs.existsSync(path.join(repoRoot, '.vscode', 'settings.json'))).toBe(
+      true,
+    );
+  });
 
-	test('repo meta docs and GitHub templates exist', () => {
-		expect(fs.existsSync(path.join(repoRoot, 'UPGRADE.md'))).toBe(true);
-		expect(fs.existsSync(path.join(repoRoot, 'SECURITY.md'))).toBe(true);
-		expect(
-			fs.existsSync(path.join(repoRoot, 'docs', 'formatting-toolchain-policy.md')),
-		).toBe(true);
-		expect(
-			fs.existsSync(path.join(repoRoot, 'docs', 'maintenance-automation-policy.md')),
-		).toBe(true);
-		expect(fs.existsSync(path.join(repoRoot, '.github', 'dependabot.yml'))).toBe(true);
-		expect(
-			fs.existsSync(path.join(repoRoot, '.github', 'workflows', 'dependency-audit.yml')),
-		).toBe(true);
-		expect(fs.existsSync(path.join(repoRoot, '.github', 'PULL_REQUEST_TEMPLATE.md'))).toBe(true);
-		expect(fs.existsSync(path.join(repoRoot, '.github', 'ISSUE_TEMPLATE', 'bug-report.yml'))).toBe(
-			true,
-		);
-		expect(
-			fs.existsSync(path.join(repoRoot, '.github', 'ISSUE_TEMPLATE', 'feature-request.yml')),
-		).toBe(true);
-		expect(
-			fs.existsSync(path.join(repoRoot, '.github', 'ISSUE_TEMPLATE', 'docs-process.yml')),
-		).toBe(true);
-		expect(fs.existsSync(path.join(repoRoot, '.github', 'ISSUE_TEMPLATE', 'config.yml'))).toBe(
-			true,
-		);
-	});
+  test('repo meta docs and GitHub templates exist', () => {
+    expect(fs.existsSync(path.join(repoRoot, 'UPGRADE.md'))).toBe(true);
+    expect(fs.existsSync(path.join(repoRoot, 'SECURITY.md'))).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(repoRoot, 'docs', 'formatting-toolchain-policy.md'),
+      ),
+    ).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(repoRoot, 'docs', 'maintenance-automation-policy.md'),
+      ),
+    ).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(repoRoot, 'docs', 'block-generator-architecture.md'),
+      ),
+    ).toBe(true);
+    expect(
+      fs.existsSync(path.join(repoRoot, '.github', 'dependabot.yml')),
+    ).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(repoRoot, '.github', 'workflows', 'dependency-audit.yml'),
+      ),
+    ).toBe(true);
+    expect(
+      fs.existsSync(path.join(repoRoot, '.github', 'PULL_REQUEST_TEMPLATE.md')),
+    ).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(repoRoot, '.github', 'ISSUE_TEMPLATE', 'bug-report.yml'),
+      ),
+    ).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(repoRoot, '.github', 'ISSUE_TEMPLATE', 'feature-request.yml'),
+      ),
+    ).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(repoRoot, '.github', 'ISSUE_TEMPLATE', 'docs-process.yml'),
+      ),
+    ).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(repoRoot, '.github', 'ISSUE_TEMPLATE', 'config.yml'),
+      ),
+    ).toBe(true);
+  });
 
-	test('example build cleanliness guard exists', () => {
-		const guardScript = fs.readFileSync(
-			path.join(repoRoot, 'scripts', 'run-clean-examples-build.mjs'),
-			'utf8',
-		);
+  test('example build cleanliness guard exists', () => {
+    const guardScript = fs.readFileSync(
+      path.join(repoRoot, 'scripts', 'run-clean-examples-build.mjs'),
+      'utf8',
+    );
 
-		expect(guardScript).toContain('git');
-		expect(guardScript).toContain('Example builds modified files under examples/.');
-	});
+    expect(guardScript).toContain('git');
+    expect(guardScript).toContain(
+      'Example builds modified files under examples/.',
+    );
+  });
 
-	test('docs explain lint ownership and ci:local guidance', () => {
-		const readme = fs.readFileSync(path.join(repoRoot, 'README.md'), 'utf8');
-		const contributing = fs.readFileSync(path.join(repoRoot, 'CONTRIBUTING.md'), 'utf8');
-		const cliReadme = fs.readFileSync(path.join(repoRoot, 'packages', 'wp-typia', 'README.md'), 'utf8');
-		const workspaceWebpackTemplate = fs.readFileSync(
-			path.join(repoRoot, 'packages', 'create-workspace-template', 'webpack.config.js.mustache'),
-			'utf8',
-		);
+  test('docs explain lint ownership and ci:local guidance', () => {
+    const readme = fs.readFileSync(path.join(repoRoot, 'README.md'), 'utf8');
+    const contributing = fs.readFileSync(
+      path.join(repoRoot, 'CONTRIBUTING.md'),
+      'utf8',
+    );
+    const cliReadme = fs.readFileSync(
+      path.join(repoRoot, 'packages', 'wp-typia', 'README.md'),
+      'utf8',
+    );
+    const workspaceWebpackTemplate = fs.readFileSync(
+      path.join(
+        repoRoot,
+        'packages',
+        'create-workspace-template',
+        'webpack.config.js.mustache',
+      ),
+      'utf8',
+    );
 
-		expect(readme).toContain('bun run ci:local');
-		expect(readme).toContain('Root ESLint covers repository infrastructure code');
-		expect(readme).toContain('[Formatting Toolchain Policy](docs/formatting-toolchain-policy.md)');
-		expect(readme).toContain('[Maintenance Automation Policy](docs/maintenance-automation-policy.md)');
-		expect(readme).toContain('Prettier 3.8.2');
-		expect(readme).toContain('bun run maintenance-automation:validate');
-		expect(readme).toContain('bun run formatting-policy:validate');
-		expect(readme).toContain('## Who this is for');
-		expect(readme).toContain('[Upgrade Guide](UPGRADE.md)');
-		expect(readme).toContain('[Security Policy](SECURITY.md)');
-		expect(contributing).toContain('Linting ownership is intentionally split');
-		expect(contributing).toContain('Formatting ownership is also explicit');
-		expect(contributing).toContain('Maintenance automation is explicit too');
-		expect(contributing).toContain('bun run lint:repo');
-		expect(contributing).toContain('bun run maintenance-automation:validate');
-		expect(contributing).toContain('bun run formatting-policy:validate');
-		expect(contributing).toContain('## Project meta docs');
-		expect(contributing).toContain('[`UPGRADE.md`](./UPGRADE.md)');
-		expect(contributing).toContain('[`SECURITY.md`](./SECURITY.md)');
-		expect(contributing).toContain(
-			'[`docs/formatting-toolchain-policy.md`](./docs/formatting-toolchain-policy.md)',
-		);
-		expect(contributing).toContain(
-			'[`docs/maintenance-automation-policy.md`](./docs/maintenance-automation-policy.md)',
-		);
-		expect(contributing).toContain('Dependabot');
-		expect(contributing).toContain('release/sampo');
-		expect(contributing).toContain('## Generated project toolchain matrix');
-		expect(contributing).toContain('## TypeScript runtime dependency audit');
-		expect(contributing).toContain('`bun run typescript-runtime:validate`');
-		expect(contributing).toContain('`@wp-typia/block-runtime` keeps `typescript` in `dependencies`');
-		expect(contributing).toContain('`@wp-typia/project-tools` keeps `typescript` in `dependencies`');
-		expect(contributing).toContain('`typia` 12.x');
-		expect(contributing).toContain('`@wordpress/scripts` 30.x');
-		expect(cliReadme).toMatch(
-			/https:\/\/github\.com\/[^/]+\/[^/]+\/blob\/[^/]+\/UPGRADE\.md/,
-		);
-		expect(cliReadme).toMatch(
-			/https:\/\/github\.com\/[^/]+\/[^/]+\/blob\/[^/]+\/SECURITY\.md/,
-		);
-		expect(workspaceWebpackTemplate).toContain('loadCompatibleTypiaWebpackPlugin');
-		expect(workspaceWebpackTemplate).toContain('projectRoot: process.cwd()');
-	});
+    expect(readme).toContain('bun run ci:local');
+    expect(readme).toContain(
+      '[Block Generator Architecture](docs/block-generator-architecture.md)',
+    );
+    expect(readme).toContain(
+      'Root ESLint covers repository infrastructure code',
+    );
+    expect(readme).toContain(
+      '[Formatting Toolchain Policy](docs/formatting-toolchain-policy.md)',
+    );
+    expect(readme).toContain(
+      '[Maintenance Automation Policy](docs/maintenance-automation-policy.md)',
+    );
+    expect(readme).toContain('Prettier 3.8.2');
+    expect(readme).toContain('bun run maintenance-automation:validate');
+    expect(readme).toContain('bun run formatting-policy:validate');
+    expect(readme).toContain('## Who this is for');
+    expect(readme).toContain('[Upgrade Guide](UPGRADE.md)');
+    expect(readme).toContain('[Security Policy](SECURITY.md)');
+    expect(contributing).toContain('Linting ownership is intentionally split');
+    expect(contributing).toContain('Formatting ownership is also explicit');
+    expect(contributing).toContain('Maintenance automation is explicit too');
+    expect(contributing).toContain('bun run lint:repo');
+    expect(contributing).toContain('bun run maintenance-automation:validate');
+    expect(contributing).toContain('bun run formatting-policy:validate');
+    expect(contributing).toContain('## Project meta docs');
+    expect(contributing).toContain('[`UPGRADE.md`](./UPGRADE.md)');
+    expect(contributing).toContain('[`SECURITY.md`](./SECURITY.md)');
+    expect(contributing).toContain(
+      '[`docs/block-generator-architecture.md`](./docs/block-generator-architecture.md)',
+    );
+    expect(contributing).toContain(
+      '[`docs/formatting-toolchain-policy.md`](./docs/formatting-toolchain-policy.md)',
+    );
+    expect(contributing).toContain(
+      '[`docs/maintenance-automation-policy.md`](./docs/maintenance-automation-policy.md)',
+    );
+    expect(contributing).toContain('Dependabot');
+    expect(contributing).toContain('release/sampo');
+    expect(contributing).toContain('## Generated project toolchain matrix');
+    expect(contributing).toContain('## TypeScript runtime dependency audit');
+    expect(contributing).toContain('`bun run typescript-runtime:validate`');
+    expect(contributing).toContain(
+      '`@wp-typia/block-runtime` keeps `typescript` in `dependencies`',
+    );
+    expect(contributing).toContain(
+      '`@wp-typia/project-tools` keeps `typescript` in `dependencies`',
+    );
+    expect(contributing).toContain('`typia` 12.x');
+    expect(contributing).toContain('`@wordpress/scripts` 30.x');
+    expect(cliReadme).toMatch(
+      /https:\/\/github\.com\/[^/]+\/[^/]+\/blob\/[^/]+\/UPGRADE\.md/,
+    );
+    expect(cliReadme).toMatch(
+      /https:\/\/github\.com\/[^/]+\/[^/]+\/blob\/[^/]+\/SECURITY\.md/,
+    );
+    expect(workspaceWebpackTemplate).toContain(
+      'loadCompatibleTypiaWebpackPlugin',
+    );
+    expect(workspaceWebpackTemplate).toContain('projectRoot: process.cwd()');
+  });
 });


### PR DESCRIPTION
## Summary
- formalize the typed built-in block generator architecture shipped through phases 1-3
- document the staged BlockSpec -> BlockGeneratorService -> emitter ownership model for AI and tooling consumers
- link the new architecture record through repo docs and lock it in with import-policy and repo DX tests

## Testing
- bun test packages/wp-typia-project-tools/tests/import-policy.test.ts tests/unit/repo-dx-baseline.test.ts
- bun run docs:build
- bun run ci:local

Closes #193

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive block generator architecture documentation with phase status map and staged tool usage model.
  * Updated multiple documentation pages with cross-references to the new architecture documentation for improved navigation and discoverability.
  * Enhanced documentation structure across README, contributing guidelines, and API documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->