### PR TITLE
docs: formalize external template-layer composition RFC

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,7 @@ bun run docs:build
 - [`UPGRADE.md`](./UPGRADE.md) collects high-signal maintainer upgrade notes
 - [`SECURITY.md`](./SECURITY.md) explains private vulnerability reporting
 - [`docs/block-generator-architecture.md`](./docs/block-generator-architecture.md) records the typed generator architecture and phase map
+- [`docs/external-template-layer-composition.md`](./docs/external-template-layer-composition.md) records the external layer package RFC on top of the built-in shared scaffold model
 - [`docs/formatting-toolchain-policy.md`](./docs/formatting-toolchain-policy.md) records the formatter baseline and CI gate
 - [`docs/maintenance-automation-policy.md`](./docs/maintenance-automation-policy.md) records the dependency update and audit baseline
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ npx wp-typia create my-block --template @scope/create-block-template --variant h
 
 - [Architecture Guide](docs/architecture.md)
 - [Block Generator Architecture](docs/block-generator-architecture.md)
+- [External Template-Layer Composition RFC](docs/external-template-layer-composition.md)
 - [API Guide](docs/API.md)
 - [Migration Guide](docs/migrations.md)
 - [Error and Export Contract Guide](docs/error-export-contracts.md)

--- a/docs/API.md
+++ b/docs/API.md
@@ -100,6 +100,11 @@ wp-typia create my-block --template @scope/create-block-template --variant hero 
 
 Security note: external template configs are trusted JavaScript and are executed during scaffold normalization. Treat local paths, GitHub locators, and npm package templates with the same trust model as `@wordpress/create-block`.
 
+That remote-template support is still seed-oriented. The separate RFC for
+reusable external layer packages on top of built-in shared scaffold layers lives
+in
+[`docs/external-template-layer-composition.md`](./external-template-layer-composition.md).
+
 Migration commands remain available inside migration-capable projects such as [`examples/my-typia-block`](../examples/my-typia-block):
 
 ```bash
@@ -202,6 +207,7 @@ project/bootstrap assets, see:
 
 - [`docs/block-generator-architecture.md`](./block-generator-architecture.md)
 - [`docs/block-generator-service.md`](./block-generator-service.md)
+- [`docs/external-template-layer-composition.md`](./external-template-layer-composition.md)
 
 ## 3. `@wp-typia/block-types`
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -92,6 +92,10 @@ runtime helper surface. Project orchestration lives in
 `@wp-typia/project-tools`, while `@wp-typia/create` remains only as a deprecated
 legacy package shell.
 
+Reusable third-party layer composition on top of this built-in shared model is
+tracked separately in
+[`docs/external-template-layer-composition.md`](./external-template-layer-composition.md).
+
 ## Intended Flow
 
 1. Scaffold a block with `wp-typia create`

--- a/docs/block-generator-architecture.md
+++ b/docs/block-generator-architecture.md
@@ -173,4 +173,5 @@ runtime surfaces under `@wp-typia/block-runtime/*`.
   defines which imports are stable and which details stay internal.
 - Issue `#198`
   remains the separate RFC for external template-layer composition on top of the
-  built-in shared scaffold model.
+  built-in shared scaffold model. See
+  [`docs/external-template-layer-composition.md`](./external-template-layer-composition.md).

--- a/docs/block-generator-service.md
+++ b/docs/block-generator-service.md
@@ -46,6 +46,8 @@ assets away from Mustache.
 ## Out of scope
 
 - external template composition
+- the external layer package contract recorded in
+  [`docs/external-template-layer-composition.md`](./external-template-layer-composition.md)
 - non-block `wp-typia add` generators such as variations, patterns,
   binding-sources, and hooked-blocks
 - full template-engine replacement

--- a/docs/external-template-layer-composition.md
+++ b/docs/external-template-layer-composition.md
@@ -1,0 +1,239 @@
+# External Template-Layer Composition RFC
+
+This document records the architecture contract for external template-layer
+composition on top of the built-in shared scaffold model.
+
+It closes the RFC thread from issue `#198`. The goal is not to replace the
+current scaffold pipeline or the existing remote-template adapter. The goal is
+to define how another package can extend the built-in shared layer graph
+without forking the whole scaffold system.
+
+## Design goals
+
+- keep built-in `_shared` layers as the canonical internal scaffold model
+- let external packages add reusable layers on top of that model
+- define deterministic `extends` and override rules
+- keep conflict handling explicit instead of implicit
+- preserve the current trust model for third-party template sources
+
+## What this RFC is and is not
+
+This RFC defines a package contract for reusable external scaffold layers.
+
+It does not:
+
+- replace current external template seed support
+- replace the typed built-in generator architecture from
+  [`docs/block-generator-architecture.md`](./block-generator-architecture.md)
+- change the official empty workspace template package contract
+- define the final CLI UX for selecting a composed external layer package
+
+The follow-up implementation work now lives in issue `#268`.
+
+## Relationship to current template support
+
+Today `wp-typia` supports three remote-template shapes:
+
+- a remote/local `wp-typia` template directory
+- an official create-block external template config
+- a create-block-style subset (`block.json` plus `src/index|edit|save`)
+
+Those flows are still seed-oriented. `wp-typia` normalizes them into a scaffold
+project and then re-applies its own package/tooling/runtime conventions around
+that seed.
+
+External template-layer composition is different:
+
+- it is layer-oriented instead of seed-oriented
+- it composes on top of built-in `_shared` scaffold layers
+- it does not replace built-in emitter ownership
+- it is intended for reusable agencies/vendors/community overlays rather than
+  one-off remote template forks
+
+## Package contract
+
+An external layer package should publish a root manifest named
+`wp-typia.layers.json`.
+
+The manifest is data, not executable code. A minimal shape is:
+
+```json
+{
+  "version": 1,
+  "layers": {
+    "acme/persistence-observability": {
+      "path": "layers/persistence-observability",
+      "extends": [
+        "builtin:shared/base",
+        "builtin:shared/rest-helpers/shared",
+        "builtin:shared/persistence/core"
+      ],
+      "description": "Adds shared observability files for persistence-capable blocks"
+    }
+  }
+}
+```
+
+### Manifest fields
+
+- `version`
+  Required. Initial contract version is `1`.
+- `layers`
+  Required object keyed by external layer id.
+- `layers.<id>.path`
+  Required relative directory path inside the package. It must stay within the
+  package root and may not resolve through symlinks.
+- `layers.<id>.extends`
+  Optional ordered array of ancestor layer ids. Ancestors may reference
+  canonical built-in ids or other external layer ids from the same package.
+- `layers.<id>.description`
+  Optional human-readable description.
+
+This RFC intentionally does not add package-level JavaScript transformers to
+the layer manifest. The manifest itself should stay statically inspectable.
+
+## Canonical built-in layer ids
+
+Built-in `_shared` layers remain the canonical internal model. The RFC maps
+those directories to stable layer ids using the rule:
+
+- `packages/wp-typia-project-tools/templates/_shared/<path>`
+- becomes `builtin:shared/<path>`
+
+Examples:
+
+- `templates/_shared/base`
+  -> `builtin:shared/base`
+- `templates/_shared/rest-helpers/shared`
+  -> `builtin:shared/rest-helpers/shared`
+- `templates/_shared/rest-helpers/public`
+  -> `builtin:shared/rest-helpers/public`
+- `templates/_shared/rest-helpers/auth`
+  -> `builtin:shared/rest-helpers/auth`
+- `templates/_shared/persistence/core`
+  -> `builtin:shared/persistence/core`
+- `templates/_shared/persistence/public`
+  -> `builtin:shared/persistence/public`
+- `templates/_shared/persistence/auth`
+  -> `builtin:shared/persistence/auth`
+- `templates/_shared/compound/core`
+  -> `builtin:shared/compound/core`
+- `templates/_shared/compound/persistence`
+  -> `builtin:shared/compound/persistence`
+- `templates/_shared/compound/persistence-public`
+  -> `builtin:shared/compound/persistence-public`
+- `templates/_shared/compound/persistence-auth`
+  -> `builtin:shared/compound/persistence-auth`
+- `templates/_shared/migration-ui/common`
+  -> `builtin:shared/migration-ui/common`
+- `templates/_shared/presets/wp-env`
+  -> `builtin:shared/presets/wp-env`
+- `templates/_shared/presets/test-preset`
+  -> `builtin:shared/presets/test-preset`
+- `templates/_shared/workspace/persistence-public`
+  -> `builtin:shared/workspace/persistence-public`
+- `templates/_shared/workspace/persistence-auth`
+  -> `builtin:shared/workspace/persistence-auth`
+
+## Resolution rules
+
+Layer resolution is deterministic and order-sensitive.
+
+Given a selected external layer:
+
+1. Resolve ancestors from `extends` depth-first, left to right.
+2. Materialize each ancestor exactly once.
+3. Apply the selected layer's own `path` last.
+4. Apply the built-in template-specific overlay and emitter-owned files after
+   shared/external layer copy.
+
+That means:
+
+- earlier `extends` entries are lower precedence
+- later `extends` entries override earlier ones
+- the selected layer overrides every ancestor
+- the typed built-in generator still owns emitter-written artifacts after layer
+  copy completes
+
+## Conflict handling and precedence
+
+The contract distinguishes between ordinary copied assets and protected
+`wp-typia`-owned outputs.
+
+### Ordinary copied assets
+
+Examples:
+
+- shared scripts
+- non-emitter README/bootstrap fragments
+- copied helper files that still live in `_shared`
+
+For these, later layers win deterministically.
+
+### Protected paths
+
+External layers may not override paths owned by the generator or by
+`wp-typia`'s package/tooling/bootstrap contract.
+
+Protected outputs include:
+
+- emitter-owned built-in artifacts such as `types.ts`, `block.json`,
+  built-in TS/TSX scaffold bodies, built-in styles, and block-local
+  `render.php`
+- starter `typia.manifest.json`
+- package/tooling bootstrap files that `wp-typia` explicitly normalizes, such
+  as package-manager metadata and sync/runtime setup
+
+If an external layer writes a protected path, the implementation should fail
+hard with an explicit conflict error instead of silently accepting drift.
+
+## Trust model
+
+External layer packages are third-party code and should be treated with the
+same trust posture as existing external template sources.
+
+- local paths, GitHub locators, and npm package sources are all trusted inputs
+- layer packages must not contain symlinks
+- the layer manifest should stay data-only so it can be inspected without
+  executing package JavaScript
+- if a package also exposes the current create-block-style external config
+  entrypoint, that JavaScript path keeps the existing trusted-JS model
+
+## Relation to workspace templates
+
+The official empty workspace template package remains a separate concept.
+
+- `@wp-typia/create-workspace-template` still defines the empty workspace root
+  used by `wp-typia create --template @wp-typia/create-workspace-template`
+- `wp-typia add block` continues to grow that workspace through the built-in
+  generator path
+- external template-layer composition is for reusable shared scaffold layers,
+  not for replacing the official empty workspace template contract
+
+Future implementation may let workspace-aware flows reuse the same external
+layer ids, but the official workspace template itself remains canonical.
+
+## Relation to the typed generator architecture
+
+This RFC extends the current generator architecture; it does not compete with
+it.
+
+- built-in block planning/validation/render/apply still flows through
+  `BlockSpec` and `BlockGeneratorService`
+- built-in emitter-owned files remain authoritative
+- external layer composition only broadens the shared copied-layer graph around
+  that typed core
+
+That is why issue `#193` could close independently while `#198` stayed open:
+the typed generator is implemented, while the external layer contract is a
+separate follow-through.
+
+## Follow-up implementation
+
+Issue `#268` tracks the implementation of:
+
+- manifest loading and validation
+- canonical built-in layer id mapping
+- `extends` resolution and precedence
+- protected-path conflict errors
+- regression coverage for composed external layers

--- a/docs/runtime-import-policy.md
+++ b/docs/runtime-import-policy.md
@@ -70,6 +70,10 @@ For the architecture record behind that boundary, including the staged
 non-mutating tool-facing contract and current phase map, see
 [`docs/block-generator-architecture.md`](./block-generator-architecture.md).
 
+For the separate external layer package RFC on top of the built-in shared
+scaffold model, see
+[`docs/external-template-layer-composition.md`](./external-template-layer-composition.md).
+
 `@wp-typia/block-runtime/schema-core` is public and stable, but it is the
 implementation owner path rather than the preferred project-tooling import.
 

--- a/docs/runtime-surface.md
+++ b/docs/runtime-surface.md
@@ -77,6 +77,8 @@ This document is descriptive, not normative. For support guarantees, see
   `render.php` Mustache files for those generated artifacts. The higher-level
   generator architecture record lives in
   [`docs/block-generator-architecture.md`](./block-generator-architecture.md).
+  External template-layer composition is a separate RFC recorded in
+  [`docs/external-template-layer-composition.md`](./external-template-layer-composition.md).
 - `@wp-typia/block-runtime/*` owns generated-project runtime helpers directly,
   including the canonical `schema-core` implementation and shared
   manifest/migration contract types.

--- a/packages/wp-typia-project-tools/README.md
+++ b/packages/wp-typia-project-tools/README.md
@@ -55,4 +55,8 @@ and the non-mutating `plan -> validate -> render -> apply` tool-facing usage
 model, lives in
 [`docs/block-generator-architecture.md`](../../docs/block-generator-architecture.md).
 
+The separate RFC for reusable external layer packages on top of the built-in
+shared scaffold model lives in
+[`docs/external-template-layer-composition.md`](../../docs/external-template-layer-composition.md).
+
 If you need metadata sync, editor helpers, validation helpers, or other generated-project runtime utilities, import them directly from `@wp-typia/block-runtime/*`.

--- a/packages/wp-typia-project-tools/tests/import-policy.test.ts
+++ b/packages/wp-typia-project-tools/tests/import-policy.test.ts
@@ -95,6 +95,10 @@ describe('@wp-typia/project-tools import policy', () => {
       path.join(repoRoot, 'docs', 'block-generator-architecture.md'),
       'utf8',
     );
+    const externalTemplateLayerDoc = fs.readFileSync(
+      path.join(repoRoot, 'docs', 'external-template-layer-composition.md'),
+      'utf8',
+    );
     const importPolicyDoc = fs.readFileSync(
       path.join(repoRoot, 'docs', 'runtime-import-policy.md'),
       'utf8',
@@ -114,11 +118,15 @@ describe('@wp-typia/project-tools import policy', () => {
     expect(apiGuide).toContain('@wp-typia/project-tools');
     expect(apiGuide).toContain('BlockGeneratorService');
     expect(apiGuide).toContain('docs/block-generator-architecture.md');
+    expect(apiGuide).toContain('docs/external-template-layer-composition.md');
     expect(apiGuide).toContain('@wp-typia/project-tools/schema-core');
     expect(apiGuide).toContain('@wp-typia/block-runtime/metadata-core');
     expect(runtimeSurfaceDoc).toContain('@wp-typia/project-tools');
     expect(runtimeSurfaceDoc).toContain('BlockGeneratorService');
     expect(runtimeSurfaceDoc).toContain('docs/block-generator-architecture.md');
+    expect(runtimeSurfaceDoc).toContain(
+      'docs/external-template-layer-composition.md',
+    );
     expect(runtimeSurfaceDoc).toContain('@wp-typia/project-tools/schema-core');
     expect(runtimeSurfaceDoc).toContain(
       '@wp-typia/block-runtime/migration-types',
@@ -132,6 +140,9 @@ describe('@wp-typia/project-tools import policy', () => {
       'built-in templates no longer ship structural, TS/TSX, style, or block-local',
     );
     expect(blockGeneratorDoc).toContain('docs/block-generator-architecture.md');
+    expect(blockGeneratorDoc).toContain(
+      'docs/external-template-layer-composition.md',
+    );
     expect(blockGeneratorArchitectureDoc).toContain('BlockSpec');
     expect(blockGeneratorArchitectureDoc).toContain('BlockGeneratorService');
     expect(blockGeneratorArchitectureDoc).toContain('Agentica');
@@ -143,12 +154,24 @@ describe('@wp-typia/project-tools import policy', () => {
     expect(blockGeneratorArchitectureDoc).toContain('Phase 1: complete');
     expect(blockGeneratorArchitectureDoc).toContain('Phase 3: complete');
     expect(blockGeneratorArchitectureDoc).toContain('Phase 4: still open');
+    expect(externalTemplateLayerDoc).toContain('wp-typia.layers.json');
+    expect(externalTemplateLayerDoc).toContain('extends');
+    expect(externalTemplateLayerDoc).toContain('builtin:shared/base');
+    expect(externalTemplateLayerDoc).toContain('protected');
+    expect(externalTemplateLayerDoc).toContain('trusted-JS model');
+    expect(externalTemplateLayerDoc).toContain(
+      '@wp-typia/create-workspace-template',
+    );
+    expect(externalTemplateLayerDoc).toContain('#268');
     expect(runtimeSurfaceDoc).not.toContain(
       '@wp-typia/project-tools/runtime/*',
     );
     expect(importPolicyDoc).toContain('@wp-typia/project-tools');
     expect(importPolicyDoc).toContain('BlockGeneratorService');
     expect(importPolicyDoc).toContain('docs/block-generator-architecture.md');
+    expect(importPolicyDoc).toContain(
+      'docs/external-template-layer-composition.md',
+    );
     expect(importPolicyDoc).toContain('@wp-typia/project-tools/schema-core');
     expect(importPolicyDoc).toContain(
       '@wp-typia/block-runtime/migration-types',

--- a/tests/unit/repo-dx-baseline.test.ts
+++ b/tests/unit/repo-dx-baseline.test.ts
@@ -84,6 +84,11 @@ describe('repository DX baseline', () => {
       ),
     ).toBe(true);
     expect(
+      fs.existsSync(
+        path.join(repoRoot, 'docs', 'external-template-layer-composition.md'),
+      ),
+    ).toBe(true);
+    expect(
       fs.existsSync(path.join(repoRoot, '.github', 'dependabot.yml')),
     ).toBe(true);
     expect(
@@ -153,6 +158,9 @@ describe('repository DX baseline', () => {
       '[Block Generator Architecture](docs/block-generator-architecture.md)',
     );
     expect(readme).toContain(
+      '[External Template-Layer Composition RFC](docs/external-template-layer-composition.md)',
+    );
+    expect(readme).toContain(
       'Root ESLint covers repository infrastructure code',
     );
     expect(readme).toContain(
@@ -178,6 +186,9 @@ describe('repository DX baseline', () => {
     expect(contributing).toContain('[`SECURITY.md`](./SECURITY.md)');
     expect(contributing).toContain(
       '[`docs/block-generator-architecture.md`](./docs/block-generator-architecture.md)',
+    );
+    expect(contributing).toContain(
+      '[`docs/external-template-layer-composition.md`](./docs/external-template-layer-composition.md)',
     );
     expect(contributing).toContain(
       '[`docs/formatting-toolchain-policy.md`](./docs/formatting-toolchain-policy.md)',


### PR DESCRIPTION
## Summary
- formalize the external template-layer composition RFC on top of the built-in `_shared` scaffold model
- define the package manifest shape, canonical built-in layer ids, precedence rules, protected-path conflicts, and trust model
- cross-link the new RFC through architecture/runtime/API docs and lock it in with repo policy tests

## Notes
- follow-up implementation gaps are now tracked in #267 and #268
- this PR closes the RFC issue itself; it does not implement external layer composition yet

## Testing
- bun test packages/wp-typia-project-tools/tests/import-policy.test.ts tests/unit/repo-dx-baseline.test.ts
- bun run docs:build
- bun run ci:local

Closes #198