### PR TITLE
feat: add non-mutating generator tool contract

### DIFF
--- a/.sampo/changesets/issue-267-generator-tool-contract.md
+++ b/.sampo/changesets/issue-267-generator-tool-contract.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Add a public non-mutating block generator inspection contract around `BlockGeneratorService`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,7 @@ bun run docs:build
 - [`UPGRADE.md`](./UPGRADE.md) collects high-signal maintainer upgrade notes
 - [`SECURITY.md`](./SECURITY.md) explains private vulnerability reporting
 - [`docs/block-generator-architecture.md`](./docs/block-generator-architecture.md) records the typed generator architecture and phase map
+- [`docs/block-generator-tool-contract.md`](./docs/block-generator-tool-contract.md) records the non-mutating staged controller/tool payload contract on top of the typed generator boundary
 - [`docs/external-template-layer-composition.md`](./docs/external-template-layer-composition.md) records the external layer package RFC on top of the built-in shared scaffold model
 - [`docs/formatting-toolchain-policy.md`](./docs/formatting-toolchain-policy.md) records the formatter baseline and CI gate
 - [`docs/maintenance-automation-policy.md`](./docs/maintenance-automation-policy.md) records the dependency update and audit baseline

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ npx wp-typia create my-block --template @scope/create-block-template --variant h
 
 - [Architecture Guide](docs/architecture.md)
 - [Block Generator Architecture](docs/block-generator-architecture.md)
+- [Block Generator Tool Contract](docs/block-generator-tool-contract.md)
 - [External Template-Layer Composition RFC](docs/external-template-layer-composition.md)
 - [API Guide](docs/API.md)
 - [Migration Guide](docs/migrations.md)

--- a/docs/API.md
+++ b/docs/API.md
@@ -9,7 +9,7 @@ This repository has multiple public surfaces:
 - `@wp-typia/project-tools`
   Project orchestration package for scaffold, add, migrate, template, doctor,
   package-manager, starter-manifest helpers, and the typed generator
-  boundary (`BlockSpec`, `BlockGeneratorService`).
+  boundary (`BlockSpec`, `BlockGeneratorService`, `inspectBlockGeneration`).
 - `@wp-typia/project-tools/schema-core`
   Project schema/OpenAPI helpers.
 - `@wp-typia/block-runtime`
@@ -207,6 +207,7 @@ project/bootstrap assets, see:
 
 - [`docs/block-generator-architecture.md`](./block-generator-architecture.md)
 - [`docs/block-generator-service.md`](./block-generator-service.md)
+- [`docs/block-generator-tool-contract.md`](./block-generator-tool-contract.md)
 - [`docs/external-template-layer-composition.md`](./external-template-layer-composition.md)
 
 ## 3. `@wp-typia/block-types`

--- a/docs/block-generator-architecture.md
+++ b/docs/block-generator-architecture.md
@@ -99,7 +99,7 @@ template-engine replacement project.
 
 ## Tool-facing usage model
 
-The current non-mutating service surface is already suitable for future
+The current non-mutating service surface is now formalized for future
 Agentica-, MCP-, or other structured tool controllers.
 
 ```ts
@@ -126,9 +126,9 @@ const rendered = await service.render({ validated });
 await service.apply({ rendered });
 ```
 
-That means the future AI/tool contract does not need a second generator. It
-only needs to expose the same staged boundary in a more formal controller
-interface.
+That means the future AI/tool contract does not need a second generator. The
+formal controller-facing follow-through now lives in
+[`docs/block-generator-tool-contract.md`](./block-generator-tool-contract.md).
 
 ## Phase status
 
@@ -145,10 +145,10 @@ The architecture in issue `#193` was implemented incrementally.
 - Phase 3: complete
   Built-in TS/TSX scaffold bodies, built-in style assets, and block-local
   `render.php` moved to emitter ownership for all built-in block families.
-- Phase 4: still open
-  The remaining follow-through is a formal tool/controller contract for
-  non-mutating generator usage plus architecture for external layer
-  composition, which now belongs with issue `#198`.
+- Phase 4: complete
+  The non-mutating tool/controller contract is now formalized around
+  `inspectBlockGeneration(...)`, while external layer composition remains the
+  separate RFC from issue `#198`.
 
 ## What this architecture does not do
 
@@ -167,6 +167,8 @@ runtime surfaces under `@wp-typia/block-runtime/*`.
 
 - [`docs/block-generator-service.md`](./block-generator-service.md)
   describes the current concrete responsibility split inside the generator.
+- [`docs/block-generator-tool-contract.md`](./block-generator-tool-contract.md)
+  records the public non-mutating generator controller contract.
 - [`docs/API.md`](./API.md)
   maps the public package surfaces that expose the generator boundary.
 - [`docs/runtime-import-policy.md`](./runtime-import-policy.md)

--- a/docs/block-generator-service.md
+++ b/docs/block-generator-service.md
@@ -6,6 +6,8 @@
 For the higher-level architecture record, phase map, and AI/tool-facing staged
 usage model, see
 [`docs/block-generator-architecture.md`](./block-generator-architecture.md).
+For the public non-mutating tool/controller contract, see
+[`docs/block-generator-tool-contract.md`](./block-generator-tool-contract.md).
 
 ## Current responsibility split
 

--- a/docs/block-generator-tool-contract.md
+++ b/docs/block-generator-tool-contract.md
@@ -1,0 +1,141 @@
+# Block Generator Tool Contract
+
+This document records the first non-mutating tool/controller contract on top of
+`BlockGeneratorService`.
+
+It closes issue `#267`. The generator already had explicit internal stages
+through `plan`, `validate`, `render`, and `apply`. This contract makes the
+non-mutating half of that flow stable for tools that need to inspect the
+generator before mutating a workspace.
+
+## Goals
+
+- expose a stable controller-friendly entrypoint around `BlockGeneratorService`
+- keep the tool-facing contract serializable
+- let a caller stop after `plan`, `validate`, or `render`
+- avoid workspace mutation until the caller explicitly chooses to call
+  `BlockGeneratorService.apply(...)`
+
+## Public entrypoint
+
+`@wp-typia/project-tools` now exports:
+
+- `inspectBlockGeneration(...)`
+- `BLOCK_GENERATION_TOOL_CONTRACT_VERSION`
+
+The current contract version is `1`.
+
+```ts
+import {
+  BLOCK_GENERATION_TOOL_CONTRACT_VERSION,
+  inspectBlockGeneration,
+} from '@wp-typia/project-tools';
+
+const inspection = await inspectBlockGeneration({
+  answers,
+  packageManager: 'bun',
+  projectDir: 'demo-block',
+  templateId: 'basic',
+  stopAfter: 'render',
+});
+
+if (inspection.contractVersion !== BLOCK_GENERATION_TOOL_CONTRACT_VERSION) {
+  throw new Error('Unexpected generator tool contract version');
+}
+```
+
+## Stage model
+
+The contract is intentionally stage-based.
+
+### `stopAfter: 'plan'`
+
+Returns:
+
+- `contractVersion`
+- `mutatesWorkspace: false`
+- `stage: 'plan'`
+- normalized `plan`
+
+This is the lightest-weight way to inspect how raw scaffold answers become a
+typed `BlockSpec` plus generation target metadata.
+
+### `stopAfter: 'validate'`
+
+Returns everything from `plan`, plus:
+
+- `stage: 'validate'`
+- `validated`
+
+This is the point where built-in invariants such as unsupported built-in
+variant usage have already been enforced.
+
+### `stopAfter: 'render'`
+
+Returns everything from `validate`, plus a serializable `rendered` snapshot:
+
+- `template`
+- `warnings`
+- `copiedTemplateFiles`
+- `emittedFiles`
+- `starterManifestFiles`
+- `readmeContent`
+- `gitignoreContent`
+- `postRender`
+
+The render contract is still non-mutating. It shows what the generator would
+copy or emit, but it does not write to the destination project directory.
+
+## Render contract shape
+
+The render-stage snapshot intentionally distinguishes three categories:
+
+- `copiedTemplateFiles`
+  Output paths that would come from the remaining built-in Mustache/copied
+  template tree.
+- `emittedFiles`
+  Emitter-owned files such as structural artifacts and built-in generated
+  source files.
+- `starterManifestFiles`
+  Starter `typia.manifest.json` documents derived from the same semantic model.
+
+That split mirrors the current generator architecture:
+
+- built-in structural files and scaffold bodies are emitter-owned
+- some shared/bootstrap assets still come from copied template layers
+
+## Mutation boundary
+
+`inspectBlockGeneration(...)` never mutates the workspace.
+
+Mutation still happens only when a caller explicitly goes through
+`BlockGeneratorService.apply(...)`.
+
+That means tool/controller code can safely:
+
+1. call `inspectBlockGeneration(...)`
+2. inspect the structured result
+3. decide whether to continue
+4. only then call the mutating path
+
+## Relation to Agentica and MCP
+
+This contract is the bridge from the typed generator architecture in
+[`docs/block-generator-architecture.md`](./block-generator-architecture.md) to
+future Agentica, MCP, or other structured controller surfaces.
+
+It does not add Agentica or MCP integration directly. Instead, it provides a
+stable serializable shape that a future controller can expose without needing to
+redefine generator stages or invent a second preview path.
+
+## Out of scope
+
+This contract intentionally does not:
+
+- implement an MCP server
+- implement Agentica runtime wiring
+- replace `BlockGeneratorService`
+- add external template-layer composition
+
+External layer composition remains a separate concern documented in
+[`docs/external-template-layer-composition.md`](./external-template-layer-composition.md).

--- a/docs/runtime-import-policy.md
+++ b/docs/runtime-import-policy.md
@@ -62,13 +62,17 @@ Manual orchestration or repo tooling should use:
 
 Those imports cover scaffold, add-block, migrate, template, doctor, package
 manager, starter manifest, schema/OpenAPI project helpers, the `BlockSpec` /
-`BlockGeneratorService` generator boundary, and the emitter-owned built-in
+`BlockGeneratorService` generator boundary, the non-mutating
+`inspectBlockGeneration(...)` tool contract, and the emitter-owned built-in
 structural/source path where built-in templates no longer ship structural,
 TS/TSX, style, or block-local `render.php` Mustache files.
 
 For the architecture record behind that boundary, including the staged
 non-mutating tool-facing contract and current phase map, see
 [`docs/block-generator-architecture.md`](./block-generator-architecture.md).
+
+For the public staged controller/tool payload contract itself, see
+[`docs/block-generator-tool-contract.md`](./block-generator-tool-contract.md).
 
 For the separate external layer package RFC on top of the built-in shared
 scaffold model, see

--- a/docs/runtime-surface.md
+++ b/docs/runtime-surface.md
@@ -16,9 +16,10 @@ This document is descriptive, not normative. For support guarantees, see
 - `@wp-typia/rest/react`
 - `@wp-typia/project-tools`
   Project orchestration helpers used by the CLI and programmatic tooling,
-  including the additive `BlockSpec` / `BlockGeneratorService` boundary and
-  emitter ownership for built-in structural files, TS/TSX scaffold bodies, and
-  built-in style/PHP source assets.
+  including the additive `BlockSpec` / `BlockGeneratorService` boundary, the
+  non-mutating `inspectBlockGeneration(...)` tool contract, and emitter
+  ownership for built-in structural files, TS/TSX scaffold bodies, and built-in
+  style/PHP source assets.
 - `@wp-typia/project-tools/schema-core`
   Schema and OpenAPI helpers for project-level documents.
 - `@wp-typia/block-runtime`
@@ -72,11 +73,15 @@ This document is descriptive, not normative. For support guarantees, see
 - `wp-typia` owns the CLI, help, TUI, completions, skills, MCP, and bin entry.
 - `@wp-typia/project-tools` owns scaffold, add-block, migrate, template,
   doctor, package-manager, starter-manifest, the typed generator boundary, the
-  built-in structural/code emitters, and the preferred schema project imports.
+  built-in structural/code emitters, the non-mutating
+  `inspectBlockGeneration(...)` tool contract, and the preferred schema project
+  imports.
   Built-in templates no longer ship structural, TS/TSX, style, or block-local
   `render.php` Mustache files for those generated artifacts. The higher-level
   generator architecture record lives in
   [`docs/block-generator-architecture.md`](./block-generator-architecture.md).
+  The public non-mutating controller contract lives in
+  [`docs/block-generator-tool-contract.md`](./block-generator-tool-contract.md).
   External template-layer composition is a separate RFC recorded in
   [`docs/external-template-layer-composition.md`](./external-template-layer-composition.md).
 - `@wp-typia/block-runtime/*` owns generated-project runtime helpers directly,

--- a/packages/wp-typia-project-tools/README.md
+++ b/packages/wp-typia-project-tools/README.md
@@ -6,7 +6,8 @@ Package roles:
 
 - `wp-typia` owns the CLI, help, TUI, completions, skills, MCP, and bin entry.
 - `@wp-typia/project-tools` owns scaffold, add-block, migrate, template, doctor, and schema project helpers.
-  It also owns the typed generator boundary via `BlockSpec` and `BlockGeneratorService`,
+  It also owns the typed generator boundary via `BlockSpec`, `BlockGeneratorService`,
+  and `inspectBlockGeneration(...)`,
   plus the emitter-owned built-in structural/code path where built-in
   templates no longer ship structural, TS/TSX, style, or block-local `render.php`
   Mustache files.
@@ -54,6 +55,8 @@ The higher-level generator architecture record, including the current phase map
 and the non-mutating `plan -> validate -> render -> apply` tool-facing usage
 model, lives in
 [`docs/block-generator-architecture.md`](../../docs/block-generator-architecture.md).
+The public non-mutating controller/tool contract now lives in
+[`docs/block-generator-tool-contract.md`](../../docs/block-generator-tool-contract.md).
 
 The separate RFC for reusable external layer packages on top of the built-in
 shared scaffold model lives in

--- a/packages/wp-typia-project-tools/src/runtime/block-generator-tool-contract.ts
+++ b/packages/wp-typia-project-tools/src/runtime/block-generator-tool-contract.ts
@@ -22,10 +22,30 @@ import {
 import { listInterpolatedDirectoryOutputs } from "./template-render.js";
 import type { BuiltInTemplateId } from "./template-registry.js";
 
+/**
+ * Semantic version marker for the public block generation tool contract.
+ *
+ * Increment this number whenever the serialized inspection payload changes in a
+ * breaking way.
+ */
 export const BLOCK_GENERATION_TOOL_CONTRACT_VERSION = 1 as const;
 
+/**
+ * Staged execution points for the non-mutating inspection workflow.
+ *
+ * - `"plan"` returns the normalized `BlockSpec` and target metadata.
+ * - `"validate"` returns the validated generation stage without rendering.
+ * - `"render"` returns the full non-mutating preview, including copied and
+ *   emitted file snapshots.
+ */
 export type BlockGenerationToolStage = "plan" | "validate" | "render";
 
+/**
+ * Input for the staged, non-mutating block generation inspection entrypoint.
+ *
+ * Extends `PlanBlockInput` with an optional `stopAfter` selector so callers can
+ * stop at `plan`, `validate`, or continue through the full `render` preview.
+ */
 export interface InspectBlockGenerationInput extends PlanBlockInput {
 	stopAfter?: BlockGenerationToolStage;
 }
@@ -219,6 +239,34 @@ export function inspectBlockGeneration(
 	input: InspectBlockGenerationInput & { stopAfter?: "render" | undefined },
 	service?: BlockGeneratorService,
 ): Promise<InspectBlockGenerationRenderResult>;
+/**
+ * Inspects built-in block generation through the staged generator boundary
+ * without mutating the destination workspace.
+ *
+ * Use `stopAfter` to halt after the `plan`, `validate`, or `render` stage.
+ * The render stage includes copied template file paths, emitter-owned source
+ * previews, starter manifest previews, and post-render intent metadata. Any
+ * temporary render state is cleaned up before the promise resolves.
+ *
+ * @example
+ * ```ts
+ * const inspection = await inspectBlockGeneration({
+ * 	answers,
+ * 	noInstall: true,
+ * 	packageManager: "bun",
+ * 	projectDir: "demo-block",
+ * 	templateId: "basic",
+ * 	stopAfter: "render",
+ * });
+ * ```
+ *
+ * @param input - Planning input plus an optional `stopAfter` stage selector.
+ * @param service - Optional generator service instance. Defaults to a new
+ * `BlockGeneratorService`.
+ * @returns The serialized inspection result for the reached stage.
+ * @throws Propagates planning, validation, or render failures from
+ * `BlockGeneratorService`.
+ */
 export async function inspectBlockGeneration(
 	{
 		stopAfter = "render",

--- a/packages/wp-typia-project-tools/src/runtime/block-generator-tool-contract.ts
+++ b/packages/wp-typia-project-tools/src/runtime/block-generator-tool-contract.ts
@@ -1,0 +1,263 @@
+import {
+	buildBuiltInBlockArtifacts,
+	stringifyBuiltInBlockJsonDocument,
+	type BuiltInBlockArtifact,
+} from "./built-in-block-artifacts.js";
+import {
+	buildBuiltInCodeArtifacts,
+	type BuiltInCodeArtifact,
+} from "./built-in-block-code-artifacts.js";
+import {
+	BlockGeneratorService,
+	type PlanBlockInput,
+	type PlanBlockResult,
+	type RenderBlockResult,
+	type ValidateBlockResult,
+} from "./block-generator-service.js";
+import type { ManifestDocument } from "./migration-types.js";
+import {
+	getStarterManifestFiles,
+	stringifyStarterManifest,
+} from "./starter-manifests.js";
+import { listInterpolatedDirectoryOutputs } from "./template-render.js";
+import type { BuiltInTemplateId } from "./template-registry.js";
+
+export const BLOCK_GENERATION_TOOL_CONTRACT_VERSION = 1 as const;
+
+export type BlockGenerationToolStage = "plan" | "validate" | "render";
+
+export interface InspectBlockGenerationInput extends PlanBlockInput {
+	stopAfter?: BlockGenerationToolStage;
+}
+
+export interface BlockGenerationTemplateCopyPreview {
+	owner: "template-copy";
+	relativePath: string;
+}
+
+export interface BlockGenerationEmittedFilePreview {
+	kind: "generated-source" | "starter-manifest" | "structural";
+	owner: "emitter";
+	relativePath: string;
+	source: string;
+}
+
+export interface BlockGenerationStarterManifestPreview {
+	document: ManifestDocument;
+	owner: "emitter";
+	relativePath: string;
+	source: string;
+}
+
+export interface BlockGenerationRenderPreview {
+	copiedTemplateFiles: BlockGenerationTemplateCopyPreview[];
+	emittedFiles: BlockGenerationEmittedFilePreview[];
+	postRender: RenderBlockResult["postRender"] & {
+		installsDependencies: boolean;
+	};
+	selectedVariant: null;
+	starterManifestFiles: BlockGenerationStarterManifestPreview[];
+	template: {
+		description: string;
+		family: BuiltInTemplateId;
+		features: string[];
+		format: "wp-typia";
+	};
+	warnings: string[];
+	readmeContent: string;
+	gitignoreContent: string;
+}
+
+interface BlockGenerationInspectionBase {
+	contractVersion: typeof BLOCK_GENERATION_TOOL_CONTRACT_VERSION;
+	mutatesWorkspace: false;
+	stage: BlockGenerationToolStage;
+}
+
+export interface InspectBlockGenerationPlanResult
+	extends BlockGenerationInspectionBase {
+	plan: PlanBlockResult;
+	stage: "plan";
+}
+
+export interface InspectBlockGenerationValidateResult
+	extends BlockGenerationInspectionBase {
+	plan: PlanBlockResult;
+	stage: "validate";
+	validated: ValidateBlockResult;
+}
+
+export interface InspectBlockGenerationRenderResult
+	extends BlockGenerationInspectionBase {
+	plan: PlanBlockResult;
+	rendered: BlockGenerationRenderPreview;
+	stage: "render";
+	validated: ValidateBlockResult;
+}
+
+export type InspectBlockGenerationResult =
+	| InspectBlockGenerationPlanResult
+	| InspectBlockGenerationValidateResult
+	| InspectBlockGenerationRenderResult;
+
+function buildStarterManifestPreviews(
+	templateId: string,
+	variables: RenderBlockResult["variables"],
+	artifacts: readonly BuiltInBlockArtifact[],
+): BlockGenerationStarterManifestPreview[] {
+	const starterManifests = getStarterManifestFiles(templateId, variables);
+	const artifactManifests = new Map(
+		artifacts.map((artifact) => [
+			`${artifact.relativeDir}/typia.manifest.json`,
+			artifact.manifestDocument,
+		]),
+	);
+
+	return starterManifests
+		.map((entry) => {
+			const document = artifactManifests.get(entry.relativePath) ?? entry.document;
+			return {
+				document,
+				owner: "emitter" as const,
+				relativePath: entry.relativePath,
+				source: stringifyStarterManifest(document),
+			};
+		})
+		.sort((left, right) => left.relativePath.localeCompare(right.relativePath));
+}
+
+function buildStructuralArtifactPreviews(
+	artifacts: readonly BuiltInBlockArtifact[],
+): BlockGenerationEmittedFilePreview[] {
+	return artifacts
+		.flatMap((artifact) => [
+			{
+				kind: "structural" as const,
+				owner: "emitter" as const,
+				relativePath: `${artifact.relativeDir}/block.json`,
+				source: stringifyBuiltInBlockJsonDocument(artifact.blockJsonDocument),
+			},
+			{
+				kind: "structural" as const,
+				owner: "emitter" as const,
+				relativePath: `${artifact.relativeDir}/types.ts`,
+				source: artifact.typesSource,
+			},
+		])
+		.sort((left, right) => left.relativePath.localeCompare(right.relativePath));
+}
+
+function buildCodeArtifactPreviews(
+	codeArtifacts: readonly BuiltInCodeArtifact[],
+): BlockGenerationEmittedFilePreview[] {
+	return codeArtifacts
+		.map((artifact) => ({
+			kind: "generated-source" as const,
+			owner: "emitter" as const,
+			relativePath: artifact.relativePath,
+			source: artifact.source,
+		}))
+		.sort((left, right) => left.relativePath.localeCompare(right.relativePath));
+}
+
+async function buildRenderPreview(
+	rendered: RenderBlockResult,
+): Promise<BlockGenerationRenderPreview> {
+	const artifacts = buildBuiltInBlockArtifacts({
+		templateId: rendered.spec.template.family,
+		variables: rendered.variables,
+	});
+	const codeArtifacts = buildBuiltInCodeArtifacts({
+		templateId: rendered.spec.template.family,
+		variables: rendered.variables,
+	});
+	const copiedTemplateFiles = await listInterpolatedDirectoryOutputs(
+		rendered.templateDir,
+		rendered.variables,
+	);
+
+	return {
+		copiedTemplateFiles: copiedTemplateFiles.map((relativePath) => ({
+			owner: "template-copy" as const,
+			relativePath,
+		})),
+		emittedFiles: [
+			...buildStructuralArtifactPreviews(artifacts),
+			...buildCodeArtifactPreviews(codeArtifacts),
+		].sort((left, right) => left.relativePath.localeCompare(right.relativePath)),
+		gitignoreContent: rendered.gitignoreContent,
+		postRender: {
+			...rendered.postRender,
+			installsDependencies: !rendered.target.noInstall,
+		},
+		readmeContent: rendered.readmeContent,
+		selectedVariant: rendered.selectedVariant,
+		starterManifestFiles: buildStarterManifestPreviews(
+			rendered.spec.template.family,
+			rendered.variables,
+			artifacts,
+		),
+		template: {
+			description: rendered.spec.template.description,
+			family: rendered.spec.template.family,
+			features: [...rendered.spec.template.features],
+			format: "wp-typia",
+		},
+		warnings: [...rendered.warnings],
+	};
+}
+
+export function inspectBlockGeneration(
+	input: InspectBlockGenerationInput & { stopAfter: "plan" },
+	service?: BlockGeneratorService,
+): Promise<InspectBlockGenerationPlanResult>;
+export function inspectBlockGeneration(
+	input: InspectBlockGenerationInput & { stopAfter: "validate" },
+	service?: BlockGeneratorService,
+): Promise<InspectBlockGenerationValidateResult>;
+export function inspectBlockGeneration(
+	input: InspectBlockGenerationInput & { stopAfter?: "render" | undefined },
+	service?: BlockGeneratorService,
+): Promise<InspectBlockGenerationRenderResult>;
+export async function inspectBlockGeneration(
+	{
+		stopAfter = "render",
+		...planInput
+	}: InspectBlockGenerationInput,
+	service = new BlockGeneratorService(),
+): Promise<InspectBlockGenerationResult> {
+	const plan = await service.plan(planInput);
+	if (stopAfter === "plan") {
+		return {
+			contractVersion: BLOCK_GENERATION_TOOL_CONTRACT_VERSION,
+			mutatesWorkspace: false,
+			plan,
+			stage: "plan",
+		};
+	}
+
+	const validated = await service.validate({ plan });
+	if (stopAfter === "validate") {
+		return {
+			contractVersion: BLOCK_GENERATION_TOOL_CONTRACT_VERSION,
+			mutatesWorkspace: false,
+			plan,
+			stage: "validate",
+			validated,
+		};
+	}
+
+	const rendered = await service.render({ validated });
+	try {
+		return {
+			contractVersion: BLOCK_GENERATION_TOOL_CONTRACT_VERSION,
+			mutatesWorkspace: false,
+			plan,
+			rendered: await buildRenderPreview(rendered),
+			stage: "render",
+			validated,
+		};
+	} finally {
+		await rendered.cleanup?.();
+	}
+}

--- a/packages/wp-typia-project-tools/src/runtime/index.ts
+++ b/packages/wp-typia-project-tools/src/runtime/index.ts
@@ -30,6 +30,22 @@ export type {
 	ValidateBlockResult,
 } from "./block-generator-service.js";
 export {
+	BLOCK_GENERATION_TOOL_CONTRACT_VERSION,
+	inspectBlockGeneration,
+} from "./block-generator-tool-contract.js";
+export type {
+	BlockGenerationEmittedFilePreview,
+	BlockGenerationRenderPreview,
+	BlockGenerationStarterManifestPreview,
+	BlockGenerationTemplateCopyPreview,
+	BlockGenerationToolStage,
+	InspectBlockGenerationInput,
+	InspectBlockGenerationPlanResult,
+	InspectBlockGenerationRenderResult,
+	InspectBlockGenerationResult,
+	InspectBlockGenerationValidateResult,
+} from "./block-generator-tool-contract.js";
+export {
 	formatMigrationHelpText,
 	parseMigrationArgs,
 	runMigrationCommand,

--- a/packages/wp-typia-project-tools/src/runtime/template-render.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-render.ts
@@ -176,6 +176,20 @@ export async function copyInterpolatedDirectory(
 	}
 }
 
+/**
+ * Lists the output file paths produced by an interpolated template directory
+ * without writing any files to disk.
+ *
+ * This walks the source directory, applies the same filename interpolation and
+ * `.mustache` stripping rules as `copyInterpolatedDirectory(...)`, and returns
+ * normalized output-relative paths under a virtual root.
+ *
+ * @param sourceDir - The template directory to traverse.
+ * @param view - The interpolation map used when resolving file and directory
+ * names.
+ * @returns A sorted array of normalized output paths relative to a virtual
+ * preview root.
+ */
 export async function listInterpolatedDirectoryOutputs(
 	sourceDir: string,
 	view: Record<string, string>,

--- a/packages/wp-typia-project-tools/src/runtime/template-render.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-render.ts
@@ -176,6 +176,36 @@ export async function copyInterpolatedDirectory(
 	}
 }
 
+export async function listInterpolatedDirectoryOutputs(
+	sourceDir: string,
+	view: Record<string, string>,
+): Promise<string[]> {
+	const virtualRoot = path.resolve("/wp-typia-template-preview");
+	const outputs: string[] = [];
+
+	async function visit(currentSourceDir: string, currentTargetDir: string): Promise<void> {
+		const entries = await fsp.readdir(currentSourceDir, { withFileTypes: true });
+		for (const entry of entries) {
+			const sourcePath = path.join(currentSourceDir, entry.name);
+			const destinationNameTemplate = entry.name.endsWith(".mustache")
+				? entry.name.slice(0, -".mustache".length)
+				: entry.name;
+			const destinationName = renderInterpolatedString(destinationNameTemplate, view);
+			const destinationPath = resolveRenderedPath(currentTargetDir, destinationName);
+
+			if (entry.isDirectory()) {
+				await visit(sourcePath, destinationPath);
+				continue;
+			}
+
+			outputs.push(path.relative(virtualRoot, destinationPath).replace(/\\/g, "/"));
+		}
+	}
+
+	await visit(sourceDir, virtualRoot);
+	return outputs.sort((left, right) => left.localeCompare(right));
+}
+
 export function pathExists(targetPath: string): boolean {
 	return fs.existsSync(targetPath);
 }

--- a/packages/wp-typia-project-tools/tests/block-generator-tool-contract.test.ts
+++ b/packages/wp-typia-project-tools/tests/block-generator-tool-contract.test.ts
@@ -1,0 +1,124 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import {
+	cleanupScaffoldTempRoot,
+	createScaffoldTempRoot,
+} from "./helpers/scaffold-test-harness.js";
+import {
+	BLOCK_GENERATION_TOOL_CONTRACT_VERSION,
+	inspectBlockGeneration,
+} from "../src/runtime/index.js";
+import { getDefaultAnswers } from "../src/runtime/scaffold.js";
+import type { BuiltInTemplateId } from "../src/runtime/template-registry.js";
+
+function buildAnswers(templateId: BuiltInTemplateId) {
+	return {
+		...getDefaultAnswers("demo-generator-tool-contract", templateId),
+		author: "Tool Contract Tester",
+		description: `Demo ${templateId} tool contract block`,
+		namespace: "demo-space",
+		phpPrefix: "demo_space",
+		slug: "demo-generator-tool-contract",
+		textDomain: "demo-space",
+		title: "Demo Generator Tool Contract",
+	};
+}
+
+describe("inspectBlockGeneration", () => {
+	const tempRoot = createScaffoldTempRoot("wp-typia-block-generator-tool-");
+
+	afterAll(() => {
+		cleanupScaffoldTempRoot(tempRoot);
+	});
+
+	test("can stop after the plan stage with a serializable non-mutating snapshot", async () => {
+		const result = await inspectBlockGeneration({
+			answers: buildAnswers("basic"),
+			noInstall: true,
+			packageManager: "npm",
+			projectDir: path.join(tempRoot, "plan-basic"),
+			stopAfter: "plan",
+			templateId: "basic",
+		});
+
+		expect(result.contractVersion).toBe(BLOCK_GENERATION_TOOL_CONTRACT_VERSION);
+		expect(result.mutatesWorkspace).toBe(false);
+		expect(result.stage).toBe("plan");
+		expect(result.plan.spec.template.family).toBe("basic");
+		expect(result.plan.target.noInstall).toBe(true);
+		expect(JSON.parse(JSON.stringify(result))).toMatchObject({
+			stage: "plan",
+		});
+	});
+
+	test("can stop after validation without rendering or mutating the workspace", async () => {
+		const result = await inspectBlockGeneration({
+			answers: buildAnswers("interactivity"),
+			noInstall: true,
+			packageManager: "npm",
+			projectDir: path.join(tempRoot, "validate-interactivity"),
+			stopAfter: "validate",
+			templateId: "interactivity",
+		});
+
+		expect(result.stage).toBe("validate");
+		expect(result.validated.spec.template.family).toBe("interactivity");
+		expect(result.validated.spec.block.slug).toBe("demo-generator-tool-contract");
+		expect(fs.existsSync(result.validated.target.projectDir)).toBe(false);
+	});
+
+	test("returns a render-stage contract with copied files, emitted files, and starter manifests", async () => {
+		const projectDir = path.join(tempRoot, "render-compound");
+		const result = await inspectBlockGeneration({
+			answers: {
+				...buildAnswers("compound"),
+				dataStorageMode: "post-meta",
+				persistencePolicy: "public",
+			},
+			noInstall: true,
+			packageManager: "npm",
+			projectDir,
+			templateId: "compound",
+		});
+
+		expect(result.stage).toBe("render");
+		expect(result.rendered.template.family).toBe("compound");
+		expect(result.rendered.template.format).toBe("wp-typia");
+		expect(result.rendered.postRender.installsDependencies).toBe(false);
+		expect(result.rendered.postRender.seedPersistenceArtifacts).toBe(true);
+		expect(result.rendered.copiedTemplateFiles).toContainEqual({
+			owner: "template-copy",
+			relativePath: "package.json",
+		});
+		expect(result.rendered.emittedFiles).toContainEqual(
+			expect.objectContaining({
+				kind: "structural",
+				owner: "emitter",
+				relativePath: "src/blocks/demo-generator-tool-contract/block.json",
+			}),
+		);
+		expect(result.rendered.emittedFiles).toContainEqual(
+			expect.objectContaining({
+				kind: "generated-source",
+				owner: "emitter",
+				relativePath: "src/blocks/demo-generator-tool-contract/edit.tsx",
+			}),
+		);
+		expect(result.rendered.starterManifestFiles).toContainEqual(
+			expect.objectContaining({
+				owner: "emitter",
+				relativePath: "src/blocks/demo-generator-tool-contract/typia.manifest.json",
+			}),
+		);
+		expect(result.rendered.starterManifestFiles).toContainEqual(
+			expect.objectContaining({
+				owner: "emitter",
+				relativePath: "src/blocks/demo-generator-tool-contract-item/typia.manifest.json",
+			}),
+		);
+		expect(fs.existsSync(projectDir)).toBe(false);
+		expect(() => JSON.parse(JSON.stringify(result))).not.toThrow();
+	});
+});

--- a/packages/wp-typia-project-tools/tests/block-generator-tool-contract.test.ts
+++ b/packages/wp-typia-project-tools/tests/block-generator-tool-contract.test.ts
@@ -64,6 +64,8 @@ describe("inspectBlockGeneration", () => {
 		});
 
 		expect(result.stage).toBe("validate");
+		expect(result.contractVersion).toBe(BLOCK_GENERATION_TOOL_CONTRACT_VERSION);
+		expect(result.mutatesWorkspace).toBe(false);
 		expect(result.validated.spec.template.family).toBe("interactivity");
 		expect(result.validated.spec.block.slug).toBe("demo-generator-tool-contract");
 		expect(fs.existsSync(result.validated.target.projectDir)).toBe(false);
@@ -84,6 +86,8 @@ describe("inspectBlockGeneration", () => {
 		});
 
 		expect(result.stage).toBe("render");
+		expect(result.contractVersion).toBe(BLOCK_GENERATION_TOOL_CONTRACT_VERSION);
+		expect(result.mutatesWorkspace).toBe(false);
 		expect(result.rendered.template.family).toBe("compound");
 		expect(result.rendered.template.format).toBe("wp-typia");
 		expect(result.rendered.postRender.installsDependencies).toBe(false);

--- a/packages/wp-typia-project-tools/tests/import-policy.test.ts
+++ b/packages/wp-typia-project-tools/tests/import-policy.test.ts
@@ -20,11 +20,13 @@ describe('@wp-typia/project-tools import policy', () => {
     ]);
 
     expect(typeof rootModule.collectScaffoldAnswers).toBe('function');
+    expect(rootModule.BLOCK_GENERATION_TOOL_CONTRACT_VERSION).toBe(1);
     expect(typeof rootModule.BlockGeneratorService).toBe('function');
     expect(typeof rootModule.formatAddHelpText).toBe('function');
     expect(typeof rootModule.formatMigrationHelpText).toBe('function');
     expect(typeof rootModule.getDoctorChecks).toBe('function');
     expect(typeof rootModule.getTemplateById).toBe('function');
+    expect(typeof rootModule.inspectBlockGeneration).toBe('function');
     expect(typeof rootModule.listTemplates).toBe('function');
     expect(typeof rootModule.parseMigrationArgs).toBe('function');
     expect(typeof rootModule.projectJsonSchemaDocument).toBe('function');
@@ -107,6 +109,8 @@ describe('@wp-typia/project-tools import policy', () => {
     expect(projectToolsReadme).toContain('@wp-typia/project-tools');
     expect(projectToolsReadme).toContain('@wp-typia/project-tools/schema-core');
     expect(projectToolsReadme).toContain('BlockGeneratorService');
+    expect(projectToolsReadme).toContain('inspectBlockGeneration');
+    expect(projectToolsReadme).toContain('docs/block-generator-tool-contract.md');
     expect(projectToolsReadme).toContain('@wp-typia/block-runtime/*');
     expect(projectToolsReadme).toContain(
       '@wp-typia/block-runtime/migration-types',
@@ -117,13 +121,17 @@ describe('@wp-typia/project-tools import policy', () => {
     expect(createReadme).toContain('@wp-typia/project-tools/schema-core');
     expect(apiGuide).toContain('@wp-typia/project-tools');
     expect(apiGuide).toContain('BlockGeneratorService');
+    expect(apiGuide).toContain('inspectBlockGeneration');
     expect(apiGuide).toContain('docs/block-generator-architecture.md');
+    expect(apiGuide).toContain('docs/block-generator-tool-contract.md');
     expect(apiGuide).toContain('docs/external-template-layer-composition.md');
     expect(apiGuide).toContain('@wp-typia/project-tools/schema-core');
     expect(apiGuide).toContain('@wp-typia/block-runtime/metadata-core');
     expect(runtimeSurfaceDoc).toContain('@wp-typia/project-tools');
     expect(runtimeSurfaceDoc).toContain('BlockGeneratorService');
+    expect(runtimeSurfaceDoc).toContain('inspectBlockGeneration');
     expect(runtimeSurfaceDoc).toContain('docs/block-generator-architecture.md');
+    expect(runtimeSurfaceDoc).toContain('docs/block-generator-tool-contract.md');
     expect(runtimeSurfaceDoc).toContain(
       'docs/external-template-layer-composition.md',
     );
@@ -140,6 +148,7 @@ describe('@wp-typia/project-tools import policy', () => {
       'built-in templates no longer ship structural, TS/TSX, style, or block-local',
     );
     expect(blockGeneratorDoc).toContain('docs/block-generator-architecture.md');
+    expect(blockGeneratorDoc).toContain('docs/block-generator-tool-contract.md');
     expect(blockGeneratorDoc).toContain(
       'docs/external-template-layer-composition.md',
     );
@@ -153,7 +162,10 @@ describe('@wp-typia/project-tools import policy', () => {
     expect(blockGeneratorArchitectureDoc).toContain('apply');
     expect(blockGeneratorArchitectureDoc).toContain('Phase 1: complete');
     expect(blockGeneratorArchitectureDoc).toContain('Phase 3: complete');
-    expect(blockGeneratorArchitectureDoc).toContain('Phase 4: still open');
+    expect(blockGeneratorArchitectureDoc).toContain('Phase 4: complete');
+    expect(blockGeneratorArchitectureDoc).toContain(
+      'docs/block-generator-tool-contract.md',
+    );
     expect(externalTemplateLayerDoc).toContain('wp-typia.layers.json');
     expect(externalTemplateLayerDoc).toContain('extends');
     expect(externalTemplateLayerDoc).toContain('builtin:shared/base');
@@ -168,7 +180,9 @@ describe('@wp-typia/project-tools import policy', () => {
     );
     expect(importPolicyDoc).toContain('@wp-typia/project-tools');
     expect(importPolicyDoc).toContain('BlockGeneratorService');
+    expect(importPolicyDoc).toContain('inspectBlockGeneration');
     expect(importPolicyDoc).toContain('docs/block-generator-architecture.md');
+    expect(importPolicyDoc).toContain('docs/block-generator-tool-contract.md');
     expect(importPolicyDoc).toContain(
       'docs/external-template-layer-composition.md',
     );

--- a/tests/unit/repo-dx-baseline.test.ts
+++ b/tests/unit/repo-dx-baseline.test.ts
@@ -85,6 +85,11 @@ describe('repository DX baseline', () => {
     ).toBe(true);
     expect(
       fs.existsSync(
+        path.join(repoRoot, 'docs', 'block-generator-tool-contract.md'),
+      ),
+    ).toBe(true);
+    expect(
+      fs.existsSync(
         path.join(repoRoot, 'docs', 'external-template-layer-composition.md'),
       ),
     ).toBe(true);
@@ -158,6 +163,9 @@ describe('repository DX baseline', () => {
       '[Block Generator Architecture](docs/block-generator-architecture.md)',
     );
     expect(readme).toContain(
+      '[Block Generator Tool Contract](docs/block-generator-tool-contract.md)',
+    );
+    expect(readme).toContain(
       '[External Template-Layer Composition RFC](docs/external-template-layer-composition.md)',
     );
     expect(readme).toContain(
@@ -186,6 +194,9 @@ describe('repository DX baseline', () => {
     expect(contributing).toContain('[`SECURITY.md`](./SECURITY.md)');
     expect(contributing).toContain(
       '[`docs/block-generator-architecture.md`](./docs/block-generator-architecture.md)',
+    );
+    expect(contributing).toContain(
+      '[`docs/block-generator-tool-contract.md`](./docs/block-generator-tool-contract.md)',
     );
     expect(contributing).toContain(
       '[`docs/external-template-layer-composition.md`](./docs/external-template-layer-composition.md)',


### PR DESCRIPTION
## Summary
- add a public staged inspection contract around `BlockGeneratorService`
- export `inspectBlockGeneration(...)` and `BLOCK_GENERATION_TOOL_CONTRACT_VERSION` from `@wp-typia/project-tools`
- document the controller/tool payload contract and cover it with policy tests

## Testing
- bun test packages/wp-typia-project-tools/tests/block-generator-service.test.ts packages/wp-typia-project-tools/tests/block-generator-tool-contract.test.ts packages/wp-typia-project-tools/tests/import-policy.test.ts tests/unit/repo-dx-baseline.test.ts
- bun run docs:build
- bun run ci:local

Closes #267

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a non-mutating block generation inspection capability, allowing users to preview generation stages (plan, validate, render) without modifying their workspace.
  * New versioned tool contract for staged generation inspection.

* **Documentation**
  * Added comprehensive documentation for the block generator tool contract.
  * Updated existing guides to reference the new inspection capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->