### PR TITLE
Prepare a targeted TypeScript strictness ratchet after boundary cleanup

### DIFF
--- a/docs/typescript-strictness-policy.md
+++ b/docs/typescript-strictness-policy.md
@@ -26,15 +26,61 @@ The following flags are intentionally deferred until the repo is ready to ratche
 
 Those flags should not appear in package or example `tsconfig` files without an explicit, temporary exception recorded in `scripts/validate-typescript-strictness-policy.mjs`.
 
-## Temporary exceptions
+## Targeted package ratchets and temporary exceptions
 
-If a package truly needs a temporary deviation:
+Deferred flags can still be enabled package-by-package, but only through an
+explicit policy entry in `scripts/validate-typescript-strictness-policy.mjs`.
 
-1. add the exact override to `TYPESCRIPT_STRICTNESS_POLICY_EXCEPTIONS`
-2. document why the exception exists
-3. remove it once the package can inherit the repo baseline cleanly
+Use that allowlist for either:
 
-The validator treats undeclared strictness overrides as policy drift.
+1. an intentional package-level ratchet that already passes cleanly
+2. a temporary exception that needs to be tracked explicitly
+
+The validator treats undeclared strictness overrides as policy drift, and it
+fails stale allowlist entries once the matching override disappears.
+
+### Current targeted ratchet
+
+- `packages/wp-typia-block-types/tsconfig.json`
+  - `exactOptionalPropertyTypes: true`
+  - `noUncheckedIndexedAccess: true`
+  - rationale: the locally owned block registration surface from `#279`,
+    plus the JSON artifact/helper cleanup from `#280`, `#281`, and `#286`,
+    reduced the package's cast-heavy boundaries enough for both flags to pass
+    cleanly.
+
+## Current blockers
+
+Focused trials on `2026-04-15` produced the following result set:
+
+- `@wp-typia/block-types`: passes `exactOptionalPropertyTypes` and
+  `noUncheckedIndexedAccess` cleanly, so the package-level ratchet is now
+  enabled.
+- `@wp-typia/block-runtime`: remains deferred for both flags.
+
+### `@wp-typia/block-runtime` blockers
+
+- `exactOptionalPropertyTypes`
+  - optional-property ownership still leaks `undefined` through runtime-facing
+    descriptors such as `EditorFieldDescriptor`, `InspectorComponentMap`,
+    metadata parsing nodes, validation results, and sync/report option bags
+  - the experiment also surfaced shared-graph fallout in
+    `packages/wp-typia-api-client/src/internal/runtime-primitives.ts`, so a
+    clean ratchet there needs coordinated optional-property cleanup across that
+    boundary rather than a one-off tsconfig flip
+- `noUncheckedIndexedAccess`
+  - remaining hotspots are concentrated in runtime indexing code:
+    identifier segments, metadata parser tree walks, diagnostic/root-node
+    selection, and validation record indexing
+  - `#281` removed the worst generic helper noise, but the remaining errors are
+    still meaningful enough that they should be fixed deliberately instead of
+    hidden behind a broad exception
+
+### Current decision
+
+- landed: package-level ratchet for `@wp-typia/block-types`
+- deferred: `@wp-typia/block-runtime`
+- no explicit `@wp-typia/block-runtime` exception is recorded yet
 
 ## Validation
 

--- a/packages/wp-typia-block-types/tsconfig.json
+++ b/packages/wp-typia-block-types/tsconfig.json
@@ -2,6 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
     "rootDir": "./src",
     "plugins": [],
     "types": []

--- a/scripts/validate-typescript-strictness-policy.mjs
+++ b/scripts/validate-typescript-strictness-policy.mjs
@@ -18,7 +18,14 @@ export const TYPESCRIPT_STRICTNESS_DEFERRED_FLAGS = Object.freeze([
 	"noUncheckedIndexedAccess",
 ]);
 
-export const TYPESCRIPT_STRICTNESS_POLICY_EXCEPTIONS = Object.freeze({});
+// This allowlist covers both temporary exceptions and intentional
+// package-level ratchets that land ahead of the repo-wide baseline.
+export const TYPESCRIPT_STRICTNESS_POLICY_EXCEPTIONS = Object.freeze({
+	"packages/wp-typia-block-types/tsconfig.json": Object.freeze({
+		exactOptionalPropertyTypes: true,
+		noUncheckedIndexedAccess: true,
+	}),
+});
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/tests/unit/typescript-strictness-policy.test.ts
+++ b/tests/unit/typescript-strictness-policy.test.ts
@@ -60,11 +60,31 @@ function createStrictnessRepo() {
 	return repoRoot;
 }
 
+function createTestPolicy(
+	exceptions: Record<string, Record<string, boolean>> = {},
+) {
+	return {
+		baseline: {
+			noFallthroughCasesInSwitch: true,
+			noImplicitOverride: true,
+			strict: true,
+			useUnknownInCatchVariables: true,
+		},
+		deferredFlags: [
+			"exactOptionalPropertyTypes",
+			"noImplicitReturns",
+			"noPropertyAccessFromIndexSignature",
+			"noUncheckedIndexedAccess",
+		],
+		exceptions,
+	};
+}
+
 describe("validateTypeScriptStrictnessPolicy", () => {
 	test("passes when the repo inherits the staged baseline from tsconfig.base.json", () => {
 		const repoRoot = createStrictnessRepo();
 
-		expect(validateTypeScriptStrictnessPolicy(repoRoot)).toEqual({
+		expect(validateTypeScriptStrictnessPolicy(repoRoot, createTestPolicy())).toEqual({
 			errors: [],
 			valid: true,
 		});
@@ -77,7 +97,7 @@ describe("validateTypeScriptStrictnessPolicy", () => {
 		delete baseConfig.compilerOptions.noImplicitOverride;
 		writeJson(basePath, baseConfig);
 
-		const result = validateTypeScriptStrictnessPolicy(repoRoot);
+		const result = validateTypeScriptStrictnessPolicy(repoRoot, createTestPolicy());
 
 		expect(result.valid).toBe(false);
 		expect(result.errors).toContain(
@@ -92,7 +112,7 @@ describe("validateTypeScriptStrictnessPolicy", () => {
 		packageConfig.compilerOptions.strict = true;
 		writeJson(packagePath, packageConfig);
 
-		const result = validateTypeScriptStrictnessPolicy(repoRoot);
+		const result = validateTypeScriptStrictnessPolicy(repoRoot, createTestPolicy());
 
 		expect(result.valid).toBe(false);
 		expect(result.errors).toContain(
@@ -107,7 +127,7 @@ describe("validateTypeScriptStrictnessPolicy", () => {
 		delete packageConfig.extends;
 		writeJson(packagePath, packageConfig);
 
-		const result = validateTypeScriptStrictnessPolicy(repoRoot);
+		const result = validateTypeScriptStrictnessPolicy(repoRoot, createTestPolicy());
 
 		expect(result.valid).toBe(false);
 		expect(result.errors).toContain(
@@ -128,7 +148,7 @@ describe("validateTypeScriptStrictnessPolicy", () => {
 		};
 		writeJson(nestedPath, nestedConfig);
 
-		const result = validateTypeScriptStrictnessPolicy(repoRoot);
+		const result = validateTypeScriptStrictnessPolicy(repoRoot, createTestPolicy());
 
 		expect(result.valid).toBe(false);
 		expect(result.errors).toContain(
@@ -146,7 +166,7 @@ describe("validateTypeScriptStrictnessPolicy", () => {
 		};
 		writeJson(packagePath, packageConfig);
 
-		const result = validateTypeScriptStrictnessPolicy(repoRoot);
+		const result = validateTypeScriptStrictnessPolicy(repoRoot, createTestPolicy());
 
 		expect(result.valid).toBe(false);
 		expect(result.errors).toContain(
@@ -164,20 +184,39 @@ describe("validateTypeScriptStrictnessPolicy", () => {
 		};
 		writeJson(packagePath, packageConfig);
 
-		const result = validateTypeScriptStrictnessPolicy(repoRoot, {
-			baseline: {
-				noFallthroughCasesInSwitch: true,
-				noImplicitOverride: true,
-				strict: true,
-				useUnknownInCatchVariables: true,
-			},
-			deferredFlags: ["noUncheckedIndexedAccess"],
-			exceptions: {
+		const result = validateTypeScriptStrictnessPolicy(
+			repoRoot,
+			createTestPolicy({
 				"examples/my-typia-block/tsconfig.json": {
 					noUncheckedIndexedAccess: true,
 				},
-			},
-		});
+			}),
+		);
+
+		expect(result.valid).toBe(true);
+		expect(result.errors).toEqual([]);
+	});
+
+	test("accepts multiple deferred flags when the overrides are declared explicitly", () => {
+		const repoRoot = createStrictnessRepo();
+		const packagePath = path.join(repoRoot, "examples/my-typia-block/tsconfig.json");
+		const packageConfig = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+		packageConfig.compilerOptions = {
+			...packageConfig.compilerOptions,
+			exactOptionalPropertyTypes: true,
+			noUncheckedIndexedAccess: true,
+		};
+		writeJson(packagePath, packageConfig);
+
+		const result = validateTypeScriptStrictnessPolicy(
+			repoRoot,
+			createTestPolicy({
+				"examples/my-typia-block/tsconfig.json": {
+					exactOptionalPropertyTypes: true,
+					noUncheckedIndexedAccess: true,
+				},
+			}),
+		);
 
 		expect(result.valid).toBe(true);
 		expect(result.errors).toEqual([]);
@@ -186,20 +225,14 @@ describe("validateTypeScriptStrictnessPolicy", () => {
 	test("fails when a strictness exception is declared but not consumed", () => {
 		const repoRoot = createStrictnessRepo();
 
-		const result = validateTypeScriptStrictnessPolicy(repoRoot, {
-			baseline: {
-				noFallthroughCasesInSwitch: true,
-				noImplicitOverride: true,
-				strict: true,
-				useUnknownInCatchVariables: true,
-			},
-			deferredFlags: ["noUncheckedIndexedAccess"],
-			exceptions: {
+		const result = validateTypeScriptStrictnessPolicy(
+			repoRoot,
+			createTestPolicy({
 				"examples/my-typia-block/tsconfig.json": {
 					noUncheckedIndexedAccess: true,
 				},
-			},
-		});
+			}),
+		);
 
 		expect(result.valid).toBe(false);
 		expect(result.errors).toContain(


### PR DESCRIPTION
## Summary
- ratchet `@wp-typia/block-types` into `exactOptionalPropertyTypes` and `noUncheckedIndexedAccess`
- keep the staged repo policy explicit by recording the package-level ratchet in the strictness validator allowlist
- document the current `@wp-typia/block-runtime` blockers instead of hiding them behind ad hoc overrides

## Testing
- bun test tests/unit/typescript-strictness-policy.test.ts
- bun run typescript-strictness:validate
- bun run --filter @wp-typia/block-types typecheck
- bun run --filter @wp-typia/block-types build
- bun run typecheck
- bun run docs:build
- bun run ci:local

Closes #282