### PR TITLE
Add a scheduled Gutenberg upstream TypeScript watch

### DIFF
--- a/.github/workflows/gutenberg-upstream-watch.yml
+++ b/.github/workflows/gutenberg-upstream-watch.yml
@@ -39,8 +39,6 @@ jobs:
           node-version: '24'
 
       - name: Generate Gutenberg watch report
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           node scripts/gutenberg-upstream-watch.mjs \
             --lookback-days "${{ github.event_name == 'workflow_dispatch' && github.event.inputs.lookback_days || '14' }}" \

--- a/.github/workflows/gutenberg-upstream-watch.yml
+++ b/.github/workflows/gutenberg-upstream-watch.yml
@@ -1,0 +1,100 @@
+name: Gutenberg Upstream TypeScript Watch
+
+on:
+  schedule:
+    - cron: '0 6 * * 2'
+  workflow_dispatch:
+    inputs:
+      lookback_days:
+        description: 'Lookback window in days'
+        required: false
+        default: '14'
+        type: string
+      max_results:
+        description: 'Maximum issues/PRs per tracked area and item type'
+        required: false
+        default: '5'
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+  GUTENBERG_UPSTREAM_REPO: 'WordPress/gutenberg'
+  WATCH_ISSUE_NUMBER: '283'
+
+jobs:
+  gutenberg-upstream-watch:
+    name: Gutenberg TypeScript Watch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Generate Gutenberg watch report
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node scripts/gutenberg-upstream-watch.mjs \
+            --lookback-days "${{ github.event_name == 'workflow_dispatch' && github.event.inputs.lookback_days || '14' }}" \
+            --max-results "${{ github.event_name == 'workflow_dispatch' && github.event.inputs.max_results || '5' }}" \
+            --report-file "${RUNNER_TEMP}/gutenberg-upstream-watch.md" \
+            --json-file "${RUNNER_TEMP}/gutenberg-upstream-watch.json"
+
+      - name: Publish workflow summary
+        run: cat "${RUNNER_TEMP}/gutenberg-upstream-watch.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Gutenberg watch artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: gutenberg-upstream-watch
+          path: |
+            ${{ runner.temp }}/gutenberg-upstream-watch.md
+            ${{ runner.temp }}/gutenberg-upstream-watch.json
+
+      - name: Update issue #283
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('node:fs');
+            const marker = '<!-- gutenberg-upstream-watch -->';
+            const issue_number = Number(process.env.WATCH_ISSUE_NUMBER);
+            const report = fs.readFileSync(`${process.env.RUNNER_TEMP}/gutenberg-upstream-watch.md`, 'utf8');
+            const body = `${marker}\n${report}`;
+            const { owner, repo } = context.repo;
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner,
+                repo,
+                issue_number,
+                per_page: 100,
+              },
+            );
+            const existing = comments.find((comment) =>
+              comment.body?.includes(marker),
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+              core.info(`Updated Gutenberg watch comment ${existing.id}.`);
+            } else {
+              const created = await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+              core.info(`Created Gutenberg watch comment ${created.data.id}.`);
+            }

--- a/.github/workflows/gutenberg-upstream-watch.yml
+++ b/.github/workflows/gutenberg-upstream-watch.yml
@@ -39,6 +39,8 @@ jobs:
           node-version: '24'
 
       - name: Generate Gutenberg watch report
+        env:
+          GUTENBERG_UPSTREAM_TOKEN: ${{ secrets.GUTENBERG_UPSTREAM_TOKEN || vars.GUTENBERG_UPSTREAM_TOKEN || '' }}
         run: |
           node scripts/gutenberg-upstream-watch.mjs \
             --lookback-days "${{ github.event_name == 'workflow_dispatch' && github.event.inputs.lookback_days || '14' }}" \

--- a/.github/workflows/gutenberg-upstream-watch.yml
+++ b/.github/workflows/gutenberg-upstream-watch.yml
@@ -78,8 +78,10 @@ jobs:
                 per_page: 100,
               },
             );
-            const existing = comments.find((comment) =>
-              comment.body?.includes(marker),
+            const existing = comments.find(
+              (comment) =>
+                comment.user?.login === 'github-actions[bot]' &&
+                comment.body?.startsWith(marker),
             );
             if (existing) {
               await github.rest.issues.updateComment({

--- a/docs/maintenance-automation-policy.md
+++ b/docs/maintenance-automation-policy.md
@@ -100,6 +100,12 @@ It is intentionally read-only and triage-oriented. Each run:
 - publishes a workflow summary + artifact
 - refreshes the durable tracking comment on issue `#283`
 
+The workflow does not pass the repository-scoped Actions `GITHUB_TOKEN` into those
+upstream `WordPress/gutenberg` reads. It defaults to unauthenticated public GitHub
+requests, and only uses an explicit `GUTENBERG_UPSTREAM_TOKEN` override when a
+maintainer wants higher rate limits from a token that is valid for the upstream
+repository.
+
 The expected follow-up path is:
 
 - review the refreshed issue comment and workflow artifact

--- a/docs/maintenance-automation-policy.md
+++ b/docs/maintenance-automation-policy.md
@@ -11,6 +11,12 @@ The current baseline uses GitHub-native Dependabot updates for the ecosystems th
 
 These PRs target `main` directly and should be reviewed like any other normal issue PR.
 
+The maintenance baseline also includes a read-only upstream watch for Gutenberg TypeScript changes:
+
+- `.github/workflows/gutenberg-upstream-watch.yml`
+- weekly schedule plus manual dispatch
+- current durable log stored on issue `#283`
+
 ## Why the baseline is intentionally narrow
 
 The JavaScript side of the repository is a Bun-first workspace with published package coupling, release PR automation, and changeset expectations. That means a broad monorepo-wide npm bot can create noisy or half-valid update PRs unless it also understands:
@@ -72,6 +78,33 @@ Today the Bun/npm side of the repository still pulls in known transitive advisor
 - CodeQL analysis
 
 That workflow remains the place for slower repository-health checks that are not appropriate to gate every PR.
+
+### Scheduled Gutenberg upstream TypeScript watch
+
+`.github/workflows/gutenberg-upstream-watch.yml` runs on:
+
+- a weekly schedule
+- manual `workflow_dispatch`
+
+It is intentionally read-only and triage-oriented. Each run:
+
+- queries recent `WordPress/gutenberg` PRs and issues touching
+  - block registration types (`@wordpress/blocks`)
+  - block editor component types (`@wordpress/block-editor`)
+  - data store types (`@wordpress/data`)
+- reads current upstream package versions for:
+  - `@wordpress/blocks`
+  - `@wordpress/block-editor`
+  - `@wordpress/data`
+- compares the upstream `@wordpress/blocks` version against the locally owned generated-project baseline
+- publishes a workflow summary + artifact
+- refreshes the durable tracking comment on issue `#283`
+
+The expected follow-up path is:
+
+- review the refreshed issue comment and workflow artifact
+- if local type facades, helper boundaries, or generated-project dependency compatibility need attention, open or refresh a normal follow-up issue/PR on `main`
+- do not patch `release/sampo` directly from the watch lane
 
 ## Review posture
 

--- a/docs/maintenance-automation-policy.md
+++ b/docs/maintenance-automation-policy.md
@@ -104,7 +104,8 @@ The workflow does not pass the repository-scoped Actions `GITHUB_TOKEN` into tho
 upstream `WordPress/gutenberg` reads. It defaults to unauthenticated public GitHub
 requests, and only uses an explicit `GUTENBERG_UPSTREAM_TOKEN` override when a
 maintainer wants higher rate limits from a token that is valid for the upstream
-repository.
+repository. When configured, that override can come from either
+`secrets.GUTENBERG_UPSTREAM_TOKEN` or `vars.GUTENBERG_UPSTREAM_TOKEN`.
 
 The expected follow-up path is:
 

--- a/scripts/gutenberg-upstream-watch.d.mts
+++ b/scripts/gutenberg-upstream-watch.d.mts
@@ -1,0 +1,119 @@
+export interface GutenbergUpstreamWatchItem {
+	number: number;
+	state: string;
+	title: string;
+	updatedAt: string;
+	url: string;
+}
+
+export interface GutenbergUpstreamWatchAreaActivity {
+	id: string;
+	issues: GutenbergUpstreamWatchItem[];
+	pullRequests: GutenbergUpstreamWatchItem[];
+	title: string;
+}
+
+export declare const GUTENBERG_UPSTREAM_WATCH_POLICY: Readonly<{
+	cadence: 'weekly';
+	defaultLookbackDays: number;
+	defaultMaxResultsPerQuery: number;
+	issueNumber: 283;
+	upstream: Readonly<{
+		owner: 'WordPress';
+		repo: 'gutenberg';
+		ref: 'trunk';
+	}>;
+	trackedPackagePaths: Readonly<Record<string, string>>;
+	localTemplatePinFiles: readonly string[];
+	areas: readonly Readonly<{
+		id: string;
+		issueTerms: readonly string[];
+		title: string;
+	}>[];
+	workflowFile: '.github/workflows/gutenberg-upstream-watch.yml';
+}>;
+
+export declare function parseArgs(argv: string[]): {
+	jsonFile: string | null;
+	lookbackDays: number;
+	maxResultsPerQuery: number;
+	reportFile: string | null;
+};
+
+export declare function buildSearchQuery(
+	area: {
+		issueTerms: readonly string[];
+	},
+	itemType: string,
+	sinceDate: string,
+): string;
+
+export declare function extractDependencySpec(
+	sourceText: string,
+	packageName: string,
+): string | null;
+
+export declare function collectLocalDependencyPins(
+	repoRoot: string,
+	packageName: string,
+	relativePaths: readonly string[],
+): Array<{
+	path: string;
+	spec: string;
+}>;
+
+export declare function evaluateBlocksVersionDrift(
+	localSpec: string,
+	upstreamVersion: string,
+): {
+	expectedSpec: string;
+	hasDrift: boolean;
+	localSpec: string;
+	upstreamVersion: string;
+};
+
+export declare function renderWatchReport(report: {
+	areaActivity: GutenbergUpstreamWatchAreaActivity[];
+	blocksVersionDrift: ReturnType<typeof evaluateBlocksVersionDrift>;
+	cadence: string;
+	generatedAt: string;
+	issueNumber: number;
+	localBlockEditorPinsSummary: {
+		allAligned: boolean;
+		uniqueSpecs: string[];
+	};
+	localBlocksBaseline: {
+		owner: string;
+		spec: string;
+	};
+	localBlocksPinsSummary: {
+		allAligned: boolean;
+		uniqueSpecs: string[];
+	};
+	lookbackDays: number;
+	sinceDate: string;
+	upstreamPackageVersions: Array<{
+		name: string;
+		path: string;
+		version: string;
+	}>;
+}): string;
+
+export declare function generateGutenbergUpstreamWatchReport(options?: {
+	lookbackDays?: number;
+	maxResultsPerQuery?: number;
+	now?: Date;
+	repoRoot?: string;
+	token?: string | null;
+}): Promise<{
+	markdown: string;
+	report: Record<string, unknown>;
+}>;
+
+export declare function runCli(options?: {
+	args?: string[];
+	cwd?: string;
+	env?: NodeJS.ProcessEnv;
+	stdout?: { write(chunk: string): unknown };
+	stderr?: { write(chunk: string): unknown };
+}): Promise<0 | 1>;

--- a/scripts/gutenberg-upstream-watch.mjs
+++ b/scripts/gutenberg-upstream-watch.mjs
@@ -1,0 +1,466 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+	BLOCK_TYPES_REGISTRATION_PEER_BASELINE,
+} from './validate-package-manifest-policy.mjs';
+
+export const GUTENBERG_UPSTREAM_WATCH_POLICY = Object.freeze({
+	cadence: 'weekly',
+	defaultLookbackDays: 14,
+	defaultMaxResultsPerQuery: 5,
+	issueNumber: 283,
+	upstream: Object.freeze({
+		owner: 'WordPress',
+		repo: 'gutenberg',
+		ref: 'trunk',
+	}),
+	trackedPackagePaths: Object.freeze({
+		'@wordpress/block-editor': 'packages/block-editor/package.json',
+		'@wordpress/blocks': 'packages/blocks/package.json',
+		'@wordpress/data': 'packages/data/package.json',
+	}),
+	localTemplatePinFiles: Object.freeze([
+		'examples/compound-patterns/package.json',
+		'examples/my-typia-block/package.json',
+		'examples/persistence-examples/package.json',
+		'packages/create-workspace-template/package.json.mustache',
+		'packages/wp-typia-project-tools/templates/_shared/base/package.json.mustache',
+		'packages/wp-typia-project-tools/templates/_shared/compound/core/package.json.mustache',
+		'packages/wp-typia-project-tools/templates/_shared/compound/persistence/package.json.mustache',
+		'packages/wp-typia-project-tools/templates/_shared/persistence/core/package.json.mustache',
+		'packages/wp-typia-project-tools/templates/interactivity/package.json.mustache',
+	]),
+	areas: Object.freeze([
+		Object.freeze({
+			id: 'blocks-registration',
+			issueTerms: Object.freeze([
+				'"@wordpress/blocks"',
+				'registerBlockType',
+				'"block.json"',
+			]),
+			title: 'Block registration types',
+		}),
+		Object.freeze({
+			id: 'block-editor-components',
+			issueTerms: Object.freeze([
+				'"@wordpress/block-editor"',
+				'InspectorControls',
+				'useBlockProps',
+			]),
+			title: 'Block editor component types',
+		}),
+		Object.freeze({
+			id: 'data-store-types',
+			issueTerms: Object.freeze([
+				'"@wordpress/data"',
+				'useSelect',
+				'createReduxStore',
+			]),
+			title: 'Data store types',
+		}),
+	]),
+	workflowFile: '.github/workflows/gutenberg-upstream-watch.yml',
+});
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const DEFAULT_REPO_ROOT = path.resolve(__dirname, '..');
+const REPORT_MARKER = '<!-- gutenberg-upstream-watch -->';
+
+function parseIntegerOption(value, optionName) {
+	const parsed = Number.parseInt(value, 10);
+	if (!Number.isInteger(parsed) || parsed <= 0) {
+		throw new Error(`${optionName} must be a positive integer, received ${JSON.stringify(value)}.`);
+	}
+
+	return parsed;
+}
+
+export function parseArgs(argv) {
+	const options = {
+		jsonFile: null,
+		lookbackDays: GUTENBERG_UPSTREAM_WATCH_POLICY.defaultLookbackDays,
+		maxResultsPerQuery: GUTENBERG_UPSTREAM_WATCH_POLICY.defaultMaxResultsPerQuery,
+		reportFile: null,
+	};
+
+	for (let index = 0; index < argv.length; index += 1) {
+		const argument = argv[index];
+
+		if (argument === '--lookback-days') {
+			options.lookbackDays = parseIntegerOption(argv[++index], '--lookback-days');
+			continue;
+		}
+
+		if (argument === '--max-results') {
+			options.maxResultsPerQuery = parseIntegerOption(argv[++index], '--max-results');
+			continue;
+		}
+
+		if (argument === '--report-file') {
+			options.reportFile = argv[++index] ?? null;
+			continue;
+		}
+
+		if (argument === '--json-file') {
+			options.jsonFile = argv[++index] ?? null;
+			continue;
+		}
+
+		throw new Error(`Unknown argument: ${argument}`);
+	}
+
+	return options;
+}
+
+function toIsoDate(date) {
+	return date.toISOString().slice(0, 10);
+}
+
+function daysAgo(days, now = new Date()) {
+	const copy = new Date(now);
+	copy.setUTCDate(copy.getUTCDate() - days);
+	return copy;
+}
+
+function authHeaders(token) {
+	const headers = {
+		Accept: 'application/vnd.github+json',
+		'User-Agent': 'wp-typia-gutenberg-upstream-watch',
+	};
+
+	if (token) {
+		headers.Authorization = `Bearer ${token}`;
+	}
+
+	return headers;
+}
+
+async function githubJson(url, token) {
+	const response = await fetch(url, {
+		headers: authHeaders(token),
+	});
+
+	if (!response.ok) {
+		const body = await response.text();
+		throw new Error(`GitHub request failed (${response.status}) for ${url}: ${body}`);
+	}
+
+	return response.json();
+}
+
+function normalizeSearchItem(item) {
+	return {
+		number: item.number,
+		state: item.state,
+		title: item.title,
+		updatedAt: item.updated_at,
+		url: item.html_url,
+	};
+}
+
+export function buildSearchQuery(area, itemType, sinceDate) {
+	return [
+		`repo:${GUTENBERG_UPSTREAM_WATCH_POLICY.upstream.owner}/${GUTENBERG_UPSTREAM_WATCH_POLICY.upstream.repo}`,
+		`is:${itemType}`,
+		`updated:>=${sinceDate}`,
+		`(${area.issueTerms.join(' OR ')})`,
+	].join(' ');
+}
+
+async function searchAreaActivity(area, itemType, sinceDate, token, maxResultsPerQuery) {
+	const url = new URL('https://api.github.com/search/issues');
+	url.searchParams.set('order', 'desc');
+	url.searchParams.set('per_page', String(maxResultsPerQuery));
+	url.searchParams.set('q', buildSearchQuery(area, itemType, sinceDate));
+	url.searchParams.set('sort', 'updated');
+
+	const data = await githubJson(url, token);
+	return (data.items ?? []).map(normalizeSearchItem);
+}
+
+async function fetchUpstreamPackageVersion(packageName, packagePath, token) {
+	const url = new URL(
+		`https://api.github.com/repos/${GUTENBERG_UPSTREAM_WATCH_POLICY.upstream.owner}/${GUTENBERG_UPSTREAM_WATCH_POLICY.upstream.repo}/contents/${packagePath}`,
+	);
+	url.searchParams.set('ref', GUTENBERG_UPSTREAM_WATCH_POLICY.upstream.ref);
+
+	const data = await githubJson(url, token);
+	const sourceText = Buffer.from(data.content, data.encoding).toString('utf8');
+	const packageJson = JSON.parse(sourceText);
+
+	return {
+		name: packageName,
+		path: packagePath,
+		version: packageJson.version,
+	};
+}
+
+function escapeRegex(text) {
+	return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function extractDependencySpec(sourceText, packageName) {
+	const pattern = new RegExp(
+		`["']${escapeRegex(packageName)}["']\\s*:\\s*["']([^"']+)["']`,
+	);
+	const match = sourceText.match(pattern);
+	return match?.[1] ?? null;
+}
+
+export function collectLocalDependencyPins(repoRoot, packageName, relativePaths) {
+	const pins = [];
+
+	for (const relativePath of relativePaths) {
+		const absolutePath = path.join(repoRoot, relativePath);
+		if (!fs.existsSync(absolutePath)) {
+			continue;
+		}
+
+		const spec = extractDependencySpec(
+			fs.readFileSync(absolutePath, 'utf8'),
+			packageName,
+		);
+		if (!spec) {
+			continue;
+		}
+
+		pins.push({
+			path: relativePath,
+			spec,
+		});
+	}
+
+	return pins;
+}
+
+function summarizePins(pins) {
+	const uniqueSpecs = [...new Set(pins.map((pin) => pin.spec))].sort();
+	return {
+		allAligned: uniqueSpecs.length <= 1,
+		uniqueSpecs,
+	};
+}
+
+export function evaluateBlocksVersionDrift(localSpec, upstreamVersion) {
+	const expectedSpec = `^${upstreamVersion}`;
+	return {
+		expectedSpec,
+		hasDrift: localSpec !== expectedSpec,
+		localSpec,
+		upstreamVersion,
+	};
+}
+
+export function renderWatchReport(report) {
+	const lines = [
+		'# Gutenberg Upstream TypeScript Watch',
+		'',
+		`- Generated at: ${report.generatedAt}`,
+		`- Cadence: ${report.cadence}`,
+		`- Lookback window: ${report.lookbackDays} days (since ${report.sinceDate})`,
+		`- Tracking issue: #${report.issueNumber}`,
+		'',
+		'## Current upstream package versions',
+		'',
+	];
+
+	for (const packageVersion of report.upstreamPackageVersions) {
+		lines.push(`- \`${packageVersion.name}\`: \`${packageVersion.version}\``);
+	}
+
+	lines.push('', '## Local generated-project dependency baseline', '');
+	lines.push(
+		`- Canonical \`@wordpress/blocks\` owner: \`${report.localBlocksBaseline.owner}\` -> \`${report.localBlocksBaseline.spec}\``,
+	);
+	lines.push(
+		`- Generated-project \`@wordpress/blocks\` pins: ${report.localBlocksPinsSummary.allAligned ? `aligned at \`${report.localBlocksPinsSummary.uniqueSpecs[0] ?? 'n/a'}\`` : report.localBlocksPinsSummary.uniqueSpecs.map((spec) => `\`${spec}\``).join(', ')}`,
+	);
+	lines.push(
+		`- Generated-project \`@wordpress/block-editor\` pins: ${report.localBlockEditorPinsSummary.allAligned ? `aligned at \`${report.localBlockEditorPinsSummary.uniqueSpecs[0] ?? 'n/a'}\`` : report.localBlockEditorPinsSummary.uniqueSpecs.map((spec) => `\`${spec}\``).join(', ')}`,
+	);
+	lines.push('', '## Compatibility signal', '');
+
+	if (report.blocksVersionDrift.hasDrift) {
+		lines.push(
+			`- Version drift detected: local \`${report.blocksVersionDrift.localSpec}\` vs upstream \`${report.blocksVersionDrift.expectedSpec}\`. Review whether generated-project pins should move.`,
+		);
+	} else {
+		lines.push(
+			`- No \`@wordpress/blocks\` pin drift detected. Local baseline \`${report.blocksVersionDrift.localSpec}\` matches upstream \`${report.blocksVersionDrift.expectedSpec}\`.`,
+		);
+	}
+
+	for (const area of report.areaActivity) {
+		lines.push('', `## ${area.title}`, '', '### Recent pull requests', '');
+		if (area.pullRequests.length === 0) {
+			lines.push('- None found in the current lookback window.');
+		} else {
+			for (const item of area.pullRequests) {
+				lines.push(
+					`- [#${item.number}](${item.url}) ${item.title} (${item.state}, updated ${item.updatedAt.slice(0, 10)})`,
+				);
+			}
+		}
+
+		lines.push('', '### Recent issues', '');
+		if (area.issues.length === 0) {
+			lines.push('- None found in the current lookback window.');
+		} else {
+			for (const item of area.issues) {
+				lines.push(
+					`- [#${item.number}](${item.url}) ${item.title} (${item.state}, updated ${item.updatedAt.slice(0, 10)})`,
+				);
+			}
+		}
+	}
+
+	lines.push(
+		'',
+		'## Follow-up path',
+		'',
+		'- Review this report in issue #283 or the uploaded workflow artifact.',
+		'- If package-version drift or an upstream TypeScript change affects local facades, generated-project compatibility, or helper assumptions, open or refresh a normal follow-up issue/PR in this repository.',
+		'- Keep release work on `main`/`release/sampo`; do not patch the release branch directly from this watch lane.',
+	);
+
+	return `${lines.join('\n')}\n`;
+}
+
+export async function generateGutenbergUpstreamWatchReport({
+	lookbackDays = GUTENBERG_UPSTREAM_WATCH_POLICY.defaultLookbackDays,
+	maxResultsPerQuery = GUTENBERG_UPSTREAM_WATCH_POLICY.defaultMaxResultsPerQuery,
+	now = new Date(),
+	repoRoot = DEFAULT_REPO_ROOT,
+	token = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN ?? null,
+} = {}) {
+	const sinceDate = toIsoDate(daysAgo(lookbackDays, now));
+
+	const upstreamPackageVersions = await Promise.all(
+		Object.entries(GUTENBERG_UPSTREAM_WATCH_POLICY.trackedPackagePaths).map(
+			([packageName, packagePath]) =>
+				fetchUpstreamPackageVersion(packageName, packagePath, token),
+		),
+	);
+
+	const areaActivity = await Promise.all(
+		GUTENBERG_UPSTREAM_WATCH_POLICY.areas.map(async (area) => ({
+			id: area.id,
+			issues: await searchAreaActivity(
+				area,
+				'issue',
+				sinceDate,
+				token,
+				maxResultsPerQuery,
+			),
+			pullRequests: await searchAreaActivity(
+				area,
+				'pr',
+				sinceDate,
+				token,
+				maxResultsPerQuery,
+			),
+			title: area.title,
+		})),
+	);
+
+	const localBlocksBaseline = {
+		owner: 'scripts/validate-package-manifest-policy.mjs',
+		spec: BLOCK_TYPES_REGISTRATION_PEER_BASELINE['@wordpress/blocks'],
+	};
+	const localBlocksPins = collectLocalDependencyPins(
+		repoRoot,
+		'@wordpress/blocks',
+		GUTENBERG_UPSTREAM_WATCH_POLICY.localTemplatePinFiles,
+	);
+	const localBlockEditorPins = collectLocalDependencyPins(
+		repoRoot,
+		'@wordpress/block-editor',
+		GUTENBERG_UPSTREAM_WATCH_POLICY.localTemplatePinFiles,
+	);
+	const upstreamBlocksVersion = upstreamPackageVersions.find(
+		(item) => item.name === '@wordpress/blocks',
+	)?.version;
+
+	if (!upstreamBlocksVersion) {
+		throw new Error('Unable to determine the upstream @wordpress/blocks version.');
+	}
+
+	const report = {
+		areaActivity,
+		blocksVersionDrift: evaluateBlocksVersionDrift(
+			localBlocksBaseline.spec,
+			upstreamBlocksVersion,
+		),
+		cadence: GUTENBERG_UPSTREAM_WATCH_POLICY.cadence,
+		generatedAt: now.toISOString(),
+		issueNumber: GUTENBERG_UPSTREAM_WATCH_POLICY.issueNumber,
+		localBlockEditorPins,
+		localBlockEditorPinsSummary: summarizePins(localBlockEditorPins),
+		localBlocksBaseline,
+		localBlocksPins,
+		localBlocksPinsSummary: summarizePins(localBlocksPins),
+		lookbackDays,
+		reportMarker: REPORT_MARKER,
+		sinceDate,
+		upstreamPackageVersions,
+	};
+
+	return {
+		markdown: renderWatchReport(report),
+		report,
+	};
+}
+
+function writeOutputFile(filePath, content) {
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, content, 'utf8');
+}
+
+export async function runCli({
+	args = process.argv.slice(2),
+	cwd = process.cwd(),
+	env = process.env,
+	stdout = process.stdout,
+	stderr = process.stderr,
+} = {}) {
+	try {
+		const options = parseArgs(args);
+		const { markdown, report } = await generateGutenbergUpstreamWatchReport({
+			lookbackDays: options.lookbackDays,
+			maxResultsPerQuery: options.maxResultsPerQuery,
+			repoRoot: cwd,
+			token: env.GITHUB_TOKEN ?? env.GH_TOKEN ?? null,
+		});
+
+		if (options.reportFile) {
+			writeOutputFile(options.reportFile, markdown);
+		} else {
+			stdout.write(markdown);
+		}
+
+		if (options.jsonFile) {
+			writeOutputFile(
+				options.jsonFile,
+				`${JSON.stringify(report, null, 2)}\n`,
+			);
+		}
+
+		return 0;
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		stderr.write(`Failed to generate Gutenberg upstream watch report: ${message}\n`);
+		return 1;
+	}
+}
+
+const currentFilePath = fileURLToPath(import.meta.url);
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : '';
+
+if (invokedPath === currentFilePath) {
+	process.exitCode = await runCli();
+}

--- a/scripts/gutenberg-upstream-watch.mjs
+++ b/scripts/gutenberg-upstream-watch.mjs
@@ -336,7 +336,7 @@ export async function generateGutenbergUpstreamWatchReport({
 	maxResultsPerQuery = GUTENBERG_UPSTREAM_WATCH_POLICY.defaultMaxResultsPerQuery,
 	now = new Date(),
 	repoRoot = DEFAULT_REPO_ROOT,
-	token = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN ?? null,
+	token = process.env.GUTENBERG_UPSTREAM_TOKEN ?? process.env.GH_TOKEN ?? null,
 } = {}) {
 	const sinceDate = toIsoDate(daysAgo(lookbackDays, now));
 
@@ -434,7 +434,7 @@ export async function runCli({
 			lookbackDays: options.lookbackDays,
 			maxResultsPerQuery: options.maxResultsPerQuery,
 			repoRoot: cwd,
-			token: env.GITHUB_TOKEN ?? env.GH_TOKEN ?? null,
+			token: env.GUTENBERG_UPSTREAM_TOKEN ?? env.GH_TOKEN ?? null,
 		});
 
 		if (options.reportFile) {

--- a/scripts/validate-maintenance-automation-policy.mjs
+++ b/scripts/validate-maintenance-automation-policy.mjs
@@ -16,7 +16,13 @@ export const MAINTENANCE_AUTOMATION_POLICY = Object.freeze({
     'composer audit --locked',
     'scheduled/manual',
     '.github/workflows/dependency-audit.yml',
+    '.github/workflows/gutenberg-upstream-watch.yml',
     '.github/workflows/test-matrix.yml',
+    'WordPress/gutenberg',
+    '@wordpress/blocks',
+    '@wordpress/block-editor',
+    '@wordpress/data',
+    'issue `#283`',
   ]),
   ciScript: 'node scripts/validate-maintenance-automation-policy.mjs',
 });
@@ -235,6 +241,28 @@ function validateScheduledWorkflow(sourceText, errors) {
   }
 }
 
+function validateGutenbergWatchWorkflow(sourceText, errors) {
+  for (const requiredSnippet of [
+    'name: Gutenberg Upstream TypeScript Watch',
+    'schedule:',
+    'workflow_dispatch:',
+    "WATCH_ISSUE_NUMBER: '283'",
+    'permissions:',
+    'issues: write',
+    'node scripts/gutenberg-upstream-watch.mjs',
+    'actions/upload-artifact@v4',
+    'Update issue #283',
+    '<!-- gutenberg-upstream-watch -->',
+    'WordPress/gutenberg',
+  ]) {
+    if (!sourceText.includes(requiredSnippet)) {
+      errors.push(
+        `.github/workflows/gutenberg-upstream-watch.yml must include ${JSON.stringify(requiredSnippet)}.`,
+      );
+    }
+  }
+}
+
 export function validateMaintenanceAutomationPolicy(repoRoot = DEFAULT_REPO_ROOT) {
   const errors = [];
   const packageJson = readJson(path.join(repoRoot, 'package.json'));
@@ -267,6 +295,10 @@ export function validateMaintenanceAutomationPolicy(repoRoot = DEFAULT_REPO_ROOT
   );
   validateScheduledWorkflow(
     readRelativeText(repoRoot, '.github/workflows/test-matrix.yml'),
+    errors,
+  );
+  validateGutenbergWatchWorkflow(
+    readRelativeText(repoRoot, '.github/workflows/gutenberg-upstream-watch.yml'),
     errors,
   );
 

--- a/scripts/validate-maintenance-automation-policy.mjs
+++ b/scripts/validate-maintenance-automation-policy.mjs
@@ -254,6 +254,8 @@ function validateGutenbergWatchWorkflow(sourceText, errors) {
     'Update issue #283',
     '<!-- gutenberg-upstream-watch -->',
     'WordPress/gutenberg',
+    "comment.user?.login === 'github-actions[bot]'",
+    'comment.body?.startsWith(marker)',
   ]) {
     if (!sourceText.includes(requiredSnippet)) {
       errors.push(

--- a/scripts/validate-maintenance-automation-policy.mjs
+++ b/scripts/validate-maintenance-automation-policy.mjs
@@ -247,6 +247,7 @@ function validateGutenbergWatchWorkflow(sourceText, errors) {
     'schedule:',
     'workflow_dispatch:',
     "WATCH_ISSUE_NUMBER: '283'",
+    'GUTENBERG_UPSTREAM_TOKEN',
     'permissions:',
     'issues: write',
     'node scripts/gutenberg-upstream-watch.mjs',

--- a/tests/unit/gutenberg-upstream-watch.test.ts
+++ b/tests/unit/gutenberg-upstream-watch.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+	buildSearchQuery,
+	collectLocalDependencyPins,
+	evaluateBlocksVersionDrift,
+	extractDependencySpec,
+	renderWatchReport,
+} from '../../scripts/gutenberg-upstream-watch.mjs';
+
+let tempDirs: string[] = [];
+
+afterEach(() => {
+	for (const tempDir of tempDirs) {
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	}
+	tempDirs = [];
+});
+
+function writeText(filePath: string, value: string) {
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, value, 'utf8');
+}
+
+describe('gutenberg-upstream-watch helpers', () => {
+	test('buildSearchQuery scopes searches to Gutenberg, type area, and lookback date', () => {
+		const query = buildSearchQuery(
+			{
+				issueTerms: ['"@wordpress/blocks"', 'registerBlockType'],
+			},
+			'pr',
+			'2026-04-01',
+		);
+
+		expect(query).toContain('repo:WordPress/gutenberg');
+		expect(query).toContain('is:pr');
+		expect(query).toContain('updated:>=2026-04-01');
+		expect(query).toContain('"@wordpress/blocks" OR registerBlockType');
+	});
+
+	test('extractDependencySpec reads package pins from package.json-like text', () => {
+		expect(
+			extractDependencySpec(
+				'{ "@wordpress/blocks": "^15.2.0", "@wordpress/data": "^12.0.0" }',
+				'@wordpress/blocks',
+			),
+		).toBe('^15.2.0');
+		expect(extractDependencySpec('{ "name": "demo" }', '@wordpress/blocks')).toBeNull();
+	});
+
+	test('collectLocalDependencyPins gathers dependency specs from tracked files', () => {
+		const repoRoot = fs.mkdtempSync(
+			path.join(os.tmpdir(), 'wp-typia-gutenberg-watch-'),
+		);
+		tempDirs.push(repoRoot);
+
+		writeText(
+			path.join(repoRoot, 'templates/a/package.json.mustache'),
+			'{ "@wordpress/blocks": "^15.2.0" }\n',
+		);
+		writeText(
+			path.join(repoRoot, 'templates/b/package.json.mustache'),
+			'{ "@wordpress/blocks": "^15.3.0" }\n',
+		);
+
+		expect(
+			collectLocalDependencyPins(repoRoot, '@wordpress/blocks', [
+				'templates/a/package.json.mustache',
+				'templates/b/package.json.mustache',
+				'templates/missing/package.json.mustache',
+			]),
+		).toEqual([
+			{ path: 'templates/a/package.json.mustache', spec: '^15.2.0' },
+			{ path: 'templates/b/package.json.mustache', spec: '^15.3.0' },
+		]);
+	});
+
+	test('evaluateBlocksVersionDrift compares the canonical local spec against Gutenberg trunk', () => {
+		expect(evaluateBlocksVersionDrift('^15.2.0', '15.2.0')).toEqual({
+			expectedSpec: '^15.2.0',
+			hasDrift: false,
+			localSpec: '^15.2.0',
+			upstreamVersion: '15.2.0',
+		});
+
+		expect(evaluateBlocksVersionDrift('^15.2.0', '15.3.0').hasDrift).toBe(true);
+	});
+
+	test('renderWatchReport includes version drift, tracked areas, and follow-up guidance', () => {
+		const markdown = renderWatchReport({
+			areaActivity: [
+				{
+					id: 'blocks-registration',
+					issues: [],
+					pullRequests: [
+						{
+							number: 76312,
+							state: 'closed',
+							title: 'Tighten Gutenberg block typing',
+							updatedAt: '2026-04-14T10:00:00Z',
+							url: 'https://github.com/WordPress/gutenberg/pull/76312',
+						},
+					],
+					title: 'Block registration types',
+				},
+			],
+			blocksVersionDrift: evaluateBlocksVersionDrift('^15.2.0', '15.3.0'),
+			cadence: 'weekly',
+			generatedAt: '2026-04-15T00:00:00.000Z',
+			issueNumber: 283,
+			localBlockEditorPinsSummary: {
+				allAligned: true,
+				uniqueSpecs: ['^15.2.0'],
+			},
+			localBlocksBaseline: {
+				owner: 'scripts/validate-package-manifest-policy.mjs',
+				spec: '^15.2.0',
+			},
+			localBlocksPinsSummary: {
+				allAligned: true,
+				uniqueSpecs: ['^15.2.0'],
+			},
+			lookbackDays: 14,
+			sinceDate: '2026-04-01',
+			upstreamPackageVersions: [
+				{
+					name: '@wordpress/blocks',
+					path: 'packages/blocks/package.json',
+					version: '15.3.0',
+				},
+				{
+					name: '@wordpress/block-editor',
+					path: 'packages/block-editor/package.json',
+					version: '15.3.0',
+				},
+				{
+					name: '@wordpress/data',
+					path: 'packages/data/package.json',
+					version: '13.0.0',
+				},
+			],
+		});
+
+		expect(markdown).toContain('# Gutenberg Upstream TypeScript Watch');
+		expect(markdown).toContain('Version drift detected');
+		expect(markdown).toContain('Block registration types');
+		expect(markdown).toContain('Tighten Gutenberg block typing');
+		expect(markdown).toContain('Follow-up path');
+	});
+});

--- a/tests/unit/maintenance-automation-policy.test.ts
+++ b/tests/unit/maintenance-automation-policy.test.ts
@@ -62,7 +62,7 @@ function createMaintenancePolicyRepo() {
 
   writeText(
     path.join(repoRoot, '.github/workflows/gutenberg-upstream-watch.yml'),
-    `name: Gutenberg Upstream TypeScript Watch\non:\n  schedule:\n    - cron: '0 6 * * 2'\n  workflow_dispatch:\npermissions:\n  contents: read\n  issues: write\nenv:\n  GUTENBERG_UPSTREAM_REPO: 'WordPress/gutenberg'\n  WATCH_ISSUE_NUMBER: '283'\njobs:\n  gutenberg-upstream-watch:\n    steps:\n      - run: node scripts/gutenberg-upstream-watch.mjs --report-file ./report.md\n      - uses: actions/upload-artifact@v4\n      - name: Update issue #283\n        run: echo '<!-- gutenberg-upstream-watch --> WordPress/gutenberg'\n`
+    `name: Gutenberg Upstream TypeScript Watch\non:\n  schedule:\n    - cron: '0 6 * * 2'\n  workflow_dispatch:\npermissions:\n  contents: read\n  issues: write\nenv:\n  GUTENBERG_UPSTREAM_REPO: 'WordPress/gutenberg'\n  WATCH_ISSUE_NUMBER: '283'\njobs:\n  gutenberg-upstream-watch:\n    steps:\n      - run: node scripts/gutenberg-upstream-watch.mjs --report-file ./report.md\n      - uses: actions/upload-artifact@v4\n      - name: Update issue #283\n        run: |\n          echo '<!-- gutenberg-upstream-watch --> WordPress/gutenberg'\n          echo \"comment.user?.login === 'github-actions[bot]'\"\n          echo 'comment.body?.startsWith(marker)'\n`
   );
 
   writeText(

--- a/tests/unit/maintenance-automation-policy.test.ts
+++ b/tests/unit/maintenance-automation-policy.test.ts
@@ -61,8 +61,13 @@ function createMaintenancePolicyRepo() {
   );
 
   writeText(
+    path.join(repoRoot, '.github/workflows/gutenberg-upstream-watch.yml'),
+    `name: Gutenberg Upstream TypeScript Watch\non:\n  schedule:\n    - cron: '0 6 * * 2'\n  workflow_dispatch:\npermissions:\n  contents: read\n  issues: write\nenv:\n  GUTENBERG_UPSTREAM_REPO: 'WordPress/gutenberg'\n  WATCH_ISSUE_NUMBER: '283'\njobs:\n  gutenberg-upstream-watch:\n    steps:\n      - run: node scripts/gutenberg-upstream-watch.mjs --report-file ./report.md\n      - uses: actions/upload-artifact@v4\n      - name: Update issue #283\n        run: echo '<!-- gutenberg-upstream-watch --> WordPress/gutenberg'\n`
+  );
+
+  writeText(
     path.join(repoRoot, 'docs/maintenance-automation-policy.md'),
-    `Dependabot updates\ngithub-actions\ncomposer\nrelease/sampo\nbun audit --audit-level high\ncomposer audit --locked\nscheduled/manual\n.github/workflows/dependency-audit.yml\n.github/workflows/test-matrix.yml\n`
+    `Dependabot updates\ngithub-actions\ncomposer\nrelease/sampo\nbun audit --audit-level high\ncomposer audit --locked\nscheduled/manual\n.github/workflows/dependency-audit.yml\n.github/workflows/gutenberg-upstream-watch.yml\n.github/workflows/test-matrix.yml\nWordPress/gutenberg\n@wordpress/blocks\n@wordpress/block-editor\n@wordpress/data\nissue \`#283\`\n`
   );
 
   writeText(
@@ -166,6 +171,10 @@ describe('validateMaintenanceAutomationPolicy', () => {
       path.join(repoRoot, '.github/workflows/test-matrix.yml'),
       `jobs:\n  security-scan:\n    name: CodeQL Scan\n    steps:\n      - name: Run Bun audit\n        run: bun audit --audit-level high\n`
     );
+    writeText(
+      path.join(repoRoot, '.github/workflows/gutenberg-upstream-watch.yml'),
+      `name: Gutenberg Upstream TypeScript Watch\njobs:\n  watch:\n    steps:\n      - run: node scripts/other-script.mjs\n`
+    );
 
     const result = validateMaintenanceAutomationPolicy(repoRoot);
 
@@ -184,6 +193,9 @@ describe('validateMaintenanceAutomationPolicy', () => {
     );
     expect(result.errors).toContain(
       '.github/workflows/test-matrix.yml should not duplicate the Bun audit step now that dependency-audit.yml owns the fast audit lane.',
+    );
+    expect(result.errors).toContain(
+      '.github/workflows/gutenberg-upstream-watch.yml must include "WATCH_ISSUE_NUMBER: \'283\'".',
     );
   });
 

--- a/tests/unit/maintenance-automation-policy.test.ts
+++ b/tests/unit/maintenance-automation-policy.test.ts
@@ -62,7 +62,7 @@ function createMaintenancePolicyRepo() {
 
   writeText(
     path.join(repoRoot, '.github/workflows/gutenberg-upstream-watch.yml'),
-    `name: Gutenberg Upstream TypeScript Watch\non:\n  schedule:\n    - cron: '0 6 * * 2'\n  workflow_dispatch:\npermissions:\n  contents: read\n  issues: write\nenv:\n  GUTENBERG_UPSTREAM_REPO: 'WordPress/gutenberg'\n  WATCH_ISSUE_NUMBER: '283'\njobs:\n  gutenberg-upstream-watch:\n    steps:\n      - run: node scripts/gutenberg-upstream-watch.mjs --report-file ./report.md\n      - uses: actions/upload-artifact@v4\n      - name: Update issue #283\n        run: |\n          echo '<!-- gutenberg-upstream-watch --> WordPress/gutenberg'\n          echo \"comment.user?.login === 'github-actions[bot]'\"\n          echo 'comment.body?.startsWith(marker)'\n`
+    `name: Gutenberg Upstream TypeScript Watch\non:\n  schedule:\n    - cron: '0 6 * * 2'\n  workflow_dispatch:\npermissions:\n  contents: read\n  issues: write\nenv:\n  GUTENBERG_UPSTREAM_REPO: 'WordPress/gutenberg'\n  WATCH_ISSUE_NUMBER: '283'\njobs:\n  gutenberg-upstream-watch:\n    steps:\n      - env:\n          GUTENBERG_UPSTREAM_TOKEN: \${{ secrets.GUTENBERG_UPSTREAM_TOKEN || vars.GUTENBERG_UPSTREAM_TOKEN || '' }}\n        run: node scripts/gutenberg-upstream-watch.mjs --report-file ./report.md\n      - uses: actions/upload-artifact@v4\n      - name: Update issue #283\n        run: |\n          echo '<!-- gutenberg-upstream-watch --> WordPress/gutenberg'\n          echo \"comment.user?.login === 'github-actions[bot]'\"\n          echo 'comment.body?.startsWith(marker)'\n`
   );
 
   writeText(


### PR DESCRIPTION
## Summary
- add a scheduled/manual Gutenberg upstream TypeScript watch workflow
- generate a durable markdown/json watch report and refresh the issue #283 tracking comment
- document and validate the new maintenance automation policy

Closes #283

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced automated weekly monitoring for upstream changes with manual trigger capability
  * Generates and publishes compatibility reports to GitHub issue tracking

* **Documentation**
  * Updated maintenance automation policy documentation

* **Tests**
  * Added comprehensive test coverage for monitoring functionality

* **Chores**
  * Enhanced validation for maintenance automation policies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->