### PR TITLE
Validate wrapped manifests in migration registry generation

### DIFF
--- a/.sampo/changesets/issue-284-review-follow-up.md
+++ b/.sampo/changesets/issue-284-review-follow-up.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Keep migration registry generation validating the current manifest even when retrofitted projects import a local `manifest-document.ts` wrapper, so malformed or stale wrappers still fail fast during migration setup.

--- a/packages/wp-typia-project-tools/src/runtime/migration-render.ts
+++ b/packages/wp-typia-project-tools/src/runtime/migration-render.ts
@@ -192,8 +192,8 @@ export function renderMigrationRuleFile({
 /**
  * Renders the generated migration registry module for a block target.
  *
- * Prefers typed manifest wrapper modules when they are available in the
- * project, and otherwise falls back to parsing the raw manifest JSON import.
+ * Prefers manifest wrapper modules when they are available in the project,
+ * while still validating the imported manifest before the registry consumes it.
  *
  * @param state The resolved migration project state.
  * @param blockKey The stable key for the block whose registry is being generated.
@@ -229,15 +229,10 @@ export function renderMigrationRegistryFile(
 		),
 		currentManifestWrapperFile !== null,
 	);
-	const currentManifestExpression = currentManifestWrapperFile !== null
-		? "rawCurrentManifest"
-		: "parseManifestDocument<ManifestDocument>(rawCurrentManifest)";
 	const imports = [
 		`import rawCurrentManifest from "${currentManifestImport}";`,
 		`import type { ManifestDocument, MigrationRiskSummary } from "${normalizeImportPath(path.relative(getGeneratedDir(block, state), path.join(state.projectDir, "src", "migrations", "helpers.ts")), true)}";`,
-		...(entries.length > 0 || currentManifestWrapperFile === null
-			? [`import { parseManifestDocument } from "@wp-typia/block-runtime/editor";`]
-			: []),
+		`import { parseManifestDocument } from "@wp-typia/block-runtime/editor";`,
 	];
 	const body: string[] = [];
 
@@ -271,7 +266,7 @@ export const migrationRegistry: {
 	entries: MigrationRegistryEntry[];
 } = {
 	currentMigrationVersion: "${state.config.currentMigrationVersion}",
-	currentManifest: ${currentManifestExpression},
+	currentManifest: parseManifestDocument<ManifestDocument>(rawCurrentManifest),
 	entries: [
 ${body.join("\n")}
 	],

--- a/packages/wp-typia-project-tools/tests/migration-init.test.ts
+++ b/packages/wp-typia-project-tools/tests/migration-init.test.ts
@@ -175,7 +175,9 @@ test("migrate init prefers src manifest wrappers for legacy-root retrofit layout
 	expect(registrySource).toContain(
 		'import rawCurrentManifest from "../../manifest-document";',
 	);
-	expect(registrySource).toContain("currentManifest: rawCurrentManifest,");
+	expect(registrySource).toContain(
+		"currentManifest: parseManifestDocument<ManifestDocument>(rawCurrentManifest),",
+	);
 });
 
 test("migrate init falls back to single-block detection when all multi-block candidates are malformed", () => {


### PR DESCRIPTION
## Summary
- keep using manifest wrapper modules when present during migration registry generation
- always validate the imported current manifest before writing it into the generated registry
- update the legacy-root retrofit regression test to cover wrapper imports that still need parsing

## Testing
- `bun test packages/wp-typia-project-tools/tests/migration-init.test.ts`
- `bun test packages/wp-typia-project-tools/tests/migration-init.test.ts -t 'prefers src manifest wrappers for legacy-root retrofit layouts when present'`

Refs #284
Follow-up to #288.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed manifest document handling in migration registry generation to ensure consistent validation across all project configurations, removing conditional logic that previously bypassed validation in certain scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->