### PR TITLE
Parameterize scaffold repository reference rewrites

### DIFF
--- a/.sampo/changesets/issue-273-fork-rewrite.md
+++ b/.sampo/changesets/issue-273-fork-rewrite.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Parameterize scaffold repository placeholder rewrites so generated projects can inherit a fork-aware `owner/repo` reference from runtime package metadata or an explicit `repositoryReference` override instead of hardcoding `imjlk/wp-typia`.

--- a/packages/wp-typia-project-tools/src/runtime/block-generator-service.ts
+++ b/packages/wp-typia-project-tools/src/runtime/block-generator-service.ts
@@ -100,6 +100,7 @@ export interface BlockGenerationTarget {
 	noInstall: boolean;
 	packageManager: PackageManagerId;
 	projectDir: string;
+	repositoryReference?: string;
 	variant?: string;
 }
 
@@ -114,6 +115,7 @@ export interface PlanBlockInput {
 	packageManager: PackageManagerId;
 	persistencePolicy?: PersistencePolicy;
 	projectDir: string;
+	repositoryReference?: string;
 	templateId: BuiltInTemplateId;
 	variant?: string;
 	withMigrationUi?: boolean;
@@ -432,6 +434,7 @@ export class BlockGeneratorService {
 		packageManager,
 		persistencePolicy,
 		projectDir,
+		repositoryReference,
 		templateId,
 		variant,
 		withMigrationUi = false,
@@ -456,6 +459,7 @@ export class BlockGeneratorService {
 				noInstall,
 				packageManager,
 				projectDir,
+				repositoryReference,
 				variant,
 			},
 		};
@@ -643,6 +647,7 @@ export class BlockGeneratorService {
 				noInstall: rendered.target.noInstall,
 				packageManager: rendered.target.packageManager,
 				projectDir: rendered.target.projectDir,
+				repositoryReference: rendered.target.repositoryReference,
 				gitignoreContent: rendered.gitignoreContent,
 				readmeContent: rendered.readmeContent,
 				templateDir: rendered.templateDir,

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-apply-utils.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-apply-utils.ts
@@ -48,6 +48,10 @@ import {
 	getPackageManager,
 	transformPackageManagerText,
 } from "./package-managers.js";
+import {
+	replaceRepositoryReferencePlaceholders,
+	resolveScaffoldRepositoryReference,
+} from "./scaffold-repository-reference.js";
 import type {
 	ScaffoldTemplateVariables,
 } from "./scaffold.js";
@@ -412,6 +416,13 @@ export async function removeUnexpectedLockfiles(
 export async function replaceTextRecursively(
 	targetDir: string,
 	packageManagerId: PackageManagerId,
+	{
+		repositoryManifestPaths,
+		repositoryReference,
+	}: {
+		repositoryManifestPaths?: readonly string[];
+		repositoryReference?: string;
+	} = {},
 ): Promise<void> {
 	const textExtensions = new Set([
 		".css",
@@ -425,6 +436,11 @@ export async function replaceTextRecursively(
 		".tsx",
 		".txt",
 	]);
+	const resolvedRepositoryReference =
+		repositoryReference ??
+		resolveScaffoldRepositoryReference({
+			manifestPaths: repositoryManifestPaths,
+		});
 
 	async function visit(currentPath: string): Promise<void> {
 		const stats = await fsp.stat(currentPath);
@@ -441,9 +457,10 @@ export async function replaceTextRecursively(
 		}
 
 		const content = await fsp.readFile(currentPath, "utf8");
-		const nextContent = transformPackageManagerText(content, packageManagerId)
-			.replace(/yourusername\/wp-typia-boilerplate/g, "imjlk/wp-typia")
-			.replace(/yourusername\/wp-typia/g, "imjlk/wp-typia");
+		const nextContent = replaceRepositoryReferencePlaceholders(
+			transformPackageManagerText(content, packageManagerId),
+			resolvedRepositoryReference,
+		);
 
 		if (nextContent !== content) {
 			await fsp.writeFile(currentPath, nextContent, "utf8");
@@ -532,6 +549,7 @@ export async function applyBuiltInScaffoldProjectFiles({
 	withWpEnv = false,
 	noInstall = false,
 	installDependencies,
+	repositoryReference,
 }: {
 	projectDir: string;
 	templateDir: string;
@@ -548,6 +566,7 @@ export async function applyBuiltInScaffoldProjectFiles({
 	withWpEnv?: boolean;
 	noInstall?: boolean;
 	installDependencies?: ((options: InstallDependenciesOptions) => Promise<void>) | undefined;
+	repositoryReference?: string;
 }): Promise<void> {
 	await ensureDirectory(projectDir, allowExistingDir);
 	await copyInterpolatedDirectory(templateDir, projectDir, variables);
@@ -607,7 +626,9 @@ export async function applyBuiltInScaffoldProjectFiles({
 	});
 	await normalizePackageManagerFiles(projectDir, packageManager);
 	await removeUnexpectedLockfiles(projectDir, packageManager);
-	await replaceTextRecursively(projectDir, packageManager);
+	await replaceTextRecursively(projectDir, packageManager, {
+		repositoryReference,
+	});
 
 	if (!noInstall) {
 		const installer = installDependencies ?? defaultInstallDependencies;

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-apply-utils.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-apply-utils.ts
@@ -413,6 +413,10 @@ export async function removeUnexpectedLockfiles(
 	);
 }
 
+/**
+ * Recursively normalizes generated text files for the selected package manager
+ * and repository reference.
+ */
 export async function replaceTextRecursively(
 	targetDir: string,
 	packageManagerId: PackageManagerId,
@@ -533,6 +537,10 @@ export async function applyWorkspaceMigrationCapability(
 	writeInitialMigrationScaffold(projectDir, "v1", []);
 }
 
+/**
+ * Applies a built-in scaffold into the target directory, including generated
+ * code artifacts, starter manifests, preset files, and placeholder rewrites.
+ */
 export async function applyBuiltInScaffoldProjectFiles({
 	projectDir,
 	templateDir,

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-repository-reference.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-repository-reference.ts
@@ -77,8 +77,9 @@ function parseRepositoryReference(
 		return null;
 	}
 
-	if (/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u.test(trimmed)) {
-		return trimmed;
+	const normalizedShorthand = trimmed.replace(/^github:/u, "");
+	if (/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+(?:#.+)?$/u.test(normalizedShorthand)) {
+		return normalizedShorthand.replace(/#.*$/u, "");
 	}
 
 	const normalizedValue = trimmed

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-repository-reference.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-repository-reference.ts
@@ -77,23 +77,48 @@ function parseRepositoryReference(
 		return null;
 	}
 
-	const normalizedShorthand = trimmed.replace(/^github:/u, "");
-	if (/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+(?:#.+)?$/u.test(normalizedShorthand)) {
-		return normalizedShorthand.replace(/#.*$/u, "");
+	const githubShorthandMatch = trimmed.match(
+		/^github:([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+?)(?:#.*)?$/u,
+	);
+	if (githubShorthandMatch) {
+		return `${githubShorthandMatch[1]}/${githubShorthandMatch[2]}`;
+	}
+
+	if (/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u.test(trimmed)) {
+		return trimmed;
+	}
+
+	const githubScpMatch = trimmed.match(
+		/^git@github\.com:([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+?)(?:\.git)?(?:#.*)?$/u,
+	);
+	if (githubScpMatch) {
+		return `${githubScpMatch[1]}/${githubScpMatch[2]}`;
 	}
 
 	const normalizedValue = trimmed
 		.replace(/^git\+/u, "")
-		.replace(/\.git$/u, "");
-	const githubMatch = normalizedValue.match(
-		/github\.com(?:[:/])([^/\s#]+)\/([^/\s#]+?)(?:\.git)?(?:[/?#]|$)/iu,
-	);
+		.replace(/#.*$/u, "");
 
-	if (!githubMatch) {
+	let parsedUrl: URL;
+	try {
+		parsedUrl = new URL(normalizedValue);
+	} catch {
 		return null;
 	}
 
-	return `${githubMatch[1]}/${githubMatch[2]}`;
+	if (parsedUrl.hostname !== "github.com") {
+		return null;
+	}
+
+	const pathSegments = parsedUrl.pathname
+		.replace(/^\/+/u, "")
+		.replace(/\.git$/u, "")
+		.split("/");
+	if (pathSegments.length < 2 || !pathSegments[0] || !pathSegments[1]) {
+		return null;
+	}
+
+	return `${pathSegments[0]}/${pathSegments[1]}`;
 }
 
 function getDefaultRepositoryManifestPaths(): string[] {

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-repository-reference.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-repository-reference.ts
@@ -1,0 +1,136 @@
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+import { PROJECT_TOOLS_PACKAGE_ROOT } from "./template-registry.js";
+
+interface RepositoryPackageManifest {
+	repository?:
+		| string
+		| {
+				type?: string;
+				url?: string;
+		  };
+}
+
+const require = createRequire(import.meta.url);
+
+export const DEFAULT_SCAFFOLD_REPOSITORY_REFERENCE = "imjlk/wp-typia";
+
+function getErrorCode(error: unknown): string | undefined {
+	return typeof error === "object" && error !== null && "code" in error
+		? String((error as { code: unknown }).code)
+		: undefined;
+}
+
+function readRepositoryPackageManifest(
+	packageJsonPath: string,
+): RepositoryPackageManifest | null {
+	try {
+		return JSON.parse(
+			fs.readFileSync(packageJsonPath, "utf8"),
+		) as RepositoryPackageManifest;
+	} catch (error) {
+		if (getErrorCode(error) === "ENOENT") {
+			return null;
+		}
+
+		throw error;
+	}
+}
+
+function resolveInstalledPackageManifestPath(
+	packageName: string,
+): string | null {
+	try {
+		return require.resolve(`${packageName}/package.json`);
+	} catch (error) {
+		if (getErrorCode(error) === "MODULE_NOT_FOUND") {
+			return null;
+		}
+
+		throw error;
+	}
+}
+
+function getRepositoryFieldValue(
+	manifest: RepositoryPackageManifest | null,
+): string | undefined {
+	if (!manifest?.repository) {
+		return undefined;
+	}
+
+	return typeof manifest.repository === "string"
+		? manifest.repository
+		: manifest.repository.url;
+}
+
+function parseRepositoryReference(
+	value: string | undefined,
+): string | null {
+	const trimmed = value?.trim();
+	if (!trimmed) {
+		return null;
+	}
+
+	if (/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u.test(trimmed)) {
+		return trimmed;
+	}
+
+	const normalizedValue = trimmed
+		.replace(/^git\+/u, "")
+		.replace(/\.git$/u, "");
+	const githubMatch = normalizedValue.match(
+		/github\.com(?:[:/])([^/\s#]+)\/([^/\s#]+?)(?:\.git)?(?:[/?#]|$)/iu,
+	);
+
+	if (!githubMatch) {
+		return null;
+	}
+
+	return `${githubMatch[1]}/${githubMatch[2]}`;
+}
+
+function getDefaultRepositoryManifestPaths(): string[] {
+	const candidatePaths = [
+		path.resolve(PROJECT_TOOLS_PACKAGE_ROOT, "..", "..", "package.json"),
+		path.join(PROJECT_TOOLS_PACKAGE_ROOT, "package.json"),
+		path.resolve(PROJECT_TOOLS_PACKAGE_ROOT, "..", "wp-typia", "package.json"),
+		resolveInstalledPackageManifestPath("@wp-typia/project-tools"),
+		resolveInstalledPackageManifestPath("wp-typia"),
+	].filter((candidatePath): candidatePath is string => Boolean(candidatePath));
+
+	return candidatePaths.filter(
+		(candidatePath, index, allPaths) =>
+			allPaths.indexOf(candidatePath) === index,
+	);
+}
+
+export function resolveScaffoldRepositoryReference({
+	fallback = DEFAULT_SCAFFOLD_REPOSITORY_REFERENCE,
+	manifestPaths = getDefaultRepositoryManifestPaths(),
+}: {
+	fallback?: string;
+	manifestPaths?: readonly string[];
+} = {}): string {
+	for (const manifestPath of manifestPaths) {
+		const repositoryReference = parseRepositoryReference(
+			getRepositoryFieldValue(readRepositoryPackageManifest(manifestPath)),
+		);
+
+		if (repositoryReference) {
+			return repositoryReference;
+		}
+	}
+
+	return fallback;
+}
+
+export function replaceRepositoryReferencePlaceholders(
+	source: string,
+	repositoryReference: string,
+): string {
+	return source
+		.replace(/yourusername\/wp-typia-boilerplate/g, repositoryReference)
+		.replace(/yourusername\/wp-typia/g, repositoryReference);
+}

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-repository-reference.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-repository-reference.ts
@@ -15,6 +15,10 @@ interface RepositoryPackageManifest {
 
 const require = createRequire(import.meta.url);
 
+/**
+ * Default scaffold repository reference used when no GitHub repository metadata
+ * can be resolved from the current runtime package manifests.
+ */
 export const DEFAULT_SCAFFOLD_REPOSITORY_REFERENCE = "imjlk/wp-typia";
 
 function getErrorCode(error: unknown): string | undefined {
@@ -94,10 +98,10 @@ function parseRepositoryReference(
 function getDefaultRepositoryManifestPaths(): string[] {
 	const candidatePaths = [
 		path.resolve(PROJECT_TOOLS_PACKAGE_ROOT, "..", "..", "package.json"),
-		path.join(PROJECT_TOOLS_PACKAGE_ROOT, "package.json"),
 		path.resolve(PROJECT_TOOLS_PACKAGE_ROOT, "..", "wp-typia", "package.json"),
-		resolveInstalledPackageManifestPath("@wp-typia/project-tools"),
+		path.join(PROJECT_TOOLS_PACKAGE_ROOT, "package.json"),
 		resolveInstalledPackageManifestPath("wp-typia"),
+		resolveInstalledPackageManifestPath("@wp-typia/project-tools"),
 	].filter((candidatePath): candidatePath is string => Boolean(candidatePath));
 
 	return candidatePaths.filter(
@@ -106,6 +110,14 @@ function getDefaultRepositoryManifestPaths(): string[] {
 	);
 }
 
+/**
+ * Resolves the canonical scaffold repository reference in `owner/repo` format.
+ *
+ * The resolver checks candidate package manifests in priority order, extracts
+ * their `repository` field, and returns the first GitHub slug it can parse.
+ * When no candidate yields a GitHub repository reference, the fallback value
+ * is returned instead.
+ */
 export function resolveScaffoldRepositoryReference({
 	fallback = DEFAULT_SCAFFOLD_REPOSITORY_REFERENCE,
 	manifestPaths = getDefaultRepositoryManifestPaths(),
@@ -126,6 +138,10 @@ export function resolveScaffoldRepositoryReference({
 	return fallback;
 }
 
+/**
+ * Replaces legacy scaffold repository placeholders with a concrete
+ * `owner/repo` reference.
+ */
 export function replaceRepositoryReferencePlaceholders(
 	source: string,
 	repositoryReference: string,

--- a/packages/wp-typia-project-tools/src/runtime/scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold.ts
@@ -12,6 +12,7 @@ import {
 	transformPackageManagerText,
 } from "./package-managers.js";
 import type { PackageManagerId } from "./package-managers.js";
+import { replaceTextRecursively } from "./scaffold-apply-utils.js";
 import {
 	applyGeneratedProjectDxPackageJson,
 	applyLocalDevPresetFiles,
@@ -208,6 +209,7 @@ interface ScaffoldProjectOptions {
 	packageManager: PackageManagerId;
 	persistencePolicy?: PersistencePolicy;
 	projectDir: string;
+	repositoryReference?: string;
 	templateId: string;
 	variant?: string;
 	withMigrationUi?: boolean;
@@ -955,50 +957,6 @@ async function removeUnexpectedLockfiles(
 	);
 }
 
-async function replaceTextRecursively(
-	targetDir: string,
-	packageManagerId: PackageManagerId,
-): Promise<void> {
-	const textExtensions = new Set([
-		".css",
-		".js",
-		".json",
-		".jsx",
-		".md",
-		".php",
-		".scss",
-		".ts",
-		".tsx",
-		".txt",
-	]);
-
-	async function visit(currentPath: string): Promise<void> {
-		const stats = await fsp.stat(currentPath);
-		if (stats.isDirectory()) {
-			const entries = await fsp.readdir(currentPath);
-			for (const entry of entries) {
-				await visit(path.join(currentPath, entry));
-			}
-			return;
-		}
-
-		if (path.basename(currentPath) === "package.json" || !textExtensions.has(path.extname(currentPath))) {
-			return;
-		}
-
-		const content = await fsp.readFile(currentPath, "utf8");
-		const nextContent = transformPackageManagerText(content, packageManagerId)
-			.replace(/yourusername\/wp-typia-boilerplate/g, "imjlk/wp-typia")
-			.replace(/yourusername\/wp-typia/g, "imjlk/wp-typia");
-
-		if (nextContent !== content) {
-			await fsp.writeFile(currentPath, nextContent, "utf8");
-		}
-	}
-
-	await visit(targetDir);
-}
-
 async function defaultInstallDependencies({
 	projectDir,
 	packageManager,
@@ -1071,6 +1029,7 @@ export async function scaffoldProject({
 	packageManager,
 	externalLayerId,
 	externalLayerSource,
+	repositoryReference,
 	cwd = process.cwd(),
 	allowExistingDir = false,
 	noInstall = false,
@@ -1103,6 +1062,7 @@ export async function scaffoldProject({
 			packageManager: resolvedPackageManager,
 			persistencePolicy: persistencePolicy ?? answers.persistencePolicy,
 			projectDir,
+			repositoryReference,
 			templateId: resolvedTemplateId,
 			variant,
 			withMigrationUi,
@@ -1210,7 +1170,9 @@ export async function scaffoldProject({
 	}
 	await normalizePackageManagerFiles(projectDir, resolvedPackageManager);
 	await removeUnexpectedLockfiles(projectDir, resolvedPackageManager);
-	await replaceTextRecursively(projectDir, resolvedPackageManager);
+	await replaceTextRecursively(projectDir, resolvedPackageManager, {
+		repositoryReference,
+	});
 
 	if (!noInstall) {
 		const installer = installDependencies ?? defaultInstallDependencies;

--- a/packages/wp-typia-project-tools/tests/scaffold-basic.test.ts
+++ b/packages/wp-typia-project-tools/tests/scaffold-basic.test.ts
@@ -313,6 +313,47 @@ describe('@wp-typia/project-tools scaffold core', () => {
   );
 
   test(
+    'scaffoldProject rewrites forked repository placeholders in existing files when repositoryReference is overridden',
+    async () => {
+      const targetDir = path.join(tempRoot, 'demo-npm-fork-reference');
+      const notesPath = path.join(targetDir, 'FORK_REFERENCE.md');
+
+      fs.mkdirSync(targetDir, { recursive: true });
+      fs.writeFileSync(
+        notesPath,
+        [
+          'Docs: https://github.com/yourusername/wp-typia-boilerplate/issues',
+          'CLI: yourusername/wp-typia',
+        ].join('\n'),
+        'utf8',
+      );
+
+      await scaffoldProject({
+        projectDir: targetDir,
+        templateId: 'basic',
+        packageManager: 'npm',
+        noInstall: true,
+        allowExistingDir: true,
+        repositoryReference: 'fork-owner/fork-typia',
+        answers: {
+          author: 'Test Runner',
+          description: 'Demo npm fork reference block',
+          namespace: 'demo-space',
+          slug: 'demo-npm-fork-reference',
+          title: 'Demo Npm Fork Reference',
+        },
+      });
+
+      const notes = fs.readFileSync(notesPath, 'utf8');
+      expect(notes).toContain(
+        'Docs: https://github.com/fork-owner/fork-typia/issues',
+      );
+      expect(notes).toContain('CLI: fork-owner/fork-typia');
+      expect(notes).not.toContain('yourusername/wp-typia');
+    },
+  );
+
+  test(
     'scaffoldProject can opt into migration UI for built-in single-block templates',
     async () => {
       const targetDir = path.join(tempRoot, 'demo-migration-ui');

--- a/packages/wp-typia-project-tools/tests/scaffold-repository-reference.test.ts
+++ b/packages/wp-typia-project-tools/tests/scaffold-repository-reference.test.ts
@@ -106,6 +106,26 @@ test("resolveScaffoldRepositoryReference parses npm github shorthands", () => {
 	).toBe("fork-owner/fork-typia");
 });
 
+test("resolveScaffoldRepositoryReference ignores non-github hosts that merely contain github.com", () => {
+	const manifestPath = path.join(tempRoot, "not-github-host-package.json");
+	fs.writeFileSync(
+		manifestPath,
+		JSON.stringify({
+			repository: {
+				type: "git",
+				url: "https://notgithub.com/fork-owner/fork-typia.git",
+			},
+		}),
+		"utf8",
+	);
+
+	expect(
+		resolveScaffoldRepositoryReference({
+			manifestPaths: [manifestPath],
+		}),
+	).toBe(DEFAULT_SCAFFOLD_REPOSITORY_REFERENCE);
+});
+
 test("replaceRepositoryReferencePlaceholders rewrites both legacy scaffold repository placeholders", () => {
 	const source = [
 		"https://github.com/yourusername/wp-typia-boilerplate/issues",

--- a/packages/wp-typia-project-tools/tests/scaffold-repository-reference.test.ts
+++ b/packages/wp-typia-project-tools/tests/scaffold-repository-reference.test.ts
@@ -89,6 +89,23 @@ test("resolveScaffoldRepositoryReference prefers the first manifest path that yi
 	).toBe("fork-owner/fork-typia");
 });
 
+test("resolveScaffoldRepositoryReference parses npm github shorthands", () => {
+	const manifestPath = path.join(tempRoot, "github-shorthand-package.json");
+	fs.writeFileSync(
+		manifestPath,
+		JSON.stringify({
+			repository: "github:fork-owner/fork-typia#main",
+		}),
+		"utf8",
+	);
+
+	expect(
+		resolveScaffoldRepositoryReference({
+			manifestPaths: [manifestPath],
+		}),
+	).toBe("fork-owner/fork-typia");
+});
+
 test("replaceRepositoryReferencePlaceholders rewrites both legacy scaffold repository placeholders", () => {
 	const source = [
 		"https://github.com/yourusername/wp-typia-boilerplate/issues",

--- a/packages/wp-typia-project-tools/tests/scaffold-repository-reference.test.ts
+++ b/packages/wp-typia-project-tools/tests/scaffold-repository-reference.test.ts
@@ -58,6 +58,37 @@ test("resolveScaffoldRepositoryReference falls back to the upstream default when
 	).toBe(DEFAULT_SCAFFOLD_REPOSITORY_REFERENCE);
 });
 
+test("resolveScaffoldRepositoryReference prefers the first manifest path that yields a GitHub repository", () => {
+	const upstreamManifestPath = path.join(tempRoot, "upstream-package.json");
+	const forkManifestPath = path.join(tempRoot, "fork-priority-package.json");
+	fs.writeFileSync(
+		upstreamManifestPath,
+		JSON.stringify({
+			repository: {
+				type: "git",
+				url: "git+https://github.com/upstream/wp-typia.git",
+			},
+		}),
+		"utf8",
+	);
+	fs.writeFileSync(
+		forkManifestPath,
+		JSON.stringify({
+			repository: {
+				type: "git",
+				url: "git+https://github.com/fork-owner/fork-typia.git",
+			},
+		}),
+		"utf8",
+	);
+
+	expect(
+		resolveScaffoldRepositoryReference({
+			manifestPaths: [forkManifestPath, upstreamManifestPath],
+		}),
+	).toBe("fork-owner/fork-typia");
+});
+
 test("replaceRepositoryReferencePlaceholders rewrites both legacy scaffold repository placeholders", () => {
 	const source = [
 		"https://github.com/yourusername/wp-typia-boilerplate/issues",

--- a/packages/wp-typia-project-tools/tests/scaffold-repository-reference.test.ts
+++ b/packages/wp-typia-project-tools/tests/scaffold-repository-reference.test.ts
@@ -1,0 +1,78 @@
+import { afterAll, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import {
+	cleanupScaffoldTempRoot,
+	createScaffoldTempRoot,
+} from "./helpers/scaffold-test-harness.js";
+import {
+	DEFAULT_SCAFFOLD_REPOSITORY_REFERENCE,
+	replaceRepositoryReferencePlaceholders,
+	resolveScaffoldRepositoryReference,
+} from "../src/runtime/scaffold-repository-reference.js";
+
+const tempRoot = createScaffoldTempRoot("wp-typia-scaffold-repository-reference-");
+
+afterAll(() => {
+	cleanupScaffoldTempRoot(tempRoot);
+});
+
+test("resolveScaffoldRepositoryReference reads GitHub repository metadata from package manifests", () => {
+	const manifestPath = path.join(tempRoot, "fork-package.json");
+	fs.writeFileSync(
+		manifestPath,
+		JSON.stringify({
+			repository: {
+				type: "git",
+				url: "git+https://github.com/fork-owner/fork-typia.git",
+			},
+		}),
+		"utf8",
+	);
+
+	expect(
+		resolveScaffoldRepositoryReference({
+			manifestPaths: [manifestPath],
+		}),
+	).toBe("fork-owner/fork-typia");
+});
+
+test("resolveScaffoldRepositoryReference falls back to the upstream default when manifests do not define a GitHub repository", () => {
+	const manifestPath = path.join(tempRoot, "invalid-package.json");
+	fs.writeFileSync(
+		manifestPath,
+		JSON.stringify({
+			repository: {
+				type: "git",
+				url: "https://example.com/not-github.git",
+			},
+		}),
+		"utf8",
+	);
+
+	expect(
+		resolveScaffoldRepositoryReference({
+			manifestPaths: [manifestPath],
+		}),
+	).toBe(DEFAULT_SCAFFOLD_REPOSITORY_REFERENCE);
+});
+
+test("replaceRepositoryReferencePlaceholders rewrites both legacy scaffold repository placeholders", () => {
+	const source = [
+		"https://github.com/yourusername/wp-typia-boilerplate/issues",
+		"CLI: yourusername/wp-typia",
+	].join("\n");
+
+	expect(
+		replaceRepositoryReferencePlaceholders(
+			source,
+			"fork-owner/fork-typia",
+		),
+	).toBe(
+		[
+			"https://github.com/fork-owner/fork-typia/issues",
+			"CLI: fork-owner/fork-typia",
+		].join("\n"),
+	);
+});

--- a/packages/wp-typia-project-tools/tests/template-source.test.ts
+++ b/packages/wp-typia-project-tools/tests/template-source.test.ts
@@ -212,6 +212,43 @@ test("local official external template configs honor --variant overrides", async
   expect(generatedBlockJson.supports.multiple).toBe(true);
 });
 
+test("external template scaffolds honor explicit repository reference overrides", async () => {
+  const fixtureDir = path.join(tempRoot, "create-block-external-fork-reference");
+  const targetDir = path.join(tempRoot, "demo-external-fork-reference");
+  fs.cpSync(createBlockExternalFixturePath, fixtureDir, { recursive: true });
+  fs.appendFileSync(
+    path.join(fixtureDir, "block-templates", "edit.js.mustache"),
+    "\n// Docs: https://github.com/yourusername/wp-typia-boilerplate/issues\n// CLI package: yourusername/wp-typia\n",
+    "utf8"
+  );
+
+  await scaffoldProject({
+    projectDir: targetDir,
+    templateId: fixtureDir,
+    packageManager: "npm",
+    noInstall: true,
+    repositoryReference: "fork-owner/fork-typia",
+    answers: {
+      author: "Test Runner",
+      description: "Demo external fork reference block",
+      namespace: "create-block",
+      slug: "demo-external-fork-reference",
+      title: "Demo External Fork Reference",
+    },
+  });
+
+  const generatedEdit = fs.readFileSync(
+    path.join(targetDir, "src", "edit.js"),
+    "utf8"
+  );
+
+  expect(generatedEdit).toContain(
+    "https://github.com/fork-owner/fork-typia/issues"
+  );
+  expect(generatedEdit).toContain("CLI package: fork-owner/fork-typia");
+  expect(generatedEdit).not.toContain("yourusername/wp-typia");
+});
+
 test("workspace template package identity is defined once and imported by runtime callers", () => {
   const runtimeDir = path.join(packageRoot, "src", "runtime");
   const templateRegistry = fs.readFileSync(


### PR DESCRIPTION
## Summary
- replace hardcoded scaffold repository rewrites with a shared helper that resolves the canonical `owner/repo` slug from local package metadata by default
- allow scaffold callers to override that slug explicitly via `repositoryReference` so forks and embedders can control emitted links deterministically
- cover both built-in and external template scaffold flows with regression tests for placeholder rewrites

## Testing
- `bun run --filter @wp-typia/project-tools build`
- `bun test packages/wp-typia-project-tools/tests/scaffold-repository-reference.test.ts`
- `bun test packages/wp-typia-project-tools/tests/template-source.test.ts -t 'external template scaffolds honor explicit repository reference overrides'`
- `bun test packages/wp-typia-project-tools/tests/scaffold-basic.test.ts -t 'forked repository placeholders'`
- `bun run changesets:validate`

Refs #273.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Projects can now use fork-aware repository references, automatically replacing placeholder URLs in generated files based on package metadata or a custom override.

* **Tests**
  * Added test coverage for repository reference resolution and placeholder replacement functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->