### PR TITLE
Define block generator tool contract versioning policy

### DIFF
--- a/docs/block-generator-architecture.md
+++ b/docs/block-generator-architecture.md
@@ -177,7 +177,10 @@ This design intentionally does not promise:
 
 The public compatibility promise is still the root
 `@wp-typia/project-tools` orchestration surface plus the generated-project
-runtime surfaces under `@wp-typia/block-runtime/*`.
+runtime surfaces under `@wp-typia/block-runtime/*`. For the non-mutating block
+generator controller surface specifically, compatibility is governed by the
+exact-match `BLOCK_GENERATION_TOOL_CONTRACT_VERSION` policy documented in
+[`docs/block-generator-tool-contract.md`](./block-generator-tool-contract.md).
 
 ## Relationship to the rest of the repo
 

--- a/docs/block-generator-tool-contract.md
+++ b/docs/block-generator-tool-contract.md
@@ -44,6 +44,79 @@ if (inspection.contractVersion !== BLOCK_GENERATION_TOOL_CONTRACT_VERSION) {
 }
 ```
 
+## Compatibility policy
+
+`BLOCK_GENERATION_TOOL_CONTRACT_VERSION` is intentionally a simple integer,
+not a SemVer string.
+
+The contract currently uses a single compatibility rule:
+
+- controller and tool consumers should treat `contractVersion` as an exact-match
+  gate before assuming the serialized shape
+
+That keeps downstream behavior predictable for MCP, AI-controller, and other
+structured integrations that need a fail-closed boundary instead of heuristic
+schema guessing.
+
+### Changes that do not require a version bump
+
+These changes stay within the same contract version:
+
+- documentation-only clarifications
+- internal implementation refactors that do not change the serialized
+  inspection payload
+- additive object fields that are both optional and safely ignorable by a
+  consumer that already understands the surrounding object
+
+In other words, consumers may ignore unknown object keys within a recognized
+`contractVersion`, but they should not assume new keys exist.
+
+### Changes that require a version bump
+
+Increment `BLOCK_GENERATION_TOOL_CONTRACT_VERSION` whenever a change would make
+an exact-version consumer misinterpret the payload or branch incorrectly.
+
+That includes:
+
+- removing, renaming, or retyping an existing field
+- changing the meaning, units, or default interpretation of an existing field
+- making an optional field effectively required for correct interpretation
+- changing stage names or stage ordering assumptions
+- adding or removing discriminator values such as preview `owner`, preview
+  `kind`, or other tagged union members
+- reshaping nested objects in ways that break an existing exact-version parser
+
+As a maintainer shortcut:
+
+- if an older consumer can keep working by ignoring a new key, it is additive
+- if an older consumer could parse the payload but act incorrectly, it is
+  breaking
+
+## Consumer behavior on version mismatch
+
+The recommended consumer behavior is intentionally strict:
+
+1. read `contractVersion`
+2. compare it to the supported constant or explicit allowlist
+3. stop immediately on mismatch with an actionable error
+
+Default controller logic should not attempt forward-compat parsing across a
+version mismatch.
+
+Recommended behavior:
+
+- newer producer, older consumer:
+  fail closed and tell the caller which contract version was expected vs
+  received
+- older producer, newer consumer:
+  fail closed unless the consumer intentionally carries compatibility logic for
+  that older version
+- same version:
+  proceed, while ignoring unknown optional object keys
+
+This is why the example above uses a direct equality check instead of a range
+comparison.
+
 ## Stage model
 
 The contract is intentionally stage-based.
@@ -128,6 +201,9 @@ future Agentica, MCP, or other structured controller surfaces.
 It does not add Agentica or MCP integration directly. Instead, it provides a
 stable serializable shape that a future controller can expose without needing to
 redefine generator stages or invent a second preview path.
+
+Future controller surfaces should keep delegating compatibility decisions to
+`contractVersion` instead of trying to infer compatibility from payload shape.
 
 ## Out of scope
 


### PR DESCRIPTION
## Summary
- document the compatibility model for `BLOCK_GENERATION_TOOL_CONTRACT_VERSION`
- define which contract changes are additive within a version line versus breaking and bump-worthy
- explain the default consumer behavior for version mismatches so downstream controller tooling can fail closed consistently

## Testing
- `bun test packages/wp-typia-project-tools/tests/import-policy.test.ts`
- `bun run docs:build`

Docs-only change. No changeset needed.

Refs #277.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated block generator compatibility documentation with versioning policy details.
  * Added guidance on version mismatch handling and contract compatibility management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->