### PR TITLE
Harden template rendering internals

### DIFF
--- a/.sampo/changesets/issue-275-rendering-hardening.md
+++ b/.sampo/changesets/issue-275-rendering-hardening.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Harden template rendering internals by removing global Mustache escape mutation, centralizing template traversal behind explicit rendering semantics, and stabilizing block-generation fingerprints with deterministic JSON serialization.

--- a/packages/wp-typia-project-tools/src/runtime/block-generator-service.ts
+++ b/packages/wp-typia-project-tools/src/runtime/block-generator-service.ts
@@ -33,6 +33,7 @@ import {
 	buildBuiltInCodeArtifacts,
 	type BuiltInCodeArtifact,
 } from "./built-in-block-code-artifacts.js";
+import { stableJsonStringify } from "./object-utils.js";
 import { getStarterManifestFiles } from "./starter-manifests.js";
 import { resolveTemplateSeed, parseTemplateLocator } from "./template-source.js";
 import {
@@ -171,7 +172,7 @@ const renderedArtifactCache = new WeakMap<
 function createVariablesFingerprint(
 	variables: ScaffoldTemplateVariables,
 ): string {
-	return JSON.stringify(variables);
+	return stableJsonStringify(variables);
 }
 
 function buildProtectedTemplateOutputPaths({

--- a/packages/wp-typia-project-tools/src/runtime/object-utils.ts
+++ b/packages/wp-typia-project-tools/src/runtime/object-utils.ts
@@ -24,7 +24,9 @@ function toStableJsonValue(value: unknown): unknown {
   if (isPlainObject(value)) {
     return Object.fromEntries(
       Object.keys(value)
-        .sort((left, right) => left.localeCompare(right))
+        .sort((left, right) =>
+          left < right ? -1 : left > right ? 1 : 0,
+        )
         .map((key) => [key, toStableJsonValue(value[key])]),
     );
   }

--- a/packages/wp-typia-project-tools/src/runtime/object-utils.ts
+++ b/packages/wp-typia-project-tools/src/runtime/object-utils.ts
@@ -15,3 +15,29 @@ export type UnknownRecord<TValue = unknown> = Record<string, TValue>;
 export function isPlainObject(value: unknown): value is UnknownRecord {
   return isSharedPlainObject(value);
 }
+
+function toStableJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => toStableJsonValue(entry));
+  }
+
+  if (isPlainObject(value)) {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort((left, right) => left.localeCompare(right))
+        .map((key) => [key, toStableJsonValue(value[key])]),
+    );
+  }
+
+  return value;
+}
+
+/**
+ * Serialize JSON-like values with deterministic plain-object key ordering.
+ *
+ * Arrays preserve their declared order, while plain objects are normalized by
+ * sorting keys recursively before calling `JSON.stringify`.
+ */
+export function stableJsonStringify(value: unknown): string {
+  return JSON.stringify(toStableJsonValue(value));
+}

--- a/packages/wp-typia-project-tools/src/runtime/template-render.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-render.ts
@@ -110,11 +110,17 @@ function renderInterpolatedString(
 	template: string,
 	view: Record<string, string>,
 ): string {
-	return Object.entries(view).reduce(
-		(output, [key, value]) =>
-			output.replace(new RegExp(`{{${escapeRegExp(key)}}}`, "g"), value),
-		template,
+	const keys = Object.keys(view);
+	if (keys.length === 0) {
+		return template;
+	}
+
+	const placeholderPattern = new RegExp(
+		keys.map((key) => `({{${escapeRegExp(key)}}})`).join("|"),
+		"g",
 	);
+
+	return template.replace(placeholderPattern, (match) => view[match.slice(2, -2)] ?? match);
 }
 
 function isBinaryTemplateFile(filePath: string): boolean {

--- a/packages/wp-typia-project-tools/src/runtime/template-render.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-render.ts
@@ -44,31 +44,75 @@ export interface CopyRawDirectoryOptions {
 	) => boolean | Promise<boolean>;
 }
 
+type TemplateStringRenderer<TView> = (
+	template: string,
+	view: TView,
+) => string;
+
+interface TemplateTraversalOptions<TView> {
+	prepareDirectory?: (directoryPath: string) => Promise<void>;
+	renderString: TemplateStringRenderer<TView>;
+	sourceDir: string;
+	targetDir: string;
+	view: TView;
+	visitFile: (paths: {
+		destinationPath: string;
+		sourcePath: string;
+	}) => Promise<void>;
+}
+
+interface MustacheWriterWithConfig {
+	render(
+		template: string,
+		view: TemplateRenderView,
+		partials: unknown,
+		config: {
+			escape: (value: string) => string;
+		},
+	): string;
+}
+
+const IDENTITY_MUSTACHE_ESCAPE = (value: string) => value;
+
 /**
- * Render a Mustache template while keeping HTML escaping disabled only for the
- * current render call.
+ * Render a Mustache template with full Mustache semantics while leaving values
+ * unescaped for scaffold source generation.
  */
 export function renderMustacheTemplateString(
 	template: string,
 	view: TemplateRenderView,
 ): string {
-	const originalEscape = Mustache.escape;
-	Mustache.escape = (value: string) => value;
+	const mustacheModule = Mustache as unknown as {
+		Writer: {
+			new (): MustacheWriterWithConfig;
+		};
+	};
+	const writer = new (
+		mustacheModule.Writer as {
+			new (): MustacheWriterWithConfig;
+		}
+	)();
 
-	try {
-		return Mustache.render(template, view);
-	} finally {
-		Mustache.escape = originalEscape;
-	}
+	return writer.render(template, view, undefined, {
+		escape: IDENTITY_MUSTACHE_ESCAPE,
+	});
 }
 
 function escapeRegExp(value: string): string {
 	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-function renderInterpolatedString(template: string, view: Record<string, string>): string {
+/**
+ * Render direct `{{key}}` placeholders without enabling sections, partials, or
+ * any other Mustache features.
+ */
+function renderInterpolatedString(
+	template: string,
+	view: Record<string, string>,
+): string {
 	return Object.entries(view).reduce(
-		(output, [key, value]) => output.replace(new RegExp(`{{${escapeRegExp(key)}}}`, "g"), value),
+		(output, [key, value]) =>
+			output.replace(new RegExp(`{{${escapeRegExp(key)}}}`, "g"), value),
 		template,
 	);
 }
@@ -85,6 +129,96 @@ function resolveRenderedPath(targetDir: string, destinationName: string): string
 		throw new Error(`Rendered template path escapes target directory: ${destinationName}`);
 	}
 	return resolvedDestinationPath;
+}
+
+function stripTemplateExtension(entryName: string): string {
+	return entryName.endsWith(".mustache")
+		? entryName.slice(0, -".mustache".length)
+		: entryName;
+}
+
+function renderTemplateDestinationName<TView>(
+	entryName: string,
+	view: TView,
+	renderString: TemplateStringRenderer<TView>,
+): string {
+	return renderString(stripTemplateExtension(entryName), view);
+}
+
+async function traverseTemplateDirectory<TView>({
+	prepareDirectory,
+	renderString,
+	sourceDir,
+	targetDir,
+	view,
+	visitFile,
+}: TemplateTraversalOptions<TView>): Promise<void> {
+	const entries = await fsp.readdir(sourceDir, { withFileTypes: true });
+	for (const entry of entries) {
+		const sourcePath = path.join(sourceDir, entry.name);
+		const destinationName = renderTemplateDestinationName(
+			entry.name,
+			view,
+			renderString,
+		);
+		const destinationPath = resolveRenderedPath(targetDir, destinationName);
+
+		if (entry.isDirectory()) {
+			await prepareDirectory?.(destinationPath);
+			await traverseTemplateDirectory({
+				prepareDirectory,
+				renderString,
+				sourceDir: sourcePath,
+				targetDir: destinationPath,
+				view,
+				visitFile,
+			});
+			continue;
+		}
+
+		await visitFile({
+			destinationPath,
+			sourcePath,
+		});
+	}
+}
+
+async function copyTemplateDirectory<TView>({
+	renderString,
+	sourceDir,
+	targetDir,
+	view,
+}: {
+	renderString: TemplateStringRenderer<TView>;
+	sourceDir: string;
+	targetDir: string;
+	view: TView;
+}): Promise<void> {
+	await fsp.mkdir(targetDir, { recursive: true });
+	await traverseTemplateDirectory({
+		prepareDirectory: async (directoryPath) => {
+			await fsp.mkdir(directoryPath, { recursive: true });
+		},
+		renderString,
+		sourceDir,
+		targetDir,
+		view,
+		visitFile: async ({ destinationPath, sourcePath }) => {
+			await fsp.mkdir(path.dirname(destinationPath), { recursive: true });
+
+			if (isBinaryTemplateFile(sourcePath)) {
+				await fsp.copyFile(sourcePath, destinationPath);
+				return;
+			}
+
+			const content = await fsp.readFile(sourcePath, "utf8");
+			await fsp.writeFile(
+				destinationPath,
+				renderString(content, view),
+				"utf8",
+			);
+		},
+	});
 }
 
 /**
@@ -112,68 +246,41 @@ export async function copyRawDirectory(
 	}
 }
 
+/**
+ * Copy a template directory using full Mustache semantics for filenames and
+ * text-file contents while leaving rendered values unescaped.
+ */
 export async function copyRenderedDirectory(
 	sourceDir: string,
 	targetDir: string,
 	view: TemplateRenderView,
 ): Promise<void> {
-	const entries = await fsp.readdir(sourceDir, { withFileTypes: true });
-	for (const entry of entries) {
-		const sourcePath = path.join(sourceDir, entry.name);
-		const destinationNameTemplate = entry.name.endsWith(".mustache")
-			? entry.name.slice(0, -".mustache".length)
-			: entry.name;
-		const destinationName = renderMustacheTemplateString(destinationNameTemplate, view);
-		const destinationPath = resolveRenderedPath(targetDir, destinationName);
-
-		if (entry.isDirectory()) {
-			await fsp.mkdir(destinationPath, { recursive: true });
-			await copyRenderedDirectory(sourcePath, destinationPath, view);
-			continue;
-		}
-
-		if (isBinaryTemplateFile(sourcePath)) {
-			await fsp.mkdir(path.dirname(destinationPath), { recursive: true });
-			await fsp.copyFile(sourcePath, destinationPath);
-			continue;
-		}
-
-		const content = await fsp.readFile(sourcePath, "utf8");
-		await fsp.mkdir(path.dirname(destinationPath), { recursive: true });
-		await fsp.writeFile(destinationPath, renderMustacheTemplateString(content, view), "utf8");
-	}
+	await copyTemplateDirectory({
+		renderString: renderMustacheTemplateString,
+		sourceDir,
+		targetDir,
+		view,
+	});
 }
 
+/**
+ * Copy a template directory using direct `{{key}}` replacement only.
+ *
+ * This intentionally preserves literal Mustache sections, partials, and other
+ * advanced constructs so built-in scaffold copy paths keep their historical
+ * interpolation behavior.
+ */
 export async function copyInterpolatedDirectory(
 	sourceDir: string,
 	targetDir: string,
 	view: Record<string, string>,
 ): Promise<void> {
-	const entries = await fsp.readdir(sourceDir, { withFileTypes: true });
-	for (const entry of entries) {
-		const sourcePath = path.join(sourceDir, entry.name);
-		const destinationNameTemplate = entry.name.endsWith(".mustache")
-			? entry.name.slice(0, -".mustache".length)
-			: entry.name;
-		const destinationName = renderInterpolatedString(destinationNameTemplate, view);
-		const destinationPath = resolveRenderedPath(targetDir, destinationName);
-
-		if (entry.isDirectory()) {
-			await fsp.mkdir(destinationPath, { recursive: true });
-			await copyInterpolatedDirectory(sourcePath, destinationPath, view);
-			continue;
-		}
-
-		if (isBinaryTemplateFile(sourcePath)) {
-			await fsp.mkdir(path.dirname(destinationPath), { recursive: true });
-			await fsp.copyFile(sourcePath, destinationPath);
-			continue;
-		}
-
-		const content = await fsp.readFile(sourcePath, "utf8");
-		await fsp.mkdir(path.dirname(destinationPath), { recursive: true });
-		await fsp.writeFile(destinationPath, renderInterpolatedString(content, view), "utf8");
-	}
+	await copyTemplateDirectory({
+		renderString: renderInterpolatedString,
+		sourceDir,
+		targetDir,
+		view,
+	});
 }
 
 /**
@@ -197,26 +304,15 @@ export async function listInterpolatedDirectoryOutputs(
 	const virtualRoot = path.resolve("/wp-typia-template-preview");
 	const outputs: string[] = [];
 
-	async function visit(currentSourceDir: string, currentTargetDir: string): Promise<void> {
-		const entries = await fsp.readdir(currentSourceDir, { withFileTypes: true });
-		for (const entry of entries) {
-			const sourcePath = path.join(currentSourceDir, entry.name);
-			const destinationNameTemplate = entry.name.endsWith(".mustache")
-				? entry.name.slice(0, -".mustache".length)
-				: entry.name;
-			const destinationName = renderInterpolatedString(destinationNameTemplate, view);
-			const destinationPath = resolveRenderedPath(currentTargetDir, destinationName);
-
-			if (entry.isDirectory()) {
-				await visit(sourcePath, destinationPath);
-				continue;
-			}
-
+	await traverseTemplateDirectory({
+		renderString: renderInterpolatedString,
+		sourceDir,
+		targetDir: virtualRoot,
+		view,
+		visitFile: async ({ destinationPath }) => {
 			outputs.push(path.relative(virtualRoot, destinationPath).replace(/\\/g, "/"));
-		}
-	}
-
-	await visit(sourceDir, virtualRoot);
+		},
+	});
 	return outputs.sort((left, right) => left.localeCompare(right));
 }
 

--- a/packages/wp-typia-project-tools/tests/template-render.test.ts
+++ b/packages/wp-typia-project-tools/tests/template-render.test.ts
@@ -148,6 +148,8 @@ describe("template render internals", () => {
 	});
 
 	test("stableJsonStringify sorts nested plain-object keys deterministically", () => {
+		const accentNfc = "\u00E9";
+		const accentNfd = "e\u0301";
 		const left = {
 			alpha: {
 				delta: 4,
@@ -170,6 +172,17 @@ describe("template render internals", () => {
 			}),
 		).toBe(
 			'{"items":[{"first":1,"second":2},{"alpha":false,"beta":true}]}',
+		);
+		expect(
+			stableJsonStringify({
+				[accentNfc]: "nfc",
+				[accentNfd]: "nfd",
+			}),
+		).toBe(
+			stableJsonStringify({
+				[accentNfd]: "nfd",
+				[accentNfc]: "nfc",
+			}),
 		);
 	});
 });

--- a/packages/wp-typia-project-tools/tests/template-render.test.ts
+++ b/packages/wp-typia-project-tools/tests/template-render.test.ts
@@ -78,6 +78,34 @@ describe("template render internals", () => {
 		).toBe("{{#show}}Hello A&B{{/show}}");
 	});
 
+	test("copyInterpolatedDirectory replaces placeholders in a single pass", async () => {
+		const templateRoot = fs.mkdtempSync(
+			path.join(tempRoot, "template-render-single-pass-"),
+		);
+		const targetDir = fs.mkdtempSync(
+			path.join(tempRoot, "template-render-single-pass-target-"),
+		);
+
+		fs.writeFileSync(
+			path.join(templateRoot, "single-pass.txt.mustache"),
+			"{{price}} :: {{alias}}",
+			"utf8",
+		);
+
+		await copyInterpolatedDirectory(templateRoot, targetDir, {
+			alias: "{{name}}",
+			name: "hero",
+			price: "$&",
+		});
+
+		expect(
+			fs.readFileSync(
+				path.join(targetDir, "single-pass.txt"),
+				"utf8",
+			),
+		).toBe("$& :: {{name}}");
+	});
+
 	test("listInterpolatedDirectoryOutputs matches interpolation traversal rules", async () => {
 		const templateRoot = fs.mkdtempSync(
 			path.join(tempRoot, "template-render-list-"),

--- a/packages/wp-typia-project-tools/tests/template-render.test.ts
+++ b/packages/wp-typia-project-tools/tests/template-render.test.ts
@@ -1,0 +1,147 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import {
+	cleanupScaffoldTempRoot,
+	createScaffoldTempRoot,
+} from "./helpers/scaffold-test-harness.js";
+import { stableJsonStringify } from "../src/runtime/object-utils.js";
+import {
+	copyInterpolatedDirectory,
+	copyRenderedDirectory,
+	listInterpolatedDirectoryOutputs,
+	renderMustacheTemplateString,
+} from "../src/runtime/template-render.js";
+
+describe("template render internals", () => {
+	const tempRoot = createScaffoldTempRoot("wp-typia-template-render-");
+
+	afterAll(() => {
+		cleanupScaffoldTempRoot(tempRoot);
+	});
+
+	test("renderMustacheTemplateString leaves scaffold values unescaped", () => {
+		expect(
+			renderMustacheTemplateString("{{value}} :: {{{value}}}", {
+				value: "<demo>&",
+			}),
+		).toBe("<demo>& :: <demo>&");
+	});
+
+	test("copyRenderedDirectory and interpolation mode keep their semantics explicit", async () => {
+		const templateRoot = fs.mkdtempSync(
+			path.join(tempRoot, "template-render-strategy-"),
+		);
+		const mustacheTarget = fs.mkdtempSync(
+			path.join(tempRoot, "template-render-mustache-"),
+		);
+		const interpolatedTarget = fs.mkdtempSync(
+			path.join(tempRoot, "template-render-interpolated-"),
+		);
+
+		fs.mkdirSync(path.join(templateRoot, "dir-{{variant}}"), {
+			recursive: true,
+		});
+		fs.writeFileSync(
+			path.join(
+				templateRoot,
+				"dir-{{variant}}",
+				"message-{{variant}}.txt.mustache",
+			),
+			"{{#show}}Hello {{name}}{{/show}}",
+			"utf8",
+		);
+
+		await copyRenderedDirectory(templateRoot, mustacheTarget, {
+			name: "A&B",
+			show: true,
+			variant: "hero",
+		});
+		await copyInterpolatedDirectory(templateRoot, interpolatedTarget, {
+			name: "A&B",
+			show: "true",
+			variant: "hero",
+		});
+
+		expect(
+			fs.readFileSync(
+				path.join(mustacheTarget, "dir-hero", "message-hero.txt"),
+				"utf8",
+			),
+		).toBe("Hello A&B");
+		expect(
+			fs.readFileSync(
+				path.join(interpolatedTarget, "dir-hero", "message-hero.txt"),
+				"utf8",
+			),
+		).toBe("{{#show}}Hello A&B{{/show}}");
+	});
+
+	test("listInterpolatedDirectoryOutputs matches interpolation traversal rules", async () => {
+		const templateRoot = fs.mkdtempSync(
+			path.join(tempRoot, "template-render-list-"),
+		);
+		const targetDir = fs.mkdtempSync(
+			path.join(tempRoot, "template-render-list-target-"),
+		);
+
+		fs.mkdirSync(path.join(templateRoot, "docs-{{variant}}"), {
+			recursive: true,
+		});
+		fs.writeFileSync(
+			path.join(templateRoot, "README-{{variant}}.md.mustache"),
+			"hello",
+			"utf8",
+		);
+		fs.writeFileSync(
+			path.join(templateRoot, "docs-{{variant}}", "note-{{variant}}.txt"),
+			"world",
+			"utf8",
+		);
+
+		const view = { variant: "hero" };
+		await copyInterpolatedDirectory(templateRoot, targetDir, view);
+		const listedOutputs = await listInterpolatedDirectoryOutputs(
+			templateRoot,
+			view,
+		);
+
+		expect(listedOutputs).toEqual([
+			"docs-hero/note-hero.txt",
+			"README-hero.md",
+		]);
+		expect(
+			fs.existsSync(path.join(targetDir, "README-hero.md")),
+		).toBe(true);
+		expect(
+			fs.existsSync(path.join(targetDir, "docs-hero", "note-hero.txt")),
+		).toBe(true);
+	});
+
+	test("stableJsonStringify sorts nested plain-object keys deterministically", () => {
+		const left = {
+			alpha: {
+				delta: 4,
+				charlie: 3,
+			},
+			bravo: [3, { zebra: "z", alpha: "a" }],
+		};
+		const right = {
+			bravo: [3, { alpha: "a", zebra: "z" }],
+			alpha: {
+				charlie: 3,
+				delta: 4,
+			},
+		};
+
+		expect(stableJsonStringify(left)).toBe(stableJsonStringify(right));
+		expect(
+			stableJsonStringify({
+				items: [{ second: 2, first: 1 }, { beta: true, alpha: false }],
+			}),
+		).toBe(
+			'{"items":[{"first":1,"second":2},{"alpha":false,"beta":true}]}',
+		);
+	});
+});


### PR DESCRIPTION
## Context

Issue #275 called out the remaining rendering hardening work after the emitter migration landed:

- we still had two rendering modes with duplicated directory traversal logic
- `renderMustacheTemplateString()` temporarily mutated global `Mustache.escape`
- render artifact fingerprints still depended on raw `JSON.stringify()` key order

## What Changed

- centralized template directory traversal behind a shared internal walker while keeping the two rendering semantics explicit:
  - `copyRenderedDirectory()` continues to use full Mustache semantics for filenames and text contents
  - `copyInterpolatedDirectory()` and `listInterpolatedDirectoryOutputs()` continue to use direct `{{key}}` replacement only, preserving literal sections and partials for built-in scaffold copy paths
- removed the temporary global `Mustache.escape` mutation and switched Mustache rendering to a per-render writer configuration that disables escaping without touching global module state
- added `stableJsonStringify()` for deterministic plain-object serialization and used it for block-generator variable fingerprints so equivalent values do not depend on insertion order
- added regression coverage for rendering semantics, interpolation output listing parity, and stable JSON serialization

## Verification

- `bun run --filter @wp-typia/project-tools build`
- `bun test packages/wp-typia-project-tools/tests/template-render.test.ts packages/wp-typia-project-tools/tests/template-source.test.ts packages/wp-typia-project-tools/tests/template-layers.test.ts packages/wp-typia-project-tools/tests/block-generator-service.test.ts packages/wp-typia-project-tools/tests/scaffold-basic.test.ts packages/wp-typia-project-tools/tests/workspace-add.test.ts`
- `bun run changesets:validate`

Closes #275


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced template rendering stability and reliability with improved escape handling and deterministic fingerprinting for block generation.

* **Refactor**
  * Reorganized template traversal and rendering infrastructure for consistency across operations.

* **Tests**
  * Added comprehensive test suite for template rendering and directory operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->