### PR TITLE
Productize binding-source starter scaffolds

### DIFF
--- a/.sampo/changesets/issue-298-binding-source-starter-contract.md
+++ b/.sampo/changesets/issue-298-binding-source-starter-contract.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Upgrade official workspace binding-source scaffolds from placeholder-only files to a field-keyed starter contract with named PHP helpers, matching editor starter values, and clearer generated guidance.

--- a/docs/API.md
+++ b/docs/API.md
@@ -587,7 +587,11 @@ Variations are generated under `src/blocks/<block>/variations/*.ts` and wired
 through the target block entrypoint. Patterns are generated as namespaced PHP
 shells under `src/patterns/*.php` and loaded by the workspace bootstrap.
 Binding sources are generated under `src/bindings/*/{server.php,editor.ts}` and
-wired through the shared workspace bootstrap plus editor bundle.
+wired through the shared workspace bootstrap plus editor bundle. The generated
+starter contract keeps one field-keyed data map in each file, so the common
+follow-up is to edit `src/bindings/<name>/server.php` and
+`src/bindings/<name>/editor.ts` in parallel by replacing the default starter
+values for the fields you want to expose.
 Hooked blocks patch `src/blocks/<block>/block.json` with `blockHooks` metadata
 so the target block is inserted relative to the chosen anchor block.
 

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace.ts
@@ -49,6 +49,10 @@ function escapeRegex(value: string): string {
 	return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
 }
 
+function quotePhpString(value: string): string {
+	return `'${value.replace(/\\/gu, "\\\\").replace(/'/gu, "\\'")}'`;
+}
+
 function buildVariationConfigEntry(
 	blockSlug: string,
 	variationSlug: string,
@@ -188,10 +192,15 @@ register_block_pattern(
 
 function buildBindingSourceServerSource(
 	bindingSourceSlug: string,
+	phpPrefix: string,
 	namespace: string,
 	textDomain: string,
 ): string {
 	const bindingSourceTitle = toTitleCase(bindingSourceSlug);
+	const bindingSourcePhpId = bindingSourceSlug.replace(/-/g, "_");
+	const bindingSourceValueFunctionName = `${phpPrefix}_${bindingSourcePhpId}_binding_source_values`;
+	const bindingSourceResolveFunctionName = `${phpPrefix}_${bindingSourcePhpId}_resolve_binding_source_value`;
+	const starterValue = `${bindingSourceTitle} starter value`;
 
 	return `<?php
 if ( ! defined( 'ABSPATH' ) ) {
@@ -202,20 +211,31 @@ if ( ! function_exists( 'register_block_bindings_source' ) ) {
 \treturn;
 }
 
-register_block_bindings_source(
-\t'${namespace}/${bindingSourceSlug}',
-\tarray(
-\t\t'label' => __( ${JSON.stringify(bindingSourceTitle)}, '${textDomain}' ),
-\t\t'get_value_callback' => static function( array $source_args ) : string {
-\t\t\t$field = isset( $source_args['field'] ) && is_string( $source_args['field'] )
-\t\t\t\t? $source_args['field']
-\t\t\t\t: '${bindingSourceSlug}';
+if ( ! function_exists( '${bindingSourceValueFunctionName}' ) ) {
+\tfunction ${bindingSourceValueFunctionName}() : array {
+\t\treturn array(
+\t\t\t${quotePhpString(bindingSourceSlug)} => ${quotePhpString(starterValue)},
+\t\t);
+\t}
+}
 
-\t\t\treturn sprintf(
-\t\t\t\t__( 'Replace %s with real binding source data.', '${textDomain}' ),
-\t\t\t\t$field
-\t\t\t);
-\t\t},
+if ( ! function_exists( '${bindingSourceResolveFunctionName}' ) ) {
+\tfunction ${bindingSourceResolveFunctionName}( array $source_args ) : string {
+\t\t$field = isset( $source_args['field'] ) && is_string( $source_args['field'] )
+\t\t\t? $source_args['field']
+\t\t\t: '${bindingSourceSlug}';
+\t\t$binding_source_values = ${bindingSourceValueFunctionName}();
+\t\t$value = $binding_source_values[ $field ] ?? '';
+
+\t\treturn is_string( $value ) ? $value : '';
+\t}
+}
+
+register_block_bindings_source(
+\t${quotePhpString(`${namespace}/${bindingSourceSlug}`)},
+\tarray(
+\t\t'label' => __( ${quotePhpString(bindingSourceTitle)}, ${quotePhpString(textDomain)} ),
+\t\t'get_value_callback' => ${quotePhpString(bindingSourceResolveFunctionName)},
 \t)
 );
 `;
@@ -227,9 +247,24 @@ function buildBindingSourceEditorSource(
 	textDomain: string,
 ): string {
 	const bindingSourceTitle = toTitleCase(bindingSourceSlug);
+	const starterValue = `${bindingSourceTitle} starter value`;
 
 	return `import { registerBlockBindingsSource } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
+
+interface BindingSourceRegistration {
+\targs?: {
+\t\tfield?: string;
+\t};
+}
+
+const BINDING_SOURCE_VALUES: Record<string, string> = {
+\t${quoteTsString(bindingSourceSlug)}: ${quoteTsString(starterValue)},
+};
+
+function resolveBindingSourceValue( field: string ): string {
+\treturn BINDING_SOURCE_VALUES[ field ] ?? '';
+}
 
 registerBlockBindingsSource( {
 \tname: ${quoteTsString(`${namespace}/${bindingSourceSlug}`)},
@@ -247,10 +282,14 @@ registerBlockBindingsSource( {
 \t},
 \tgetValues( { bindings } ) {
 \t\tconst values: Record<string, string> = {};
-\t\tfor ( const attributeName of Object.keys( bindings ) ) {
-\t\t\tvalues[ attributeName ] = ${quoteTsString(
-				`TODO: replace ${bindingSourceSlug} with real editor-side values.`,
-			)};
+\t\tfor ( const [ attributeName, binding ] of Object.entries(
+\t\t\tbindings as Record<string, BindingSourceRegistration>
+\t\t) ) {
+\t\t\tconst field =
+\t\t\t\ttypeof binding?.args?.field === 'string'
+\t\t\t\t\t? binding.args.field
+\t\t\t\t\t: ${quoteTsString(bindingSourceSlug)};
+\t\t\tvalues[ attributeName ] = resolveBindingSourceValue( field );
 \t\t}
 \t\treturn values;
 \t},
@@ -708,6 +747,7 @@ export async function runAddBindingSourceCommand({
 			serverFilePath,
 			buildBindingSourceServerSource(
 				bindingSourceSlug,
+				workspace.workspace.phpPrefix,
 				workspace.workspace.namespace,
 				workspace.workspace.textDomain,
 			),

--- a/packages/wp-typia-project-tools/tests/workspace-add.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-add.test.ts
@@ -1964,7 +1964,17 @@ test("canonical CLI can add a binding source to an official workspace template",
   expect(bootstrapSource).toContain("build/bindings/index.js");
   expect(bindingsIndexSource).toContain("import './hero-data/editor';");
   expect(bindingServerSource).toContain("register_block_bindings_source");
+  expect(bindingServerSource).toContain(
+    "function demo_space_hero_data_binding_source_values() : array"
+  );
+  expect(bindingServerSource).toContain(
+    "'get_value_callback' => 'demo_space_hero_data_resolve_binding_source_value'"
+  );
+  expect(bindingServerSource).toContain("'hero-data' => 'Hero Data starter value'");
   expect(bindingEditorSource).toContain("registerBlockBindingsSource");
+  expect(bindingEditorSource).toContain("const BINDING_SOURCE_VALUES");
+  expect(bindingEditorSource).toContain('"hero-data": "Hero Data starter value"');
+  expect(bindingEditorSource).toContain("resolveBindingSourceValue( field )");
   expect(bindingEditorSource).toContain("getFieldsList()");
 
   const doctorOutput = runCli("node", [entryPath, "doctor"], {
@@ -1992,6 +2002,9 @@ test("canonical CLI can add a binding source to an official workspace template",
   expect(
     fs.existsSync(path.join(targetDir, "build", "bindings", "index.js"))
   ).toBe(true);
+  expect(
+    fs.readFileSync(path.join(targetDir, "build", "bindings", "index.js"), "utf8")
+  ).toContain("Hero Data starter value");
   expect(
     fs.existsSync(
       path.join(targetDir, "build", "bindings", "index.asset.php")


### PR DESCRIPTION
## Context

Issue #298 tracks the remaining gap in `wp-typia add binding-source`: the generated PHP and editor files compiled, but they only returned placeholder strings instead of giving workspace authors a usable starter contract to fill in.

## What Changed

- replaced the inline PHP placeholder callback with named helper functions that resolve binding values from one field-keyed map per binding source
- updated the generated editor module to use the same field-keyed starter data pattern and resolve values from `bindings[*].args.field` instead of emitting per-attribute TODO strings
- documented the generated binding-source starter flow in `docs/API.md` so workspace authors know exactly which generated files to edit next
- expanded the binding-source workspace regression to assert the generated helper names, starter values, and emitted build output

## Verification

- `bun run --filter @wp-typia/project-tools build`
- `bun test packages/wp-typia-project-tools/tests/workspace-add.test.ts packages/wp-typia-project-tools/tests/workspace-doctor.test.ts`
- `bun run changesets:validate`

Closes #298


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded API guide with clearer instructions for editing binding source starter contracts, including specific guidance on parallel editing workflows

* **New Features**
  * Improved binding source scaffolding generation with field-keyed starter contracts and proper helper functions, replacing placeholder content with structured, production-ready generated code

* **Chores**
  * Version updates for workspace binding tools and related packages to support enhanced scaffolding

<!-- end of auto-generated comment: release notes by coderabbit.ai -->