### PR TITLE
Add interactive external layer selection

### DIFF
--- a/.sampo/changesets/issue-299-external-layer-selector.md
+++ b/.sampo/changesets/issue-299-external-layer-selector.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Add interactive external layer selection for built-in create and add-block CLI flows when a package exposes multiple public layer roots, while keeping non-interactive and programmatic calls explicit.

--- a/docs/block-generator-tool-contract.md
+++ b/docs/block-generator-tool-contract.md
@@ -212,10 +212,11 @@ This contract intentionally does not:
 - implement an MCP server
 - implement Agentica runtime wiring
 - replace `BlockGeneratorService`
-- add interactive discovery/selection UX for external template-layer composition
+- add richer discovery UX beyond the current interactive layer selector
 
 External layer composition is now available through the same inspection input
 shape (`externalLayerSource` and optional `externalLayerId`) and the canonical
-`wp-typia create` / `wp-typia add block` built-in flags. The remaining
-interactive selection/discovery questions are documented in
-[`docs/external-template-layer-composition.md`](./external-template-layer-composition.md).
+`wp-typia create` / `wp-typia add block` built-in flags. The canonical CLI now
+prompts for a layer when a package exposes multiple public roots and the caller
+omits `externalLayerId`, while programmatic and non-interactive callers still
+pass the layer id explicitly when ambiguity exists.

--- a/docs/external-template-layer-composition.md
+++ b/docs/external-template-layer-composition.md
@@ -26,7 +26,7 @@ It does not:
 - replace the typed built-in generator architecture from
   [`docs/block-generator-architecture.md`](./block-generator-architecture.md)
 - change the official empty workspace template package contract
-- define richer interactive discovery/selection UX beyond the canonical flags
+- define discovery UX beyond the current interactive selector plus canonical flags
 
 The implementation follow-through was tracked in issue `#268`.
 
@@ -249,8 +249,9 @@ using:
   root containing `wp-typia.layers.json`.
 - `externalLayerId`
   Optional explicit layer id. Omit it when the package exposes a single public
-  layer. If the package exposes multiple public roots, callers must choose one
-  explicitly until an interactive selector is added.
+  layer. Built-in interactive CLI flows can prompt when a package exposes
+  multiple public roots. Programmatic and non-interactive callers still choose
+  one explicitly in that case.
 
 The implemented behavior now includes:
 

--- a/packages/wp-typia-project-tools/src/runtime/block-generator-service.ts
+++ b/packages/wp-typia-project-tools/src/runtime/block-generator-service.ts
@@ -98,6 +98,7 @@ export interface BlockGenerationTarget {
 	cwd: string;
 	externalLayerId?: string;
 	externalLayerSource?: string;
+	externalLayerSourceLabel?: string;
 	noInstall: boolean;
 	packageManager: PackageManagerId;
 	projectDir: string;
@@ -112,6 +113,7 @@ export interface PlanBlockInput {
 	dataStorageMode?: DataStorageMode;
 	externalLayerId?: string;
 	externalLayerSource?: string;
+	externalLayerSourceLabel?: string;
 	noInstall?: boolean;
 	packageManager: PackageManagerId;
 	persistencePolicy?: PersistencePolicy;
@@ -431,6 +433,7 @@ export class BlockGeneratorService {
 		dataStorageMode,
 		externalLayerId,
 		externalLayerSource,
+		externalLayerSourceLabel,
 		noInstall = false,
 		packageManager,
 		persistencePolicy,
@@ -457,6 +460,7 @@ export class BlockGeneratorService {
 				cwd,
 				externalLayerId,
 				externalLayerSource,
+				externalLayerSourceLabel,
 				noInstall,
 				packageManager,
 				projectDir,
@@ -568,7 +572,7 @@ export class BlockGeneratorService {
 					}
 				};
 				warnings.push(
-					`Applied external layer "${resolvedLayers.selectedLayerId}" from "${validated.target.externalLayerSource}".`,
+					`Applied external layer "${resolvedLayers.selectedLayerId}" from "${validated.target.externalLayerSourceLabel ?? validated.target.externalLayerSource}".`,
 				);
 			} catch (error) {
 				await templateSource.cleanup?.();

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-block.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-block.ts
@@ -887,7 +887,8 @@ export async function runAddBlockCommand({
 		normalizeExternalLayerOption(externalLayerSource),
 		cwd,
 	);
-	const resolvedExternalLayerId = await resolveOptionalInteractiveExternalLayerId({
+	const resolvedExternalLayerSelection =
+		await resolveOptionalInteractiveExternalLayerId({
 		callerCwd: cwd,
 		externalLayerId: normalizedExternalLayerId,
 		externalLayerSource: normalizedExternalLayerSource,
@@ -923,33 +924,46 @@ export async function runAddBlockCommand({
 			resolvedTemplateId === "compound"
 				? await collectLegacyCompoundValidatorPaths(workspace.projectDir)
 				: [];
-		const result = await scaffoldProject({
-			answers: {
-				...defaults,
-				author: workspace.author,
-				namespace: workspace.workspace.namespace,
-				phpPrefix: blockPhpPrefix,
-				slug: normalizedSlug,
-				textDomain: workspace.workspace.textDomain,
-				title: defaults.title,
-			},
-			cwd: workspace.projectDir,
-			dataStorageMode: dataStorageMode as "custom-table" | "post-meta" | undefined,
-			externalLayerId: resolvedExternalLayerId,
-			externalLayerSource: normalizedExternalLayerSource,
-			noInstall: true,
-			packageManager: workspace.packageManager,
-			persistencePolicy: persistencePolicy as "authenticated" | "public" | undefined,
-			projectDir: tempProjectDir,
-			templateId: resolvedTemplateId,
-		});
-		await assertAddBlockSupportsExternalLayerOutputs({
-			callerCwd: cwd,
-			externalLayerId: resolvedExternalLayerId,
-			externalLayerSource: normalizedExternalLayerSource,
-			templateId: resolvedTemplateId,
-			variables: result.variables,
-		});
+		const result = await (async () => {
+			try {
+				const scaffoldResult = await scaffoldProject({
+					answers: {
+						...defaults,
+						author: workspace.author,
+						namespace: workspace.workspace.namespace,
+						phpPrefix: blockPhpPrefix,
+						slug: normalizedSlug,
+						textDomain: workspace.workspace.textDomain,
+						title: defaults.title,
+					},
+					cwd: workspace.projectDir,
+					dataStorageMode: dataStorageMode as "custom-table" | "post-meta" | undefined,
+					externalLayerId:
+						resolvedExternalLayerSelection.externalLayerId,
+					externalLayerSource:
+						resolvedExternalLayerSelection.externalLayerSource,
+					externalLayerSourceLabel: normalizedExternalLayerSource,
+					noInstall: true,
+					packageManager: workspace.packageManager,
+					persistencePolicy:
+						persistencePolicy as "authenticated" | "public" | undefined,
+					projectDir: tempProjectDir,
+					templateId: resolvedTemplateId,
+				});
+				await assertAddBlockSupportsExternalLayerOutputs({
+					callerCwd: cwd,
+					externalLayerId:
+						resolvedExternalLayerSelection.externalLayerId,
+					externalLayerSource:
+						resolvedExternalLayerSelection.externalLayerSource,
+					templateId: resolvedTemplateId,
+					variables: scaffoldResult.variables,
+				});
+				return scaffoldResult;
+			} finally {
+				await resolvedExternalLayerSelection.cleanup?.();
+			}
+		})();
 		assertBlockTargetsDoNotExist(workspace.projectDir, resolvedTemplateId, result.variables);
 		const mutationSnapshot: WorkspaceMutationSnapshot = {
 			fileSources: await snapshotWorkspaceFiles([

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-block.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-block.ts
@@ -54,6 +54,9 @@ import {
 import {
 	resolveExternalTemplateLayers,
 } from "./template-layers.js";
+import {
+	resolveOptionalInteractiveExternalLayerId,
+} from "./external-layer-selection.js";
 
 const COLLECTION_IMPORT_LINE = "import '../../collection';";
 const REST_MANIFEST_IMPORT_PATTERN =
@@ -861,6 +864,7 @@ export async function runAddBlockCommand({
 	externalLayerId,
 	externalLayerSource,
 	persistencePolicy,
+	selectExternalLayerId,
 	templateId = "basic",
 }: RunAddBlockCommandOptions): Promise<{
 	blockSlugs: string[];
@@ -883,6 +887,12 @@ export async function runAddBlockCommand({
 		normalizeExternalLayerOption(externalLayerSource),
 		cwd,
 	);
+	const resolvedExternalLayerId = await resolveOptionalInteractiveExternalLayerId({
+		callerCwd: cwd,
+		externalLayerId: normalizedExternalLayerId,
+		externalLayerSource: normalizedExternalLayerSource,
+		selectExternalLayerId,
+	});
 	const normalizedSlug = normalizeBlockSlug(blockName);
 	if (!normalizedSlug) {
 		throw new Error("Block name is required. Use `wp-typia add block <name> --template <family>`.");
@@ -925,7 +935,7 @@ export async function runAddBlockCommand({
 			},
 			cwd: workspace.projectDir,
 			dataStorageMode: dataStorageMode as "custom-table" | "post-meta" | undefined,
-			externalLayerId: normalizedExternalLayerId,
+			externalLayerId: resolvedExternalLayerId,
 			externalLayerSource: normalizedExternalLayerSource,
 			noInstall: true,
 			packageManager: workspace.packageManager,
@@ -935,7 +945,7 @@ export async function runAddBlockCommand({
 		});
 		await assertAddBlockSupportsExternalLayerOutputs({
 			callerCwd: cwd,
-			externalLayerId: normalizedExternalLayerId,
+			externalLayerId: resolvedExternalLayerId,
 			externalLayerSource: normalizedExternalLayerSource,
 			templateId: resolvedTemplateId,
 			variables: result.variables,

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-block.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-block.ts
@@ -894,15 +894,15 @@ export async function runAddBlockCommand({
 		externalLayerSource: normalizedExternalLayerSource,
 		selectExternalLayerId,
 	});
-	const normalizedSlug = normalizeBlockSlug(blockName);
-	if (!normalizedSlug) {
-		throw new Error("Block name is required. Use `wp-typia add block <name> --template <family>`.");
-	}
-
-	const defaults = getDefaultAnswers(normalizedSlug, resolvedTemplateId);
 	let tempRoot = "";
 
 	try {
+		const normalizedSlug = normalizeBlockSlug(blockName);
+		if (!normalizedSlug) {
+			throw new Error("Block name is required. Use `wp-typia add block <name> --template <family>`.");
+		}
+
+		const defaults = getDefaultAnswers(normalizedSlug, resolvedTemplateId);
 		tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "wp-typia-add-block-"));
 		const tempProjectDir = path.join(tempRoot, normalizedSlug);
 		const blockConfigPath = path.join(workspace.projectDir, "scripts", "block-config.ts");
@@ -925,44 +925,40 @@ export async function runAddBlockCommand({
 				? await collectLegacyCompoundValidatorPaths(workspace.projectDir)
 				: [];
 		const result = await (async () => {
-			try {
-				const scaffoldResult = await scaffoldProject({
-					answers: {
-						...defaults,
-						author: workspace.author,
-						namespace: workspace.workspace.namespace,
-						phpPrefix: blockPhpPrefix,
-						slug: normalizedSlug,
-						textDomain: workspace.workspace.textDomain,
-						title: defaults.title,
-					},
-					cwd: workspace.projectDir,
-					dataStorageMode: dataStorageMode as "custom-table" | "post-meta" | undefined,
-					externalLayerId:
-						resolvedExternalLayerSelection.externalLayerId,
-					externalLayerSource:
-						resolvedExternalLayerSelection.externalLayerSource,
-					externalLayerSourceLabel: normalizedExternalLayerSource,
-					noInstall: true,
-					packageManager: workspace.packageManager,
-					persistencePolicy:
-						persistencePolicy as "authenticated" | "public" | undefined,
-					projectDir: tempProjectDir,
-					templateId: resolvedTemplateId,
-				});
-				await assertAddBlockSupportsExternalLayerOutputs({
-					callerCwd: cwd,
-					externalLayerId:
-						resolvedExternalLayerSelection.externalLayerId,
-					externalLayerSource:
-						resolvedExternalLayerSelection.externalLayerSource,
-					templateId: resolvedTemplateId,
-					variables: scaffoldResult.variables,
-				});
-				return scaffoldResult;
-			} finally {
-				await resolvedExternalLayerSelection.cleanup?.();
-			}
+			const scaffoldResult = await scaffoldProject({
+				answers: {
+					...defaults,
+					author: workspace.author,
+					namespace: workspace.workspace.namespace,
+					phpPrefix: blockPhpPrefix,
+					slug: normalizedSlug,
+					textDomain: workspace.workspace.textDomain,
+					title: defaults.title,
+				},
+				cwd: workspace.projectDir,
+				dataStorageMode: dataStorageMode as "custom-table" | "post-meta" | undefined,
+				externalLayerId:
+					resolvedExternalLayerSelection.externalLayerId,
+				externalLayerSource:
+					resolvedExternalLayerSelection.externalLayerSource,
+				externalLayerSourceLabel: normalizedExternalLayerSource,
+				noInstall: true,
+				packageManager: workspace.packageManager,
+				persistencePolicy:
+					persistencePolicy as "authenticated" | "public" | undefined,
+				projectDir: tempProjectDir,
+				templateId: resolvedTemplateId,
+			});
+			await assertAddBlockSupportsExternalLayerOutputs({
+				callerCwd: cwd,
+				externalLayerId:
+					resolvedExternalLayerSelection.externalLayerId,
+				externalLayerSource:
+					resolvedExternalLayerSelection.externalLayerSource,
+				templateId: resolvedTemplateId,
+				variables: scaffoldResult.variables,
+			});
+			return scaffoldResult;
 		})();
 		assertBlockTargetsDoNotExist(workspace.projectDir, resolvedTemplateId, result.variables);
 		const mutationSnapshot: WorkspaceMutationSnapshot = {
@@ -1035,6 +1031,7 @@ export async function runAddBlockCommand({
 			throw error;
 		}
 	} finally {
+		await resolvedExternalLayerSelection.cleanup?.();
 		if (tempRoot) {
 			await fsp.rm(tempRoot, { force: true, recursive: true });
 		}

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-shared.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-shared.ts
@@ -69,6 +69,13 @@ export interface RunAddBlockCommandOptions {
 	externalLayerId?: string;
 	externalLayerSource?: string;
 	persistencePolicy?: string;
+	selectExternalLayerId?: (
+		options: Array<{
+			description?: string;
+			extends: string[];
+			id: string;
+		}>,
+	) => Promise<string>;
 	templateId?: string;
 }
 

--- a/packages/wp-typia-project-tools/src/runtime/cli-scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-scaffold.ts
@@ -26,6 +26,10 @@ import {
 	OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE,
 	isBuiltInTemplateId,
 } from "./template-registry.js";
+import {
+	resolveOptionalInteractiveExternalLayerId,
+	type ExternalLayerSelectionOption,
+} from "./external-layer-selection.js";
 import type { TemplateDefinition } from "./template-registry.js";
 
 interface GetNextStepsOptions {
@@ -63,6 +67,9 @@ interface RunScaffoldFlowOptions {
 	projectInput: string;
 	promptText?: Parameters<typeof collectScaffoldAnswers>[0]["promptText"];
 	selectDataStorage?: () => Promise<DataStorageMode>;
+	selectExternalLayerId?: (
+		options: ExternalLayerSelectionOption[],
+	) => Promise<string>;
 	selectPackageManager?: () => Promise<PackageManagerId>;
 	selectPersistencePolicy?: () => Promise<PersistencePolicy>;
 	selectTemplate?: () => Promise<TemplateDefinition["id"]>;
@@ -271,6 +278,7 @@ export async function runScaffoldFlow({
 	allowExistingDir = false,
 	selectTemplate,
 	selectDataStorage,
+	selectExternalLayerId,
 	selectPersistencePolicy,
 	selectPackageManager,
 	promptText,
@@ -305,6 +313,15 @@ export async function runScaffoldFlow({
 		isInteractive,
 		selectTemplate,
 	});
+	const resolvedExternalLayerId =
+		isBuiltInTemplateId(resolvedTemplateId) && isInteractive
+			? await resolveOptionalInteractiveExternalLayerId({
+					callerCwd: cwd,
+					externalLayerId: normalizedExternalLayerId,
+					externalLayerSource: normalizedExternalLayerSource,
+					selectExternalLayerId,
+				})
+			: normalizedExternalLayerId;
 	const shouldResolvePersistence = templateUsesPersistenceSettings(resolvedTemplateId, {
 		dataStorageMode,
 		persistencePolicy,
@@ -377,7 +394,7 @@ export async function runScaffoldFlow({
 		allowExistingDir,
 		cwd,
 		dataStorageMode: resolvedDataStorage,
-		externalLayerId: normalizedExternalLayerId,
+		externalLayerId: resolvedExternalLayerId,
 		externalLayerSource: normalizedExternalLayerSource,
 		installDependencies,
 		noInstall,

--- a/packages/wp-typia-project-tools/src/runtime/cli-scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-scaffold.ts
@@ -325,76 +325,75 @@ export async function runScaffoldFlow({
 					externalLayerId: normalizedExternalLayerId,
 					externalLayerSource: normalizedExternalLayerSource,
 				};
-	const shouldResolvePersistence = templateUsesPersistenceSettings(resolvedTemplateId, {
-		dataStorageMode,
-		persistencePolicy,
-	});
-	const resolvedDataStorage = await resolveOptionalSelection({
-		allowedValues: DATA_STORAGE_MODES,
-		defaultValue: "custom-table",
-		explicitValue: dataStorageMode,
-		isInteractive,
-		isValue: isDataStorageMode,
-		label: "data storage mode",
-		select: selectDataStorage,
-		shouldResolve: shouldResolvePersistence,
-		yes,
-	});
-	const resolvedPersistencePolicy = await resolveOptionalSelection({
-		allowedValues: PERSISTENCE_POLICIES,
-		defaultValue: "authenticated",
-		explicitValue: persistencePolicy,
-		isInteractive,
-		isValue: isPersistencePolicy,
-		label: "persistence policy",
-		select: selectPersistencePolicy,
-		shouldResolve: shouldResolvePersistence,
-		yes,
-	});
-	const resolvedPackageManager = await resolvePackageManagerId({
-		packageManager,
-		yes,
-		isInteractive,
-		selectPackageManager,
-	});
-	const resolvedWithWpEnv = await resolveOptionalBooleanFlag({
-		explicitValue: withWpEnv,
-		isInteractive,
-		select: selectWithWpEnv,
-		yes,
-	});
-	const resolvedWithTestPreset = await resolveOptionalBooleanFlag({
-		explicitValue: withTestPreset,
-		isInteractive,
-		select: selectWithTestPreset,
-		yes,
-	});
-	const resolvedWithMigrationUi = await resolveOptionalBooleanFlag({
-		disabled:
-			!isBuiltInTemplateId(resolvedTemplateId) &&
-			resolvedTemplateId !== OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE,
-		explicitValue: withMigrationUi,
-		isInteractive,
-		select: selectWithMigrationUi,
-		yes,
-	});
-	const projectDir = path.resolve(cwd, projectInput);
-	const projectName = path.basename(projectDir);
-	const answers = await collectScaffoldAnswers({
-		dataStorageMode: resolvedDataStorage,
-		namespace,
-		persistencePolicy: resolvedPersistencePolicy,
-		phpPrefix,
-		projectName,
-		templateId: resolvedTemplateId,
-		textDomain,
-		yes,
-		promptText,
-	});
-
-	let result;
 	try {
-		result = await scaffoldProject({
+		const shouldResolvePersistence = templateUsesPersistenceSettings(resolvedTemplateId, {
+			dataStorageMode,
+			persistencePolicy,
+		});
+		const resolvedDataStorage = await resolveOptionalSelection({
+			allowedValues: DATA_STORAGE_MODES,
+			defaultValue: "custom-table",
+			explicitValue: dataStorageMode,
+			isInteractive,
+			isValue: isDataStorageMode,
+			label: "data storage mode",
+			select: selectDataStorage,
+			shouldResolve: shouldResolvePersistence,
+			yes,
+		});
+		const resolvedPersistencePolicy = await resolveOptionalSelection({
+			allowedValues: PERSISTENCE_POLICIES,
+			defaultValue: "authenticated",
+			explicitValue: persistencePolicy,
+			isInteractive,
+			isValue: isPersistencePolicy,
+			label: "persistence policy",
+			select: selectPersistencePolicy,
+			shouldResolve: shouldResolvePersistence,
+			yes,
+		});
+		const resolvedPackageManager = await resolvePackageManagerId({
+			packageManager,
+			yes,
+			isInteractive,
+			selectPackageManager,
+		});
+		const resolvedWithWpEnv = await resolveOptionalBooleanFlag({
+			explicitValue: withWpEnv,
+			isInteractive,
+			select: selectWithWpEnv,
+			yes,
+		});
+		const resolvedWithTestPreset = await resolveOptionalBooleanFlag({
+			explicitValue: withTestPreset,
+			isInteractive,
+			select: selectWithTestPreset,
+			yes,
+		});
+		const resolvedWithMigrationUi = await resolveOptionalBooleanFlag({
+			disabled:
+				!isBuiltInTemplateId(resolvedTemplateId) &&
+				resolvedTemplateId !== OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE,
+			explicitValue: withMigrationUi,
+			isInteractive,
+			select: selectWithMigrationUi,
+			yes,
+		});
+		const projectDir = path.resolve(cwd, projectInput);
+		const projectName = path.basename(projectDir);
+		const answers = await collectScaffoldAnswers({
+			dataStorageMode: resolvedDataStorage,
+			namespace,
+			persistencePolicy: resolvedPersistencePolicy,
+			phpPrefix,
+			projectName,
+			templateId: resolvedTemplateId,
+			textDomain,
+			yes,
+			promptText,
+		});
+
+		const result = await scaffoldProject({
 			answers,
 			allowExistingDir,
 			cwd,
@@ -414,46 +413,46 @@ export async function runScaffoldFlow({
 			withTestPreset: resolvedWithTestPreset,
 			withWpEnv: resolvedWithWpEnv,
 		});
+		let availableScripts: string[] | undefined;
+		try {
+			const parsedPackageJson = JSON.parse(
+				fs.readFileSync(path.join(projectDir, "package.json"), "utf8"),
+			) as {
+				scripts?: unknown;
+			};
+			const scripts =
+				parsedPackageJson.scripts &&
+				typeof parsedPackageJson.scripts === "object" &&
+				!Array.isArray(parsedPackageJson.scripts)
+					? parsedPackageJson.scripts
+					: {};
+			availableScripts = Object.entries(scripts)
+				.filter(([, value]) => typeof value === "string")
+				.map(([scriptName]) => scriptName);
+		} catch {
+			availableScripts = undefined;
+		}
+
+		return {
+			optionalOnboarding: getOptionalOnboarding({
+				availableScripts,
+				packageManager: resolvedPackageManager,
+				templateId: resolvedTemplateId,
+				compoundPersistenceEnabled: result.variables.compoundPersistenceEnabled === "true",
+			}),
+			projectDir,
+			projectInput,
+			packageManager: resolvedPackageManager,
+			result,
+			nextSteps: getNextSteps({
+				projectInput,
+				projectDir,
+				packageManager: resolvedPackageManager,
+				noInstall,
+				templateId: resolvedTemplateId,
+			}),
+		};
 	} finally {
 		await resolvedExternalLayerSelection.cleanup?.();
 	}
-	let availableScripts: string[] | undefined;
-	try {
-		const parsedPackageJson = JSON.parse(
-			fs.readFileSync(path.join(projectDir, "package.json"), "utf8"),
-		) as {
-			scripts?: unknown;
-		};
-		const scripts =
-			parsedPackageJson.scripts &&
-			typeof parsedPackageJson.scripts === "object" &&
-			!Array.isArray(parsedPackageJson.scripts)
-				? parsedPackageJson.scripts
-				: {};
-		availableScripts = Object.entries(scripts)
-			.filter(([, value]) => typeof value === "string")
-			.map(([scriptName]) => scriptName);
-	} catch {
-		availableScripts = undefined;
-	}
-
-	return {
-		optionalOnboarding: getOptionalOnboarding({
-			availableScripts,
-			packageManager: resolvedPackageManager,
-			templateId: resolvedTemplateId,
-			compoundPersistenceEnabled: result.variables.compoundPersistenceEnabled === "true",
-		}),
-		projectDir,
-		projectInput,
-		packageManager: resolvedPackageManager,
-		result,
-		nextSteps: getNextSteps({
-			projectInput,
-			projectDir,
-			packageManager: resolvedPackageManager,
-			noInstall,
-			templateId: resolvedTemplateId,
-		}),
-	};
 }

--- a/packages/wp-typia-project-tools/src/runtime/cli-scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-scaffold.ts
@@ -313,7 +313,7 @@ export async function runScaffoldFlow({
 		isInteractive,
 		selectTemplate,
 	});
-	const resolvedExternalLayerId =
+	const resolvedExternalLayerSelection =
 		isBuiltInTemplateId(resolvedTemplateId) && isInteractive
 			? await resolveOptionalInteractiveExternalLayerId({
 					callerCwd: cwd,
@@ -321,7 +321,10 @@ export async function runScaffoldFlow({
 					externalLayerSource: normalizedExternalLayerSource,
 					selectExternalLayerId,
 				})
-			: normalizedExternalLayerId;
+			: {
+					externalLayerId: normalizedExternalLayerId,
+					externalLayerSource: normalizedExternalLayerSource,
+				};
 	const shouldResolvePersistence = templateUsesPersistenceSettings(resolvedTemplateId, {
 		dataStorageMode,
 		persistencePolicy,
@@ -389,24 +392,31 @@ export async function runScaffoldFlow({
 		promptText,
 	});
 
-	const result = await scaffoldProject({
-		answers,
-		allowExistingDir,
-		cwd,
-		dataStorageMode: resolvedDataStorage,
-		externalLayerId: resolvedExternalLayerId,
-		externalLayerSource: normalizedExternalLayerSource,
-		installDependencies,
-		noInstall,
-		packageManager: resolvedPackageManager,
-		persistencePolicy: resolvedPersistencePolicy,
-		projectDir,
-		templateId: resolvedTemplateId,
-		variant,
-		withMigrationUi: resolvedWithMigrationUi,
-		withTestPreset: resolvedWithTestPreset,
-		withWpEnv: resolvedWithWpEnv,
-	});
+	let result;
+	try {
+		result = await scaffoldProject({
+			answers,
+			allowExistingDir,
+			cwd,
+			dataStorageMode: resolvedDataStorage,
+			externalLayerId: resolvedExternalLayerSelection.externalLayerId,
+			externalLayerSource:
+				resolvedExternalLayerSelection.externalLayerSource,
+			externalLayerSourceLabel: normalizedExternalLayerSource,
+			installDependencies,
+			noInstall,
+			packageManager: resolvedPackageManager,
+			persistencePolicy: resolvedPersistencePolicy,
+			projectDir,
+			templateId: resolvedTemplateId,
+			variant,
+			withMigrationUi: resolvedWithMigrationUi,
+			withTestPreset: resolvedWithTestPreset,
+			withWpEnv: resolvedWithWpEnv,
+		});
+	} finally {
+		await resolvedExternalLayerSelection.cleanup?.();
+	}
 	let availableScripts: string[] | undefined;
 	try {
 		const parsedPackageJson = JSON.parse(

--- a/packages/wp-typia-project-tools/src/runtime/external-layer-selection.ts
+++ b/packages/wp-typia-project-tools/src/runtime/external-layer-selection.ts
@@ -10,6 +10,12 @@ import {
 export interface ExternalLayerSelectionOption
 	extends SelectableExternalTemplateLayer {}
 
+export interface ResolvedExternalLayerSelection {
+	cleanup?: () => Promise<void>;
+	externalLayerId?: string;
+	externalLayerSource?: string;
+}
+
 export async function resolveOptionalInteractiveExternalLayerId({
 	callerCwd,
 	externalLayerId,
@@ -22,9 +28,12 @@ export async function resolveOptionalInteractiveExternalLayerId({
 	selectExternalLayerId?: (
 		options: ExternalLayerSelectionOption[],
 	) => Promise<string>;
-}): Promise<string | undefined> {
+}): Promise<ResolvedExternalLayerSelection> {
 	if (!externalLayerSource || externalLayerId || !selectExternalLayerId) {
-		return externalLayerId;
+		return {
+			externalLayerId,
+			externalLayerSource,
+		};
 	}
 
 	const layerSeed = await resolveTemplateSeed(
@@ -36,18 +45,28 @@ export async function resolveOptionalInteractiveExternalLayerId({
 			layerSeed.rootDir,
 		);
 		if (selectableLayers.length <= 1) {
-			return externalLayerId;
+			await layerSeed.cleanup?.();
+			return {
+				externalLayerId,
+				externalLayerSource,
+			};
 		}
 
 		const selectedLayerId = await selectExternalLayerId(selectableLayers);
 		if (selectableLayers.some((layer) => layer.id === selectedLayerId)) {
-			return selectedLayerId;
+			return {
+				cleanup: layerSeed.cleanup,
+				externalLayerId: selectedLayerId,
+				externalLayerSource: layerSeed.rootDir,
+			};
 		}
 
+		await layerSeed.cleanup?.();
 		throw new Error(
 			`Unknown external layer "${selectedLayerId}". Expected one of: ${selectableLayers.map((layer) => layer.id).join(", ")}`,
 		);
-	} finally {
+	} catch (error) {
 		await layerSeed.cleanup?.();
+		throw error;
 	}
 }

--- a/packages/wp-typia-project-tools/src/runtime/external-layer-selection.ts
+++ b/packages/wp-typia-project-tools/src/runtime/external-layer-selection.ts
@@ -1,0 +1,53 @@
+import {
+	parseTemplateLocator,
+	resolveTemplateSeed,
+} from "./template-source.js";
+import {
+	listSelectableExternalTemplateLayers,
+	type SelectableExternalTemplateLayer,
+} from "./template-layers.js";
+
+export interface ExternalLayerSelectionOption
+	extends SelectableExternalTemplateLayer {}
+
+export async function resolveOptionalInteractiveExternalLayerId({
+	callerCwd,
+	externalLayerId,
+	externalLayerSource,
+	selectExternalLayerId,
+}: {
+	callerCwd: string;
+	externalLayerId?: string;
+	externalLayerSource?: string;
+	selectExternalLayerId?: (
+		options: ExternalLayerSelectionOption[],
+	) => Promise<string>;
+}): Promise<string | undefined> {
+	if (!externalLayerSource || externalLayerId || !selectExternalLayerId) {
+		return externalLayerId;
+	}
+
+	const layerSeed = await resolveTemplateSeed(
+		parseTemplateLocator(externalLayerSource),
+		callerCwd,
+	);
+	try {
+		const selectableLayers = await listSelectableExternalTemplateLayers(
+			layerSeed.rootDir,
+		);
+		if (selectableLayers.length <= 1) {
+			return externalLayerId;
+		}
+
+		const selectedLayerId = await selectExternalLayerId(selectableLayers);
+		if (selectableLayers.some((layer) => layer.id === selectedLayerId)) {
+			return selectedLayerId;
+		}
+
+		throw new Error(
+			`Unknown external layer "${selectedLayerId}". Expected one of: ${selectableLayers.map((layer) => layer.id).join(", ")}`,
+		);
+	} finally {
+		await layerSeed.cleanup?.();
+	}
+}

--- a/packages/wp-typia-project-tools/src/runtime/scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold.ts
@@ -204,6 +204,7 @@ interface ScaffoldProjectOptions {
 	dataStorageMode?: DataStorageMode;
 	externalLayerId?: string;
 	externalLayerSource?: string;
+	externalLayerSourceLabel?: string;
 	installDependencies?: ((options: InstallDependenciesOptions) => Promise<void>) | undefined;
 	noInstall?: boolean;
 	packageManager: PackageManagerId;
@@ -1029,6 +1030,7 @@ export async function scaffoldProject({
 	packageManager,
 	externalLayerId,
 	externalLayerSource,
+	externalLayerSourceLabel,
 	repositoryReference,
 	cwd = process.cwd(),
 	allowExistingDir = false,
@@ -1058,6 +1060,7 @@ export async function scaffoldProject({
 			dataStorageMode: dataStorageMode ?? answers.dataStorageMode,
 			externalLayerId,
 			externalLayerSource,
+			externalLayerSourceLabel,
 			noInstall,
 			packageManager: resolvedPackageManager,
 			persistencePolicy: persistencePolicy ?? answers.persistencePolicy,

--- a/packages/wp-typia-project-tools/src/runtime/template-layers.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-layers.ts
@@ -34,6 +34,12 @@ export interface ResolvedExternalTemplateLayers {
 	selectedLayerId: string;
 }
 
+export interface SelectableExternalTemplateLayer {
+	description?: string;
+	extends: string[];
+	id: string;
+}
+
 function resolveLayerPath(sourceRoot: string, relativePath: string): string {
 	const targetPath = path.resolve(sourceRoot, relativePath);
 	const relativeTarget = path.relative(sourceRoot, targetPath);
@@ -147,14 +153,10 @@ export async function loadExternalTemplateLayerManifest(
 	};
 }
 
-function getDefaultExternalLayerId(
+function getSelectableExternalLayers(
 	manifest: ExternalTemplateLayerManifest,
-): string {
+): SelectableExternalTemplateLayer[] {
 	const layerIds = Object.keys(manifest.layers);
-	if (layerIds.length === 1) {
-		return layerIds[0];
-	}
-
 	const referencedExternalLayerIds = new Set<string>();
 	for (const definition of Object.values(manifest.layers)) {
 		for (const ancestorId of definition.extends ?? []) {
@@ -167,13 +169,38 @@ function getDefaultExternalLayerId(
 	const publicLayerIds = layerIds.filter(
 		(layerId) => !referencedExternalLayerIds.has(layerId),
 	);
-	if (publicLayerIds.length === 1) {
-		return publicLayerIds[0];
+	return publicLayerIds.map((layerId) => ({
+		description: manifest.layers[layerId]?.description,
+		extends: [...(manifest.layers[layerId]?.extends ?? [])],
+		id: layerId,
+	}));
+}
+
+function getDefaultExternalLayerId(
+	manifest: ExternalTemplateLayerManifest,
+): string {
+	const selectableLayers = getSelectableExternalLayers(manifest);
+	if (selectableLayers.length === 1) {
+		return selectableLayers[0].id;
 	}
+	const layerIds = Object.keys(manifest.layers);
 
 	throw new Error(
-		`External layer package defines multiple selectable layers (${layerIds.join(", ")}). Pass an explicit externalLayerId until a final CLI selection UX exists.`,
+		`External layer package defines multiple selectable layers (${layerIds.join(", ")}). Pass an explicit externalLayerId or rerun through the interactive CLI selector.`,
 	);
+}
+
+export async function listSelectableExternalTemplateLayers(
+	sourceRoot: string,
+): Promise<SelectableExternalTemplateLayer[]> {
+	const manifest = await loadExternalTemplateLayerManifest(sourceRoot);
+	if (!manifest) {
+		throw new Error(
+			`No ${TEMPLATE_LAYER_MANIFEST_FILENAME} manifest found in ${sourceRoot}.`,
+		);
+	}
+
+	return getSelectableExternalLayers(manifest);
 }
 
 export async function resolveExternalTemplateLayers({

--- a/packages/wp-typia-project-tools/tests/cli-entry.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-entry.test.ts
@@ -211,6 +211,51 @@ test("runScaffoldFlow honors explicit external layer ids when a package exposes 
   );
 });
 
+test("runScaffoldFlow prompts for an external layer when multiple public roots are available", async () => {
+  let promptedOptions: Array<{
+    description?: string;
+    extends: string[];
+    id: string;
+  }> = [];
+
+  const flow = await runScaffoldFlow({
+    cwd: tempRoot,
+    externalLayerSource: templateLayerAmbiguousFixturePath,
+    isInteractive: true,
+    noInstall: true,
+    packageManager: "npm",
+    projectInput: "demo-layered-ambiguous-prompt",
+    promptText: async (_message, defaultValue) => defaultValue,
+    selectExternalLayerId: async (options) => {
+      promptedOptions = options;
+      return "acme/beta";
+    },
+    templateId: "basic",
+  });
+
+  expect(promptedOptions).toEqual([
+    {
+      description: "Alpha external layer",
+      extends: ["acme/internal-base"],
+      id: "acme/alpha",
+    },
+    {
+      description: "Beta external layer",
+      extends: ["acme/internal-base"],
+      id: "acme/beta",
+    },
+  ]);
+  expect(flow.result.warnings).toContain(
+    `Applied external layer "acme/beta" from "${templateLayerAmbiguousFixturePath}".`
+  );
+  expect(
+    fs.readFileSync(path.join(flow.projectDir, "base.txt"), "utf8")
+  ).toContain("base external layer");
+  expect(fs.readFileSync(path.join(flow.projectDir, "beta.txt"), "utf8")).toContain(
+    "beta layer"
+  );
+});
+
 test("optional onboarding derives sync steps from available custom-template scripts", () => {
   const onboarding = getOptionalOnboarding({
     availableScripts: ["sync-types", "sync-rest"],
@@ -293,6 +338,22 @@ test("runScaffoldFlow rejects external layer ids without a layer source", async 
     })
   ).rejects.toThrow(
     "externalLayerId requires externalLayerSource when composing built-in template layers."
+  );
+});
+
+test("runScaffoldFlow keeps multi-layer external packages fail-fast outside interactive mode", async () => {
+  await expect(
+    runScaffoldFlow({
+      cwd: tempRoot,
+      externalLayerSource: templateLayerAmbiguousFixturePath,
+      noInstall: true,
+      packageManager: "npm",
+      projectInput: "demo-layered-ambiguous-noninteractive",
+      templateId: "basic",
+      yes: true,
+    })
+  ).rejects.toThrow(
+    "External layer package defines multiple selectable layers (acme/internal-base, acme/alpha, acme/beta). Pass an explicit externalLayerId or rerun through the interactive CLI selector."
   );
 });
 

--- a/packages/wp-typia-project-tools/tests/fixtures/wp-typia-layer-ambiguous/layers/base/base.txt.mustache
+++ b/packages/wp-typia-project-tools/tests/fixtures/wp-typia-layer-ambiguous/layers/base/base.txt.mustache
@@ -1,0 +1,1 @@
+base external layer

--- a/packages/wp-typia-project-tools/tests/fixtures/wp-typia-layer-workspace-ambiguous/layers/alpha/src/alpha.txt.mustache
+++ b/packages/wp-typia-project-tools/tests/fixtures/wp-typia-layer-workspace-ambiguous/layers/alpha/src/alpha.txt.mustache
@@ -1,0 +1,1 @@
+alpha workspace layer for {{slugKebabCase}}

--- a/packages/wp-typia-project-tools/tests/fixtures/wp-typia-layer-workspace-ambiguous/layers/base/src/base.txt.mustache
+++ b/packages/wp-typia-project-tools/tests/fixtures/wp-typia-layer-workspace-ambiguous/layers/base/src/base.txt.mustache
@@ -1,0 +1,1 @@
+base workspace layer for {{slugKebabCase}}

--- a/packages/wp-typia-project-tools/tests/fixtures/wp-typia-layer-workspace-ambiguous/layers/beta/src/beta.txt.mustache
+++ b/packages/wp-typia-project-tools/tests/fixtures/wp-typia-layer-workspace-ambiguous/layers/beta/src/beta.txt.mustache
@@ -1,0 +1,1 @@
+beta workspace layer for {{slugKebabCase}}

--- a/packages/wp-typia-project-tools/tests/fixtures/wp-typia-layer-workspace-ambiguous/wp-typia.layers.json
+++ b/packages/wp-typia-project-tools/tests/fixtures/wp-typia-layer-workspace-ambiguous/wp-typia.layers.json
@@ -2,16 +2,16 @@
   "version": 1,
   "layers": {
     "acme/internal-base": {
-      "description": "Shared external layer base",
+      "description": "Shared workspace block helpers",
       "path": "layers/base"
     },
     "acme/alpha": {
-      "description": "Alpha external layer",
+      "description": "Alpha block-local workspace layer",
       "extends": ["acme/internal-base"],
       "path": "layers/alpha"
     },
     "acme/beta": {
-      "description": "Beta external layer",
+      "description": "Beta block-local workspace layer",
       "extends": ["acme/internal-base"],
       "path": "layers/beta"
     }

--- a/packages/wp-typia-project-tools/tests/helpers/scaffold-test-harness.ts
+++ b/packages/wp-typia-project-tools/tests/helpers/scaffold-test-harness.ts
@@ -46,6 +46,12 @@ export const templateLayerWorkspaceFixturePath = path.join(
   "fixtures",
   "wp-typia-layer-workspace-package"
 );
+export const templateLayerWorkspaceAmbiguousFixturePath = path.join(
+  packageRoot,
+  "tests",
+  "fixtures",
+  "wp-typia-layer-workspace-ambiguous"
+);
 export const templateLayerAmbiguousFixturePath = path.join(
   packageRoot,
   "tests",

--- a/packages/wp-typia-project-tools/tests/template-layers.test.ts
+++ b/packages/wp-typia-project-tools/tests/template-layers.test.ts
@@ -11,6 +11,7 @@ import {
 	templateLayerFixturePath,
 } from "./helpers/scaffold-test-harness.js";
 import {
+	listSelectableExternalTemplateLayers,
 	loadExternalTemplateLayerManifest,
 	resolveExternalTemplateLayers,
 } from "../src/runtime/template-layers.js";
@@ -42,11 +43,26 @@ describe("external template layer manifests", () => {
 
 	test("requires an explicit externalLayerId when a package exposes multiple public layers", async () => {
 		await expect(
+			listSelectableExternalTemplateLayers(templateLayerAmbiguousFixturePath),
+		).resolves.toEqual([
+			{
+				description: "Alpha external layer",
+				extends: ["acme/internal-base"],
+				id: "acme/alpha",
+			},
+			{
+				description: "Beta external layer",
+				extends: ["acme/internal-base"],
+				id: "acme/beta",
+			},
+		]);
+
+		await expect(
 			resolveExternalTemplateLayers({
 				sourceRoot: templateLayerAmbiguousFixturePath,
 			}),
 		).rejects.toThrow(
-			"External layer package defines multiple selectable layers",
+			"Pass an explicit externalLayerId or rerun through the interactive CLI selector.",
 		);
 
 		await expect(

--- a/packages/wp-typia-project-tools/tests/workspace-add.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-add.test.ts
@@ -1,7 +1,8 @@
 import { afterAll, describe, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { cleanupScaffoldTempRoot, createScaffoldTempRoot, entryPath, getCommandErrorMessage, linkWorkspaceNodeModules, runCli, runGeneratedScript, scaffoldOfficialWorkspace, templateLayerFixturePath, templateLayerWorkspaceFixturePath, typecheckGeneratedProject, workspaceTemplatePackageManifest } from "./helpers/scaffold-test-harness.js";
+import { cleanupScaffoldTempRoot, createScaffoldTempRoot, entryPath, getCommandErrorMessage, linkWorkspaceNodeModules, runCli, runGeneratedScript, scaffoldOfficialWorkspace, templateLayerFixturePath, templateLayerWorkspaceAmbiguousFixturePath, templateLayerWorkspaceFixturePath, typecheckGeneratedProject, workspaceTemplatePackageManifest } from "./helpers/scaffold-test-harness.js";
+import { runAddBlockCommand } from "../src/runtime/cli-core.js";
 import { scaffoldProject } from "../src/runtime/index.js";
 
 const legacyValidatorToolkitSource = [
@@ -194,6 +195,73 @@ test("canonical CLI can add a basic block with an external layer package", async
       "utf8"
     )
   ).toContain("counter-card-telemetry");
+  typecheckGeneratedProject(targetDir);
+}, 20_000);
+
+test("runAddBlockCommand can select an external layer when multiple workspace-safe roots are available", async () => {
+  const targetDir = path.join(tempRoot, "demo-workspace-add-basic-layered-prompt");
+  let promptedOptions: Array<{
+    description?: string;
+    extends: string[];
+    id: string;
+  }> = [];
+
+  await scaffoldProject({
+    projectDir: targetDir,
+    templateId: workspaceTemplatePackageManifest.name,
+    packageManager: "npm",
+    noInstall: true,
+    answers: {
+      author: "Test Runner",
+      description: "Demo workspace add basic layered prompt",
+      namespace: "demo-space",
+      phpPrefix: "demo_space",
+      slug: "demo-workspace-add-basic-layered-prompt",
+      textDomain: "demo-space",
+      title: "Demo Workspace Add Basic Layered Prompt",
+    },
+  });
+
+  linkWorkspaceNodeModules(targetDir);
+
+  const result = await runAddBlockCommand({
+    blockName: "counter-card",
+    cwd: targetDir,
+    externalLayerSource: templateLayerWorkspaceAmbiguousFixturePath,
+    selectExternalLayerId: async (options) => {
+      promptedOptions = options;
+      return "acme/beta";
+    },
+    templateId: "basic",
+  });
+
+  expect(promptedOptions).toEqual([
+    {
+      description: "Alpha block-local workspace layer",
+      extends: ["acme/internal-base"],
+      id: "acme/alpha",
+    },
+    {
+      description: "Beta block-local workspace layer",
+      extends: ["acme/internal-base"],
+      id: "acme/beta",
+    },
+  ]);
+  expect(result.warnings).toContain(
+    `Applied external layer "acme/beta" from "${templateLayerWorkspaceAmbiguousFixturePath}".`
+  );
+  expect(
+    fs.readFileSync(
+      path.join(targetDir, "src", "blocks", "counter-card", "base.txt"),
+      "utf8"
+    )
+  ).toContain("base workspace layer for counter-card");
+  expect(
+    fs.readFileSync(
+      path.join(targetDir, "src", "blocks", "counter-card", "beta.txt"),
+      "utf8"
+    )
+  ).toContain("beta workspace layer for counter-card");
   typecheckGeneratedProject(targetDir);
 }, 20_000);
 

--- a/packages/wp-typia/src/runtime-bridge.ts
+++ b/packages/wp-typia/src/runtime-bridge.ts
@@ -458,6 +458,8 @@ export async function executeCreateCommand({
 	const shouldPrompt =
 		interactive ?? (!Boolean(flags.yes) && Boolean(process.stdin.isTTY) && Boolean(process.stdout.isTTY));
 	const activePrompt = shouldPrompt ? (prompt ?? createReadlinePrompt()) : undefined;
+	const shouldPromptForExternalLayerSelection =
+		Boolean(activePrompt) && activePrompt !== prompt;
 
 	try {
 		const flow = await runScaffoldFlow({
@@ -478,7 +480,7 @@ export async function executeCreateCommand({
 			selectDataStorage: activePrompt
 				? () => activePrompt.select("Select a data storage mode", [...DATA_STORAGE_PROMPT_OPTIONS], 1)
 				: undefined,
-			selectExternalLayerId: activePrompt
+			selectExternalLayerId: shouldPromptForExternalLayerSelection
 				? (options) =>
 						activePrompt.select(
 							"Select an external layer",

--- a/packages/wp-typia/src/runtime-bridge.ts
+++ b/packages/wp-typia/src/runtime-bridge.ts
@@ -480,7 +480,7 @@ export async function executeCreateCommand({
 			selectDataStorage: activePrompt
 				? () => activePrompt.select("Select a data storage mode", [...DATA_STORAGE_PROMPT_OPTIONS], 1)
 				: undefined,
-			selectExternalLayerId: shouldPromptForExternalLayerSelection
+			selectExternalLayerId: shouldPromptForExternalLayerSelection && activePrompt
 				? (options) =>
 						activePrompt.select(
 							"Select an external layer",

--- a/packages/wp-typia/src/runtime-bridge.ts
+++ b/packages/wp-typia/src/runtime-bridge.ts
@@ -29,9 +29,11 @@ type AddExecutionInput = {
 	cwd: string;
 	emitOutput?: boolean;
 	flags: Record<string, unknown>;
+	interactive?: boolean;
 	kind?: string;
 	name?: string;
 	printLine?: PrintLine;
+	prompt?: ReadlinePrompt;
 	warnLine?: PrintLine;
 };
 
@@ -57,6 +59,11 @@ type MigrateExecutionInput = {
 
 type PrintLine = (line: string) => void;
 type PackageManagerId = "bun" | "npm" | "pnpm" | "yarn";
+type ExternalLayerSelectOption = {
+	description?: string;
+	extends: string[];
+	id: string;
+};
 
 type SyncProjectContext = {
 	cwd: string;
@@ -76,6 +83,23 @@ function printBlock(lines: string[], printLine: PrintLine): void {
 	for (const line of lines) {
 		printLine(line);
 	}
+}
+
+function formatExternalLayerSelectHint(option: ExternalLayerSelectOption): string | undefined {
+	const details = [
+		option.description,
+		option.extends.length > 0 ? `extends ${option.extends.join(", ")}` : undefined,
+	].filter((value): value is string => typeof value === "string" && value.length > 0);
+
+	return details.length > 0 ? details.join(" · ") : undefined;
+}
+
+function toExternalLayerPromptOptions(options: ExternalLayerSelectOption[]) {
+	return options.map((option) => ({
+		hint: formatExternalLayerSelectHint(option),
+		label: option.id,
+		value: option.id,
+	}));
 }
 
 export function printCompletionPayload(
@@ -454,6 +478,14 @@ export async function executeCreateCommand({
 			selectDataStorage: activePrompt
 				? () => activePrompt.select("Select a data storage mode", [...DATA_STORAGE_PROMPT_OPTIONS], 1)
 				: undefined,
+			selectExternalLayerId: activePrompt
+				? (options) =>
+						activePrompt.select(
+							"Select an external layer",
+							toExternalLayerPromptOptions(options),
+							1,
+						)
+				: undefined,
 			selectPackageManager: activePrompt
 				? () => activePrompt.select("Select a package manager", [...PACKAGE_MANAGER_PROMPT_OPTIONS], 1)
 				: undefined,
@@ -511,9 +543,11 @@ export async function executeAddCommand({
 	cwd,
 	emitOutput = true,
 	flags,
+	interactive,
 	kind,
 	name,
 	printLine = console.log as PrintLine,
+	prompt,
 	warnLine = console.warn as PrintLine,
 }: AddExecutionInput): Promise<AlternateBufferCompletionPayload | void> {
 	if (!kind) {
@@ -661,33 +695,60 @@ export async function executeAddCommand({
 		);
 	}
 
-	const result = await addRuntime.runAddBlockCommand({
-		blockName: name,
-		cwd,
-		dataStorageMode: readOptionalStringFlag(flags, "data-storage"),
-		externalLayerId: readOptionalStringFlag(flags, "external-layer-id"),
-		externalLayerSource: readOptionalStringFlag(flags, "external-layer-source"),
-		persistencePolicy: readOptionalStringFlag(flags, "persistence-policy"),
-		templateId: readOptionalStringFlag(flags, "template") as
-			| "basic"
-			| "interactivity"
-			| "persistence"
-			| "compound",
-	});
+	const externalLayerId = readOptionalStringFlag(flags, "external-layer-id");
+	const externalLayerSource = readOptionalStringFlag(flags, "external-layer-source");
+	const shouldPromptForLayerSelection =
+		Boolean(externalLayerSource) &&
+		!Boolean(externalLayerId) &&
+		(interactive ?? (Boolean(process.stdin.isTTY) && Boolean(process.stdout.isTTY)));
+	const promptRuntime = shouldPromptForLayerSelection
+		? await loadCliPromptRuntime()
+		: undefined;
+	const activePrompt = shouldPromptForLayerSelection
+		? (prompt ?? promptRuntime?.createReadlinePrompt())
+		: undefined;
 
-	const payload = buildAddCompletionPayload({
-		kind: "block",
-		projectDir: result.projectDir,
-		values: {
-			blockSlugs: result.blockSlugs.join(", "),
-			templateId: result.templateId,
-		},
-		warnings: result.warnings,
-	});
-	if (emitOutput) {
-		printCompletionPayload(payload, { printLine, warnLine });
+	try {
+		const result = await addRuntime.runAddBlockCommand({
+			blockName: name,
+			cwd,
+			dataStorageMode: readOptionalStringFlag(flags, "data-storage"),
+			externalLayerId,
+			externalLayerSource,
+			persistencePolicy: readOptionalStringFlag(flags, "persistence-policy"),
+			selectExternalLayerId: activePrompt
+				? (options) =>
+						activePrompt.select(
+							"Select an external layer",
+							toExternalLayerPromptOptions(options),
+							1,
+						)
+				: undefined,
+			templateId: readOptionalStringFlag(flags, "template") as
+				| "basic"
+				| "interactivity"
+				| "persistence"
+				| "compound",
+		});
+
+		const payload = buildAddCompletionPayload({
+			kind: "block",
+			projectDir: result.projectDir,
+			values: {
+				blockSlugs: result.blockSlugs.join(", "),
+				templateId: result.templateId,
+			},
+			warnings: result.warnings,
+		});
+		if (emitOutput) {
+			printCompletionPayload(payload, { printLine, warnLine });
+		}
+		return payload;
+	} finally {
+		if (activePrompt && activePrompt !== prompt) {
+			activePrompt.close();
+		}
 	}
-	return payload;
 }
 
 export async function executeTemplatesCommand(

--- a/packages/wp-typia/src/ui/add-flow.tsx
+++ b/packages/wp-typia/src/ui/add-flow.tsx
@@ -310,6 +310,7 @@ export function AddFlow({ cwd, initialValues }: AddFlowProps) {
 						cwd,
 						emitOutput: false,
 						flags,
+						interactive: false,
 						kind: values.kind,
 						name: typeof flags.name === "string" ? flags.name : undefined,
 					});

--- a/packages/wp-typia/tests/create-command.test.ts
+++ b/packages/wp-typia/tests/create-command.test.ts
@@ -1,0 +1,59 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { executeCreateCommand } from "../src/runtime-bridge";
+
+const ambiguousLayerFixturePath = path.resolve(
+	import.meta.dir,
+	"..",
+	"..",
+	"wp-typia-project-tools",
+	"tests",
+	"fixtures",
+	"wp-typia-layer-ambiguous",
+);
+
+describe("wp-typia create command bridge", () => {
+	const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "wp-typia-create-bridge-"));
+
+	afterAll(() => {
+		fs.rmSync(tempRoot, { force: true, recursive: true });
+	});
+
+	test("keeps ambiguous external layers fail-fast when a synthetic prompt is supplied", async () => {
+		const defaultPrompt = {
+			close() {},
+			select<T extends string>(
+				_message: string,
+				options: Array<{ value: T }>,
+				defaultValue = 1,
+			) {
+				const fallback = options[Math.max(0, defaultValue - 1)] ?? options[0];
+				return Promise.resolve(fallback.value);
+			},
+			text(_message: string, defaultValue: string) {
+				return Promise.resolve(defaultValue);
+			},
+		};
+
+		await expect(
+			executeCreateCommand({
+				cwd: tempRoot,
+				emitOutput: false,
+				flags: {
+					"external-layer-source": ambiguousLayerFixturePath,
+					"no-install": true,
+					"package-manager": "npm",
+					template: "basic",
+				},
+				interactive: true,
+				projectDir: "demo-tui-ambiguous-layer",
+				prompt: defaultPrompt,
+			}),
+		).rejects.toThrow(
+			"External layer package defines multiple selectable layers (acme/internal-base, acme/alpha, acme/beta). Pass an explicit externalLayerId or rerun through the interactive CLI selector.",
+		);
+	});
+});


### PR DESCRIPTION
## Context

Issue #299 tracks the missing interactive layer-selection path after external template-layer composition shipped. Built-in `wp-typia create` and `wp-typia add block` could already compose external layers, but multi-root layer packages still required callers to discover and pass `externalLayerId` manually.

## What Changed

- added a shared external-layer selection helper that inspects `wp-typia.layers.json`, collects public selectable layers, and only prompts when a caller omits `externalLayerId` for a multi-root package
- wired the interactive create flow and the block-add CLI bridge through the same selector while keeping non-interactive and programmatic callers explicit
- expanded fixture coverage to exercise descriptions plus `extends` context in prompt options, and added regressions for create-flow prompting, non-interactive fail-fast behavior, and workspace-safe add-block selection
- updated the external layer contract docs to describe the current CLI behavior without implying the selector is still future work

## Verification

- `bun run --filter @wp-typia/project-tools build`
- `bun run --filter wp-typia build`
- `bun test packages/wp-typia-project-tools/tests/cli-entry.test.ts packages/wp-typia-project-tools/tests/template-layers.test.ts packages/wp-typia-project-tools/tests/workspace-add.test.ts`
- `bun run changesets:validate`

Closes #299


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added interactive external layer selection when building or adding blocks with packages that expose multiple template layers.

* **Documentation**
  * Updated documentation to clarify that interactive CLI flows prompt for layer selection while programmatic callers must provide explicit selection.

* **Tests**
  * Added tests for interactive and non-interactive layer selection scenarios.

* **Chores**
  * Added test fixtures for ambiguous layer scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->