### PR TITLE
Unify CLI diagnostic formatting

### DIFF
--- a/.sampo/changesets/issue-300-cli-diagnostics.md
+++ b/.sampo/changesets/issue-300-cli-diagnostics.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Unify human-readable CLI diagnostics across create, add, migrate, and doctor.

--- a/docs/API.md
+++ b/docs/API.md
@@ -190,6 +190,11 @@ artifact drift. `wp-typia migrate doctor --all` is the deep migration audit for
 migration-enabled workspaces. It validates migration target alignment,
 snapshots, generated migration artifacts, and fixture coverage.
 
+In non-interactive shells, `wp-typia create`, `add`, `migrate`, and `doctor`
+now share the same summary-first failure layout. Root `doctor` still streams
+PASS/FAIL check rows plus a final summary, while the other commands render the
+shared diagnostic block only when they fail.
+
 Compatibility note: `@wp-typia/project-tools` is the canonical programmatic package, `wp-typia` is the canonical CLI package, and `@wp-typia/create` is now the deprecated legacy package shell. `create-wp-typia` is archived and no longer a supported path for new installs.
 
 ## 2. `@wp-typia/create`

--- a/packages/wp-typia-project-tools/package.json
+++ b/packages/wp-typia-project-tools/package.json
@@ -17,6 +17,11 @@
       "import": "./dist/runtime/cli-add.js",
       "default": "./dist/runtime/cli-add.js"
     },
+    "./cli-diagnostics": {
+      "types": "./dist/runtime/cli-diagnostics.d.ts",
+      "import": "./dist/runtime/cli-diagnostics.js",
+      "default": "./dist/runtime/cli-diagnostics.js"
+    },
     "./cli-doctor": {
       "types": "./dist/runtime/cli-doctor.d.ts",
       "import": "./dist/runtime/cli-doctor.js",

--- a/packages/wp-typia-project-tools/src/runtime/cli-core.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-core.ts
@@ -12,6 +12,8 @@
  * `getWorkspaceBlockSelectOptions`, and `seedWorkspaceMigrationProject` for
  * explicit `wp-typia add` flows,
  * `getDoctorChecks`, `runDoctor`, and `DoctorCheck` for diagnostics,
+ * `createCliCommandError` and `formatCliDiagnosticError` for shared
+ * non-interactive failure rendering,
  * `formatHelpText` for top-level CLI usage output, scaffold helpers such as
  * `createReadlinePrompt`, `getNextSteps`, `getOptionalOnboarding`,
  * `runScaffoldFlow`, and `ReadlinePrompt` for interactive project creation,
@@ -21,6 +23,17 @@
  * template inspection flows.
  */
 export { getDoctorChecks, runDoctor, type DoctorCheck } from "./cli-doctor.js";
+export {
+	createCliCommandError,
+	CliDiagnosticError,
+	formatCliDiagnosticError,
+	formatDoctorCheckLine,
+	formatDoctorSummaryLine,
+	getDoctorFailureDetailLines,
+	getFailingDoctorChecks,
+	isCliDiagnosticError,
+} from "./cli-diagnostics.js";
+export type { CliDiagnosticMessage } from "./cli-diagnostics.js";
 export {
 	formatAddHelpText,
 	getWorkspaceBlockSelectOptions,

--- a/packages/wp-typia-project-tools/src/runtime/cli-diagnostics.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-diagnostics.ts
@@ -1,0 +1,152 @@
+/**
+ * Shared human-readable diagnostics for non-interactive `wp-typia` CLI flows.
+ */
+export interface CliDiagnosticMessage {
+	command: string;
+	detailLines: string[];
+	summary: string;
+}
+
+type DoctorCheckLike = {
+	detail: string;
+	label: string;
+	status: "pass" | "fail";
+};
+
+const DEFAULT_CLI_FAILURE_SUMMARIES: Record<string, string> = {
+	add: "Unable to complete the requested add workflow.",
+	create: "Unable to complete the requested create workflow.",
+	doctor: "One or more doctor checks failed.",
+	migrate: "Unable to complete the requested migration command.",
+};
+
+function formatCliDiagnosticBlock(message: CliDiagnosticMessage): string {
+	const lines = [`wp-typia ${message.command} failed`, `Summary: ${message.summary}`];
+
+	if (message.detailLines.length > 0) {
+		lines.push("Details:");
+		for (const detailLine of message.detailLines) {
+			lines.push(`- ${detailLine}`);
+		}
+	}
+
+	return lines.join("\n");
+}
+
+function getErrorMessage(error: unknown): string {
+	if (error instanceof Error) {
+		return error.message;
+	}
+
+	return String(error);
+}
+
+function normalizeDetailLines(detailLines: Array<string | null | undefined>): string[] {
+	return detailLines
+		.flatMap((detailLine) =>
+			typeof detailLine === "string" ? detailLine.split("\n") : [],
+		)
+		.map((detailLine) => detailLine.trim())
+		.filter((detailLine) => detailLine.length > 0);
+}
+
+/**
+ * Structured CLI failure carrying a stable summary/detail layout.
+ */
+export class CliDiagnosticError extends Error {
+	readonly command: string;
+	readonly detailLines: string[];
+	readonly summary: string;
+
+	constructor(message: CliDiagnosticMessage, options?: ErrorOptions) {
+		super(formatCliDiagnosticBlock(message), options);
+		this.command = message.command;
+		this.detailLines = [...message.detailLines];
+		this.name = "CliDiagnosticError";
+		this.summary = message.summary;
+	}
+}
+
+/**
+ * Narrow an unknown error to the shared CLI diagnostic error shape.
+ */
+export function isCliDiagnosticError(error: unknown): error is CliDiagnosticError {
+	return error instanceof CliDiagnosticError;
+}
+
+/**
+ * Build a shared diagnostic error for one CLI command failure.
+ */
+export function createCliCommandError(options: {
+	command: string;
+	detailLines?: string[];
+	error?: unknown;
+	summary?: string;
+}): CliDiagnosticError {
+	if (isCliDiagnosticError(options.error)) {
+		return options.error;
+	}
+
+	const summary =
+		options.summary ?? DEFAULT_CLI_FAILURE_SUMMARIES[options.command] ?? "Command failed.";
+	const detailLines = normalizeDetailLines(
+		options.detailLines ?? [options.error === undefined ? undefined : getErrorMessage(options.error)],
+	);
+
+	return new CliDiagnosticError(
+		{
+			command: options.command,
+			detailLines,
+			summary,
+		},
+		options.error instanceof Error ? { cause: options.error } : undefined,
+	);
+}
+
+/**
+ * Render a CLI diagnostic block. Non-diagnostic errors fall back to their
+ * plain message so existing non-command failures keep working.
+ */
+export function formatCliDiagnosticError(error: unknown): string {
+	if (!isCliDiagnosticError(error)) {
+		return getErrorMessage(error);
+	}
+
+	return formatCliDiagnosticBlock({
+		command: error.command,
+		detailLines: error.detailLines,
+		summary: error.summary,
+	});
+}
+
+/**
+ * Format one human-readable doctor check row.
+ */
+export function formatDoctorCheckLine(check: DoctorCheckLike): string {
+	return `${check.status === "pass" ? "PASS" : "FAIL"} ${check.label}: ${check.detail}`;
+}
+
+/**
+ * Return the failing doctor checks from one doctor run.
+ */
+export function getFailingDoctorChecks<TCheck extends DoctorCheckLike>(
+	checks: readonly TCheck[],
+): TCheck[] {
+	return checks.filter((check) => check.status === "fail");
+}
+
+/**
+ * Format the final doctor summary row.
+ */
+export function formatDoctorSummaryLine(checks: readonly DoctorCheckLike[]): string {
+	const failedChecks = getFailingDoctorChecks(checks);
+	return `${failedChecks.length === 0 ? "PASS" : "FAIL"} wp-typia doctor summary: ${checks.length - failedChecks.length}/${checks.length} checks passed`;
+}
+
+/**
+ * Build detail lines for doctor failures so the non-interactive formatter can
+ * restate the failed checks after the streaming rows.
+ */
+export function getDoctorFailureDetailLines(checks: readonly DoctorCheckLike[]): string[] {
+	return getFailingDoctorChecks(checks).map((check) => `${check.label}: ${check.detail}`);
+}

--- a/packages/wp-typia-project-tools/src/runtime/cli-doctor.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-doctor.ts
@@ -708,11 +708,13 @@ export async function getDoctorChecks(cwd: string): Promise<DoctorCheck[]> {
  */
 export async function runDoctor(
 	cwd: string,
-	{
-		renderLine = (check: DoctorCheck) => console.log(formatDoctorCheckLine(check)),
-		renderSummaryLine = (summaryLine: string) => console.log(summaryLine),
-	}: RunDoctorOptions = {},
+	options: RunDoctorOptions = {},
 ): Promise<DoctorCheck[]> {
+	const renderLine =
+		options.renderLine ?? ((check: DoctorCheck) => console.log(formatDoctorCheckLine(check)));
+	const renderSummaryLine =
+		options.renderSummaryLine ??
+		(options.renderLine ? () => undefined : (summaryLine: string) => console.log(summaryLine));
 	const checks = await getDoctorChecks(cwd);
 
 	for (const check of checks) {

--- a/packages/wp-typia-project-tools/src/runtime/cli-doctor.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-doctor.ts
@@ -23,6 +23,12 @@ import {
 	type WorkspacePackageJson,
 	type WorkspaceProject,
 } from "./workspace-project.js";
+import {
+	createCliCommandError,
+	formatDoctorCheckLine,
+	formatDoctorSummaryLine,
+	getDoctorFailureDetailLines,
+} from "./cli-diagnostics.js";
 
 /**
  * One doctor check rendered by the CLI diagnostics flow.
@@ -38,6 +44,7 @@ export interface DoctorCheck {
 
 interface RunDoctorOptions {
 	renderLine?: (check: DoctorCheck) => void;
+	renderSummaryLine?: (summaryLine: string) => void;
 }
 
 const WORKSPACE_COLLECTION_IMPORT_LINE = "import '../../collection';";
@@ -702,8 +709,8 @@ export async function getDoctorChecks(cwd: string): Promise<DoctorCheck[]> {
 export async function runDoctor(
 	cwd: string,
 	{
-		renderLine = (check: DoctorCheck) =>
-			console.log(`${check.status.toUpperCase()} ${check.label}: ${check.detail}`),
+		renderLine = (check: DoctorCheck) => console.log(formatDoctorCheckLine(check)),
+		renderSummaryLine = (summaryLine: string) => console.log(summaryLine),
 	}: RunDoctorOptions = {},
 ): Promise<DoctorCheck[]> {
 	const checks = await getDoctorChecks(cwd);
@@ -712,8 +719,15 @@ export async function runDoctor(
 		renderLine(check);
 	}
 
-	if (checks.some((check) => check.status === "fail")) {
-		throw new Error("Doctor found one or more failing checks.");
+	renderSummaryLine(formatDoctorSummaryLine(checks));
+
+	const failureDetailLines = getDoctorFailureDetailLines(checks);
+	if (failureDetailLines.length > 0) {
+		throw createCliCommandError({
+			command: "doctor",
+			detailLines: failureDetailLines,
+			summary: "One or more doctor checks failed.",
+		});
 	}
 
 	return checks;

--- a/packages/wp-typia-project-tools/src/runtime/index.ts
+++ b/packages/wp-typia-project-tools/src/runtime/index.ts
@@ -106,16 +106,24 @@ export {
 } from "./template-registry.js";
 export {
 	createReadlinePrompt,
+	createCliCommandError,
+	CliDiagnosticError,
+	formatCliDiagnosticError,
 	formatAddHelpText,
+	formatDoctorCheckLine,
+	formatDoctorSummaryLine,
 	formatHelpText,
 	formatTemplateDetails,
 	formatTemplateFeatures,
 	formatTemplateSummary,
 	getDoctorChecks,
+	getDoctorFailureDetailLines,
+	getFailingDoctorChecks,
 	getNextSteps,
 	getOptionalOnboarding,
 	getWorkspaceBlockSelectOptions,
 	HOOKED_BLOCK_POSITION_IDS,
+	isCliDiagnosticError,
 	runAddBindingSourceCommand,
 	runAddBlockCommand,
 	runAddHookedBlockCommand,
@@ -124,4 +132,9 @@ export {
 	runAddVariationCommand,
 	runScaffoldFlow,
 } from "./cli-core.js";
-export type { DoctorCheck, HookedBlockPositionId, ReadlinePrompt } from "./cli-core.js";
+export type {
+	CliDiagnosticMessage,
+	DoctorCheck,
+	HookedBlockPositionId,
+	ReadlinePrompt,
+} from "./cli-core.js";

--- a/packages/wp-typia-project-tools/tests/cli-entry.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-entry.test.ts
@@ -430,7 +430,7 @@ test("runScaffoldFlow does not prompt for migration UI on external templates", a
 
 test("node entry exposes templates and doctor commands", () => {
   const templatesOutput = runCli("node", [entryPath, "templates", "list"]);
-  const doctorOutput = runCli("node", [entryPath, "doctor"]);
+  const doctorOutput = runCli("node", [entryPath, "doctor", "--format", "json"]);
 
   expect(templatesOutput).toContain("basic");
   expect(templatesOutput).toContain("interactivity");
@@ -507,7 +507,7 @@ test("node entry exposes Bunli-owned help and rejects the removed migrations ali
 
 test("bun entry exposes templates and doctor commands", () => {
   const templatesOutput = runCli("bun", [entryPath, "templates", "list"]);
-  const doctorOutput = runCli("bun", [entryPath, "doctor"]);
+  const doctorOutput = runCli("bun", [entryPath, "doctor", "--format", "json"]);
 
   expect(templatesOutput).toContain("basic");
   expect(templatesOutput).toContain("interactivity");

--- a/packages/wp-typia-project-tools/tests/workspace-add.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-add.test.ts
@@ -354,7 +354,7 @@ test("canonical CLI rejects add-block external layers that emit workspace-level 
   );
 
   expect(commandError).toMatch(
-    /External layer \\\"acme\/basic-observability\\\" writes workspace-level output \\\"inc\/observability\.php\\\"/
+    /External layer "acme\/basic-observability" writes workspace-level output "inc\/observability\.php"/
   );
   expect(
     fs.existsSync(path.join(targetDir, "src", "blocks", "counter-card"))
@@ -437,7 +437,7 @@ test("canonical CLI can add a variation to an official workspace template", asyn
   );
   expect(variationSource).toContain("A starter variation for Hero Card.");
 
-  const doctorOutput = runCli("node", [entryPath, "doctor"], {
+  const doctorOutput = runCli("node", [entryPath, "doctor", "--format", "json"], {
     cwd: targetDir,
   });
   const doctorChecks = JSON.parse(doctorOutput) as {
@@ -579,7 +579,7 @@ test("canonical CLI can add hooked-block metadata to an official workspace block
     "core/post-content": "after",
   });
 
-  const doctorOutput = runCli("node", [entryPath, "doctor"], {
+  const doctorOutput = runCli("node", [entryPath, "doctor", "--format", "json"], {
     cwd: targetDir,
   });
   const doctorChecks = JSON.parse(doctorOutput) as {
@@ -1893,7 +1893,7 @@ test("add block updates migration config in a migration-enabled workspace templa
     }
   );
   expect(doctorOutput).toContain("PASS Migration config");
-  const rootDoctorOutput = runCli("node", [entryPath, "doctor"], {
+  const rootDoctorOutput = runCli("node", [entryPath, "doctor", "--format", "json"], {
     cwd: targetDir,
   });
   const rootDoctorChecks = JSON.parse(rootDoctorOutput) as {
@@ -1959,7 +1959,7 @@ test("canonical CLI can add a pattern to an official workspace template", async 
   expect(bootstrapSource).toContain("/src/patterns/*.php");
   expect(patternSource).toContain("demo-space/hero-layout");
 
-  const doctorOutput = runCli("node", [entryPath, "doctor"], {
+  const doctorOutput = runCli("node", [entryPath, "doctor", "--format", "json"], {
     cwd: targetDir,
   });
   const doctorChecks = JSON.parse(doctorOutput) as {
@@ -2045,7 +2045,7 @@ test("canonical CLI can add a binding source to an official workspace template",
   expect(bindingEditorSource).toContain("resolveBindingSourceValue( field )");
   expect(bindingEditorSource).toContain("getFieldsList()");
 
-  const doctorOutput = runCli("node", [entryPath, "doctor"], {
+  const doctorOutput = runCli("node", [entryPath, "doctor", "--format", "json"], {
     cwd: targetDir,
   });
   const doctorChecks = JSON.parse(doctorOutput) as {

--- a/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
@@ -8,6 +8,19 @@ import { updateWorkspaceInventorySource } from "../src/runtime/workspace-invento
 
 describe("@wp-typia/project-tools workspace doctor", () => {
   const tempRoot = createScaffoldTempRoot("wp-typia-workspace-doctor-");
+  const humanCliEnv = {
+    ...process.env,
+    AGENT: "",
+    AMP_CURRENT_THREAD_ID: "",
+    CLAUDECODE: "",
+    CLAUDE_CODE: "",
+    CODEX_CI: "",
+    CODEX_SANDBOX: "",
+    CODEX_THREAD_ID: "",
+    CURSOR_AGENT: "",
+    GEMINI_CLI: "",
+    OPENCODE: "",
+  } satisfies NodeJS.ProcessEnv;
 
   afterAll(() => {
     cleanupScaffoldTempRoot(tempRoot);
@@ -620,6 +633,7 @@ test("doctor fails on missing variation and pattern inventory files", async () =
   const errorMessage = getCommandErrorMessage(() =>
     runCli("node", [entryPath, "doctor"], {
       cwd: targetDir,
+      env: humanCliEnv,
     })
   );
 
@@ -666,6 +680,7 @@ test("doctor fails when workspace inventory entries are malformed", async () => 
   const errorMessage = getCommandErrorMessage(() =>
     runCli("node", [entryPath, "doctor"], {
       cwd: targetDir,
+      env: humanCliEnv,
     })
   );
 
@@ -711,6 +726,7 @@ test("doctor fails when workspace inventory exports use non-array initializers",
   const errorMessage = getCommandErrorMessage(() =>
     runCli("node", [entryPath, "doctor"], {
       cwd: targetDir,
+      env: humanCliEnv,
     })
   );
 

--- a/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
@@ -44,7 +44,7 @@ test("doctor accepts workspaces that keep binding registries in src/bindings/ind
   const bindingsJsPath = path.join(targetDir, "src", "bindings", "index.js");
   fs.renameSync(bindingsTsPath, bindingsJsPath);
 
-  const doctorOutput = runCli("node", [entryPath, "doctor"], {
+  const doctorOutput = runCli("node", [entryPath, "doctor", "--format", "json"], {
     cwd: targetDir,
   });
   const doctorChecks = JSON.parse(doctorOutput) as {
@@ -623,7 +623,7 @@ test("doctor fails on missing variation and pattern inventory files", async () =
     })
   );
 
-  expect(errorMessage).toContain("Doctor found one or more failing checks.");
+  expect(errorMessage).toContain("Summary: One or more doctor checks failed.");
   expect(errorMessage).toContain("Variation counter-card/hero-card");
   expect(errorMessage).toContain("Pattern hero-layout");
 }, 15_000);

--- a/packages/wp-typia/src/cli.ts
+++ b/packages/wp-typia/src/cli.ts
@@ -73,6 +73,15 @@ function resolveGeneratedMetadataPath(moduleUrl: string): string {
 	return fileURLToPath(new URL("../.bunli/commands.gen.ts", moduleUrl));
 }
 
+async function formatCliError(error: unknown): Promise<string> {
+	try {
+		const { formatCliDiagnosticError } = await import("@wp-typia/project-tools/cli-diagnostics");
+		return formatCliDiagnosticError(error);
+	} catch {
+		return error instanceof Error ? error.message : String(error);
+	}
+}
+
 export async function createWpTypiaCli(options: {
 	configOverridePath?: string;
 } = {}): Promise<CLI> {
@@ -117,10 +126,14 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
 }
 
 if (import.meta.main) {
-	void main().catch((error) => {
-		console.error(error instanceof Error ? error.message : error);
-		process.exit(1);
-	});
+	void (async () => {
+		try {
+			await main();
+		} catch (error) {
+			console.error(await formatCliError(error));
+			process.exit(1);
+		}
+	})();
 }
 
 export default createWpTypiaCli;

--- a/packages/wp-typia/src/commands/add.ts
+++ b/packages/wp-typia/src/commands/add.ts
@@ -57,6 +57,7 @@ const addOptions = {
 };
 
 export const addCommand = defineCommand({
+	defaultFormat: "toon",
 	description: "Extend an official wp-typia workspace with blocks, variations, patterns, binding sources, or hooked blocks.",
 	handler: async (args) => {
 		await executeAddCommand({

--- a/packages/wp-typia/src/commands/create.ts
+++ b/packages/wp-typia/src/commands/create.ts
@@ -93,11 +93,16 @@ const createOptions = {
 };
 
 export const createCommand = defineCommand({
+	defaultFormat: "toon",
 	description: "Scaffold a new wp-typia project.",
 	handler: async (args) => {
 		const projectDir = args.positional[0];
 		if (!projectDir) {
-			throw new Error("`wp-typia create` requires <project-dir>.");
+			const { createCliCommandError } = await import("@wp-typia/project-tools/cli-diagnostics");
+			throw createCliCommandError({
+				command: "create",
+				detailLines: ["`wp-typia create` requires <project-dir>."],
+			});
 		}
 		await executeCreateCommand({
 			cwd: args.cwd,

--- a/packages/wp-typia/src/commands/doctor.ts
+++ b/packages/wp-typia/src/commands/doctor.ts
@@ -2,18 +2,24 @@ import { defineCommand } from "@bunli/core";
 import { executeDoctorCommand } from "../runtime-bridge";
 
 export const doctorCommand = defineCommand({
+	defaultFormat: "toon",
 	description: "Run repository and project diagnostics.",
 	handler: async (args) => {
-		const prefersStructuredOutput =
-			(args.formatExplicit && args.format !== "toon") ||
-			args.agent ||
-			Boolean(args.context?.store?.isAIAgent);
+		const prefersStructuredOutput = args.formatExplicit && args.format !== "toon";
 		if (prefersStructuredOutput) {
-			const { getDoctorChecks } = await import("@wp-typia/project-tools/cli-doctor");
+			const [{ getDoctorChecks }, { createCliCommandError, getDoctorFailureDetailLines }] =
+				await Promise.all([
+					import("@wp-typia/project-tools/cli-doctor"),
+					import("@wp-typia/project-tools/cli-diagnostics"),
+				]);
 			const checks = await getDoctorChecks(args.cwd);
 			args.output({ checks });
 			if (checks.some((check) => check.status === "fail")) {
-				throw new Error("Doctor found one or more failing checks.");
+				throw createCliCommandError({
+					command: "doctor",
+					detailLines: getDoctorFailureDetailLines(checks),
+					summary: "One or more doctor checks failed.",
+				});
 			}
 			return;
 		}

--- a/packages/wp-typia/src/commands/doctor.ts
+++ b/packages/wp-typia/src/commands/doctor.ts
@@ -5,7 +5,9 @@ export const doctorCommand = defineCommand({
 	defaultFormat: "toon",
 	description: "Run repository and project diagnostics.",
 	handler: async (args) => {
-		const prefersStructuredOutput = args.formatExplicit && args.format !== "toon";
+		const prefersStructuredOutput =
+			(args.formatExplicit && args.format !== "toon") ||
+			Boolean(args.context?.store?.isAIAgent);
 		if (prefersStructuredOutput) {
 			const [{ getDoctorChecks }, { createCliCommandError, getDoctorFailureDetailLines }] =
 				await Promise.all([

--- a/packages/wp-typia/src/commands/migrate.ts
+++ b/packages/wp-typia/src/commands/migrate.ts
@@ -58,6 +58,7 @@ const migrateOptions = {
 };
 
 export const migrateCommand = defineCommand({
+	defaultFormat: "toon",
 	description: "Run migration workflows for migration-capable wp-typia projects.",
 	handler: async (args) => {
 		await executeMigrateCommand({

--- a/packages/wp-typia/src/runtime-bridge.ts
+++ b/packages/wp-typia/src/runtime-bridge.ts
@@ -86,6 +86,21 @@ async function wrapCliCommandError(command: CliCommandId, error: unknown) {
 	return createCliCommandError({ command, error });
 }
 
+function shouldWrapCliCommandError(options: {
+	emitOutput?: boolean;
+	renderLine?: ((line: string) => void) | undefined;
+}): boolean {
+	if (options.emitOutput === false) {
+		return false;
+	}
+
+	if (options.renderLine) {
+		return false;
+	}
+
+	return true;
+}
+
 function printBlock(lines: string[], printLine: PrintLine): void {
 	for (const line of lines) {
 		printLine(line);
@@ -542,6 +557,9 @@ export async function executeCreateCommand({
 		}
 		return payload;
 	} catch (error) {
+		if (!shouldWrapCliCommandError({ emitOutput })) {
+			throw error;
+		}
 		throw await wrapCliCommandError("create", error);
 	} finally {
 		if (activePrompt && activePrompt !== prompt) {
@@ -757,6 +775,9 @@ export async function executeAddCommand({
 		}
 		return payload;
 	} catch (error) {
+		if (!shouldWrapCliCommandError({ emitOutput })) {
+			throw error;
+		}
 		throw await wrapCliCommandError("add", error);
 	} finally {
 		if (activePrompt && activePrompt !== prompt) {
@@ -905,6 +926,9 @@ export async function executeMigrateCommand({
 			return;
 		}
 	} catch (error) {
+		if (!shouldWrapCliCommandError({ renderLine })) {
+			throw error;
+		}
 		throw await wrapCliCommandError("migrate", error);
 	}
 }

--- a/packages/wp-typia/src/runtime-bridge.ts
+++ b/packages/wp-typia/src/runtime-bridge.ts
@@ -738,6 +738,7 @@ export async function executeAddCommand({
 		activePrompt = shouldPromptForLayerSelection
 			? (prompt ?? promptRuntime?.createReadlinePrompt())
 			: undefined;
+		const selectPrompt = activePrompt;
 
 		const result = await addRuntime.runAddBlockCommand({
 			blockName: name,
@@ -746,9 +747,9 @@ export async function executeAddCommand({
 			externalLayerId,
 			externalLayerSource,
 			persistencePolicy: readOptionalStringFlag(flags, "persistence-policy"),
-			selectExternalLayerId: activePrompt
+			selectExternalLayerId: selectPrompt
 				? (options) =>
-						activePrompt.select(
+						selectPrompt.select(
 							"Select an external layer",
 							toExternalLayerPromptOptions(options),
 							1,

--- a/packages/wp-typia/src/runtime-bridge.ts
+++ b/packages/wp-typia/src/runtime-bridge.ts
@@ -59,6 +59,7 @@ type MigrateExecutionInput = {
 
 type PrintLine = (line: string) => void;
 type PackageManagerId = "bun" | "npm" | "pnpm" | "yarn";
+type CliCommandId = "add" | "create" | "doctor" | "migrate";
 type ExternalLayerSelectOption = {
 	description?: string;
 	extends: string[];
@@ -73,11 +74,17 @@ type SyncProjectContext = {
 };
 
 const loadCliAddRuntime = () => import("@wp-typia/project-tools/cli-add");
+const loadCliDiagnosticsRuntime = () => import("@wp-typia/project-tools/cli-diagnostics");
 const loadCliDoctorRuntime = () => import("@wp-typia/project-tools/cli-doctor");
 const loadCliPromptRuntime = () => import("@wp-typia/project-tools/cli-prompt");
 const loadCliScaffoldRuntime = () => import("@wp-typia/project-tools/cli-scaffold");
 const loadCliTemplatesRuntime = () => import("@wp-typia/project-tools/cli-templates");
 const loadMigrationsRuntime = () => import("@wp-typia/project-tools/migrations");
+
+async function wrapCliCommandError(command: CliCommandId, error: unknown) {
+	const { createCliCommandError } = await loadCliDiagnosticsRuntime();
+	return createCliCommandError({ command, error });
+}
 
 function printBlock(lines: string[], printLine: PrintLine): void {
 	for (const line of lines) {
@@ -534,6 +541,8 @@ export async function executeCreateCommand({
 			});
 		}
 		return payload;
+	} catch (error) {
+		throw await wrapCliCommandError("create", error);
 	} finally {
 		if (activePrompt && activePrompt !== prompt) {
 			activePrompt.close();
@@ -559,158 +568,159 @@ export async function executeAddCommand({
 	}
 
 	const addRuntime = await loadCliAddRuntime();
-
-	if (kind === "variation") {
-		if (!name) {
-			throw new Error(
-				"`wp-typia add variation` requires <name>. Usage: wp-typia add variation <name> --block <block-slug>",
-			);
-		}
-
-		const blockSlug = readOptionalStringFlag(flags, "block");
-		if (!blockSlug) {
-			throw new Error("`wp-typia add variation` requires --block <block-slug>.");
-		}
-
-		const result = await addRuntime.runAddVariationCommand({
-			blockName: blockSlug,
-			cwd,
-			variationName: name,
-		});
-		const payload = buildAddCompletionPayload({
-			kind: "variation",
-			projectDir: result.projectDir,
-			values: {
-				blockSlug: result.blockSlug,
-				variationSlug: result.variationSlug,
-			},
-		});
-		if (emitOutput) {
-			printCompletionPayload(payload, { printLine });
-		}
-		return payload;
-	}
-
-	if (kind === "pattern") {
-		if (!name) {
-			throw new Error(
-				"`wp-typia add pattern` requires <name>. Usage: wp-typia add pattern <name>.",
-			);
-		}
-
-		const result = await addRuntime.runAddPatternCommand({
-			cwd,
-			patternName: name,
-		});
-		const payload = buildAddCompletionPayload({
-			kind: "pattern",
-			projectDir: result.projectDir,
-			values: {
-				patternSlug: result.patternSlug,
-			},
-		});
-		if (emitOutput) {
-			printCompletionPayload(payload, { printLine });
-		}
-		return payload;
-	}
-
-	if (kind === "binding-source") {
-		if (!name) {
-			throw new Error(
-				"`wp-typia add binding-source` requires <name>. Usage: wp-typia add binding-source <name>.",
-			);
-		}
-
-		const result = await addRuntime.runAddBindingSourceCommand({
-			bindingSourceName: name,
-			cwd,
-		});
-		const payload = buildAddCompletionPayload({
-			kind: "binding-source",
-			projectDir: result.projectDir,
-			values: {
-				bindingSourceSlug: result.bindingSourceSlug,
-			},
-		});
-		if (emitOutput) {
-			printCompletionPayload(payload, { printLine });
-		}
-		return payload;
-	}
-
-	if (kind === "hooked-block") {
-		if (!name) {
-			throw new Error(
-				"`wp-typia add hooked-block` requires <block-slug>. Usage: wp-typia add hooked-block <block-slug> --anchor <anchor-block-name> --position <before|after|firstChild|lastChild>.",
-			);
-		}
-
-		const anchorBlockName = readOptionalStringFlag(flags, "anchor");
-		if (!anchorBlockName) {
-			throw new Error("`wp-typia add hooked-block` requires --anchor <anchor-block-name>.");
-		}
-
-		const position = readOptionalStringFlag(flags, "position");
-		if (!position) {
-			throw new Error(
-				"`wp-typia add hooked-block` requires --position <before|after|firstChild|lastChild>.",
-			);
-		}
-
-		const result = await addRuntime.runAddHookedBlockCommand({
-			anchorBlockName,
-			blockName: name,
-			cwd,
-			position,
-		});
-		const payload = buildAddCompletionPayload({
-			kind: "hooked-block",
-			projectDir: result.projectDir,
-			values: {
-				anchorBlockName: result.anchorBlockName,
-				blockSlug: result.blockSlug,
-				position: result.position,
-			},
-		});
-		if (emitOutput) {
-			printCompletionPayload(payload, { printLine });
-		}
-		return payload;
-	}
-
-	if (kind !== "block") {
-		throw new Error(
-			`Unknown add kind "${kind}". Expected one of: block, variation, pattern, binding-source, hooked-block.`,
-		);
-	}
-
-	if (!name) {
-		throw new Error(
-			"`wp-typia add block` requires <name>. Usage: wp-typia add block <name> --template <basic|interactivity|persistence|compound>",
-		);
-	}
-
-	if (!flags.template) {
-		throw new Error(
-			"`wp-typia add block` requires --template <basic|interactivity|persistence|compound>.",
-		);
-	}
-
-	const externalLayerId = readOptionalStringFlag(flags, "external-layer-id");
-	const externalLayerSource = readOptionalStringFlag(flags, "external-layer-source");
-	const shouldPromptForLayerSelection =
-		Boolean(externalLayerSource) &&
-		!Boolean(externalLayerId) &&
-		(interactive ?? (Boolean(process.stdin.isTTY) && Boolean(process.stdout.isTTY)));
-	const promptRuntime = shouldPromptForLayerSelection
-		? await loadCliPromptRuntime()
-		: undefined;
-	const activePrompt = shouldPromptForLayerSelection
-		? (prompt ?? promptRuntime?.createReadlinePrompt())
-		: undefined;
+	let activePrompt: ReadlinePrompt | undefined;
 
 	try {
+		if (kind === "variation") {
+			if (!name) {
+				throw new Error(
+					"`wp-typia add variation` requires <name>. Usage: wp-typia add variation <name> --block <block-slug>",
+				);
+			}
+
+			const blockSlug = readOptionalStringFlag(flags, "block");
+			if (!blockSlug) {
+				throw new Error("`wp-typia add variation` requires --block <block-slug>.");
+			}
+
+			const result = await addRuntime.runAddVariationCommand({
+				blockName: blockSlug,
+				cwd,
+				variationName: name,
+			});
+			const payload = buildAddCompletionPayload({
+				kind: "variation",
+				projectDir: result.projectDir,
+				values: {
+					blockSlug: result.blockSlug,
+					variationSlug: result.variationSlug,
+				},
+			});
+			if (emitOutput) {
+				printCompletionPayload(payload, { printLine });
+			}
+			return payload;
+		}
+
+		if (kind === "pattern") {
+			if (!name) {
+				throw new Error(
+					"`wp-typia add pattern` requires <name>. Usage: wp-typia add pattern <name>.",
+				);
+			}
+
+			const result = await addRuntime.runAddPatternCommand({
+				cwd,
+				patternName: name,
+			});
+			const payload = buildAddCompletionPayload({
+				kind: "pattern",
+				projectDir: result.projectDir,
+				values: {
+					patternSlug: result.patternSlug,
+				},
+			});
+			if (emitOutput) {
+				printCompletionPayload(payload, { printLine });
+			}
+			return payload;
+		}
+
+		if (kind === "binding-source") {
+			if (!name) {
+				throw new Error(
+					"`wp-typia add binding-source` requires <name>. Usage: wp-typia add binding-source <name>.",
+				);
+			}
+
+			const result = await addRuntime.runAddBindingSourceCommand({
+				bindingSourceName: name,
+				cwd,
+			});
+			const payload = buildAddCompletionPayload({
+				kind: "binding-source",
+				projectDir: result.projectDir,
+				values: {
+					bindingSourceSlug: result.bindingSourceSlug,
+				},
+			});
+			if (emitOutput) {
+				printCompletionPayload(payload, { printLine });
+			}
+			return payload;
+		}
+
+		if (kind === "hooked-block") {
+			if (!name) {
+				throw new Error(
+					"`wp-typia add hooked-block` requires <block-slug>. Usage: wp-typia add hooked-block <block-slug> --anchor <anchor-block-name> --position <before|after|firstChild|lastChild>.",
+				);
+			}
+
+			const anchorBlockName = readOptionalStringFlag(flags, "anchor");
+			if (!anchorBlockName) {
+				throw new Error("`wp-typia add hooked-block` requires --anchor <anchor-block-name>.");
+			}
+
+			const position = readOptionalStringFlag(flags, "position");
+			if (!position) {
+				throw new Error(
+					"`wp-typia add hooked-block` requires --position <before|after|firstChild|lastChild>.",
+				);
+			}
+
+			const result = await addRuntime.runAddHookedBlockCommand({
+				anchorBlockName,
+				blockName: name,
+				cwd,
+				position,
+			});
+			const payload = buildAddCompletionPayload({
+				kind: "hooked-block",
+				projectDir: result.projectDir,
+				values: {
+					anchorBlockName: result.anchorBlockName,
+					blockSlug: result.blockSlug,
+					position: result.position,
+				},
+			});
+			if (emitOutput) {
+				printCompletionPayload(payload, { printLine });
+			}
+			return payload;
+		}
+
+		if (kind !== "block") {
+			throw new Error(
+				`Unknown add kind "${kind}". Expected one of: block, variation, pattern, binding-source, hooked-block.`,
+			);
+		}
+
+		if (!name) {
+			throw new Error(
+				"`wp-typia add block` requires <name>. Usage: wp-typia add block <name> --template <basic|interactivity|persistence|compound>",
+			);
+		}
+
+		if (!flags.template) {
+			throw new Error(
+				"`wp-typia add block` requires --template <basic|interactivity|persistence|compound>.",
+			);
+		}
+
+		const externalLayerId = readOptionalStringFlag(flags, "external-layer-id");
+		const externalLayerSource = readOptionalStringFlag(flags, "external-layer-source");
+		const shouldPromptForLayerSelection =
+			Boolean(externalLayerSource) &&
+			!Boolean(externalLayerId) &&
+			(interactive ?? (Boolean(process.stdin.isTTY) && Boolean(process.stdout.isTTY)));
+		const promptRuntime = shouldPromptForLayerSelection
+			? await loadCliPromptRuntime()
+			: undefined;
+		activePrompt = shouldPromptForLayerSelection
+			? (prompt ?? promptRuntime?.createReadlinePrompt())
+			: undefined;
+
 		const result = await addRuntime.runAddBlockCommand({
 			blockName: name,
 			cwd,
@@ -746,6 +756,8 @@ export async function executeAddCommand({
 			printCompletionPayload(payload, { printLine, warnLine });
 		}
 		return payload;
+	} catch (error) {
+		throw await wrapCliCommandError("add", error);
 	} finally {
 		if (activePrompt && activePrompt !== prompt) {
 			activePrompt.close();
@@ -792,8 +804,12 @@ export async function executeTemplatesCommand(
 }
 
 export async function executeDoctorCommand(cwd: string): Promise<void> {
-	const { runDoctor } = await loadCliDoctorRuntime();
-	await runDoctor(cwd);
+	try {
+		const { runDoctor } = await loadCliDoctorRuntime();
+		await runDoctor(cwd);
+	} catch (error) {
+		throw await wrapCliCommandError("doctor", error);
+	}
 }
 
 export async function loadAddWorkspaceBlockOptions(cwd: string) {
@@ -839,53 +855,57 @@ export async function executeMigrateCommand({
 		return;
 	}
 
-	const argv = [command];
-	pushFlag(argv, "all", flags.all);
-	pushFlag(argv, "force", flags.force);
-	pushFlag(
-		argv,
-		"current-migration-version",
-		readOptionalLooseStringFlag(flags, "current-migration-version"),
-	);
-	pushFlag(argv, "migration-version", readOptionalLooseStringFlag(flags, "migration-version"));
-	pushFlag(
-		argv,
-		"from-migration-version",
-		readOptionalLooseStringFlag(flags, "from-migration-version"),
-	);
-	pushFlag(
-		argv,
-		"to-migration-version",
-		readOptionalLooseStringFlag(flags, "to-migration-version"),
-	);
-	pushFlag(argv, "iterations", readOptionalLooseStringFlag(flags, "iterations"));
-	pushFlag(argv, "seed", readOptionalLooseStringFlag(flags, "seed"));
+	try {
+		const argv = [command];
+		pushFlag(argv, "all", flags.all);
+		pushFlag(argv, "force", flags.force);
+		pushFlag(
+			argv,
+			"current-migration-version",
+			readOptionalLooseStringFlag(flags, "current-migration-version"),
+		);
+		pushFlag(argv, "migration-version", readOptionalLooseStringFlag(flags, "migration-version"));
+		pushFlag(
+			argv,
+			"from-migration-version",
+			readOptionalLooseStringFlag(flags, "from-migration-version"),
+		);
+		pushFlag(
+			argv,
+			"to-migration-version",
+			readOptionalLooseStringFlag(flags, "to-migration-version"),
+		);
+		pushFlag(argv, "iterations", readOptionalLooseStringFlag(flags, "iterations"));
+		pushFlag(argv, "seed", readOptionalLooseStringFlag(flags, "seed"));
 
-	const parsed = parseMigrationArgs(argv);
-	const lines: string[] | null = renderLine ? [] : null;
-	const captureLine = (line: string) => {
-		lines?.push(line);
+		const parsed = parseMigrationArgs(argv);
+		const lines: string[] | null = renderLine ? [] : null;
+		const captureLine = (line: string) => {
+			lines?.push(line);
+			if (renderLine) {
+				renderLine(line);
+				return;
+			}
+			console.log(line);
+		};
+		const result = await runMigrationCommand(parsed, cwd, {
+			prompt,
+			renderLine: captureLine,
+		});
 		if (renderLine) {
-			renderLine(line);
+			return result && typeof result === "object" && "cancelled" in result && result.cancelled === true
+					? undefined
+					: buildMigrationCompletionPayload({
+						command: parsed.command ?? "plan",
+						lines: lines ?? [],
+					});
+		}
+
+		if (result && typeof result === "object" && "cancelled" in result && result.cancelled === true) {
 			return;
 		}
-		console.log(line);
-	};
-	const result = await runMigrationCommand(parsed, cwd, {
-		prompt,
-		renderLine: captureLine,
-	});
-	if (renderLine) {
-		return result && typeof result === "object" && "cancelled" in result && result.cancelled === true
-				? undefined
-				: buildMigrationCompletionPayload({
-					command: parsed.command ?? "plan",
-					lines: lines ?? [],
-				});
-	}
-
-	if (result && typeof result === "object" && "cancelled" in result && result.cancelled === true) {
-		return;
+	} catch (error) {
+		throw await wrapCliCommandError("migrate", error);
 	}
 }
 

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
@@ -27,6 +28,17 @@ const addFlowSource = fs.readFileSync(
 	path.join(packageRoot, "src", "ui", "add-flow.tsx"),
 	"utf8",
 );
+
+function runCapturedCommand(
+	command: string,
+	args: string[],
+	options: Parameters<typeof spawnSync>[2] = {},
+) {
+	return spawnSync(command, args, {
+		...options,
+		encoding: "utf8",
+	});
+}
 
 function createSyncFixture(options: {
 	packageManager?: string | null;
@@ -107,6 +119,7 @@ describe("wp-typia package", () => {
 		expect(projectToolsPackageManifest.bin).toBeUndefined();
 		expect(projectToolsPackageManifest.exports["./cli"]).toBeUndefined();
 		expect(projectToolsPackageManifest.exports["./cli-add"]).toBeDefined();
+		expect(projectToolsPackageManifest.exports["./cli-diagnostics"]).toBeDefined();
 		expect(projectToolsPackageManifest.exports["./cli-doctor"]).toBeDefined();
 		expect(projectToolsPackageManifest.exports["./cli-prompt"]).toBeDefined();
 		expect(projectToolsPackageManifest.exports["./cli-scaffold"]).toBeDefined();
@@ -355,6 +368,72 @@ describe("wp-typia package", () => {
 		expect(() => runUtf8Command("node", [entryPath, "create"])).toThrow(
 			"`wp-typia create` requires <project-dir>.",
 		);
+	});
+
+	test("formats create failures with a shared non-interactive diagnostic block", () => {
+		const result = runCapturedCommand("node", [entryPath, "create"]);
+
+		expect(result.status).toBe(1);
+		expect(result.stderr).toContain("Error: wp-typia create failed");
+		expect(result.stderr).toContain("Summary: Unable to complete the requested create workflow.");
+		expect(result.stderr).toContain("- `wp-typia create` requires <project-dir>.");
+	});
+
+	test("formats add failures with a shared non-interactive diagnostic block", () => {
+		const result = runCapturedCommand("node", [entryPath, "add", "variation", "promo-card"]);
+
+		expect(result.status).toBe(1);
+		expect(result.stderr).toContain("Error: wp-typia add failed");
+		expect(result.stderr).toContain("Summary: Unable to complete the requested add workflow.");
+		expect(result.stderr).toContain("- `wp-typia add variation` requires --block <block-slug>.");
+	});
+
+	test("formats migrate failures with a shared non-interactive diagnostic block", () => {
+		const result = runCapturedCommand("node", [entryPath, "migrate", "init"]);
+
+		expect(result.status).toBe(1);
+		expect(result.stderr).toContain("Error: wp-typia migrate failed");
+		expect(result.stderr).toContain(
+			"Summary: Unable to complete the requested migration command.",
+		);
+		expect(result.stderr).toContain(
+			"- `migrate init` requires --current-migration-version <label>.",
+		);
+	});
+
+	test("formats doctor failures with a summary block while keeping streamed check output", () => {
+		const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "wp-typia-doctor-diagnostics-"));
+
+		try {
+			fs.writeFileSync(
+				path.join(fixtureRoot, "package.json"),
+				`${JSON.stringify(
+					{
+						name: "broken-workspace",
+						private: true,
+						wpTypia: {
+							projectType: "workspace",
+						},
+					},
+					null,
+					2,
+				)}\n`,
+				"utf8",
+			);
+
+			const result = runCapturedCommand("node", [entryPath, "doctor"], {
+				cwd: fixtureRoot,
+			});
+
+			expect(result.status).toBe(1);
+			expect(result.stdout).toContain("FAIL Workspace package metadata:");
+			expect(result.stdout).toContain("FAIL wp-typia doctor summary:");
+			expect(result.stderr).toContain("Error: wp-typia doctor failed");
+			expect(result.stderr).toContain("Summary: One or more doctor checks failed.");
+			expect(result.stderr).toContain("- Workspace package metadata:");
+		} finally {
+			fs.rmSync(fixtureRoot, { force: true, recursive: true });
+		}
 	});
 
 	test("prints migrate help through the canonical verb", () => {

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -40,6 +40,22 @@ function runCapturedCommand(
 	});
 }
 
+function withoutAIAgentEnv(): NodeJS.ProcessEnv {
+	return {
+		...process.env,
+		AGENT: "",
+		AMP_CURRENT_THREAD_ID: "",
+		CLAUDECODE: "",
+		CLAUDE_CODE: "",
+		CODEX_CI: "",
+		CODEX_SANDBOX: "",
+		CODEX_THREAD_ID: "",
+		CURSOR_AGENT: "",
+		GEMINI_CLI: "",
+		OPENCODE: "",
+	};
+}
+
 function createSyncFixture(options: {
 	packageManager?: string | null;
 	scripts: Record<string, string>;
@@ -423,6 +439,7 @@ describe("wp-typia package", () => {
 
 			const result = runCapturedCommand("node", [entryPath, "doctor"], {
 				cwd: fixtureRoot,
+				env: withoutAIAgentEnv(),
 			});
 
 			expect(result.status).toBe(1);

--- a/packages/wp-typia/tests/create-command.test.ts
+++ b/packages/wp-typia/tests/create-command.test.ts
@@ -22,7 +22,7 @@ describe("wp-typia create command bridge", () => {
 		fs.rmSync(tempRoot, { force: true, recursive: true });
 	});
 
-	test("keeps ambiguous external layers fail-fast when a synthetic prompt is supplied", async () => {
+test("keeps ambiguous external layers fail-fast when a synthetic prompt is supplied", async () => {
 		const defaultPrompt = {
 			close() {},
 			select<T extends string>(
@@ -38,21 +38,22 @@ describe("wp-typia create command bridge", () => {
 			},
 		};
 
-		await expect(
-			executeCreateCommand({
-				cwd: tempRoot,
-				emitOutput: false,
-				flags: {
-					"external-layer-source": ambiguousLayerFixturePath,
-					"no-install": true,
-					"package-manager": "npm",
-					template: "basic",
-				},
-				interactive: true,
-				projectDir: "demo-tui-ambiguous-layer",
-				prompt: defaultPrompt,
-			}),
-		).rejects.toThrow(
+		const error = await executeCreateCommand({
+			cwd: tempRoot,
+			emitOutput: false,
+			flags: {
+				"external-layer-source": ambiguousLayerFixturePath,
+				"no-install": true,
+				"package-manager": "npm",
+				template: "basic",
+			},
+			interactive: true,
+			projectDir: "demo-tui-ambiguous-layer",
+			prompt: defaultPrompt,
+		}).catch((error) => error);
+
+		expect(error).toBeInstanceOf(Error);
+		expect((error as Error).message).toBe(
 			"External layer package defines multiple selectable layers (acme/internal-base, acme/alpha, acme/beta). Pass an explicit externalLayerId or rerun through the interactive CLI selector.",
 		);
 	});

--- a/packages/wp-typia/tests/tui-lifecycle.test.ts
+++ b/packages/wp-typia/tests/tui-lifecycle.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
+import {
+	createCliCommandError,
+	formatCliDiagnosticError,
+} from "@wp-typia/project-tools/cli-diagnostics";
 
 import { addCommand } from "../src/commands/add";
 import { createCommand } from "../src/commands/create";
@@ -50,6 +54,28 @@ describe("alternate-buffer TUI lifecycle", () => {
 		);
 		expect(describeAlternateBufferFailure("wp-typia add failed", "plain")).toBe(
 			"wp-typia add failed: plain",
+		);
+	});
+
+	test("keeps alternate-buffer failures compact while non-interactive CLI failures expand into shared diagnostics", () => {
+		expect(describeAlternateBufferFailure("wp-typia create failed", new Error("boom"))).toBe(
+			"wp-typia create failed: boom",
+		);
+
+		expect(
+			formatCliDiagnosticError(
+				createCliCommandError({
+					command: "create",
+					error: new Error("boom"),
+				}),
+			),
+		).toBe(
+			[
+				"wp-typia create failed",
+				"Summary: Unable to complete the requested create workflow.",
+				"Details:",
+				"- boom",
+			].join("\n"),
 		);
 	});
 


### PR DESCRIPTION
## Context

- closes the remaining follow-up from #300 to make `create`, `add`, `migrate`, and root `doctor` failures easier to read and easier to test
- keeps `doctor`'s explicit machine-readable path intact while moving the default non-interactive path back to human-readable PASS/FAIL output

## What Changed

- added a shared `cli-diagnostics` runtime utility in `@wp-typia/project-tools` for summary/detail failure blocks and doctor summary helpers
- wired `create`, `add`, `migrate`, and `doctor` through the shared diagnostic wrapper, including command-level `defaultFormat: "toon"` so non-interactive runs stop defaulting to Bunli JSON envelopes
- kept alternate-buffer TUI failures compact while documenting and testing the difference from non-interactive CLI output
- updated doctor-facing tests to request `--format json` only when they truly need structured output, and documented the new default behavior in `docs/API.md`
- added a Sampo changeset for `wp-typia` and `@wp-typia/project-tools`

## Verification

- `bun run --filter @wp-typia/project-tools build`
- `bun run --filter wp-typia build`
- `bun test packages/wp-typia/tests/cli-package.test.ts packages/wp-typia/tests/tui-lifecycle.test.ts packages/wp-typia/tests/create-command.test.ts`
- `bun test packages/wp-typia-project-tools/tests/cli-entry.test.ts packages/wp-typia-project-tools/tests/workspace-doctor.test.ts packages/wp-typia-project-tools/tests/migration-doctor.test.ts`
- `bun run changesets:validate`

Closes #300
