### PR TITLE
Stabilize published scaffold registrations and smoke coverage

### DIFF
--- a/.sampo/changesets/issue-306-published-scaffold-hotfix.md
+++ b/.sampo/changesets/issue-306-published-scaffold-hotfix.md
@@ -1,0 +1,7 @@
+---
+npm/@wp-typia/block-types: patch
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Fixed published scaffold outputs so generated basic, persistence, and compound block registration files no longer rely on `registerBlockType<T>()` generic calls that break against the current published `@wordpress/blocks` type surface. Hardened the packed publish-install smoke to verify wrapper exports and to typecheck generated basic and compound scaffolds, including the compound `add-compound-child` path, against packed local release tarballs before publish.

--- a/examples/compound-patterns/src/blocks/compound-patterns-item/index.tsx
+++ b/examples/compound-patterns/src/blocks/compound-patterns-item/index.tsx
@@ -1,5 +1,7 @@
-import { registerBlockType } from '@wordpress/blocks';
-import type { BlockConfiguration } from '@wp-typia/block-types/blocks/registration';
+import {
+	registerScaffoldBlockType,
+	type BlockConfiguration,
+} from '@wp-typia/block-types/blocks/registration';
 import {
 	buildScaffoldBlockRegistration,
 	parseScaffoldBlockMetadata,
@@ -22,7 +24,4 @@ const registration = buildScaffoldBlockRegistration(
 	}
 );
 
-registerBlockType< CompoundPatternsItemAttributes >(
-	registration.name,
-	registration.settings
-);
+registerScaffoldBlockType( registration.name, registration.settings );

--- a/examples/compound-patterns/src/blocks/compound-patterns/index.tsx
+++ b/examples/compound-patterns/src/blocks/compound-patterns/index.tsx
@@ -1,5 +1,7 @@
-import { registerBlockType } from '@wordpress/blocks';
-import type { BlockConfiguration } from '@wp-typia/block-types/blocks/registration';
+import {
+	registerScaffoldBlockType,
+	type BlockConfiguration,
+} from '@wp-typia/block-types/blocks/registration';
 import {
 	buildScaffoldBlockRegistration,
 	parseScaffoldBlockMetadata,
@@ -22,7 +24,4 @@ const registration = buildScaffoldBlockRegistration(
 	}
 );
 
-registerBlockType< CompoundPatternsAttributes >(
-	registration.name,
-	registration.settings
-);
+registerScaffoldBlockType( registration.name, registration.settings );

--- a/examples/my-typia-block/src/index.tsx
+++ b/examples/my-typia-block/src/index.tsx
@@ -1,7 +1,7 @@
-import { registerBlockType } from '@wordpress/blocks';
-import type {
-	BlockConfiguration,
-	RegisterBlockTypeResult,
+import {
+	registerScaffoldBlockType,
+	type BlockConfiguration,
+	type RegisterBlockTypeResult,
 } from '@wp-typia/block-types/blocks/registration';
 import {
 	buildScaffoldBlockRegistration,
@@ -29,10 +29,7 @@ const registration = buildScaffoldBlockRegistration(
 	}
 );
 
-const registeredBlock: RegisterBlockTypeResult< MyTypiaBlockAttributes > =
-	registerBlockType< MyTypiaBlockAttributes >(
-		registration.name,
-		registration.settings
-	);
+const registeredBlock: RegisterBlockTypeResult =
+	registerScaffoldBlockType( registration.name, registration.settings );
 
 void registeredBlock;

--- a/examples/my-typia-block/src/index.tsx
+++ b/examples/my-typia-block/src/index.tsx
@@ -1,7 +1,6 @@
 import {
 	registerScaffoldBlockType,
 	type BlockConfiguration,
-	type RegisterBlockTypeResult,
 } from '@wp-typia/block-types/blocks/registration';
 import {
 	buildScaffoldBlockRegistration,
@@ -29,7 +28,7 @@ const registration = buildScaffoldBlockRegistration(
 	}
 );
 
-const registeredBlock: RegisterBlockTypeResult = registerScaffoldBlockType(
+const registeredBlock = registerScaffoldBlockType(
 	registration.name,
 	registration.settings
 );

--- a/examples/my-typia-block/src/index.tsx
+++ b/examples/my-typia-block/src/index.tsx
@@ -29,7 +29,9 @@ const registration = buildScaffoldBlockRegistration(
 	}
 );
 
-const registeredBlock: RegisterBlockTypeResult =
-	registerScaffoldBlockType( registration.name, registration.settings );
+const registeredBlock: RegisterBlockTypeResult = registerScaffoldBlockType(
+	registration.name,
+	registration.settings
+);
 
 void registeredBlock;

--- a/examples/persistence-examples/src/blocks/counter/index.tsx
+++ b/examples/persistence-examples/src/blocks/counter/index.tsx
@@ -1,5 +1,7 @@
-import { registerBlockType } from '@wordpress/blocks';
-import type { BlockConfiguration } from '@wp-typia/block-types/blocks/registration';
+import {
+	registerScaffoldBlockType,
+	type BlockConfiguration,
+} from '@wp-typia/block-types/blocks/registration';
 import {
 	buildScaffoldBlockRegistration,
 	parseScaffoldBlockMetadata,
@@ -22,7 +24,4 @@ const registration = buildScaffoldBlockRegistration(
 	}
 );
 
-registerBlockType< PersistenceCounterAttributes >(
-	registration.name,
-	registration.settings
-);
+registerScaffoldBlockType( registration.name, registration.settings );

--- a/examples/persistence-examples/src/blocks/like-button/index.tsx
+++ b/examples/persistence-examples/src/blocks/like-button/index.tsx
@@ -1,5 +1,7 @@
-import { registerBlockType } from '@wordpress/blocks';
-import type { BlockConfiguration } from '@wp-typia/block-types/blocks/registration';
+import {
+	registerScaffoldBlockType,
+	type BlockConfiguration,
+} from '@wp-typia/block-types/blocks/registration';
 import {
 	buildScaffoldBlockRegistration,
 	parseScaffoldBlockMetadata,
@@ -22,7 +24,4 @@ const registration = buildScaffoldBlockRegistration(
 	}
 );
 
-registerBlockType< PersistenceLikeButtonAttributes >(
-	registration.name,
-	registration.settings
-);
+registerScaffoldBlockType( registration.name, registration.settings );

--- a/packages/wp-typia-block-types/src/blocks/registration.ts
+++ b/packages/wp-typia-block-types/src/blocks/registration.ts
@@ -1,3 +1,4 @@
+import { registerBlockType } from '@wordpress/blocks';
 import type {
   Block as WordPressRegisteredBlockType,
   BlockAttribute as WordPressBlockAttribute,
@@ -71,3 +72,30 @@ export type RegisteredBlockType<
 export type RegisterBlockTypeResult<
   TAttributes extends BlockAttributes = BlockAttributes,
 > = RegisteredBlockType<TAttributes> | undefined;
+
+/**
+ * Runtime shim for scaffolded registrations.
+ *
+ * Generated projects keep strong typing around scaffold metadata while
+ * centralizing the compatibility cast required by the currently published
+ * `@wordpress/blocks` registration surface.
+ */
+export function registerScaffoldBlockType<
+  TAttributes extends BlockAttributes = BlockAttributes,
+  TSettings extends object = object,
+>(
+  blockName: string,
+  settings: TSettings,
+): RegisterBlockTypeResult<TAttributes>;
+export function registerScaffoldBlockType<
+  TAttributes extends BlockAttributes = BlockAttributes,
+  TSettings extends object = object,
+>(
+  blockName: string,
+  settings: TSettings,
+): RegisterBlockTypeResult<TAttributes> {
+  return registerBlockType(
+    blockName,
+    settings as WordPressBlockConfiguration<Record<string, unknown>>,
+  ) as RegisterBlockTypeResult<TAttributes>;
+}

--- a/packages/wp-typia-project-tools/src/runtime/built-in-block-code-templates.ts
+++ b/packages/wp-typia-project-tools/src/runtime/built-in-block-code-templates.ts
@@ -218,8 +218,10 @@ export const BASIC_INDEX_TEMPLATE = `/**
  * Typia-powered type-safe block
  */
 
-import { registerBlockType } from '@wordpress/blocks';
-import type { BlockConfiguration } from '@wp-typia/block-types/blocks/registration';
+import {
+  registerScaffoldBlockType,
+  type BlockConfiguration,
+} from '@wp-typia/block-types/blocks/registration';
 import type { BlockSupports } from '@wp-typia/block-types/blocks/supports';
 import { __ } from '@wordpress/i18n';
 import {
@@ -257,7 +259,7 @@ const registration = buildScaffoldBlockRegistration(
   }
 );
 
-registerBlockType<{{pascalCase}}Attributes>(registration.name, registration.settings);
+registerScaffoldBlockType(registration.name, registration.settings);
 `;
 
 export const BASIC_VALIDATORS_TEMPLATE = `import typia from 'typia';
@@ -664,8 +666,10 @@ export default function Save({ attributes }: { attributes: {{pascalCase}}Attribu
 }
 `;
 
-export const INTERACTIVITY_INDEX_TEMPLATE = `import { registerBlockType } from '@wordpress/blocks';
-import type { BlockConfiguration } from '@wp-typia/block-types/blocks/registration';
+export const INTERACTIVITY_INDEX_TEMPLATE = `import {
+  registerScaffoldBlockType,
+  type BlockConfiguration,
+} from '@wp-typia/block-types/blocks/registration';
 import type { BlockSupports } from '@wp-typia/block-types/blocks/supports';
 import {
   buildScaffoldBlockRegistration,
@@ -697,7 +701,7 @@ const registration = buildScaffoldBlockRegistration(
   }
 );
 
-registerBlockType<{{pascalCase}}Attributes>(registration.name, registration.settings);
+registerScaffoldBlockType(registration.name, registration.settings);
 `;
 
 export const INTERACTIVITY_SCRIPT_TEMPLATE = `/**
@@ -1015,8 +1019,10 @@ export default function Edit( {
 }
 `;
 
-export const PERSISTENCE_INDEX_TEMPLATE = `import { registerBlockType } from '@wordpress/blocks';
-import type { BlockConfiguration } from '@wp-typia/block-types/blocks/registration';
+export const PERSISTENCE_INDEX_TEMPLATE = `import {
+\tregisterScaffoldBlockType,
+\ttype BlockConfiguration,
+} from '@wp-typia/block-types/blocks/registration';
 import {
 	buildScaffoldBlockRegistration,
 	parseScaffoldBlockMetadata,
@@ -1037,10 +1043,7 @@ const registration = buildScaffoldBlockRegistration(
 	}
 );
 
-registerBlockType< {{pascalCase}}Attributes >(
-	registration.name,
-	registration.settings
-);
+registerScaffoldBlockType(registration.name, registration.settings);
 `;
 
 export const PERSISTENCE_SAVE_TEMPLATE = `export default function Save() {
@@ -1534,8 +1537,10 @@ export default function Save( {
 }
 `;
 
-export const COMPOUND_PARENT_INDEX_TEMPLATE = `import { registerBlockType } from '@wordpress/blocks';
-import type { BlockConfiguration } from '@wp-typia/block-types/blocks/registration';
+export const COMPOUND_PARENT_INDEX_TEMPLATE = `import {
+\tregisterScaffoldBlockType,
+\ttype BlockConfiguration,
+} from '@wp-typia/block-types/blocks/registration';
 import {
 	buildScaffoldBlockRegistration,
 	parseScaffoldBlockMetadata,
@@ -1556,10 +1561,7 @@ const registration = buildScaffoldBlockRegistration(
 	}
 );
 
-registerBlockType< {{pascalCase}}Attributes >(
-	registration.name,
-	registration.settings
-);
+registerScaffoldBlockType(registration.name, registration.settings);
 `;
 
 export const COMPOUND_LOCAL_HOOKS_TEMPLATE = `export {
@@ -1717,8 +1719,10 @@ export default function Save( {
 }
 `;
 
-export const COMPOUND_CHILD_INDEX_TEMPLATE = `import { registerBlockType } from '@wordpress/blocks';
-import type { BlockConfiguration } from '@wp-typia/block-types/blocks/registration';
+export const COMPOUND_CHILD_INDEX_TEMPLATE = `import {
+\tregisterScaffoldBlockType,
+\ttype BlockConfiguration,
+} from '@wp-typia/block-types/blocks/registration';
 import {
 	buildScaffoldBlockRegistration,
 	parseScaffoldBlockMetadata,
@@ -1739,10 +1743,7 @@ const registration = buildScaffoldBlockRegistration(
 	}
 );
 
-registerBlockType< {{pascalCase}}ItemAttributes >(
-	registration.name,
-	registration.settings
-);
+registerScaffoldBlockType(registration.name, registration.settings);
 `;
 
 export const COMPOUND_CHILD_VALIDATORS_TEMPLATE = `import typia from 'typia';

--- a/packages/wp-typia-project-tools/templates/_shared/compound/core/scripts/add-compound-child.ts.mustache
+++ b/packages/wp-typia-project-tools/templates/_shared/compound/core/scripts/add-compound-child.ts.mustache
@@ -576,8 +576,10 @@ export default function Save( {
 }
 
 function renderIndexFile( childTypeName: string, childFolderSlug: string ): string {
-return `import { registerBlockType } from '@wordpress/blocks';
-import type { BlockConfiguration } from '@wp-typia/block-types/blocks/registration';
+return `import {
+\tregisterScaffoldBlockType,
+\ttype BlockConfiguration,
+} from '@wp-typia/block-types/blocks/registration';
 import {
 \tbuildScaffoldBlockRegistration,
 \tparseScaffoldBlockMetadata,
@@ -598,10 +600,7 @@ const registration = buildScaffoldBlockRegistration(
 \t}
 );
 
-registerBlockType< ${ childTypeName } >(
-\tregistration.name,
-\tregistration.settings
-);
+registerScaffoldBlockType( registration.name, registration.settings );
 `;
 }
 

--- a/packages/wp-typia-project-tools/tests/helpers/scaffold-test-harness.ts
+++ b/packages/wp-typia-project-tools/tests/helpers/scaffold-test-harness.ts
@@ -436,19 +436,47 @@ export function linkWorkspaceNodeModules(targetDir: string) {
     ...generatedProjectTypecheckSupportPackages,
   ]);
 
+  const linkedWorkspacePackages = new Set<string>();
+
+  function linkWorkspacePackage(packageName: keyof typeof workspacePackagePaths) {
+    if (linkedWorkspacePackages.has(packageName)) {
+      return;
+    }
+
+    const workspacePackagePath = workspacePackagePaths[packageName];
+    ensureWorkspacePackageBuilt(packageName, workspacePackagePath);
+    ensureDirSymlink(
+      path.join(nodeModulesPath, ...packageName.split("/")),
+      workspacePackagePath
+    );
+    linkPackageBins(targetDir, packageName, workspacePackagePath);
+    linkedWorkspacePackages.add(packageName);
+
+    const workspaceManifestPath = path.join(workspacePackagePath, "package.json");
+    if (!fs.existsSync(workspaceManifestPath)) {
+      return;
+    }
+
+    const workspaceManifest = JSON.parse(
+      fs.readFileSync(workspaceManifestPath, "utf8")
+    ) as {
+      dependencies?: Record<string, string>;
+    };
+
+    for (const dependencyName of Object.keys(workspaceManifest.dependencies ?? {})) {
+      if (!(dependencyName in workspacePackagePaths)) {
+        continue;
+      }
+
+      linkWorkspacePackage(dependencyName as keyof typeof workspacePackagePaths);
+    }
+  }
+
   for (const packageName of dependencyNames) {
     const workspacePackagePath =
       workspacePackagePaths[packageName as keyof typeof workspacePackagePaths];
     if (workspacePackagePath) {
-      ensureWorkspacePackageBuilt(
-        packageName as keyof typeof workspacePackagePaths,
-        workspacePackagePath
-      );
-      ensureDirSymlink(
-        path.join(nodeModulesPath, ...packageName.split("/")),
-        workspacePackagePath
-      );
-      linkPackageBins(targetDir, packageName, workspacePackagePath);
+      linkWorkspacePackage(packageName as keyof typeof workspacePackagePaths);
       continue;
     }
 

--- a/packages/wp-typia-project-tools/tests/scaffold-basic.test.ts
+++ b/packages/wp-typia-project-tools/tests/scaffold-basic.test.ts
@@ -226,6 +226,11 @@ describe('@wp-typia/project-tools scaffold core', () => {
       expect(generatedIndex).toContain(
         '@wp-typia/block-types/blocks/registration',
       );
+      expect(generatedIndex).toContain(
+        'registerScaffoldBlockType(registration.name, registration.settings);',
+      );
+      expect(generatedIndex).not.toContain('registerBlockType<');
+      expect(generatedIndex).toContain('registerScaffoldBlockType');
       expect(generatedIndex).not.toContain('type ScaffoldBlockMetadata');
       expect(generatedIndex).toContain("import metadata from './block-metadata';");
       expect(generatedIndex).toContain('@wp-typia/block-types/blocks/supports');

--- a/packages/wp-typia-project-tools/tests/scaffold-compound.test.ts
+++ b/packages/wp-typia-project-tools/tests/scaffold-compound.test.ts
@@ -372,6 +372,11 @@ describe('@wp-typia/project-tools scaffold compound', () => {
       );
       expect(addChildScript).toContain('buildScaffoldBlockRegistration');
       expect(addChildScript).toContain(
+        'registerScaffoldBlockType( registration.name, registration.settings );',
+      );
+      expect(addChildScript).not.toContain('registerBlockType<');
+      expect(addChildScript).toContain('registerScaffoldBlockType');
+      expect(addChildScript).toContain(
         "import metadata from './block-metadata';",
       );
       expect(addChildScript).toContain('renderBlockMetadataFile()');
@@ -892,6 +897,11 @@ describe('@wp-typia/project-tools scaffold compound', () => {
       expect(parentIndex).toContain(
         "import metadata from './block-metadata';",
       );
+      expect(parentIndex).toContain(
+        'registerScaffoldBlockType(registration.name, registration.settings);',
+      );
+      expect(parentIndex).not.toContain('registerBlockType<');
+      expect(parentIndex).toContain('registerScaffoldBlockType');
       expect(parentValidators).toContain('@wp-typia/block-runtime/identifiers');
       expect(parentValidators).toContain('generateResourceKey');
       expect(parentValidators).not.toContain('const generateResourceKey');
@@ -925,6 +935,11 @@ describe('@wp-typia/project-tools scaffold compound', () => {
       expect(generatedValidatorToolkit).not.toContain('typia.createValidate');
       expect(generatedAddChild).toContain('ALLOWED_CHILD_MARKER');
       expect(generatedAddChild).toContain('buildScaffoldBlockRegistration');
+      expect(generatedAddChild).toContain(
+        'registerScaffoldBlockType( registration.name, registration.settings );',
+      );
+      expect(generatedAddChild).not.toContain('registerBlockType<');
+      expect(generatedAddChild).toContain('registerScaffoldBlockType');
       expect(generatedAddChild).toContain(
         "import metadata from './block-metadata';",
       );
@@ -1211,6 +1226,11 @@ describe('@wp-typia/project-tools scaffold compound', () => {
       expect(newChildIndex).toContain(
         "import metadata from './block-metadata';",
       );
+      expect(newChildIndex).toContain(
+        'registerScaffoldBlockType( registration.name, registration.settings );',
+      );
+      expect(newChildIndex).not.toContain('registerBlockType<');
+      expect(newChildIndex).toContain('registerScaffoldBlockType');
       expect(newChildValidators).toContain(
         "import currentManifest from './manifest-defaults-document';",
       );

--- a/packages/wp-typia-project-tools/tests/scaffold-persistence.test.ts
+++ b/packages/wp-typia-project-tools/tests/scaffold-persistence.test.ts
@@ -91,6 +91,10 @@ test(
       path.join(targetDir, "src", "edit.tsx"),
       "utf8"
     );
+    const generatedIndex = fs.readFileSync(
+      path.join(targetDir, "src", "index.tsx"),
+      "utf8"
+    );
     const generatedValidators = fs.readFileSync(
       path.join(targetDir, "src", "validators.ts"),
       "utf8"
@@ -262,6 +266,12 @@ test(
     expect(generatedEdit).toContain(
       "type EditProps = BlockEditProps< DemoPersistencePublicAttributes >;"
     );
+    expect(generatedIndex).toContain('buildScaffoldBlockRegistration');
+    expect(generatedIndex).toContain(
+      'registerScaffoldBlockType(registration.name, registration.settings);'
+    );
+    expect(generatedIndex).not.toContain('registerBlockType<');
+    expect(generatedIndex).toContain('registerScaffoldBlockType');
     expect(generatedEdit).toContain("}: EditProps )");
     expect(generatedEdit).not.toContain(
       "attributes as unknown as Record< string, unknown >"

--- a/scripts/run-publish-install-smoke.mjs
+++ b/scripts/run-publish-install-smoke.mjs
@@ -75,6 +75,7 @@ function runWpTypiaCli(projectDir, cliPath, args) {
 function materializeTarballDependencies(projectDir, tarballs) {
 	const packageJsonPath = path.join(projectDir, "package.json");
 	const packageJson = readJson(packageJsonPath);
+	const directDependencies = new Set();
 
 	for (const field of ["dependencies", "devDependencies"] ) {
 		const section = packageJson[field];
@@ -88,7 +89,17 @@ function materializeTarballDependencies(projectDir, tarballs) {
 			}
 
 			section[packageName] = `file:${tarballs.get(packageName)}`;
+			directDependencies.add(packageName);
 		}
+	}
+
+	packageJson.overrides ??= {};
+	for (const packageName of GENERATED_PROJECT_OVERRIDE_PACKAGES) {
+		if (directDependencies.has(packageName)) {
+			continue;
+		}
+
+		packageJson.overrides[packageName] = `file:${tarballs.get(packageName)}`;
 	}
 
 	writeJson(packageJsonPath, packageJson);
@@ -194,11 +205,12 @@ withTempDir("wp-typia-publish-install-smoke-", (tempRoot) => {
 		"wrapper-export-smoke.mjs",
 		[
 			'import "@wp-typia/block-types/blocks/registration";',
-			'import { defineScaffoldBlockMetadata, parseScaffoldBlockMetadata } from "@wp-typia/block-runtime/blocks";',
+			'import { buildScaffoldBlockRegistration, defineScaffoldBlockMetadata, parseScaffoldBlockMetadata } from "@wp-typia/block-runtime/blocks";',
 			'import { defineManifestDocument } from "@wp-typia/block-runtime/editor";',
 			'import { defineManifestDefaultsDocument, parseManifestDefaultsDocument } from "@wp-typia/block-runtime/defaults";',
 			"",
 			"for (const [name, value] of Object.entries({",
+			"\tbuildScaffoldBlockRegistration,",
 			"\tdefineScaffoldBlockMetadata,",
 			"\tparseScaffoldBlockMetadata,",
 			"\tdefineManifestDocument,",

--- a/scripts/run-publish-install-smoke.mjs
+++ b/scripts/run-publish-install-smoke.mjs
@@ -6,6 +6,7 @@ import { execFileSync } from "node:child_process";
 
 import {
 	findWorkspaceProtocolLeaks,
+	getNpmCommand,
 	packWorkspacePackage,
 	readPackedPackageManifest,
 	repoRoot,
@@ -20,6 +21,13 @@ const PACKAGE_CHAIN = [
 	["packages/wp-typia-project-tools", "@wp-typia/project-tools"],
 	["packages/wp-typia", "wp-typia"],
 ];
+const GENERATED_PROJECT_OVERRIDE_PACKAGES = [
+	"@wp-typia/api-client",
+	"@wp-typia/rest",
+	"@wp-typia/block-types",
+	"@wp-typia/block-runtime",
+];
+const npmCommand = getNpmCommand();
 
 function run(command, args, options = {}) {
 	return execFileSync(command, args, {
@@ -30,10 +38,92 @@ function run(command, args, options = {}) {
 	});
 }
 
-function runNodeScript(projectDir, fileName, source, args = []) {
+function runScript(projectDir, command, fileName, source, args = []) {
 	const scriptPath = path.join(projectDir, fileName);
 	fs.writeFileSync(scriptPath, source, "utf8");
-	return run("node", [scriptPath, ...args], { cwd: projectDir });
+	return run(command, [scriptPath, ...args], { cwd: projectDir });
+}
+
+function writeJson(filePath, value) {
+	fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function readJson(filePath) {
+	return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function getInstalledWpTypiaCliPath(projectDir) {
+	const installedManifest = readJson(
+		path.join(projectDir, "node_modules", "wp-typia", "package.json"),
+	);
+	const binEntry =
+		typeof installedManifest.bin === "string"
+			? installedManifest.bin
+			: installedManifest.bin?.["wp-typia"] ??
+				Object.values(installedManifest.bin ?? {})[0];
+	if (typeof binEntry !== "string" || binEntry.length === 0) {
+		throw new Error("Unable to resolve wp-typia CLI entry from the installed package manifest.");
+	}
+
+	return path.join(projectDir, "node_modules", "wp-typia", binEntry);
+}
+
+function runWpTypiaCli(projectDir, cliPath, args) {
+	return run("node", [cliPath, ...args], { cwd: projectDir });
+}
+
+function materializeTarballDependencies(projectDir, tarballs) {
+	const packageJsonPath = path.join(projectDir, "package.json");
+	const packageJson = readJson(packageJsonPath);
+
+	for (const field of ["dependencies", "devDependencies"] ) {
+		const section = packageJson[field];
+		if (!section || typeof section !== "object") {
+			continue;
+		}
+
+		for (const packageName of GENERATED_PROJECT_OVERRIDE_PACKAGES) {
+			if (typeof section[packageName] !== "string") {
+				continue;
+			}
+
+			section[packageName] = `file:${tarballs.get(packageName)}`;
+		}
+	}
+
+	writeJson(packageJsonPath, packageJson);
+}
+
+function assertScaffoldDependencyRanges(projectDir, expectations) {
+	const packageJson = readJson(path.join(projectDir, "package.json"));
+
+	for (const [packageName, expectedRange] of Object.entries(expectations)) {
+		const actualRange = packageJson.devDependencies?.[packageName];
+		if (actualRange !== expectedRange) {
+			throw new Error(
+				`Generated ${path.basename(projectDir)} package.json expected ${packageName}=${expectedRange}, found ${JSON.stringify(actualRange ?? null)}.`,
+			);
+		}
+	}
+}
+
+function assertFilesExist(projectDir, relativePaths) {
+	for (const relativePath of relativePaths) {
+		if (!fs.existsSync(path.join(projectDir, relativePath))) {
+			throw new Error(
+				`Expected ${path.basename(projectDir)} to contain ${relativePath}, but it was missing.`,
+			);
+		}
+	}
+}
+
+function installGeneratedProject(projectDir, tarballs) {
+	materializeTarballDependencies(projectDir, tarballs);
+	run(npmCommand, ["install"], { cwd: projectDir });
+}
+
+function typecheckGeneratedProject(projectDir) {
+	run(npmCommand, ["exec", "--", "tsc", "--noEmit"], { cwd: projectDir });
 }
 
 execFileSync("bun", ["run", "packages:build"], {
@@ -45,14 +135,15 @@ withTempDir("wp-typia-publish-install-smoke-", (tempRoot) => {
 	const tarballDir = path.join(tempRoot, "tarballs");
 	const projectDir = path.join(tempRoot, "project");
 	const tarballs = new Map();
+	const packedManifests = new Map();
 
 	for (const [packageDir, packageName] of PACKAGE_CHAIN) {
 		const tarballPath = packWorkspacePackage(packageDir, tarballDir);
 		tarballs.set(packageName, tarballPath);
+		packedManifests.set(packageName, readPackedPackageManifest(tarballPath));
 
 		if (packageName === "@wp-typia/rest") {
-			const packedManifest = readPackedPackageManifest(tarballPath);
-			const leaks = findWorkspaceProtocolLeaks(packedManifest);
+			const leaks = findWorkspaceProtocolLeaks(packedManifests.get(packageName));
 			if (leaks.length > 0) {
 				throw new Error(
 					`Packed ${packageName} manifest still contains workspace protocol dependencies: ${leaks.join(", ")}`,
@@ -62,44 +153,25 @@ withTempDir("wp-typia-publish-install-smoke-", (tempRoot) => {
 	}
 
 	fs.mkdirSync(projectDir, { recursive: true });
-	fs.writeFileSync(
-		path.join(projectDir, "package.json"),
-		`${JSON.stringify({
-			dependencies: {
-				"wp-typia": `file:${tarballs.get("wp-typia")}`,
-			},
-			name: "wp-typia-publish-install-smoke",
-			overrides: Object.fromEntries(
-				[...tarballs.entries()].map(([packageName, tarballPath]) => [
-					packageName,
-					`file:${tarballPath}`,
-				]),
-			),
-			private: true,
-			packageManager: "bun@1.3.11",
-		}, null, 2)}\n`,
-		"utf8",
-	);
+	writeJson(path.join(projectDir, "package.json"), {
+		dependencies: {
+			"wp-typia": `file:${tarballs.get("wp-typia")}`,
+		},
+		name: "wp-typia-publish-install-smoke",
+		overrides: Object.fromEntries(
+			[...tarballs.entries()].map(([packageName, tarballPath]) => [
+				packageName,
+				`file:${tarballPath}`,
+			]),
+		),
+		private: true,
+		packageManager: "bun@1.3.11",
+	});
 
 	run("bun", ["install"], { cwd: projectDir });
 
-	const installedManifest = JSON.parse(
-		fs.readFileSync(path.join(projectDir, "node_modules", "wp-typia", "package.json"), "utf8"),
-	);
-	const binEntry =
-		typeof installedManifest.bin === "string"
-			? installedManifest.bin
-			: installedManifest.bin?.["wp-typia"] ??
-				Object.values(installedManifest.bin ?? {})[0];
-	if (typeof binEntry !== "string" || binEntry.length === 0) {
-		throw new Error("Unable to resolve wp-typia CLI entry from the installed package manifest.");
-	}
-
-	const versionOutput = run(
-		"node",
-		[path.join(projectDir, "node_modules", "wp-typia", binEntry), "--version"],
-		{ cwd: projectDir },
-	).trim();
+	const cliPath = getInstalledWpTypiaCliPath(projectDir);
+	const versionOutput = run("node", [cliPath, "--version"], { cwd: projectDir }).trim();
 	let parsed;
 	try {
 		parsed = JSON.parse(versionOutput);
@@ -115,6 +187,31 @@ withTempDir("wp-typia-publish-install-smoke-", (tempRoot) => {
 	) {
 		throw new Error(`Unexpected wp-typia --version output: ${versionOutput}`);
 	}
+
+	runScript(
+		projectDir,
+		"bun",
+		"wrapper-export-smoke.mjs",
+		[
+			'import "@wp-typia/block-types/blocks/registration";',
+			'import { defineScaffoldBlockMetadata, parseScaffoldBlockMetadata } from "@wp-typia/block-runtime/blocks";',
+			'import { defineManifestDocument } from "@wp-typia/block-runtime/editor";',
+			'import { defineManifestDefaultsDocument, parseManifestDefaultsDocument } from "@wp-typia/block-runtime/defaults";',
+			"",
+			"for (const [name, value] of Object.entries({",
+			"\tdefineScaffoldBlockMetadata,",
+			"\tparseScaffoldBlockMetadata,",
+			"\tdefineManifestDocument,",
+			"\tdefineManifestDefaultsDocument,",
+			"\tparseManifestDefaultsDocument,",
+			"})) {",
+			'\tif (typeof value !== "function") {',
+			'\t\tthrow new Error(`Expected ${name} to be a function export.`);',
+			"\t}",
+			"}",
+			"",
+		].join("\n"),
+	);
 
 	const blockRuntimeSmokeDir = path.join(projectDir, "block-runtime-smoke");
 	fs.mkdirSync(blockRuntimeSmokeDir, { recursive: true });
@@ -134,8 +231,9 @@ withTempDir("wp-typia-publish-install-smoke-", (tempRoot) => {
 		`${JSON.stringify({ name: "smoke/counter" }, null, 2)}\n`,
 		"utf8",
 	);
-	runNodeScript(
+	runScript(
 		projectDir,
+		"node",
 		"block-runtime-smoke.mjs",
 		[
 			'import fs from "node:fs";',
@@ -188,8 +286,9 @@ withTempDir("wp-typia-publish-install-smoke-", (tempRoot) => {
 		].join("\n"),
 		"utf8",
 	);
-	runNodeScript(
+	runScript(
 		projectDir,
+		"node",
 		"project-tools-smoke.mjs",
 		[
 			'import { getWorkspaceBlockSelectOptions } from "@wp-typia/project-tools";',
@@ -205,7 +304,66 @@ withTempDir("wp-typia-publish-install-smoke-", (tempRoot) => {
 		[projectToolsSmokeDir],
 	);
 
+	const expectedRanges = {
+		"@wp-typia/block-runtime": `^${packedManifests.get("@wp-typia/block-runtime").version}`,
+		"@wp-typia/block-types": `^${packedManifests.get("@wp-typia/block-types").version}`,
+	};
+
+	const basicDir = path.join(projectDir, "demo-basic");
+	runWpTypiaCli(projectDir, cliPath, [
+		"create",
+		"demo-basic",
+		"--template",
+		"basic",
+		"--package-manager",
+		"npm",
+		"--namespace",
+		"smoke-space",
+		"--text-domain",
+		"smoke-space",
+		"--yes",
+		"--no-install",
+	]);
+	assertScaffoldDependencyRanges(basicDir, expectedRanges);
+	assertFilesExist(basicDir, [
+		"src/block-metadata.ts",
+		"src/manifest-document.ts",
+		"src/manifest-defaults-document.ts",
+	]);
+	installGeneratedProject(basicDir, tarballs);
+	typecheckGeneratedProject(basicDir);
+
+	const compoundDir = path.join(projectDir, "demo-compound");
+	runWpTypiaCli(projectDir, cliPath, [
+		"create",
+		"demo-compound",
+		"--template",
+		"compound",
+		"--package-manager",
+		"npm",
+		"--namespace",
+		"smoke-space",
+		"--text-domain",
+		"smoke-space",
+		"--yes",
+		"--no-install",
+	]);
+	assertScaffoldDependencyRanges(compoundDir, expectedRanges);
+	installGeneratedProject(compoundDir, tarballs);
+	run(npmCommand, ["exec", "--", "tsx", "scripts/add-compound-child.ts", "--slug", "faq-item", "--title", "FAQ Item"], {
+		cwd: compoundDir,
+	});
+	assertFilesExist(compoundDir, [
+		"src/blocks/demo-compound/block-metadata.ts",
+		"src/blocks/demo-compound/manifest-document.ts",
+		"src/blocks/demo-compound/manifest-defaults-document.ts",
+		"src/blocks/demo-compound-faq-item/block-metadata.ts",
+		"src/blocks/demo-compound-faq-item/manifest-document.ts",
+		"src/blocks/demo-compound-faq-item/manifest-defaults-document.ts",
+	]);
+	typecheckGeneratedProject(compoundDir);
+
 	process.stdout.write(
-		`Verified published-install smoke for wp-typia ${parsed.data.version}, block-runtime metadata sync, and project-tools workspace inventory runtime paths.\n`,
+		`Verified published-install smoke for wp-typia ${parsed.data.version}, runtime wrapper exports, block-runtime metadata sync, project-tools runtime paths, and generated basic/compound scaffold installs.\n`,
 	);
 });

--- a/tests/type-smoke/block-types-smoke.ts
+++ b/tests/type-smoke/block-types-smoke.ts
@@ -1,4 +1,3 @@
-import { registerBlockType } from '@wordpress/blocks';
 import type {
   BlockAlignment,
   BlockContentPosition,
@@ -35,6 +34,7 @@ import type {
   BlockVariation,
   RegisterBlockTypeResult,
 } from '@wp-typia/block-types/blocks/registration';
+import { registerScaffoldBlockType } from '@wp-typia/block-types/blocks/registration';
 import type {
   BlockSupports,
   SpacingSize,
@@ -234,7 +234,10 @@ const blockConfiguration = {
 } satisfies BlockConfiguration<DemoRegistrationAttributes> &
   import('@wordpress/blocks').BlockConfiguration<DemoRegistrationAttributes>;
 const registeredBlock: RegisterBlockTypeResult<DemoRegistrationAttributes> =
-  registerBlockType<DemoRegistrationAttributes>('demo/smoke', blockConfiguration);
+  registerScaffoldBlockType<DemoRegistrationAttributes>(
+    'demo/smoke',
+    blockConfiguration,
+  );
 
 void aspectRatio;
 void blockAlignment;

--- a/tests/unit/my-typia-block-reference-app.test.tsx
+++ b/tests/unit/my-typia-block-reference-app.test.tsx
@@ -141,6 +141,11 @@ describe('my-typia-block reference app helpers', () => {
     expect(indexSource).not.toContain('metadata as ScaffoldBlockMetadata');
     expect(indexSource).toContain('parseScaffoldBlockMetadata');
     expect(indexSource).toContain('BlockConfiguration');
+    expect(indexSource).toContain(
+      'registerScaffoldBlockType( registration.name, registration.settings );',
+    );
+    expect(indexSource).not.toContain('registerBlockType<');
+    expect(indexSource).toContain('registerScaffoldBlockType');
   });
 
   test('reference app validator wiring uses the current validator toolkit pattern', () => {

--- a/tests/unit/my-typia-block-reference-app.test.tsx
+++ b/tests/unit/my-typia-block-reference-app.test.tsx
@@ -141,9 +141,9 @@ describe('my-typia-block reference app helpers', () => {
     expect(indexSource).not.toContain('metadata as ScaffoldBlockMetadata');
     expect(indexSource).toContain('parseScaffoldBlockMetadata');
     expect(indexSource).toContain('BlockConfiguration');
-    expect(indexSource).toContain(
-      'registerScaffoldBlockType( registration.name, registration.settings );',
-    );
+    expect(indexSource).toContain('registerScaffoldBlockType(');
+    expect(indexSource).toContain('registration.name');
+    expect(indexSource).toContain('registration.settings');
     expect(indexSource).not.toContain('registerBlockType<');
     expect(indexSource).toContain('registerScaffoldBlockType');
   });

--- a/tests/unit/sync-types.test.ts
+++ b/tests/unit/sync-types.test.ts
@@ -12,9 +12,31 @@ ensureExampleShowcaseSynced();
 
 describe('Type Sync Tests', () => {
 	const exampleDir = getExampleShowcaseDir();
+	const repoRoot = path.resolve(exampleDir, '..', '..');
 	const blockJsonPath = path.join(exampleDir, 'block.json');
 	const manifestPath = path.join(exampleDir, 'typia.manifest.json');
 	const phpValidatorPath = path.join(exampleDir, 'typia-validator.php');
+	let workspacePackagesPrepared = false;
+
+	const ensureExampleWorkspacePackagesBuilt = () => {
+		if (workspacePackagesPrepared) {
+			return;
+		}
+
+		for (const filter of [
+			'@wp-typia/block-types',
+			'@wp-typia/rest',
+			'@wp-typia/api-client',
+			'@wp-typia/block-runtime',
+		]) {
+			execSync(`bun run --filter ${filter} build`, {
+				cwd: repoRoot,
+				stdio: 'inherit',
+			});
+		}
+
+		workspacePackagesPrepared = true;
+	};
 
 	test('should sync types to block.json and generate typia.manifest.json', () => {
 		expect(fs.existsSync(blockJsonPath)).toBe(true);
@@ -73,6 +95,7 @@ describe('Type Sync Tests', () => {
 	test(
 		'should copy typia.manifest.json into the build output',
 		() => {
+			ensureExampleWorkspacePackagesBuilt();
 			execSync('bun run build', { cwd: exampleDir, stdio: 'inherit' });
 
 			const buildManifestPath = findExampleShowcaseBuildArtifact(


### PR DESCRIPTION
## Context

Published `wp-typia@0.16.10` scaffolds still tripped `tsc --noEmit` because generated block registration files were calling `registerBlockType<T>()` against the current published `@wordpress/blocks` type surface. This PR fixes the generated registration path and hardens packed publish-install smoke so the release lane proves the actual tarball combination works before publish.

## What Changed

- added `registerScaffoldBlockType(...)` to `@wp-typia/block-types/blocks/registration` and switched generated basic/interactivity/persistence/compound registration files plus the compound add-child scaffold to use it
- aligned the repo examples/reference sources and scaffold assertions with the new registration shim while keeping typed wrapper imports and add-child wrapper generation intact
- expanded `scripts/run-publish-install-smoke.mjs` to verify wrapper exports, scaffold basic + compound projects through the packed `wp-typia` CLI, install them against packed local tarballs, run compound `add-compound-child`, and finish with `tsc --noEmit`
- taught the generated-project scaffold harness to link workspace runtime package dependencies recursively so compound sync tests do not miss transitive workspace packages
- added a Sampo changeset for `@wp-typia/block-types`, `@wp-typia/project-tools`, and `wp-typia`

## Verification

- `bun run typecheck`
- `bun test tests/unit/my-typia-block-reference-app.test.tsx`
- `bun run --filter @wp-typia/project-tools test:scaffold-core`
- `bun run --filter @wp-typia/project-tools test:compound`
- `bun run test:publish-install-smoke`
- `bun run changesets:validate`
- `bun run runtime-coupling:validate`
- `bun run manifest-policy:validate`

Closes #306


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed published scaffold outputs: generated block registration files no longer conflict with the current WordPress blocks API by removing incompatible generic type parameters.

* **Tests**
  * Hardened smoke tests to validate generated block scaffolds and wrapper exports type-check correctly against packaged releases prior to publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->