### PR TITLE
Refactor built-in block artifact attribute specs

### DIFF
--- a/.sampo/changesets/issue-316-built-in-block-artifacts-refactor.md
+++ b/.sampo/changesets/issue-316-built-in-block-artifacts-refactor.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Refactored the built-in block artifact emitter so template attribute definitions are driven by shared declarative spec tables while preserving the generated `block.json`, `typia.manifest.json`, and TypeScript outputs. Added explicit artifact summary equivalence coverage to guard against refactor-only output drift across the built-in template families.

--- a/packages/wp-typia-project-tools/src/runtime/built-in-block-artifacts.ts
+++ b/packages/wp-typia-project-tools/src/runtime/built-in-block-artifacts.ts
@@ -69,6 +69,49 @@ interface BuiltInAttributeSpec {
 	typeExpression: string;
 }
 
+type BuiltInAttributeValueResolver<TContext, TValue> =
+	| TValue
+	| ((context: TContext) => TValue);
+
+interface BuiltInAttributeTemplateSpec<TContext> {
+	attributeType: "boolean" | "number" | "string";
+	blockJsonDefaultValue?: BuiltInAttributeValueResolver<
+		TContext,
+		JsonValue | undefined
+	>;
+	constraints?: BuiltInAttributeValueResolver<
+		TContext,
+		Partial<ManifestConstraints> | undefined
+	>;
+	defaultValue?: BuiltInAttributeValueResolver<TContext, JsonValue | undefined>;
+	description?: BuiltInAttributeValueResolver<
+		TContext,
+		AttributeDescription | undefined
+	>;
+	enumValues?: BuiltInAttributeValueResolver<
+		TContext,
+		Array<string | number | boolean> | null | undefined
+	>;
+	manifestDefaultValue?: BuiltInAttributeValueResolver<
+		TContext,
+		JsonValue | undefined
+	>;
+	name: string;
+	optional: boolean;
+	selector?: BuiltInAttributeValueResolver<TContext, string | null | undefined>;
+	source?: BuiltInAttributeValueResolver<
+		TContext,
+		WordPressAttributeSource | null | undefined
+	>;
+	typeExpression: BuiltInAttributeValueResolver<TContext, string>;
+}
+
+interface CompoundChildAttributeVariables {
+	bodyPlaceholder: string;
+	childCssClassName?: string | null;
+	childTitle: string;
+}
+
 interface InterfaceMemberDefinition {
 	description?: AttributeDescription;
 	name: string;
@@ -258,6 +301,57 @@ function defineNumberAttribute(
 	});
 }
 
+function resolveBuiltInAttributeValue<TContext, TValue>(
+	value: BuiltInAttributeValueResolver<TContext, TValue> | undefined,
+	context: TContext,
+): TValue | undefined {
+	if (typeof value === "function") {
+		return (value as (context: TContext) => TValue)(context);
+	}
+
+	return value;
+}
+
+function buildAttributesFromSpecs<TContext>(
+	specs: readonly BuiltInAttributeTemplateSpec<TContext>[],
+	context: TContext,
+): EmittedAttributeDefinition[] {
+	return specs.map((spec) => {
+		const resolvedSpec: Omit<BuiltInAttributeSpec, "kind" | "sourceType"> = {
+			blockJsonDefaultValue: resolveBuiltInAttributeValue(
+				spec.blockJsonDefaultValue,
+				context,
+			),
+			constraints: resolveBuiltInAttributeValue(spec.constraints, context),
+			defaultValue: resolveBuiltInAttributeValue(spec.defaultValue, context),
+			description: resolveBuiltInAttributeValue(spec.description, context),
+			enumValues: resolveBuiltInAttributeValue(spec.enumValues, context),
+			manifestDefaultValue: resolveBuiltInAttributeValue(
+				spec.manifestDefaultValue,
+				context,
+			),
+			name: spec.name,
+			optional: spec.optional,
+			selector: resolveBuiltInAttributeValue(spec.selector, context),
+			source: resolveBuiltInAttributeValue(spec.source, context),
+			typeExpression: resolveBuiltInAttributeValue(
+				spec.typeExpression,
+				context,
+			) ?? "unknown",
+		};
+
+		if (spec.attributeType === "boolean") {
+			return defineBooleanAttribute(resolvedSpec);
+		}
+
+		if (spec.attributeType === "number") {
+			return defineNumberAttribute(resolvedSpec);
+		}
+
+		return defineStringAttribute(resolvedSpec);
+	});
+}
+
 function buildManifestDocument(
 	sourceType: string,
 	attributes: readonly EmittedAttributeDefinition[],
@@ -357,278 +451,358 @@ function stringifyBlockJsonDocument(document: Record<string, unknown>): string {
 	return `${JSON.stringify(document, null, "\t")}\n`;
 }
 
+const BASIC_ATTRIBUTE_SPECS = [
+	{
+		attributeType: "string",
+		constraints: {
+			maxLength: 1000,
+		},
+		defaultValue: "",
+		description: describe("Main block content"),
+		name: "content",
+		optional: false,
+		typeExpression: 'string & tags.MaxLength<1000> & tags.Default<"">',
+	},
+	{
+		attributeType: "string",
+		defaultValue: "left",
+		description: describe("Alignment"),
+		enumValues: [...BASIC_ALIGNMENT_VALUES],
+		name: "alignment",
+		optional: true,
+		typeExpression: 'TextAlignment & tags.Default<"left">',
+	},
+	{
+		attributeType: "boolean",
+		defaultValue: true,
+		description: describe("Visibility toggle"),
+		name: "isVisible",
+		optional: true,
+		typeExpression: "boolean & tags.Default<true>",
+	},
+	{
+		attributeType: "string",
+		constraints: {
+			maxLength: 100,
+		},
+		defaultValue: "",
+		description: describe("Custom CSS class"),
+		name: "className",
+		optional: true,
+		typeExpression: 'string & tags.MaxLength<100> & tags.Default<"">',
+	},
+	{
+		attributeType: "string",
+		constraints: {
+			format: "uuid",
+		},
+		description: describe("Generated runtime ID"),
+		name: "id",
+		optional: true,
+		typeExpression: 'string & tags.Format<"uuid">',
+	},
+	{
+		attributeType: "number",
+		constraints: {
+			typeTag: "uint32",
+		},
+		defaultValue: 1,
+		description: describe("Block version for migrations"),
+		name: "schemaVersion",
+		optional: true,
+		typeExpression: 'number & tags.Type<"uint32"> & tags.Default<1>',
+	},
+] as const satisfies readonly BuiltInAttributeTemplateSpec<void>[];
+
+const INTERACTIVITY_ATTRIBUTE_SPECS = [
+	{
+		attributeType: "string",
+		constraints: {
+			maxLength: 1000,
+		},
+		defaultValue: "",
+		name: "content",
+		optional: false,
+		selector: (variables: ScaffoldTemplateVariables) =>
+			`.${variables.cssClassName}__content`,
+		source: "html",
+		typeExpression: 'string & tags.MaxLength<1000> & tags.Default<"">',
+	},
+	{
+		attributeType: "string",
+		defaultValue: "left",
+		enumValues: [...ALIGNMENT_VALUES],
+		name: "alignment",
+		optional: true,
+		typeExpression: 'TextAlignment & tags.Default<"left">',
+	},
+	{
+		attributeType: "boolean",
+		defaultValue: true,
+		name: "isVisible",
+		optional: true,
+		typeExpression: "boolean & tags.Default<true>",
+	},
+	{
+		attributeType: "string",
+		defaultValue: "click",
+		enumValues: [...INTERACTIVE_MODE_VALUES],
+		name: "interactiveMode",
+		optional: true,
+		typeExpression: '("click" | "hover") & tags.Default<"click">',
+	},
+	{
+		attributeType: "string",
+		defaultValue: "none",
+		enumValues: [...ANIMATION_VALUES],
+		name: "animation",
+		optional: true,
+		typeExpression:
+			'("none" | "bounce" | "pulse" | "shake" | "flip") & tags.Default<"none">',
+	},
+	{
+		attributeType: "number",
+		constraints: {
+			minimum: 0,
+			typeTag: "uint32",
+		},
+		defaultValue: 0,
+		name: "clickCount",
+		optional: true,
+		typeExpression: 'number & tags.Minimum<0> & tags.Type<"uint32"> & tags.Default<0>',
+	},
+	{
+		attributeType: "boolean",
+		defaultValue: false,
+		name: "isAnimating",
+		optional: true,
+		typeExpression: "boolean & tags.Default<false>",
+	},
+	{
+		attributeType: "boolean",
+		defaultValue: true,
+		name: "showCounter",
+		optional: true,
+		typeExpression: "boolean & tags.Default<true>",
+	},
+	{
+		attributeType: "number",
+		constraints: {
+			minimum: 0,
+			typeTag: "uint32",
+		},
+		defaultValue: 10,
+		name: "maxClicks",
+		optional: true,
+		typeExpression: 'number & tags.Minimum<0> & tags.Type<"uint32"> & tags.Default<10>',
+	},
+] as const satisfies readonly BuiltInAttributeTemplateSpec<ScaffoldTemplateVariables>[];
+
+const PERSISTENCE_ATTRIBUTE_SPECS = [
+	{
+		attributeType: "string",
+		constraints: {
+			maxLength: 250,
+			minLength: 1,
+		},
+		defaultValue: (variables: ScaffoldTemplateVariables) =>
+			`${variables.title} persistence block`,
+		name: "content",
+		optional: false,
+		selector: (variables: ScaffoldTemplateVariables) =>
+			`.${variables.cssClassName}__content`,
+		source: "html",
+		typeExpression: (variables: ScaffoldTemplateVariables) =>
+			`string & tags.MinLength<1> & tags.MaxLength<250> & tags.Default<${quote(`${variables.title} persistence block`)}>`,
+	},
+	{
+		attributeType: "string",
+		defaultValue: "left",
+		enumValues: [...ALIGNMENT_VALUES],
+		name: "alignment",
+		optional: true,
+		typeExpression: 'TextAlignment & tags.Default<"left">',
+	},
+	{
+		attributeType: "boolean",
+		defaultValue: true,
+		name: "isVisible",
+		optional: true,
+		typeExpression: "boolean & tags.Default<true>",
+	},
+	{
+		attributeType: "boolean",
+		defaultValue: true,
+		name: "showCount",
+		optional: true,
+		typeExpression: "boolean & tags.Default<true>",
+	},
+	{
+		attributeType: "string",
+		constraints: {
+			maxLength: 40,
+			minLength: 1,
+		},
+		defaultValue: "Persist Count",
+		name: "buttonLabel",
+		optional: true,
+		typeExpression:
+			'string & tags.MinLength<1> & tags.MaxLength<40> & tags.Default<"Persist Count">',
+	},
+	{
+		attributeType: "string",
+		blockJsonDefaultValue: "",
+		constraints: {
+			maxLength: 100,
+			minLength: 1,
+		},
+		manifestDefaultValue: "primary",
+		name: "resourceKey",
+		optional: true,
+		typeExpression:
+			'string & tags.MinLength<1> & tags.MaxLength<100> & tags.Default<"primary">',
+	},
+] as const satisfies readonly BuiltInAttributeTemplateSpec<ScaffoldTemplateVariables>[];
+
+const COMPOUND_PARENT_BASE_ATTRIBUTE_SPECS = [
+	{
+		attributeType: "string",
+		constraints: {
+			maxLength: 80,
+			minLength: 1,
+		},
+		defaultValue: (variables: ScaffoldTemplateVariables) => variables.title,
+		name: "heading",
+		optional: false,
+		selector: (variables: ScaffoldTemplateVariables) =>
+			`.${variables.cssClassName}__heading`,
+		source: "html",
+		typeExpression: (variables: ScaffoldTemplateVariables) =>
+			`string & tags.MinLength<1> & tags.MaxLength<80> & tags.Default<${quote(variables.title)}>`,
+	},
+	{
+		attributeType: "string",
+		constraints: {
+			maxLength: 180,
+			minLength: 1,
+		},
+		defaultValue: "Add and reorder internal items inside this compound block.",
+		name: "intro",
+		optional: true,
+		selector: (variables: ScaffoldTemplateVariables) =>
+			`.${variables.cssClassName}__intro`,
+		source: "html",
+		typeExpression:
+			'string & tags.MinLength<1> & tags.MaxLength<180> & tags.Default<"Add and reorder internal items inside this compound block.">',
+	},
+	{
+		attributeType: "boolean",
+		defaultValue: true,
+		name: "showDividers",
+		optional: true,
+		typeExpression: "boolean & tags.Default<true>",
+	},
+] as const satisfies readonly BuiltInAttributeTemplateSpec<ScaffoldTemplateVariables>[];
+
+const COMPOUND_PARENT_PERSISTENCE_ATTRIBUTE_SPECS = [
+	{
+		attributeType: "boolean",
+		defaultValue: true,
+		name: "showCount",
+		optional: true,
+		typeExpression: "boolean & tags.Default<true>",
+	},
+	{
+		attributeType: "string",
+		constraints: {
+			maxLength: 40,
+			minLength: 1,
+		},
+		defaultValue: "Persist Count",
+		name: "buttonLabel",
+		optional: true,
+		typeExpression:
+			'string & tags.MinLength<1> & tags.MaxLength<40> & tags.Default<"Persist Count">',
+	},
+	{
+		attributeType: "string",
+		blockJsonDefaultValue: "",
+		constraints: {
+			maxLength: 100,
+			minLength: 1,
+		},
+		manifestDefaultValue: "primary",
+		name: "resourceKey",
+		optional: true,
+		typeExpression:
+			'string & tags.MinLength<1> & tags.MaxLength<100> & tags.Default<"primary">',
+	},
+] as const satisfies readonly BuiltInAttributeTemplateSpec<ScaffoldTemplateVariables>[];
+
+const COMPOUND_CHILD_ATTRIBUTE_SPECS = [
+	{
+		attributeType: "string",
+		constraints: {
+			maxLength: 80,
+			minLength: 1,
+		},
+		defaultValue: ({ childTitle }: CompoundChildAttributeVariables) => childTitle,
+		name: "title",
+		optional: false,
+		selector: ({ childCssClassName }: CompoundChildAttributeVariables) =>
+			childCssClassName ? `.${childCssClassName}__title` : null,
+		source: ({ childCssClassName }: CompoundChildAttributeVariables) =>
+			childCssClassName ? "html" : null,
+		typeExpression: ({ childTitle }: CompoundChildAttributeVariables) =>
+			`string & tags.MinLength<1> & tags.MaxLength<80> & tags.Default<${quote(childTitle)}>`,
+	},
+	{
+		attributeType: "string",
+		constraints: {
+			maxLength: 280,
+			minLength: 1,
+		},
+		defaultValue: ({ bodyPlaceholder }: CompoundChildAttributeVariables) =>
+			bodyPlaceholder,
+		name: "body",
+		optional: false,
+		selector: ({ childCssClassName }: CompoundChildAttributeVariables) =>
+			childCssClassName ? `.${childCssClassName}__body` : null,
+		source: ({ childCssClassName }: CompoundChildAttributeVariables) =>
+			childCssClassName ? "html" : null,
+		typeExpression: ({ bodyPlaceholder }: CompoundChildAttributeVariables) =>
+			`string & tags.MinLength<1> & tags.MaxLength<280> & tags.Default<${quote(bodyPlaceholder)}>`,
+	},
+] as const satisfies readonly BuiltInAttributeTemplateSpec<CompoundChildAttributeVariables>[];
+
 function buildBasicAttributes(): EmittedAttributeDefinition[] {
-	return [
-		defineStringAttribute({
-			constraints: {
-				maxLength: 1000,
-			},
-			defaultValue: "",
-			description: describe("Main block content"),
-			name: "content",
-			optional: false,
-			typeExpression: 'string & tags.MaxLength<1000> & tags.Default<"">',
-		}),
-		defineStringAttribute({
-			defaultValue: "left",
-			description: describe("Alignment"),
-			enumValues: [...BASIC_ALIGNMENT_VALUES],
-			name: "alignment",
-			optional: true,
-			typeExpression: 'TextAlignment & tags.Default<"left">',
-		}),
-		defineBooleanAttribute({
-			defaultValue: true,
-			description: describe("Visibility toggle"),
-			name: "isVisible",
-			optional: true,
-			typeExpression: "boolean & tags.Default<true>",
-		}),
-		defineStringAttribute({
-			constraints: {
-				maxLength: 100,
-			},
-			defaultValue: "",
-			description: describe("Custom CSS class"),
-			name: "className",
-			optional: true,
-			typeExpression: 'string & tags.MaxLength<100> & tags.Default<"">',
-		}),
-		defineStringAttribute({
-			constraints: {
-				format: "uuid",
-			},
-			description: describe("Generated runtime ID"),
-			name: "id",
-			optional: true,
-			typeExpression: 'string & tags.Format<"uuid">',
-		}),
-		defineNumberAttribute({
-			constraints: {
-				typeTag: "uint32",
-			},
-			defaultValue: 1,
-			description: describe("Block version for migrations"),
-			name: "schemaVersion",
-			optional: true,
-			typeExpression: 'number & tags.Type<"uint32"> & tags.Default<1>',
-		}),
-	];
+	return buildAttributesFromSpecs(BASIC_ATTRIBUTE_SPECS, undefined);
 }
 
 function buildInteractivityAttributes(
 	variables: ScaffoldTemplateVariables,
 ): EmittedAttributeDefinition[] {
-	return [
-		defineStringAttribute({
-			constraints: {
-				maxLength: 1000,
-			},
-			defaultValue: "",
-			name: "content",
-			optional: false,
-			selector: `.${variables.cssClassName}__content`,
-			source: "html",
-			typeExpression: 'string & tags.MaxLength<1000> & tags.Default<"">',
-		}),
-		defineStringAttribute({
-			defaultValue: "left",
-			enumValues: [...ALIGNMENT_VALUES],
-			name: "alignment",
-			optional: true,
-			typeExpression: 'TextAlignment & tags.Default<"left">',
-		}),
-		defineBooleanAttribute({
-			defaultValue: true,
-			name: "isVisible",
-			optional: true,
-			typeExpression: "boolean & tags.Default<true>",
-		}),
-		defineStringAttribute({
-			defaultValue: "click",
-			enumValues: [...INTERACTIVE_MODE_VALUES],
-			name: "interactiveMode",
-			optional: true,
-			typeExpression: '("click" | "hover") & tags.Default<"click">',
-		}),
-		defineStringAttribute({
-			defaultValue: "none",
-			enumValues: [...ANIMATION_VALUES],
-			name: "animation",
-			optional: true,
-			typeExpression:
-				'("none" | "bounce" | "pulse" | "shake" | "flip") & tags.Default<"none">',
-		}),
-		defineNumberAttribute({
-			constraints: {
-				minimum: 0,
-				typeTag: "uint32",
-			},
-			defaultValue: 0,
-			name: "clickCount",
-			optional: true,
-			typeExpression: 'number & tags.Minimum<0> & tags.Type<"uint32"> & tags.Default<0>',
-		}),
-		defineBooleanAttribute({
-			defaultValue: false,
-			name: "isAnimating",
-			optional: true,
-			typeExpression: "boolean & tags.Default<false>",
-		}),
-		defineBooleanAttribute({
-			defaultValue: true,
-			name: "showCounter",
-			optional: true,
-			typeExpression: "boolean & tags.Default<true>",
-		}),
-		defineNumberAttribute({
-			constraints: {
-				minimum: 0,
-				typeTag: "uint32",
-			},
-			defaultValue: 10,
-			name: "maxClicks",
-			optional: true,
-			typeExpression: 'number & tags.Minimum<0> & tags.Type<"uint32"> & tags.Default<10>',
-		}),
-	];
+	return buildAttributesFromSpecs(INTERACTIVITY_ATTRIBUTE_SPECS, variables);
 }
 
 function buildPersistenceAttributes(
 	variables: ScaffoldTemplateVariables,
 ): EmittedAttributeDefinition[] {
-	return [
-		defineStringAttribute({
-			constraints: {
-				maxLength: 250,
-				minLength: 1,
-			},
-			defaultValue: `${variables.title} persistence block`,
-			name: "content",
-			optional: false,
-			selector: `.${variables.cssClassName}__content`,
-			source: "html",
-			typeExpression:
-				`string & tags.MinLength<1> & tags.MaxLength<250> & tags.Default<${quote(`${variables.title} persistence block`)}>`,
-		}),
-		defineStringAttribute({
-			defaultValue: "left",
-			enumValues: [...ALIGNMENT_VALUES],
-			name: "alignment",
-			optional: true,
-			typeExpression: 'TextAlignment & tags.Default<"left">',
-		}),
-		defineBooleanAttribute({
-			defaultValue: true,
-			name: "isVisible",
-			optional: true,
-			typeExpression: "boolean & tags.Default<true>",
-		}),
-		defineBooleanAttribute({
-			defaultValue: true,
-			name: "showCount",
-			optional: true,
-			typeExpression: "boolean & tags.Default<true>",
-		}),
-		defineStringAttribute({
-			constraints: {
-				maxLength: 40,
-				minLength: 1,
-			},
-			defaultValue: "Persist Count",
-			name: "buttonLabel",
-			optional: true,
-			typeExpression:
-				'string & tags.MinLength<1> & tags.MaxLength<40> & tags.Default<"Persist Count">',
-		}),
-		defineStringAttribute({
-			blockJsonDefaultValue: "",
-			constraints: {
-				maxLength: 100,
-				minLength: 1,
-			},
-			manifestDefaultValue: "primary",
-			name: "resourceKey",
-			optional: true,
-			typeExpression:
-				'string & tags.MinLength<1> & tags.MaxLength<100> & tags.Default<"primary">',
-		}),
-	];
+	return buildAttributesFromSpecs(PERSISTENCE_ATTRIBUTE_SPECS, variables);
 }
 
 function buildCompoundParentAttributes(
 	variables: ScaffoldTemplateVariables,
 ): EmittedAttributeDefinition[] {
-	const attributes: EmittedAttributeDefinition[] = [
-		defineStringAttribute({
-			constraints: {
-				maxLength: 80,
-				minLength: 1,
-			},
-			defaultValue: variables.title,
-			name: "heading",
-			optional: false,
-			selector: `.${variables.cssClassName}__heading`,
-			source: "html",
-			typeExpression:
-				`string & tags.MinLength<1> & tags.MaxLength<80> & tags.Default<${quote(variables.title)}>`,
-		}),
-		defineStringAttribute({
-			constraints: {
-				maxLength: 180,
-				minLength: 1,
-			},
-			defaultValue: "Add and reorder internal items inside this compound block.",
-			name: "intro",
-			optional: true,
-			selector: `.${variables.cssClassName}__intro`,
-			source: "html",
-			typeExpression:
-				'string & tags.MinLength<1> & tags.MaxLength<180> & tags.Default<"Add and reorder internal items inside this compound block.">',
-		}),
-		defineBooleanAttribute({
-			defaultValue: true,
-			name: "showDividers",
-			optional: true,
-			typeExpression: "boolean & tags.Default<true>",
-		}),
-	];
-
-	if (variables.compoundPersistenceEnabled === "true") {
-		attributes.push(
-			defineBooleanAttribute({
-				defaultValue: true,
-				name: "showCount",
-				optional: true,
-				typeExpression: "boolean & tags.Default<true>",
-			}),
-			defineStringAttribute({
-				constraints: {
-					maxLength: 40,
-					minLength: 1,
-				},
-				defaultValue: "Persist Count",
-				name: "buttonLabel",
-				optional: true,
-				typeExpression:
-					'string & tags.MinLength<1> & tags.MaxLength<40> & tags.Default<"Persist Count">',
-			}),
-			defineStringAttribute({
-				blockJsonDefaultValue: "",
-				constraints: {
-					maxLength: 100,
-					minLength: 1,
-				},
-				manifestDefaultValue: "primary",
-				name: "resourceKey",
-				optional: true,
-				typeExpression:
-					'string & tags.MinLength<1> & tags.MaxLength<100> & tags.Default<"primary">',
-			}),
-		);
-	}
-
-	return attributes;
+	return buildAttributesFromSpecs(
+		variables.compoundPersistenceEnabled === "true"
+			? [
+				...COMPOUND_PARENT_BASE_ATTRIBUTE_SPECS,
+				...COMPOUND_PARENT_PERSISTENCE_ATTRIBUTE_SPECS,
+			]
+			: COMPOUND_PARENT_BASE_ATTRIBUTE_SPECS,
+		variables,
+	);
 }
 
 function buildCompoundChildAttributes(
@@ -636,41 +810,11 @@ function buildCompoundChildAttributes(
 	childTitle: string,
 	childCssClassName?: string | null,
 ): EmittedAttributeDefinition[] {
-	const titleSelector = childCssClassName
-		? `.${childCssClassName}__title`
-		: null;
-	const bodySelector = childCssClassName
-		? `.${childCssClassName}__body`
-		: null;
-
-	return [
-		defineStringAttribute({
-			constraints: {
-				maxLength: 80,
-				minLength: 1,
-			},
-			defaultValue: childTitle,
-			name: "title",
-			optional: false,
-			selector: titleSelector,
-			source: titleSelector ? "html" : null,
-			typeExpression:
-				`string & tags.MinLength<1> & tags.MaxLength<80> & tags.Default<${quote(childTitle)}>`,
-		}),
-		defineStringAttribute({
-			constraints: {
-				maxLength: 280,
-				minLength: 1,
-			},
-			defaultValue: bodyPlaceholder,
-			name: "body",
-			optional: false,
-			selector: bodySelector,
-			source: bodySelector ? "html" : null,
-			typeExpression:
-				`string & tags.MinLength<1> & tags.MaxLength<280> & tags.Default<${quote(bodyPlaceholder)}>`,
-		}),
-	];
+	return buildAttributesFromSpecs(COMPOUND_CHILD_ATTRIBUTE_SPECS, {
+		bodyPlaceholder,
+		childCssClassName,
+		childTitle,
+	});
 }
 
 function buildBasicTypesSource(

--- a/packages/wp-typia-project-tools/tests/built-in-block-artifacts.test.ts
+++ b/packages/wp-typia-project-tools/tests/built-in-block-artifacts.test.ts
@@ -74,6 +74,476 @@ function buildArtifacts(templateId: BuiltInTemplateId) {
   };
 }
 
+function summarizeArtifactAttributes(
+  artifact: ReturnType<typeof buildArtifacts>['artifacts'][number],
+) {
+  const blockJsonAttributes =
+    (artifact.blockJsonDocument.attributes as
+      | Record<string, Record<string, unknown>>
+      | undefined) ?? {};
+  const manifestAttributes = artifact.manifestDocument.attributes ?? {};
+
+  return {
+    attributes: Object.fromEntries(
+      Object.keys(blockJsonAttributes).map((name) => [
+        name,
+        {
+          blockJson: blockJsonAttributes[name],
+          manifest: {
+            defaultValue: manifestAttributes[name]?.typia.defaultValue ?? null,
+            required: manifestAttributes[name]?.ts.required ?? null,
+            selector: manifestAttributes[name]?.wp.selector ?? null,
+            source: manifestAttributes[name]?.wp.source ?? null,
+            type: manifestAttributes[name]?.wp.type ?? null,
+          },
+        },
+      ]),
+    ),
+    relativeDir: artifact.relativeDir,
+    sourceType: artifact.manifestDocument.sourceType,
+  };
+}
+
+type ArtifactAttributeSummary = ReturnType<typeof summarizeArtifactAttributes>;
+
+const EXPECTED_ARTIFACT_ATTRIBUTE_SUMMARIES: Record<
+  BuiltInTemplateId,
+  ArtifactAttributeSummary[]
+> = {
+  basic: [
+    {
+      attributes: {
+        alignment: {
+          blockJson: {
+            default: 'left',
+            enum: ['left', 'center', 'right', 'justify'],
+            type: 'string',
+          },
+          manifest: {
+            defaultValue: 'left',
+            required: false,
+            selector: null,
+            source: null,
+            type: 'string',
+          },
+        },
+        className: {
+          blockJson: {
+            default: '',
+            type: 'string',
+          },
+          manifest: {
+            defaultValue: '',
+            required: false,
+            selector: null,
+            source: null,
+            type: 'string',
+          },
+        },
+        content: {
+          blockJson: {
+            default: '',
+            type: 'string',
+          },
+          manifest: {
+            defaultValue: '',
+            required: true,
+            selector: null,
+            source: null,
+            type: 'string',
+          },
+        },
+        id: {
+          blockJson: {
+            type: 'string',
+          },
+          manifest: {
+            defaultValue: null,
+            required: false,
+            selector: null,
+            source: null,
+            type: 'string',
+          },
+        },
+        isVisible: {
+          blockJson: {
+            default: true,
+            type: 'boolean',
+          },
+          manifest: {
+            defaultValue: true,
+            required: false,
+            selector: null,
+            source: null,
+            type: 'boolean',
+          },
+        },
+        schemaVersion: {
+          blockJson: {
+            default: 1,
+            type: 'number',
+          },
+          manifest: {
+            defaultValue: 1,
+            required: false,
+            selector: null,
+            source: null,
+            type: 'number',
+          },
+        },
+      },
+      relativeDir: 'src',
+      sourceType: 'DemoBasicAttributes',
+    },
+  ],
+  compound: [
+    {
+      attributes: {
+        buttonLabel: {
+          blockJson: {
+            default: 'Persist Count',
+            type: 'string',
+          },
+          manifest: {
+            defaultValue: 'Persist Count',
+            required: false,
+            selector: null,
+            source: null,
+            type: 'string',
+          },
+        },
+        heading: {
+          blockJson: {
+            default: 'Demo Compound',
+            selector: '.wp-block-demo-space-demo-compound__heading',
+            source: 'html',
+            type: 'string',
+          },
+          manifest: {
+            defaultValue: 'Demo Compound',
+            required: true,
+            selector: '.wp-block-demo-space-demo-compound__heading',
+            source: 'html',
+            type: 'string',
+          },
+        },
+        intro: {
+          blockJson: {
+            default: 'Add and reorder internal items inside this compound block.',
+            selector: '.wp-block-demo-space-demo-compound__intro',
+            source: 'html',
+            type: 'string',
+          },
+          manifest: {
+            defaultValue:
+              'Add and reorder internal items inside this compound block.',
+            required: false,
+            selector: '.wp-block-demo-space-demo-compound__intro',
+            source: 'html',
+            type: 'string',
+          },
+        },
+        resourceKey: {
+          blockJson: {
+            default: '',
+            type: 'string',
+          },
+          manifest: {
+            defaultValue: 'primary',
+            required: false,
+            selector: null,
+            source: null,
+            type: 'string',
+          },
+        },
+        showCount: {
+          blockJson: {
+            default: true,
+            type: 'boolean',
+          },
+          manifest: {
+            defaultValue: true,
+            required: false,
+            selector: null,
+            source: null,
+            type: 'boolean',
+          },
+        },
+        showDividers: {
+          blockJson: {
+            default: true,
+            type: 'boolean',
+          },
+          manifest: {
+            defaultValue: true,
+            required: false,
+            selector: null,
+            source: null,
+            type: 'boolean',
+          },
+        },
+      },
+      relativeDir: 'src/blocks/demo-compound',
+      sourceType: 'DemoCompoundAttributes',
+    },
+    {
+      attributes: {
+        body: {
+          blockJson: {
+            default: 'Add supporting details for this internal item.',
+            selector: '.wp-block-demo-space-demo-compound-item__body',
+            source: 'html',
+            type: 'string',
+          },
+          manifest: {
+            defaultValue: 'Add supporting details for this internal item.',
+            required: true,
+            selector: '.wp-block-demo-space-demo-compound-item__body',
+            source: 'html',
+            type: 'string',
+          },
+        },
+        title: {
+          blockJson: {
+            default: 'Demo Compound Item',
+            selector: '.wp-block-demo-space-demo-compound-item__title',
+            source: 'html',
+            type: 'string',
+          },
+          manifest: {
+            defaultValue: 'Demo Compound Item',
+            required: true,
+            selector: '.wp-block-demo-space-demo-compound-item__title',
+            source: 'html',
+            type: 'string',
+          },
+        },
+      },
+      relativeDir: 'src/blocks/demo-compound-item',
+      sourceType: 'DemoCompoundItemAttributes',
+    },
+  ],
+  interactivity: [
+    {
+      attributes: {
+        alignment: {
+          blockJson: {
+            default: 'left',
+            enum: ['left', 'center', 'right'],
+            type: 'string',
+          },
+          manifest: {
+            defaultValue: 'left',
+            required: false,
+            selector: null,
+            source: null,
+            type: 'string',
+          },
+        },
+        animation: {
+          blockJson: {
+            default: 'none',
+            enum: ['none', 'bounce', 'pulse', 'shake', 'flip'],
+            type: 'string',
+          },
+          manifest: {
+            defaultValue: 'none',
+            required: false,
+            selector: null,
+            source: null,
+            type: 'string',
+          },
+        },
+        clickCount: {
+          blockJson: {
+            default: 0,
+            type: 'number',
+          },
+          manifest: {
+            defaultValue: 0,
+            required: false,
+            selector: null,
+            source: null,
+            type: 'number',
+          },
+        },
+        content: {
+          blockJson: {
+            default: '',
+            selector: '.wp-block-demo-space-demo-interactivity__content',
+            source: 'html',
+            type: 'string',
+          },
+          manifest: {
+            defaultValue: '',
+            required: true,
+            selector: '.wp-block-demo-space-demo-interactivity__content',
+            source: 'html',
+            type: 'string',
+          },
+        },
+        interactiveMode: {
+          blockJson: {
+            default: 'click',
+            enum: ['click', 'hover'],
+            type: 'string',
+          },
+          manifest: {
+            defaultValue: 'click',
+            required: false,
+            selector: null,
+            source: null,
+            type: 'string',
+          },
+        },
+        isAnimating: {
+          blockJson: {
+            default: false,
+            type: 'boolean',
+          },
+          manifest: {
+            defaultValue: false,
+            required: false,
+            selector: null,
+            source: null,
+            type: 'boolean',
+          },
+        },
+        isVisible: {
+          blockJson: {
+            default: true,
+            type: 'boolean',
+          },
+          manifest: {
+            defaultValue: true,
+            required: false,
+            selector: null,
+            source: null,
+            type: 'boolean',
+          },
+        },
+        maxClicks: {
+          blockJson: {
+            default: 10,
+            type: 'number',
+          },
+          manifest: {
+            defaultValue: 10,
+            required: false,
+            selector: null,
+            source: null,
+            type: 'number',
+          },
+        },
+        showCounter: {
+          blockJson: {
+            default: true,
+            type: 'boolean',
+          },
+          manifest: {
+            defaultValue: true,
+            required: false,
+            selector: null,
+            source: null,
+            type: 'boolean',
+          },
+        },
+      },
+      relativeDir: 'src',
+      sourceType: 'DemoInteractivityAttributes',
+    },
+  ],
+  persistence: [
+    {
+      attributes: {
+        alignment: {
+          blockJson: {
+            default: 'left',
+            enum: ['left', 'center', 'right'],
+            type: 'string',
+          },
+          manifest: {
+            defaultValue: 'left',
+            required: false,
+            selector: null,
+            source: null,
+            type: 'string',
+          },
+        },
+        buttonLabel: {
+          blockJson: {
+            default: 'Persist Count',
+            type: 'string',
+          },
+          manifest: {
+            defaultValue: 'Persist Count',
+            required: false,
+            selector: null,
+            source: null,
+            type: 'string',
+          },
+        },
+        content: {
+          blockJson: {
+            default: 'Demo Persistence persistence block',
+            selector: '.wp-block-demo-space-demo-persistence__content',
+            source: 'html',
+            type: 'string',
+          },
+          manifest: {
+            defaultValue: 'Demo Persistence persistence block',
+            required: true,
+            selector: '.wp-block-demo-space-demo-persistence__content',
+            source: 'html',
+            type: 'string',
+          },
+        },
+        isVisible: {
+          blockJson: {
+            default: true,
+            type: 'boolean',
+          },
+          manifest: {
+            defaultValue: true,
+            required: false,
+            selector: null,
+            source: null,
+            type: 'boolean',
+          },
+        },
+        resourceKey: {
+          blockJson: {
+            default: '',
+            type: 'string',
+          },
+          manifest: {
+            defaultValue: 'primary',
+            required: false,
+            selector: null,
+            source: null,
+            type: 'string',
+          },
+        },
+        showCount: {
+          blockJson: {
+            default: true,
+            type: 'boolean',
+          },
+          manifest: {
+            defaultValue: true,
+            required: false,
+            selector: null,
+            source: null,
+            type: 'boolean',
+          },
+        },
+      },
+      relativeDir: 'src',
+      sourceType: 'DemoPersistenceAttributes',
+    },
+  ],
+};
+
 describe('built-in block artifacts', () => {
   const tempRoot = createScaffoldTempRoot('wp-typia-built-in-artifacts-');
 
@@ -276,6 +746,17 @@ describe('built-in block artifacts', () => {
         );
         expect(parentResourceKeyBlockJson?.default).toBe('');
       }
+    },
+  );
+
+  test.each(['basic', 'interactivity', 'persistence', 'compound'] as const)(
+    'attribute emission summaries stay stable for %s',
+    (templateId) => {
+      const { artifacts } = buildArtifacts(templateId);
+
+      expect(artifacts.map(summarizeArtifactAttributes)).toEqual(
+        EXPECTED_ARTIFACT_ATTRIBUTE_SUMMARIES[templateId],
+      );
     },
   );
 


### PR DESCRIPTION
## Context

`built-in-block-artifacts.ts` had grown into a cluster of large per-template attribute builder functions. This PR moves those built-in attribute definitions into shared declarative spec tables while keeping the generated `block.json`, `typia.manifest.json`, and TypeScript outputs unchanged.

## What Changed

- introduced shared attribute-spec resolver helpers so built-in template families can express attribute metadata as declarative tables plus small dynamic callbacks
- rewired the basic, interactivity, persistence, compound parent, and compound child attribute builders to resolve through those spec tables instead of hand-building each emitted attribute inline
- added explicit attribute-summary equivalence coverage in `built-in-block-artifacts.test.ts` so refactor-only output drift is caught independently of the implementation structure
- added a Sampo changeset for `@wp-typia/project-tools`

## Verification

- `bun test packages/wp-typia-project-tools/tests/built-in-block-artifacts.test.ts`
- `bun run --filter @wp-typia/project-tools test:scaffold-core`
- `bun run --filter @wp-typia/project-tools test:compound`
- `bun run typecheck`
- `bun run changesets:validate`

Closes #316


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored internal attribute generation system to use parameterized templates and shared declarative resolver patterns, improving code organization and maintainability while maintaining complete backward compatibility with existing output.

* **Tests**
  * Added comprehensive artifact equivalence test coverage to verify output consistency and correctness across all built-in template families, preventing unintended output changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->