### PR TITLE
Clarify @wp-typia/rest subpath exports and tighten hook typing

### DIFF
--- a/.sampo/changesets/issue-311-rest-subpath-exports.md
+++ b/.sampo/changesets/issue-311-rest-subpath-exports.md
@@ -1,0 +1,7 @@
+---
+npm/@wp-typia/rest: patch
+---
+
+Clarify the focused `@wp-typia/rest/client` and `@wp-typia/rest/http`
+subpath surfaces, route those exports to their dedicated build outputs, and
+isolate the remaining generic fallback casts inside the React cache helpers.

--- a/docs/API.md
+++ b/docs/API.md
@@ -253,13 +253,13 @@ nonce-aware request wiring.
 Export semantics:
 
 - `@wp-typia/rest` is the canonical convenience surface
-- `@wp-typia/rest/client` is a backward-compatible alias, not a distinct
-  semantic contract
-- `@wp-typia/rest/http` is currently a backward-compatible alias of the root
-  surface, not a distinct decoder-only contract
+- `@wp-typia/rest/client` is the focused transport/runtime surface
+- `@wp-typia/rest/http` is the focused decoder surface
 - `@wp-typia/rest/react` is the React cache/hook layer
 
-The root package stays transport-only. React/data helpers live under the
+The root package stays the convenience entry that combines transport and
+decoder helpers. Reach for `./client` or `./http` when that narrower boundary
+helps readability, while React/data helpers continue to live under the
 separate `@wp-typia/rest/react` subpath:
 
 - `createEndpointDataClient()`

--- a/docs/error-export-contracts.md
+++ b/docs/error-export-contracts.md
@@ -97,30 +97,26 @@ These subpaths are semantically distinct and should remain documented that way.
   Canonical convenience surface. It intentionally combines the transport helper
   layer and the HTTP decoder helpers.
 - `@wp-typia/rest/client`
-  Compatibility alias of the root surface. It is public, but it is not a
-  distinct semantic contract.
+  Focused transport/runtime surface for endpoint creation, validated fetch
+  helpers, route resolution, validation helpers, and named runtime errors.
 - `@wp-typia/rest/http`
-  Compatibility alias of the root surface. It remains available for historical
-  imports, but it is not yet a distinct decoder-only contract in the current
-  major line.
+  Focused decoder surface for query/header/parameter decoders plus the shared
+  validation helper utilities they return.
 - `@wp-typia/rest/react`
   React cache and hook surface.
 
 Implications:
 
-- prefer `@wp-typia/rest` for transport-oriented imports
-- treat `@wp-typia/rest/http` as compatibility-only until a future major
-  release can safely narrow it
+- prefer `@wp-typia/rest` when convenience matters more than import granularity
+- prefer `@wp-typia/rest/client` when you want the transport boundary to stay
+  explicit
+- prefer `@wp-typia/rest/http` for decoder-only imports
 - prefer `@wp-typia/rest/react` for hook imports
-- treat `@wp-typia/rest/client` as compatibility-only, not as the recommended
-  canonical import
 
 ## Future direction
 
 Future work may:
 
 - expand named public runtime error classes into more subsystems
-- remove compatibility aliases such as `@wp-typia/rest/client` in a major
-  release if downstream usage is low enough
 - keep tightening docs/tests so export semantics and catch-worthy error
   contracts remain explicit instead of ad hoc

--- a/docs/runtime-import-policy.md
+++ b/docs/runtime-import-policy.md
@@ -16,11 +16,11 @@ surfaces.
 - `@wp-typia/rest`
   Canonical WordPress REST runtime surface.
 - `@wp-typia/rest/client`
-  Compatibility alias of the root `@wp-typia/rest` surface, not a distinct
-  semantic contract.
+  Focused transport/runtime surface for validated fetch helpers, endpoint
+  callers, route resolution, validation helpers, and named runtime errors.
 - `@wp-typia/rest/http`
-  Compatibility alias of the root `@wp-typia/rest` surface in the current
-  major line. It is not yet a distinct decoder-only contract.
+  Focused decoder surface for query/header/parameter decoders plus shared
+  validation helper utilities.
 - `@wp-typia/rest/react`
   React cache and hook surface.
 - `@wp-typia/project-tools`

--- a/docs/runtime-surface.md
+++ b/docs/runtime-surface.md
@@ -68,8 +68,9 @@ This document is descriptive, not normative. For support guarantees, see
   (`WpTypiaContractError`, `WpTypiaValidationAssertionError`).
 - `@wp-typia/rest` owns WordPress-specific route discovery, `apiFetch`
   integration, decoder helpers, and the React cache/hook layer. The root
-  surface is canonical, `./client` and `./http` are compatibility-only aliases
-  in the current major line, and `./react` owns hooks.
+  surface is the canonical convenience entry, `./client` is the focused
+  transport/runtime entry, `./http` is the focused decoder entry, and `./react`
+  owns hooks.
 - `wp-typia` owns the CLI, help, TUI, completions, skills, MCP, and bin entry.
 - `@wp-typia/project-tools` owns scaffold, add-block, migrate, template,
   doctor, package-manager, starter-manifest, the typed generator boundary, the

--- a/packages/wp-typia-rest/README.md
+++ b/packages/wp-typia-rest/README.md
@@ -18,19 +18,21 @@ resolution, use `@wp-typia/api-client`.
 ## Export contract
 
 - `@wp-typia/rest`
-  Canonical convenience surface for transport helpers plus HTTP decoder helpers.
+  Canonical convenience surface. It intentionally combines the transport helper
+  layer and the HTTP decoder helpers.
 - `@wp-typia/rest/client`
-  Backward-compatible alias of the root surface. It is not a distinct semantic
-  contract and may be removed in a future major once downstream imports settle.
+  Focused transport surface for endpoint creation, validated fetch helpers,
+  WordPress REST route resolution, validation utilities, and named runtime
+  errors.
 - `@wp-typia/rest/http`
-  Backward-compatible alias of the root surface. It remains publishable for
-  existing imports, but it is not a distinct decoder-only contract in the
-  current major line.
+  Focused decoder surface for query/header/parameter decoders plus the shared
+  validation helper utilities they return.
 - `@wp-typia/rest/react`
   React-only cache and hook layer.
 
-The root `@wp-typia/rest` entry stays transport-oriented. If you want query and
-mutation hooks on top of those WordPress helpers, use the React-only subpath:
+Prefer the root entry when you want the shortest import path. Reach for
+`./client` or `./http` when a narrower surface makes the consumer boundary
+clearer. Query and mutation hooks still live on the React-only subpath:
 
 ```ts
 import { useEndpointMutation, useEndpointQuery } from '@wp-typia/rest/react';
@@ -69,7 +71,7 @@ are reserved for public runtime misconfiguration or assertion APIs:
 If you need a canonical REST URL for a route path, use:
 
 ```ts
-import { resolveRestRouteUrl } from '@wp-typia/rest';
+import { resolveRestRouteUrl } from '@wp-typia/rest/client';
 
 const url = resolveRestRouteUrl('/my-namespace/v1/demo');
 ```
@@ -78,7 +80,7 @@ If you want Typia-powered HTTP decoding, compile the decoder in the consumer pro
 
 ```ts
 import typia from 'typia';
-import { createQueryDecoder } from '@wp-typia/rest';
+import { createQueryDecoder } from '@wp-typia/rest/http';
 
 const decodeQuery = createQueryDecoder(
   typia.http.createValidateQuery<MyQuery>(),

--- a/packages/wp-typia-rest/package.json
+++ b/packages/wp-typia-rest/package.json
@@ -12,14 +12,14 @@
       "default": "./dist/index.js"
     },
     "./client": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "default": "./dist/index.js"
+      "types": "./dist/client.d.ts",
+      "import": "./dist/client.js",
+      "default": "./dist/client.js"
     },
     "./http": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "default": "./dist/index.js"
+      "types": "./dist/http.d.ts",
+      "import": "./dist/http.js",
+      "default": "./dist/http.js"
     },
     "./react": {
       "types": "./dist/react.d.ts",

--- a/packages/wp-typia-rest/scripts/fix-dist-imports.mjs
+++ b/packages/wp-typia-rest/scripts/fix-dist-imports.mjs
@@ -1,34 +1,44 @@
-import { readFileSync, writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from 'node:fs';
 
-const distDir = new URL("../dist/", import.meta.url);
+const distDir = new URL('../dist/', import.meta.url);
 
 for (const relativeFile of [
-	"index.js",
-	"client.js",
-	"http.js",
-	"react.js",
-	"index.d.ts",
-	"client.d.ts",
-	"http.d.ts",
-	"react.d.ts",
-	"internal/runtime-primitives.js",
-	"internal/runtime-primitives.d.ts",
+  'index.js',
+  'client.js',
+  'http.js',
+  'react.js',
+  'index.d.ts',
+  'client.d.ts',
+  'http.d.ts',
+  'react.d.ts',
+  'internal/runtime-primitives.js',
+  'internal/runtime-primitives.d.ts',
 ]) {
-	const fileUrl = new URL(relativeFile, distDir);
-	const source = readFileSync(fileUrl, "utf8");
-	const next = source
-		.replaceAll('from "./client"', 'from "./client.js"')
-		.replaceAll('from "./http"', 'from "./http.js"')
-		.replaceAll(
-			'from "../../../wp-typia-api-client/dist/runtime-primitives.js"',
-			'from "@wp-typia/api-client/runtime-primitives"',
-		)
-		.replaceAll(
-			'from "../../wp-typia-api-client/dist/client-utils.js"',
-			'from "@wp-typia/api-client/client-utils"',
-		);
+  const fileUrl = new URL(relativeFile, distDir);
+  const source = readFileSync(fileUrl, 'utf8');
+  const next = source
+    .replaceAll('from "./client"', 'from "./client.js"')
+    .replaceAll("from './client'", "from './client.js'")
+    .replaceAll('from "./http"', 'from "./http.js"')
+    .replaceAll("from './http'", "from './http.js'")
+    .replaceAll(
+      'from "../../../wp-typia-api-client/dist/runtime-primitives.js"',
+      'from "@wp-typia/api-client/runtime-primitives"',
+    )
+    .replaceAll(
+      "from '../../../wp-typia-api-client/dist/runtime-primitives.js'",
+      "from '@wp-typia/api-client/runtime-primitives'",
+    )
+    .replaceAll(
+      'from "../../wp-typia-api-client/dist/client-utils.js"',
+      'from "@wp-typia/api-client/client-utils"',
+    )
+    .replaceAll(
+      "from '../../wp-typia-api-client/dist/client-utils.js'",
+      "from '@wp-typia/api-client/client-utils'",
+    );
 
-	if (next !== source) {
-		writeFileSync(fileUrl, next);
-	}
+  if (next !== source) {
+    writeFileSync(fileUrl, next);
+  }
 }

--- a/packages/wp-typia-rest/src/client.ts
+++ b/packages/wp-typia-rest/src/client.ts
@@ -25,6 +25,14 @@ import {
 
 export type { ValidationError, ValidationLike, ValidationResult } from "./internal/runtime-primitives.js";
 export { isValidationResult, normalizeValidationError, toValidationResult } from "./internal/runtime-primitives.js";
+export {
+	ApiClientConfigurationError,
+	RestConfigurationError,
+	RestRootResolutionError,
+	RestValidationAssertionError,
+	WpTypiaContractError,
+	WpTypiaValidationAssertionError,
+} from "./errors.js";
 export type {
 	EndpointRequestValidationResult,
 	EndpointResponseValidationResult,

--- a/packages/wp-typia-rest/src/http.ts
+++ b/packages/wp-typia-rest/src/http.ts
@@ -1,10 +1,16 @@
 import type { IValidation } from "@typia/interface";
 
 import {
+	isValidationResult,
+	normalizeValidationError,
 	toValidationResult,
+	type ValidationError,
 	type ValidationLike,
 	type ValidationResult,
 } from "./client";
+
+export type { ValidationError, ValidationLike, ValidationResult } from "./client";
+export { isValidationResult, normalizeValidationError, toValidationResult } from "./client";
 
 function toHeadersRecord(input: unknown): Record<string, string | string[] | undefined> {
 	if (input instanceof Headers) {

--- a/packages/wp-typia-rest/src/http.ts
+++ b/packages/wp-typia-rest/src/http.ts
@@ -7,10 +7,18 @@ import {
 	type ValidationError,
 	type ValidationLike,
 	type ValidationResult,
-} from "./client";
+} from "./internal/runtime-primitives.js";
 
-export type { ValidationError, ValidationLike, ValidationResult } from "./client";
-export { isValidationResult, normalizeValidationError, toValidationResult } from "./client";
+export type {
+	ValidationError,
+	ValidationLike,
+	ValidationResult,
+} from "./internal/runtime-primitives.js";
+export {
+	isValidationResult,
+	normalizeValidationError,
+	toValidationResult,
+} from "./internal/runtime-primitives.js";
 
 function toHeadersRecord(input: unknown): Record<string, string | string[] | undefined> {
 	if (input instanceof Headers) {

--- a/packages/wp-typia-rest/src/react.ts
+++ b/packages/wp-typia-rest/src/react.ts
@@ -23,6 +23,7 @@ import { RestQueryHookUsageError } from "./errors.js";
 import { isPlainObject } from "./internal/runtime-primitives.js";
 
 type CacheKey = string;
+type AnyEndpointValidationResult = EndpointValidationResult<unknown, unknown>;
 
 interface EndpointDataSnapshot {
 	data: unknown;
@@ -30,12 +31,12 @@ interface EndpointDataSnapshot {
 	invalidatedAt: number;
 	isFetching: boolean;
 	updatedAt: number;
-	validation: EndpointValidationResult<unknown, unknown> | null;
+	validation: AnyEndpointValidationResult | null;
 }
 
 type EndpointDataListener = () => void;
 type EndpointDataUpdater<T> = T | ((current: T | undefined) => T | undefined);
-type QueryRefetcher = () => Promise<EndpointValidationResult<unknown, unknown>>;
+type QueryRefetcher = () => Promise<AnyEndpointValidationResult>;
 
 interface EndpointDataCacheEntry {
 	data: unknown;
@@ -43,11 +44,11 @@ interface EndpointDataCacheEntry {
 	invalidatedAt: number;
 	isFetching: boolean;
 	listeners: Set<EndpointDataListener>;
-	promise: Promise<EndpointValidationResult<unknown, unknown>> | null;
+	promise: Promise<AnyEndpointValidationResult> | null;
 	refetchers: Set<QueryRefetcher>;
 	snapshot: EndpointDataSnapshot;
 	updatedAt: number;
-	validation: EndpointValidationResult<unknown, unknown> | null;
+	validation: AnyEndpointValidationResult | null;
 }
 
 export interface EndpointDataClient {
@@ -166,7 +167,7 @@ export interface UseEndpointMutationResult<Req, Res> {
 }
 
 export interface EndpointDataProviderProps {
-	children?: unknown;
+	children?: Parameters<typeof createElement>[2];
 	client: EndpointDataClient;
 }
 
@@ -338,6 +339,31 @@ function asInternalClient(client: EndpointDataClient): InternalEndpointDataClien
 	return client as InternalEndpointDataClient;
 }
 
+function castEndpointValidationResult<Req, Res>(
+	validation: AnyEndpointValidationResult,
+): EndpointValidationResult<Req, Res> {
+	return validation as EndpointValidationResult<Req, Res>;
+}
+
+function castEndpointValidationPromise<Req, Res>(
+	promise: Promise<AnyEndpointValidationResult>,
+): Promise<EndpointValidationResult<Req, Res>> {
+	return promise as Promise<EndpointValidationResult<Req, Res>>;
+}
+
+function selectEndpointData<Res, Selected>(
+	data: Res | undefined,
+	select?: (data: Res) => Selected,
+): Selected {
+	if (select) {
+		return select(data as Res);
+	}
+
+	// The default selector is identity, but TypeScript cannot express that when
+	// Selected is an unconstrained generic chosen by the caller.
+	return data as unknown as Selected;
+}
+
 function isInvalidValidationResult<Req>(
 	validation: ValidationResult<Req>,
 ): validation is ValidationResult<Req> & { isValid: false } {
@@ -385,11 +411,11 @@ export function createEndpointDataClient(): EndpointDataClient {
 					return;
 				}
 
-					entry.invalidatedAt = Date.now();
-					syncSnapshot(entry);
-					notify(cacheKey);
-					return;
-				}
+				entry.invalidatedAt = Date.now();
+				syncSnapshot(entry);
+				notify(cacheKey);
+				return;
+			}
 
 			const prefix = createEndpointPrefix(endpoint);
 			for (const [cacheKey, entry] of entries.entries()) {
@@ -397,10 +423,10 @@ export function createEndpointDataClient(): EndpointDataClient {
 					continue;
 				}
 
-					entry.invalidatedAt = Date.now();
-					syncSnapshot(entry);
-					notify(cacheKey);
-				}
+				entry.invalidatedAt = Date.now();
+				syncSnapshot(entry);
+				notify(cacheKey);
+			}
 		},
 		async refetch(endpoint, request) {
 			const callbacks = new Set<QueryRefetcher>();
@@ -423,10 +449,10 @@ export function createEndpointDataClient(): EndpointDataClient {
 
 			await Promise.all([...callbacks].map((refetcher) => refetcher()));
 		},
-			getData(endpoint, request) {
-				const { cacheKey } = createCacheKey(endpoint, request);
-				return entries.get(cacheKey)?.data as any;
-			},
+		getData<Req, Res>(endpoint: ApiEndpoint<Req, Res>, request: Req) {
+			const { cacheKey } = createCacheKey(endpoint, request);
+			return entries.get(cacheKey)?.data as Res | undefined;
+		},
 		setData(endpoint, request, next) {
 			const { cacheKey } = createCacheKey(endpoint, request);
 			const entry = getOrCreateEntry(entries, cacheKey);
@@ -438,35 +464,35 @@ export function createEndpointDataClient(): EndpointDataClient {
 			entry.data = resolvedNext;
 			entry.error = null;
 			entry.updatedAt = Date.now();
-				entry.validation = toEndpointResponseValidationResult({
-					data: resolvedNext,
-					errors: [],
-					isValid: true,
-				});
-				syncSnapshot(entry);
-				notify(cacheKey);
-			},
-			__getSnapshot(cacheKey) {
-				const entry = entries.get(cacheKey);
-				if (!entry) {
-					return EMPTY_SNAPSHOT;
-				}
+			entry.validation = toEndpointResponseValidationResult({
+				data: resolvedNext,
+				errors: [],
+				isValid: true,
+			});
+			syncSnapshot(entry);
+			notify(cacheKey);
+		},
+		__getSnapshot(cacheKey) {
+			const entry = entries.get(cacheKey);
+			if (!entry) {
+				return EMPTY_SNAPSHOT;
+			}
 
-				return entry.snapshot;
-			},
-			__publishValidation(cacheKey, validation) {
-				const entry = getOrCreateEntry(entries, cacheKey);
-				entry.error = null;
-				entry.updatedAt = Date.now();
-				entry.validation = validation as EndpointValidationResult<unknown, unknown>;
-				if (validation.isValid) {
-					entry.data = validation.data;
-				} else if (validation.validationTarget === "request") {
-					entry.data = undefined;
-				}
-				syncSnapshot(entry);
-				notify(cacheKey);
-			},
+			return entry.snapshot;
+		},
+		__publishValidation(cacheKey, validation) {
+			const entry = getOrCreateEntry(entries, cacheKey);
+			entry.error = null;
+			entry.updatedAt = Date.now();
+			entry.validation = validation;
+			if (validation.isValid) {
+				entry.data = validation.data;
+			} else if (validation.validationTarget === "request") {
+				entry.data = undefined;
+			}
+			syncSnapshot(entry);
+			notify(cacheKey);
+		},
 		__registerRefetcher(cacheKey, refetcher) {
 			const entry = getOrCreateEntry(entries, cacheKey);
 			entry.refetchers.add(refetcher);
@@ -475,15 +501,19 @@ export function createEndpointDataClient(): EndpointDataClient {
 				entry.refetchers.delete(refetcher);
 			};
 		},
-			async __runQuery(cacheKey, execute, { force = false, staleTime }) {
+		async __runQuery<Req, Res>(
+			cacheKey: CacheKey,
+			execute: () => Promise<EndpointValidationResult<Req, Res>>,
+			{ force = false, staleTime }: { force?: boolean; staleTime: number },
+		) {
 			const entry = getOrCreateEntry(entries, cacheKey);
 			if (entry.promise) {
-				return entry.promise as Promise<EndpointValidationResult<any, any>>;
+				return castEndpointValidationPromise(entry.promise);
 			}
 
 			if (!force) {
 				if (!isEntryStale(entry, staleTime) && entry.validation) {
-					return entry.validation as EndpointValidationResult<any, any>;
+					return castEndpointValidationResult(entry.validation);
 				}
 			}
 
@@ -498,7 +528,7 @@ export function createEndpointDataClient(): EndpointDataClient {
 					entry.error = null;
 					if (entry.invalidatedAt <= startedAt) {
 						entry.updatedAt = Date.now();
-						entry.validation = validation as EndpointValidationResult<unknown, unknown>;
+						entry.validation = validation;
 						if (validation.isValid) {
 							entry.data = validation.data;
 						}
@@ -521,8 +551,8 @@ export function createEndpointDataClient(): EndpointDataClient {
 					notify(cacheKey);
 				});
 
-			entry.promise = promise as Promise<EndpointValidationResult<unknown, unknown>>;
-			return promise as Promise<EndpointValidationResult<any, any>>;
+			entry.promise = promise;
+			return castEndpointValidationPromise(promise);
 		},
 		__seedData(cacheKey, data) {
 			const entry = getOrCreateEntry(entries, cacheKey);
@@ -533,14 +563,14 @@ export function createEndpointDataClient(): EndpointDataClient {
 			entry.data = data;
 			entry.error = null;
 			entry.updatedAt = Date.now();
-				entry.validation = toEndpointResponseValidationResult({
-					data,
-					errors: [],
-					isValid: true,
-				});
-				syncSnapshot(entry);
-				notify(cacheKey);
-			},
+			entry.validation = toEndpointResponseValidationResult({
+				data,
+				errors: [],
+				isValid: true,
+			});
+			syncSnapshot(entry);
+			notify(cacheKey);
+		},
 		__subscribe(cacheKey, listener) {
 			const entry = getOrCreateEntry(entries, cacheKey);
 			entry.listeners.add(listener);
@@ -560,11 +590,9 @@ export function EndpointDataProvider({
 	children,
 	client,
 }: EndpointDataProviderProps): ReturnType<typeof createElement> {
-	return createElement(
-		EndpointDataClientContext.Provider,
-		{ value: client },
-		children as any,
-	);
+	return children === undefined
+		? createElement(EndpointDataClientContext.Provider, { value: client })
+		: createElement(EndpointDataClientContext.Provider, { value: client }, children);
 }
 
 export function useEndpointDataClient(): EndpointDataClient {
@@ -664,10 +692,7 @@ export function useEndpointQuery<Req, Res, Selected = Res>(
 				);
 
 				if (validation.isValid) {
-					const selected =
-						latest.select !== undefined
-							? latest.select(validation.data as Res)
-							: (validation.data as unknown as Selected);
+					const selected = selectEndpointData(validation.data, latest.select);
 					await latest.onSuccess?.(selected, validation);
 				}
 
@@ -686,7 +711,7 @@ export function useEndpointQuery<Req, Res, Selected = Res>(
 
 	useEffect(() => {
 		return client.__registerRefetcher(prepared.cacheKey, () =>
-			refetch() as Promise<EndpointValidationResult<unknown, unknown>>,
+			refetch(),
 		);
 	}, [client, prepared.cacheKey, refetch]);
 
@@ -761,9 +786,7 @@ export function useEndpointQuery<Req, Res, Selected = Res>(
 			return undefined;
 		}
 
-		return select !== undefined
-			? select(rawData)
-			: (rawData as unknown as Selected);
+		return selectEndpointData(rawData, select);
 	}, [initialData, select, snapshot.data, snapshot.validation]);
 
 	return {
@@ -774,7 +797,10 @@ export function useEndpointQuery<Req, Res, Selected = Res>(
 			snapshot.isFetching &&
 			data === undefined,
 		refetch,
-		validation: snapshot.validation as EndpointValidationResult<Req, Res> | null,
+		validation:
+			snapshot.validation === null
+				? null
+				: castEndpointValidationResult(snapshot.validation),
 	};
 }
 

--- a/packages/wp-typia-rest/tests/package-contracts.test.ts
+++ b/packages/wp-typia-rest/tests/package-contracts.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { describe, expect, test } from "bun:test";
 
 describe("@wp-typia/rest export contracts", () => {
-	test("publishes legacy root aliases for ./client and ./http while keeping ./react distinct", async () => {
+	test("publishes focused ./client and ./http entries while keeping ./react distinct", async () => {
 		const packageJson = JSON.parse(
 			readFileSync(new URL("../package.json", import.meta.url), "utf8"),
 		) as {
@@ -10,14 +10,14 @@ describe("@wp-typia/rest export contracts", () => {
 		};
 
 		expect(packageJson.exports?.["./client"]).toEqual({
-			default: "./dist/index.js",
-			import: "./dist/index.js",
-			types: "./dist/index.d.ts",
+			default: "./dist/client.js",
+			import: "./dist/client.js",
+			types: "./dist/client.d.ts",
 		});
 		expect(packageJson.exports?.["./http"]).toEqual({
-			default: "./dist/index.js",
-			import: "./dist/index.js",
-			types: "./dist/index.d.ts",
+			default: "./dist/http.js",
+			import: "./dist/http.js",
+			types: "./dist/http.d.ts",
 		});
 		expect(packageJson.exports?.["./react"]).toEqual({
 			default: "./dist/react.js",
@@ -25,25 +25,23 @@ describe("@wp-typia/rest export contracts", () => {
 			types: "./dist/react.d.ts",
 		});
 
-		const importRestClient = new Function(
-			'return import("@wp-typia/rest/client");',
-		) as () => Promise<Record<string, unknown>>;
-		const importRestHttp = new Function(
-			'return import("@wp-typia/rest/http");',
-		) as () => Promise<Record<string, unknown>>;
 		const [restRoot, restClient, restHttp, restReact] = await Promise.all([
-			import("@wp-typia/rest"),
-			importRestClient(),
-			importRestHttp(),
-			import("@wp-typia/rest/react"),
+			import(new URL("../dist/index.js", import.meta.url).href),
+			import(new URL("../dist/client.js", import.meta.url).href),
+			import(new URL("../dist/http.js", import.meta.url).href),
+			import(new URL("../dist/react.js", import.meta.url).href),
 		]);
 
 		expect(typeof restRoot.callEndpoint).toBe("function");
 		expect(typeof restRoot.createHeadersDecoder).toBe("function");
 		expect(typeof restClient.callEndpoint).toBe("function");
-		expect(typeof restClient.createHeadersDecoder).toBe("function");
-		expect(typeof restHttp.callEndpoint).toBe("function");
+		expect(typeof restClient.resolveRestRouteUrl).toBe("function");
+		expect(typeof restClient.RestRootResolutionError).toBe("function");
+		expect("createHeadersDecoder" in restClient).toBe(false);
 		expect(typeof restHttp.createHeadersDecoder).toBe("function");
+		expect(typeof restHttp.createParameterDecoder).toBe("function");
+		expect(typeof restHttp.toValidationResult).toBe("function");
+		expect("callEndpoint" in restHttp).toBe(false);
 		expect(typeof restReact.useEndpointQuery).toBe("function");
 		expect("callEndpoint" in restReact).toBe(false);
 	});
@@ -64,5 +62,16 @@ describe("@wp-typia/rest export contracts", () => {
 		expect(builtIndexDts).toContain('from "./client.js"');
 		expect(builtIndexDts).toContain('from "./errors.js"');
 		expect(builtIndexDts).toContain('from "./http.js"');
+	});
+
+	test("react source isolates generic fallback casts instead of using raw as any", () => {
+		const reactSource = readFileSync(
+			new URL("../src/react.ts", import.meta.url),
+			"utf8",
+		);
+
+		expect(reactSource).not.toContain("as any");
+		expect(reactSource).toContain("selectEndpointData");
+		expect(reactSource).toContain("castEndpointValidationResult");
 	});
 });

--- a/packages/wp-typia-rest/tests/react.test.tsx
+++ b/packages/wp-typia-rest/tests/react.test.tsx
@@ -12,13 +12,13 @@ import {
 	RestQueryHookUsageError,
 	toValidationResult,
 	type ValidationLike,
-} from "../src/index";
+} from "../dist/index.js";
 import {
 	EndpointDataProvider,
 	createEndpointDataClient,
 	useEndpointMutation,
 	useEndpointQuery,
-} from "../src/react";
+} from "../dist/react.js";
 import type { ApiFetch } from "@wordpress/api-fetch";
 
 function success<T>(data: T): ValidationLike<T> {

--- a/packages/wp-typia-rest/tests/react.test.tsx
+++ b/packages/wp-typia-rest/tests/react.test.tsx
@@ -12,13 +12,13 @@ import {
 	RestQueryHookUsageError,
 	toValidationResult,
 	type ValidationLike,
-} from "../dist/index.js";
+} from "../src/index";
 import {
 	EndpointDataProvider,
 	createEndpointDataClient,
 	useEndpointMutation,
 	useEndpointQuery,
-} from "../dist/react.js";
+} from "../src/react";
 import type { ApiFetch } from "@wordpress/api-fetch";
 
 function success<T>(data: T): ValidationLike<T> {

--- a/packages/wp-typia-rest/tests/rest.test.ts
+++ b/packages/wp-typia-rest/tests/rest.test.ts
@@ -4,7 +4,7 @@ import type { ApiFetch } from "@wordpress/api-fetch";
 import {
 	createEndpoint as createPortableEndpoint,
 	toValidationResult as toPortableValidationResult,
-} from "../../wp-typia-api-client/dist/index.js";
+} from "../../wp-typia-api-client/src/index";
 
 import {
 	RestConfigurationError,
@@ -19,7 +19,7 @@ import {
 	resolveRestRouteUrl,
 	toValidationResult,
 	type ValidationLike,
-} from "../dist/index.js";
+} from "../src/index";
 
 function success<T>(data: T): ValidationLike<T> {
 	return {

--- a/packages/wp-typia-rest/tests/rest.test.ts
+++ b/packages/wp-typia-rest/tests/rest.test.ts
@@ -4,7 +4,7 @@ import type { ApiFetch } from "@wordpress/api-fetch";
 import {
 	createEndpoint as createPortableEndpoint,
 	toValidationResult as toPortableValidationResult,
-} from "../../wp-typia-api-client/src/index";
+} from "../../wp-typia-api-client/dist/index.js";
 
 import {
 	RestConfigurationError,
@@ -19,7 +19,7 @@ import {
 	resolveRestRouteUrl,
 	toValidationResult,
 	type ValidationLike,
-} from "../src/index";
+} from "../dist/index.js";
 
 function success<T>(data: T): ValidationLike<T> {
 	return {
@@ -432,15 +432,15 @@ describe("@wp-typia/rest", () => {
 			"utf8",
 		);
 
-		expect(clientDist).toContain('from "@wp-typia/api-client/client-utils"');
-		expect(clientTypes).toContain('from "./internal/runtime-primitives.js"');
-		expect(reactDist).toContain('from "./client.js"');
-		expect(reactTypes).toContain('from "./client.js"');
+		expect(clientDist).toContain("@wp-typia/api-client/client-utils");
+		expect(clientTypes).toContain("./internal/runtime-primitives.js");
+		expect(reactDist).toContain("./client.js");
+		expect(reactTypes).toContain("./client.js");
 		expect(sharedRuntimePrimitivesDist).toContain(
-			'from "@wp-typia/api-client/runtime-primitives"',
+			"@wp-typia/api-client/runtime-primitives",
 		);
 		expect(sharedRuntimePrimitivesTypes).toContain(
-			'from "@wp-typia/api-client/runtime-primitives"',
+			"@wp-typia/api-client/runtime-primitives",
 		);
 	});
 

--- a/tests/unit/error-export-contracts.test.ts
+++ b/tests/unit/error-export-contracts.test.ts
@@ -1,41 +1,47 @@
-import { readFileSync } from "node:fs";
-import { describe, expect, test } from "bun:test";
+import { readFileSync } from 'node:fs';
+import { describe, expect, test } from 'bun:test';
 
-describe("repository error and export contracts", () => {
-	test("documents the chosen error taxonomy and runtime subpath semantics", () => {
-		const readme = readFileSync(new URL("../../README.md", import.meta.url), "utf8");
-		const apiGuide = readFileSync(new URL("../../docs/API.md", import.meta.url), "utf8");
-		const contractGuide = readFileSync(
-			new URL("../../docs/error-export-contracts.md", import.meta.url),
-			"utf8",
-		);
-		const importPolicy = readFileSync(
-			new URL("../../docs/runtime-import-policy.md", import.meta.url),
-			"utf8",
-		);
-		const runtimeSurface = readFileSync(
-			new URL("../../docs/runtime-surface.md", import.meta.url),
-			"utf8",
-		);
+describe('repository error and export contracts', () => {
+  test('documents the chosen error taxonomy and runtime subpath semantics', () => {
+    const readme = readFileSync(
+      new URL('../../README.md', import.meta.url),
+      'utf8',
+    );
+    const apiGuide = readFileSync(
+      new URL('../../docs/API.md', import.meta.url),
+      'utf8',
+    );
+    const contractGuide = readFileSync(
+      new URL('../../docs/error-export-contracts.md', import.meta.url),
+      'utf8',
+    );
+    const importPolicy = readFileSync(
+      new URL('../../docs/runtime-import-policy.md', import.meta.url),
+      'utf8',
+    );
+    const runtimeSurface = readFileSync(
+      new URL('../../docs/runtime-surface.md', import.meta.url),
+      'utf8',
+    );
 
-		expect(readme).toContain("Error and Export Contract Guide");
-		expect(apiGuide).toContain("@wp-typia/rest/http");
-		expect(apiGuide).toContain("@wp-typia/rest/client");
-		expect(apiGuide).toContain("WpTypiaContractError");
-		expect(contractGuide).toContain("ValidationResult<T>");
-		expect(contractGuide).toContain("EndpointValidationResult<Req, Res>");
-		expect(contractGuide).toContain("WpTypiaContractError");
-		expect(contractGuide).toContain("ApiClientConfigurationError");
-		expect(contractGuide).toContain("RestRootResolutionError");
-		expect(contractGuide).toContain("@wp-typia/rest/client");
-		expect(contractGuide).toContain("@wp-typia/rest/http");
-		expect(contractGuide).toContain("compatibility alias");
-		expect(importPolicy).toContain("@wp-typia/api-client");
-		expect(importPolicy).toContain("@wp-typia/rest/http");
-		expect(importPolicy).toContain("Compatibility alias of the root");
-		expect(importPolicy).toContain("RestQueryHookUsageError");
-		expect(runtimeSurface).toContain("@wp-typia/rest/client");
-		expect(runtimeSurface).toContain("`./client` and `./http` are compatibility-only aliases");
-		expect(runtimeSurface).toContain("@wp-typia/api-client/runtime-primitives");
-	});
+    expect(readme).toContain('Error and Export Contract Guide');
+    expect(apiGuide).toContain('@wp-typia/rest/http');
+    expect(apiGuide).toContain('@wp-typia/rest/client');
+    expect(apiGuide).toContain('WpTypiaContractError');
+    expect(contractGuide).toContain('ValidationResult<T>');
+    expect(contractGuide).toContain('EndpointValidationResult<Req, Res>');
+    expect(contractGuide).toContain('WpTypiaContractError');
+    expect(contractGuide).toContain('ApiClientConfigurationError');
+    expect(contractGuide).toContain('RestRootResolutionError');
+    expect(contractGuide).toContain('@wp-typia/rest/client');
+    expect(contractGuide).toContain('@wp-typia/rest/http');
+    expect(contractGuide).toContain('Focused transport/runtime surface');
+    expect(importPolicy).toContain('@wp-typia/api-client');
+    expect(importPolicy).toContain('@wp-typia/rest/http');
+    expect(importPolicy).toContain('Focused decoder surface');
+    expect(importPolicy).toContain('RestQueryHookUsageError');
+    expect(runtimeSurface).toContain('@wp-typia/rest/client');
+    expect(runtimeSurface).toContain('`./client` is the focused');
+    expect(runtimeSurface).toContain('@wp-typia/api-client/runtime-primitives');
+  });
 });


### PR DESCRIPTION
## Context

`#311` tracks two related concerns in `@wp-typia/rest`: the published `./client` and `./http` subpaths were documented as if they mattered, but both still resolved to the same built root entry, and `src/react.ts` still relied on a few cast-heavy escape hatches in the cache/query internals.

## What Changed

- routed `@wp-typia/rest/client` and `@wp-typia/rest/http` to their dedicated built entries so the export map now matches the focused `src/client.ts` and `src/http.ts` surfaces instead of two root aliases
- clarified the intended meaning of the root, `./client`, `./http`, and `./react` entries across the package README and the repo-level runtime/export contract docs
- re-exported the named transport/runtime errors from `src/client.ts` and the shared validation helpers from `src/http.ts` so the focused subpaths still expose the pieces that naturally belong with those entry points
- tightened the React cache/query implementation by removing the raw `as any` hotspots, isolating the remaining generic fallback casts in named helpers, and keeping the built-entry package tests pointed at actual dist outputs
- made `fix-dist-imports.mjs` normalize both single-quoted and double-quoted emit patterns so the built ESM specifiers stay stable
- added a Sampo changeset for `@wp-typia/rest`

## Verification

- `bun run --filter @wp-typia/rest build`
- `bun test packages/wp-typia-rest/tests/package-contracts.test.ts`
- `bun test packages/wp-typia-rest/tests/rest.test.ts`
- `bun test packages/wp-typia-rest/tests/react.test.tsx`
- `bun test tests/unit/error-export-contracts.test.ts`
- `bun run changesets:validate`

Closes #311


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Error types now re-exported from `@wp-typia/rest/client` subpath for easier access
  * Validation utilities now re-exported from `@wp-typia/rest/http` subpath

* **Documentation**
  * Clarified export semantics for `/client` (transport/runtime surface) and `/http` (decoder surface) subpaths

* **Refactor**
  * Reorganized package exports: `/client` and `/http` now have dedicated build artifacts instead of shared root entry
  * Enhanced React hook implementation with improved type safety

<!-- end of auto-generated comment: release notes by coderabbit.ai -->