### PR TITLE
Polish repo metadata and tighten positional create alias safety

### DIFF
--- a/.sampo/changesets/issue-313-cli-safety-polish.md
+++ b/.sampo/changesets/issue-313-cli-safety-polish.md
@@ -1,0 +1,8 @@
+---
+npm/wp-typia: patch
+---
+
+Added the missing root `LICENSE` file and tightened the positional
+`wp-typia <project-dir>` alias so typo-like invocations with extra positional
+arguments fail with explicit guidance instead of silently scaffolding a new
+project.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,283 @@
+Unless otherwise noted, this repository is licensed under the GNU General
+Public License, version 2 or any later version.
+
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+SPDX-License-Identifier: GPL-2.0-or-later
+
 Unless otherwise noted, this repository is licensed under the GNU General
 Public License, version 2 or any later version.
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ bunx wp-typia create my-block
 npx wp-typia create my-block
 ```
 
-`wp-typia <project-dir>` remains available as a backward-compatible alias to `create`.
+`wp-typia <project-dir>` remains available as a backward-compatible alias to
+`create` when `<project-dir>` is the only positional argument.
 
 ### Built-in templates
 
@@ -191,6 +192,7 @@ npx wp-typia create my-block --template @scope/create-block-template --variant h
 - [Package Manifest Policy](docs/package-manifest-policy.md)
 - [TypeScript Strictness Policy](docs/typescript-strictness-policy.md)
 - [Upgrade Guide](UPGRADE.md)
+- [License](LICENSE)
 - [Security Policy](SECURITY.md)
 - [Interactivity Guide](docs/interactivity.md)
 - [Examples Guide](examples/EXAMPLES.md)

--- a/docs/API.md
+++ b/docs/API.md
@@ -56,7 +56,7 @@ watch workflow, and can opt into local presets with `--with-wp-env` and
 `--with-test-preset`. They can also opt into the migration dashboard/runtime
 bundle with `--with-migration-ui`.
 
-The positional `wp-typia <project-dir>` form remains available as a backward-compatible alias to `create`.
+The positional `wp-typia <project-dir>` form remains available as a backward-compatible alias to `create` when `<project-dir>` is the only positional argument.
 
 Official empty workspace flow:
 

--- a/docs/bunli-cli-migration.md
+++ b/docs/bunli-cli-migration.md
@@ -17,7 +17,7 @@ Canonical usage remains:
 
 - `npx wp-typia create <project-dir>`
 - `bunx wp-typia create <project-dir>`
-- `wp-typia <project-dir>` as the compatibility alias
+- `wp-typia <project-dir>` as the compatibility alias when `<project-dir>` is the only positional argument
 - `wp-typia migrate <subcommand>`
 
 Shorthand references like `npx wp-typia` and `bunx wp-typia` should still map
@@ -64,7 +64,8 @@ to the canonical `create` surface in docs and review notes.
 Compatibility alias:
 
 - `wp-typia <project-dir>` remains supported as a compatibility alias to
-  `wp-typia create <project-dir>`.
+  `wp-typia create <project-dir>` when `<project-dir>` is the only positional
+  argument.
 
 Breaking change:
 

--- a/packages/create-wp-typia/bin/create-wp-typia.js
+++ b/packages/create-wp-typia/bin/create-wp-typia.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
 console.error(
-	"create-wp-typia is archived. Use `npx wp-typia <project-dir>` or `bunx wp-typia <project-dir>` instead.",
+	"create-wp-typia is archived. Use `npx wp-typia create <project-dir>` or `bunx wp-typia create <project-dir>` instead.",
 );
 process.exit(1);

--- a/packages/wp-typia-project-tools/src/runtime/cli-help.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-help.ts
@@ -34,7 +34,7 @@ Built-in templates: ${TEMPLATE_IDS.join(", ")}
 Package managers: ${PACKAGE_MANAGER_IDS.join(", ")}
 Notes:
   \`wp-typia create\` is the canonical scaffold command.
-  \`wp-typia <project-dir>\` remains a backward-compatible alias to \`create\`.
+  \`wp-typia <project-dir>\` remains a backward-compatible alias to \`create\` when \`<project-dir>\` is the only positional argument.
   Use \`--template workspace\` as shorthand for \`@wp-typia/create-workspace-template\`, the official empty workspace scaffold behind \`wp-typia add ...\`.
   \`add variation\` uses an existing workspace block from \`scripts/block-config.ts\`.
   \`add pattern\` scaffolds a namespaced PHP pattern shell under \`src/patterns/\`.

--- a/packages/wp-typia-project-tools/src/runtime/cli-scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-scaffold.ts
@@ -303,7 +303,7 @@ export async function runScaffoldFlow({
 
 	if (!projectInput) {
 		throw new Error(
-			"Project directory is required. Usage: wp-typia create <project-dir> (or wp-typia <project-dir>).",
+			"Project directory is required. Usage: wp-typia create <project-dir> (or wp-typia <project-dir> when <project-dir> is the only positional argument).",
 		);
 	}
 

--- a/packages/wp-typia/README.md
+++ b/packages/wp-typia/README.md
@@ -12,7 +12,8 @@ Use this package for new installs:
 - `wp-typia add hooked-block counter-card --anchor core/post-content --position after`
 
 `wp-typia <project-dir>` remains available as a backward-compatible alias to
-`wp-typia create <project-dir>`.
+`wp-typia create <project-dir>` when `<project-dir>` is the only positional
+argument.
 
 Compatibility notes:
 
@@ -26,5 +27,6 @@ for the active CLI ownership contract and the staged Bunli cutover plan.
 Project meta docs:
 
 - [Upgrade Guide](https://github.com/imjlk/wp-typia/blob/main/UPGRADE.md)
+- [License](https://github.com/imjlk/wp-typia/blob/main/LICENSE)
 - [Security Policy](https://github.com/imjlk/wp-typia/blob/main/SECURITY.md)
 - [Contributing Guide](https://github.com/imjlk/wp-typia/blob/main/CONTRIBUTING.md)

--- a/packages/wp-typia/src/command-contract.ts
+++ b/packages/wp-typia/src/command-contract.ts
@@ -84,13 +84,24 @@ function isLongOptionValueConsumer(optionName: string): boolean {
 }
 
 function findFirstPositionalIndex(argv: string[]): number {
+	const positionalIndexes = collectPositionalIndexes(argv);
+	return positionalIndexes[0] ?? -1;
+}
+
+function collectPositionalIndexes(argv: string[]): number[] {
+	const positionalIndexes: number[] = [];
+
 	for (let index = 0; index < argv.length; index += 1) {
 		const arg = argv[index];
 		if (arg === "--") {
-			return index + 1 < argv.length ? index + 1 : -1;
+			for (let restIndex = index + 1; restIndex < argv.length; restIndex += 1) {
+				positionalIndexes.push(restIndex);
+			}
+			break;
 		}
 		if (!arg.startsWith("-") || arg === "-") {
-			return index;
+			positionalIndexes.push(index);
+			continue;
 		}
 		if (arg.startsWith("--")) {
 			if (arg.includes("=")) {
@@ -106,7 +117,7 @@ function findFirstPositionalIndex(argv: string[]): number {
 		}
 	}
 
-	return -1;
+	return positionalIndexes;
 }
 
 export const WP_TYPIA_FUTURE_COMMAND_TREE = [
@@ -213,7 +224,8 @@ function assertStringOptionValues(argv: string[]): void {
 }
 
 export function normalizeWpTypiaArgv(argv: string[]): string[] {
-	const firstPositionalIndex = findFirstPositionalIndex(argv);
+	const positionalIndexes = collectPositionalIndexes(argv);
+	const firstPositionalIndex = positionalIndexes[0] ?? -1;
 	if (firstPositionalIndex === -1) {
 		return argv;
 	}
@@ -232,6 +244,17 @@ export function normalizeWpTypiaArgv(argv: string[]): string[] {
 	if (isReservedTopLevelCommandName(firstPositional)) {
 		assertStringOptionValues(argv);
 		return argv;
+	}
+
+	if (positionalIndexes.length > 1) {
+		const extraPositionals = positionalIndexes
+			.slice(1)
+			.map((index) => argv[index])
+			.filter((value): value is string => typeof value === "string" && value.length > 0);
+
+		throw new Error(
+			`The positional alias only accepts a single project directory. Use \`${WP_TYPIA_CANONICAL_CREATE_USAGE}\` for scaffold invocations with additional positional arguments, or check the command spelling if you meant another top-level command. Extra positional arguments: ${extraPositionals.map((value) => `\`${value}\``).join(", ")}.`,
+		);
 	}
 
 	const normalizedArgv = [

--- a/packages/wp-typia/tests/bunli-prep.test.ts
+++ b/packages/wp-typia/tests/bunli-prep.test.ts
@@ -91,6 +91,9 @@ describe("wp-typia Bunli preparation", () => {
 			normalizeWpTypiaArgv(["-c", "./custom.json", "templates", "list"]),
 		).toEqual(["-c", "./custom.json", "templates", "list"]);
 		expect(
+			normalizeWpTypiaArgv(["demo-block", "--template", "basic"]),
+		).toEqual(["create", "demo-block", "--template", "basic"]);
+		expect(
 			normalizeWpTypiaArgv([
 				"add",
 				"hooked-block",
@@ -114,6 +117,9 @@ describe("wp-typia Bunli preparation", () => {
 		);
 		expect(() => normalizeWpTypiaArgv(["mcp", "sync", "--output-dir"])).toThrow(
 			/`--output-dir` requires a value\./,
+		);
+		expect(() => normalizeWpTypiaArgv(["temlates", "list"])).toThrow(
+			/only accepts a single project directory.*check the command spelling.*`list`/s,
 		);
 	});
 });

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -386,6 +386,20 @@ describe("wp-typia package", () => {
 		);
 	});
 
+	test("rejects typo-like positional alias invocations with extra arguments", () => {
+		const result = runCapturedCommand("node", [entryPath, "temlates", "list"], {
+			env: withoutAIAgentEnv(),
+		});
+
+		expect(result.status).toBe(1);
+		expect(result.stderr).toContain(
+			"The positional alias only accepts a single project directory.",
+		);
+		expect(result.stderr).toContain("`wp-typia create <project-dir>`");
+		expect(result.stderr).toContain("check the command spelling");
+		expect(result.stderr).toContain("`list`");
+	});
+
 	test("formats create failures with a shared non-interactive diagnostic block", () => {
 		const result = runCapturedCommand("node", [entryPath, "create"]);
 

--- a/tests/unit/repo-dx-baseline.test.ts
+++ b/tests/unit/repo-dx-baseline.test.ts
@@ -67,7 +67,17 @@ describe('repository DX baseline', () => {
   });
 
   test('repo meta docs and GitHub templates exist', () => {
+    const packageJson = readJson('package.json');
+    const licenseContents = fs.readFileSync(
+      path.join(repoRoot, 'LICENSE'),
+      'utf8',
+    );
+
+    expect(packageJson.license).toBe('GPL-2.0-or-later');
     expect(fs.existsSync(path.join(repoRoot, 'LICENSE'))).toBe(true);
+    expect(licenseContents).toContain(
+      'SPDX-License-Identifier: GPL-2.0-or-later',
+    );
     expect(fs.existsSync(path.join(repoRoot, 'UPGRADE.md'))).toBe(true);
     expect(fs.existsSync(path.join(repoRoot, 'SECURITY.md'))).toBe(true);
     expect(

--- a/tests/unit/repo-dx-baseline.test.ts
+++ b/tests/unit/repo-dx-baseline.test.ts
@@ -67,6 +67,7 @@ describe('repository DX baseline', () => {
   });
 
   test('repo meta docs and GitHub templates exist', () => {
+    expect(fs.existsSync(path.join(repoRoot, 'LICENSE'))).toBe(true);
     expect(fs.existsSync(path.join(repoRoot, 'UPGRADE.md'))).toBe(true);
     expect(fs.existsSync(path.join(repoRoot, 'SECURITY.md'))).toBe(true);
     expect(
@@ -216,6 +217,7 @@ describe('repository DX baseline', () => {
     expect(readme).toContain('bun run formatting-policy:validate');
     expect(readme).toContain('## Who this is for');
     expect(readme).toContain('[Upgrade Guide](UPGRADE.md)');
+    expect(readme).toContain('[License](LICENSE)');
     expect(readme).toContain('[Security Policy](SECURITY.md)');
     expect(contributing).toContain('Linting ownership is intentionally split');
     expect(contributing).toContain('Formatting ownership is also explicit');


### PR DESCRIPTION
## Context

- the repository root was still missing the canonical `LICENSE` file even though the package metadata already points at `GPL-2.0-or-later`
- the positional `wp-typia <project-dir>` compatibility alias would also accept typo-like multi-positional invocations such as `wp-typia temlates list`, which could silently start a scaffold instead of failing with clear guidance

## What Changed

- added the missing root `LICENSE` file and linked it from the repo and CLI package readmes
- tightened `normalizeWpTypiaArgv()` so the positional alias only applies when `<project-dir>` is the only positional argument
- made typo-like multi-positional invocations fail with explicit guidance toward `wp-typia create <project-dir>` and a command-spelling hint
- updated CLI help, scaffold guidance, archived package guidance, and migration docs to describe the guarded alias behavior consistently
- added regression coverage for the new alias guard and for the repo metadata baseline
- added a patch changeset for `wp-typia`

## Verification

- `bun run --filter wp-typia test`
- `bun test packages/wp-typia-project-tools/tests/cli-entry.test.ts tests/unit/repo-dx-baseline.test.ts`
- `bun run typecheck`
- `bun run changesets:validate`

Closes #313


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added GPLv2 LICENSE file to repository.
  * CLI now validates `wp-typia <project-dir>` usage—accepts only a single positional argument and provides explicit error guidance for typos or extra arguments instead of silently proceeding.

* **Documentation**
  * Clarified `wp-typia <project-dir>` backward-compatible alias applies only when used as the sole positional argument.
  * Added License documentation link.

* **Tests**
  * Added CLI validation test coverage for error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->