### PR TITLE
Expand generated project smoke coverage across example and reference lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,15 +376,17 @@ jobs:
 
       - name: Run generated project smoke
         run: |
-          args=(
-            --runtime "${{ matrix.runtime }}"
-            --template "${{ matrix.template }}"
-            --package-manager "${{ matrix.package_manager }}"
-            --project-name "${{ matrix.project_name }}"
-          )
-          if [ -n "${{ matrix.variant || '' }}" ]; then
-            args+=(--variant "${{ matrix.variant }}")
-          fi
+        args=(
+          --runtime "${{ matrix.runtime }}"
+          --package-manager "${{ matrix.package_manager }}"
+          --project-name "${{ matrix.project_name }}"
+        )
+        if [ -n "${{ matrix.template || '' }}" ]; then
+          args+=(--template "${{ matrix.template }}")
+        fi
+        if [ -n "${{ matrix.variant || '' }}" ]; then
+          args+=(--variant "${{ matrix.variant }}")
+        fi
           if [ -n "${{ matrix.example_project || '' }}" ]; then
             args+=(--example-project "${{ matrix.example_project }}")
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,6 +351,10 @@ jobs:
             add_hooked_block_slug: counter-card
             add_hooked_block_anchor: core/post-content
             add_hooked_block_position: after
+          - runtime: bun
+            example_project: my-typia-block
+            package_manager: bun
+            project_name: smoke-reference-my-typia-block-bun
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -380,6 +384,9 @@ jobs:
           )
           if [ -n "${{ matrix.variant || '' }}" ]; then
             args+=(--variant "${{ matrix.variant }}")
+          fi
+          if [ -n "${{ matrix.example_project || '' }}" ]; then
+            args+=(--example-project "${{ matrix.example_project }}")
           fi
           if [ -n "${{ matrix.data_storage || '' }}" ]; then
             args+=(--data-storage "${{ matrix.data_storage }}")

--- a/examples/my-typia-block/src/hooks.ts
+++ b/examples/my-typia-block/src/hooks.ts
@@ -61,7 +61,9 @@ export function useUUID() {
  * Hook for logging attribute changes in development
  * @param attributes Current block attributes.
  */
-export function useAttributeLogger( attributes: Record< string, unknown > ) {
+export function useAttributeLogger< TAttributes extends object >(
+	attributes: TAttributes
+) {
 	useEffect( () => {
 		if ( process.env.NODE_ENV === 'development' ) {
 			// eslint-disable-next-line no-console

--- a/scripts/run-generated-project-smoke.mjs
+++ b/scripts/run-generated-project-smoke.mjs
@@ -49,6 +49,7 @@ function parseArgs(argv) {
 		addVariationBlock: undefined,
 		addVariationName: undefined,
 		dataStorage: undefined,
+		exampleProject: undefined,
 		namespace: undefined,
 		packageManager: undefined,
 		persistencePolicy: undefined,
@@ -152,6 +153,11 @@ function parseArgs(argv) {
 		}
 		if (arg === "--data-storage") {
 			parsed.dataStorage = next;
+			index += 1;
+			continue;
+		}
+		if (arg === "--example-project") {
+			parsed.exampleProject = next;
 			index += 1;
 			continue;
 		}
@@ -324,6 +330,23 @@ function runScaffoldRefreshScripts(projectDir, packageManager, packageJson) {
 
 function runLocalMigrationDoctor(projectDir, runtime) {
 	run(runtime, [entryPath, "migrate", "doctor", "--all"], {
+		cwd: projectDir,
+	});
+}
+
+function refreshCurrentMigrationSnapshot(projectDir, runtime) {
+	const configPath = path.join(projectDir, "src", "migrations", "config.ts");
+	if (!fs.existsSync(configPath)) {
+		return;
+	}
+
+	const configSource = fs.readFileSync(configPath, "utf8");
+	const match = configSource.match(/currentMigrationVersion:\s*['"]([^'"]+)['"]/u);
+	if (!match?.[1]) {
+		return;
+	}
+
+	run(runtime, [entryPath, "migrate", "snapshot", "--migration-version", match[1]], {
 		cwd: projectDir,
 	});
 }
@@ -815,13 +838,16 @@ function assertNoRawRenderedContentEcho(filePath) {
 	}
 }
 
-function rewriteWorkspaceDependencies(projectDir) {
+function rewriteWorkspaceDependencies(projectDir, packageManager) {
 	const packageJsonPath = path.join(projectDir, "package.json");
 	const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
 	const localApiClientDependency = `file:${path.resolve(__dirname, "../packages/wp-typia-api-client")}`;
 	const localBlockRuntimeDependency = `file:${path.resolve(__dirname, "../packages/wp-typia-block-runtime")}`;
 	const localBlockTypesDependency = `file:${path.resolve(__dirname, "../packages/wp-typia-block-types")}`;
 	const localRestDependency = `file:${path.resolve(__dirname, "../packages/wp-typia-rest")}`;
+	const localCliDependency = `file:${path.resolve(__dirname, "../packages/wp-typia")}`;
+
+	packageJson.packageManager = getPackageManager(packageManager).packageManagerField;
 
 	if (packageJson.devDependencies?.["@wp-typia/api-client"]) {
 		packageJson.devDependencies["@wp-typia/api-client"] = localApiClientDependency;
@@ -847,6 +873,12 @@ function rewriteWorkspaceDependencies(projectDir) {
 	if (packageJson.dependencies?.["@wp-typia/rest"]) {
 		packageJson.dependencies["@wp-typia/rest"] = localRestDependency;
 	}
+	if (packageJson.devDependencies?.["wp-typia"]) {
+		packageJson.devDependencies["wp-typia"] = localCliDependency;
+	}
+	if (packageJson.dependencies?.["wp-typia"]) {
+		packageJson.dependencies["wp-typia"] = localCliDependency;
+	}
 
 	packageJson.overrides = {
 		...(packageJson.overrides ?? {}),
@@ -854,6 +886,7 @@ function rewriteWorkspaceDependencies(projectDir) {
 		"@wp-typia/api-client": localApiClientDependency,
 		"@wp-typia/block-types": localBlockTypesDependency,
 		"@wp-typia/rest": localRestDependency,
+		"wp-typia": localCliDependency,
 	};
 	packageJson.pnpm = {
 		...(packageJson.pnpm ?? {}),
@@ -863,6 +896,7 @@ function rewriteWorkspaceDependencies(projectDir) {
 			"@wp-typia/api-client": localApiClientDependency,
 			"@wp-typia/block-types": localBlockTypesDependency,
 			"@wp-typia/rest": localRestDependency,
+			"wp-typia": localCliDependency,
 		},
 	};
 	packageJson.resolutions = {
@@ -871,9 +905,168 @@ function rewriteWorkspaceDependencies(projectDir) {
 		"@wp-typia/api-client": localApiClientDependency,
 		"@wp-typia/block-types": localBlockTypesDependency,
 		"@wp-typia/rest": localRestDependency,
+		"wp-typia": localCliDependency,
 	};
 
 	fs.writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`, "utf8");
+}
+
+function prepareExampleWorkspaceRoot(workspaceRoot) {
+	const repoRoot = path.resolve(__dirname, "..");
+	const packagesLinkPath = path.join(workspaceRoot, "packages");
+
+	if (!fs.existsSync(packagesLinkPath)) {
+		fs.symlinkSync(path.join(repoRoot, "packages"), packagesLinkPath, "dir");
+	}
+
+	for (const configFile of ["tsconfig.json", "tsconfig.base.json"]) {
+		const sourcePath = path.join(repoRoot, configFile);
+		const targetPath = path.join(workspaceRoot, configFile);
+		if (!fs.existsSync(targetPath)) {
+			fs.copyFileSync(sourcePath, targetPath);
+		}
+	}
+}
+
+function prepareExampleProject(exampleProject, projectDir) {
+	const sourceDir = path.resolve(__dirname, "..", "examples", exampleProject);
+	if (!fs.existsSync(sourceDir)) {
+		throw new Error(`Unknown example project: ${exampleProject}`);
+	}
+
+	fs.cpSync(sourceDir, projectDir, {
+		dereference: false,
+		filter: (sourcePath) => {
+			const relativePath = path.relative(sourceDir, sourcePath);
+			return !relativePath.split(path.sep).includes("node_modules");
+		},
+		recursive: true,
+	});
+
+	rewriteCopiedExampleTsconfig(projectDir);
+	ensureCopiedExampleSupportDependencies(projectDir);
+}
+
+function rewriteCopiedExampleTsconfig(projectDir) {
+	const tsconfigPath = path.join(projectDir, "tsconfig.json");
+	if (!fs.existsSync(tsconfigPath)) {
+		return;
+	}
+
+	const tsconfig = readJsonFile(tsconfigPath);
+	if (tsconfig.extends !== "../../tsconfig.json") {
+		return;
+	}
+
+	const nextConfig = {
+		compilerOptions: {
+			jsx: "react-jsx",
+			module: "esnext",
+			moduleResolution: "bundler",
+			noEmit: true,
+			skipLibCheck: true,
+			strict: true,
+			target: "es2022",
+			types: ["bun-types", "node"],
+		},
+		exclude: ["node_modules", "build"],
+		include: ["src/**/*", "scripts/**/*"],
+	};
+
+	fs.writeFileSync(tsconfigPath, `${JSON.stringify(nextConfig, null, "\t")}\n`, "utf8");
+}
+
+function ensureCopiedExampleSupportDependencies(projectDir) {
+	const packageJsonPath = path.join(projectDir, "package.json");
+	if (!fs.existsSync(packageJsonPath)) {
+		return;
+	}
+
+	const repoPackageJson = readJsonFile(path.resolve(__dirname, "..", "package.json"));
+	const packageJson = readJsonFile(packageJsonPath);
+	const devDependencies = {
+		...(packageJson.devDependencies ?? {}),
+	};
+
+	if (!devDependencies["bun-types"]) {
+		devDependencies["bun-types"] =
+			repoPackageJson.devDependencies?.["bun-types"] ?? "^1.3.11";
+	}
+	if (!devDependencies["@types/node"]) {
+		devDependencies["@types/node"] =
+			repoPackageJson.devDependencies?.["@types/node"] ?? "^24.0.0";
+	}
+
+	packageJson.devDependencies = devDependencies;
+	fs.writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`, "utf8");
+}
+
+function assertExampleProjectScaffold(projectDir, exampleProject) {
+	const packageJson = readJsonFile(path.join(projectDir, "package.json"));
+	const blockJsonPath = path.join(projectDir, "block.json");
+	const pluginBootstrapPath = path.join(projectDir, `${exampleProject}.php`);
+
+	if (!fs.existsSync(blockJsonPath)) {
+		throw new Error(`Expected example project block.json at ${blockJsonPath}`);
+	}
+	if (!fs.existsSync(pluginBootstrapPath)) {
+		throw new Error(`Expected example project bootstrap at ${pluginBootstrapPath}`);
+	}
+	if (typeof packageJson.scripts?.["migration:doctor"] !== "string") {
+		throw new Error("Expected example project to expose migration:doctor");
+	}
+
+	assertPluginBootstrapExists(pluginBootstrapPath);
+	assertPluginBootstrapHardening(pluginBootstrapPath);
+	assertNoRawRenderedContentEcho(path.join(projectDir, "render.php"));
+	assertBuildArtifacts(projectDir, exampleProject);
+	assertBlockMetadataFileReferences(projectDir);
+	assertGeneratedRuntimeImports(projectDir);
+}
+
+function runExampleProjectSmoke({
+	exampleProject,
+	packageManager,
+	projectDir,
+	runtime,
+}) {
+	const workspaceRoot = path.dirname(projectDir);
+	const exampleDir = path.join(workspaceRoot, "examples", exampleProject);
+
+	prepareExampleWorkspaceRoot(workspaceRoot);
+	prepareExampleProject(exampleProject, exampleDir);
+	rewriteWorkspaceDependencies(exampleDir, packageManager);
+
+	const packageJson = readJsonFile(path.join(exampleDir, "package.json"));
+	ensureCorepackPackageManager(packageManager);
+
+	const [installCommand, installArgs] = getInstallCommand(packageManager);
+	run(installCommand, installArgs, {
+		cwd: exampleDir,
+		env: {
+			...process.env,
+			...(packageManager === "yarn"
+				? { YARN_ENABLE_IMMUTABLE_INSTALLS: "false" }
+				: {}),
+		},
+	});
+
+	runScaffoldRefreshScripts(exampleDir, packageManager, packageJson);
+	refreshCurrentMigrationSnapshot(exampleDir, runtime);
+	runLocalMigrationDoctor(exampleDir, runtime);
+
+	const [buildCommand, buildArgs] = getRunCommand(packageManager);
+	run(buildCommand, buildArgs, { cwd: exampleDir });
+
+	if (typeof packageJson.scripts?.typecheck === "string") {
+		const [typecheckCommand, typecheckArgs] = getRunScriptCommand(
+			packageManager,
+			"typecheck",
+		);
+		run(typecheckCommand, typecheckArgs, { cwd: exampleDir });
+	}
+
+	assertExampleProjectScaffold(exampleDir, exampleProject);
 }
 
 function main() {
@@ -888,6 +1081,7 @@ function main() {
 		namespace,
 		textDomain,
 		phpPrefix,
+		exampleProject,
 		addBlockName,
 		addBindingSourceName,
 		addDataStorage,
@@ -902,9 +1096,14 @@ function main() {
 		withMigrationUi,
 	} = parseArgs(process.argv.slice(2));
 
-	if (!runtime || !template || !packageManager || !projectName) {
+	if (
+		!runtime ||
+		!packageManager ||
+		!projectName ||
+		((!template && !exampleProject) || (template && exampleProject))
+	) {
 		throw new Error(
-			"Usage: node scripts/run-generated-project-smoke.mjs --runtime <node|bun> --template <id> [--variant <name>] [--namespace <value>] [--text-domain <value>] [--php-prefix <value>] [--data-storage <post-meta|custom-table>] [--persistence-policy <authenticated|public>] [--with-migration-ui] [--add-block-name <name> --add-template <basic|interactivity|persistence|compound> [--add-data-storage <post-meta|custom-table>] [--add-persistence-policy <authenticated|public>]] [--add-variation-name <name> --add-variation-block <block-slug>] [--add-pattern-name <name>] [--add-binding-source-name <name>] [--add-hooked-block-slug <block-slug> --add-hooked-block-anchor <anchor-block-name> --add-hooked-block-position <before|after|firstChild|lastChild>] --package-manager <id> --project-name <name>",
+			"Usage: node scripts/run-generated-project-smoke.mjs --runtime <node|bun> (--template <id> | --example-project <slug>) [--variant <name>] [--namespace <value>] [--text-domain <value>] [--php-prefix <value>] [--data-storage <post-meta|custom-table>] [--persistence-policy <authenticated|public>] [--with-migration-ui] [--add-block-name <name> --add-template <basic|interactivity|persistence|compound> [--add-data-storage <post-meta|custom-table>] [--add-persistence-policy <authenticated|public>]] [--add-variation-name <name> --add-variation-block <block-slug>] [--add-pattern-name <name>] [--add-binding-source-name <name>] [--add-hooked-block-slug <block-slug> --add-hooked-block-anchor <anchor-block-name> --add-hooked-block-position <before|after|firstChild|lastChild>] --package-manager <id> --project-name <name>",
 		);
 	}
 
@@ -913,6 +1112,16 @@ function main() {
 
 	try {
 	ensureCanonicalCliReady();
+
+		if (exampleProject) {
+			runExampleProjectSmoke({
+				exampleProject,
+				packageManager,
+				projectDir,
+				runtime,
+			});
+			return;
+		}
 
 		run(runtime, [
 			entryPath,
@@ -940,7 +1149,7 @@ function main() {
 			);
 		}
 
-		rewriteWorkspaceDependencies(projectDir);
+		rewriteWorkspaceDependencies(projectDir, packageManager);
 
 		ensureCorepackPackageManager(packageManager);
 

--- a/scripts/run-generated-project-smoke.mjs
+++ b/scripts/run-generated-project-smoke.mjs
@@ -343,7 +343,9 @@ function refreshCurrentMigrationSnapshot(projectDir, runtime) {
 	const configSource = fs.readFileSync(configPath, "utf8");
 	const match = configSource.match(/currentMigrationVersion:\s*['"]([^'"]+)['"]/u);
 	if (!match?.[1]) {
-		return;
+		throw new Error(
+			`Expected ${configPath} to declare currentMigrationVersion in a supported format`,
+		);
 	}
 
 	run(runtime, [entryPath, "migrate", "snapshot", "--migration-version", match[1]], {
@@ -1058,13 +1060,17 @@ function runExampleProjectSmoke({
 	const [buildCommand, buildArgs] = getRunCommand(packageManager);
 	run(buildCommand, buildArgs, { cwd: exampleDir });
 
-	if (typeof packageJson.scripts?.typecheck === "string") {
-		const [typecheckCommand, typecheckArgs] = getRunScriptCommand(
-			packageManager,
-			"typecheck",
+	if (typeof packageJson.scripts?.typecheck !== "string") {
+		throw new Error(
+			`Missing "typecheck" script in ${path.join(exampleDir, "package.json")} for example-project smoke`,
 		);
-		run(typecheckCommand, typecheckArgs, { cwd: exampleDir });
 	}
+
+	const [typecheckCommand, typecheckArgs] = getRunScriptCommand(
+		packageManager,
+		"typecheck",
+	);
+	run(typecheckCommand, typecheckArgs, { cwd: exampleDir });
 
 	assertExampleProjectScaffold(exampleDir, exampleProject);
 }

--- a/tests/unit/generated-project-smoke-reference-lane.test.ts
+++ b/tests/unit/generated-project-smoke-reference-lane.test.ts
@@ -17,6 +17,10 @@ test("generated project smoke script supports a reference example lane", () => {
 	expect(smokeScript).toContain("ensureCopiedExampleSupportDependencies");
 	expect(smokeScript).toContain('devDependencies["bun-types"]');
 	expect(smokeScript).toContain('devDependencies["@types/node"]');
+	expect(smokeScript).toContain(
+		'Expected ${configPath} to declare currentMigrationVersion in a supported format'
+	);
+	expect(smokeScript).toContain('Missing "typecheck" script in');
 	expect(smokeScript).toContain('path.resolve(__dirname, "..", "examples", exampleProject)');
 });
 
@@ -28,5 +32,7 @@ test("CI generated smoke matrix includes the reference app lane", () => {
 
 	expect(ciWorkflow).toContain("example_project: my-typia-block");
 	expect(ciWorkflow).toContain("smoke-reference-my-typia-block-bun");
+	expect(ciWorkflow).toContain('if [ -n "${{ matrix.template || \'\' }}" ]; then');
+	expect(ciWorkflow).toContain('args+=(--template "${{ matrix.template }}")');
 	expect(ciWorkflow).toContain('--example-project "${{ matrix.example_project }}"');
 });

--- a/tests/unit/generated-project-smoke-reference-lane.test.ts
+++ b/tests/unit/generated-project-smoke-reference-lane.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const repoRoot = join(import.meta.dir, "..", "..");
+
+test("generated project smoke script supports a reference example lane", () => {
+	const smokeScript = readFileSync(
+		join(repoRoot, "scripts", "run-generated-project-smoke.mjs"),
+		"utf8",
+	);
+
+	expect(smokeScript).toContain("exampleProject");
+	expect(smokeScript).toContain("--example-project");
+	expect(smokeScript).toContain("runExampleProjectSmoke");
+	expect(smokeScript).toContain("assertExampleProjectScaffold");
+	expect(smokeScript).toContain("ensureCopiedExampleSupportDependencies");
+	expect(smokeScript).toContain('devDependencies["bun-types"]');
+	expect(smokeScript).toContain('devDependencies["@types/node"]');
+	expect(smokeScript).toContain('path.resolve(__dirname, "..", "examples", exampleProject)');
+});
+
+test("CI generated smoke matrix includes the reference app lane", () => {
+	const ciWorkflow = readFileSync(
+		join(repoRoot, ".github", "workflows", "ci.yml"),
+		"utf8",
+	);
+
+	expect(ciWorkflow).toContain("example_project: my-typia-block");
+	expect(ciWorkflow).toContain("smoke-reference-my-typia-block-bun");
+	expect(ciWorkflow).toContain('--example-project "${{ matrix.example_project }}"');
+});


### PR DESCRIPTION
## Context
- closes #330
- the generated project smoke lane only exercised freshly scaffolded templates, so it could miss drift in the checked-in reference app
- the `examples/my-typia-block` workflow still relied on repo-root TypeScript support packages during standalone smoke installs

## What Changed
- taught `scripts/run-generated-project-smoke.mjs` to run an `--example-project` lane alongside template-based scaffolds
- added a CI matrix entry that copies `examples/my-typia-block` into a temp workspace shell, rewrites local workspace package dependencies, refreshes migrations, builds, and runs `tsc --noEmit`
- hardened the copied reference app setup by supplying the standalone TypeScript support deps it expects and by broadening `useAttributeLogger()` so typed attribute objects do not require a `Record<string, unknown>` index signature
- added unit coverage that locks the new smoke entrypoint and CI workflow wiring in place

## Verification
- `bun test tests/unit/generated-project-smoke-reference-lane.test.ts tests/unit/my-typia-block-reference-app.test.tsx`
- `bun run typecheck`
- `bun run lint:repo`
- `node scripts/run-generated-project-smoke.mjs --runtime bun --example-project my-typia-block --package-manager bun --project-name smoke-reference-my-typia-block-bun`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Bun runtime in the example project smoke testing pipeline.

* **Improvements**
  * Enhanced TypeScript type inference for attribute logging hooks to preserve specific object shapes.
  * Expanded the smoke testing framework to support example-project based validation workflows.

* **Tests**
  * Added comprehensive test coverage for the example-project smoke testing pipeline and CI integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->