### PR TITLE
Expand generated smoke coverage across checked-in examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,6 +355,14 @@ jobs:
             example_project: my-typia-block
             package_manager: bun
             project_name: smoke-reference-my-typia-block-bun
+          - runtime: bun
+            example_project: compound-patterns
+            package_manager: bun
+            project_name: smoke-example-compound-patterns-bun
+          - runtime: bun
+            example_project: persistence-examples
+            package_manager: bun
+            project_name: smoke-example-persistence-examples-bun
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/scripts/run-generated-project-smoke.mjs
+++ b/scripts/run-generated-project-smoke.mjs
@@ -367,7 +367,40 @@ function ensureCorepackPackageManager(packageManager) {
 	run("corepack", ["prepare", getPackageManager(packageManager).packageManagerField, "--activate"]);
 }
 
+function listSourceBlockSlugs(projectDir) {
+	const sourceBlocksDir = path.join(projectDir, "src", "blocks");
+	if (!fs.existsSync(sourceBlocksDir)) {
+		return [];
+	}
+
+	return fs
+		.readdirSync(sourceBlocksDir, { withFileTypes: true })
+		.filter((entry) => entry.isDirectory())
+		.map((entry) => entry.name)
+		.sort();
+}
+
 function assertBuildArtifacts(projectDir, projectName) {
+	const blockSlugs = listSourceBlockSlugs(projectDir);
+	if (blockSlugs.length > 0) {
+		for (const blockSlug of blockSlugs) {
+			const buildDir = path.join(projectDir, "build", "blocks", blockSlug);
+			for (const artifact of [
+				"block.json",
+				"typia.manifest.json",
+				"typia-validator.php",
+			]) {
+				if (!fs.existsSync(path.join(buildDir, artifact))) {
+					throw new Error(
+						`Expected ${buildDir} to include ${artifact} for example-project smoke`,
+					);
+				}
+			}
+		}
+
+		return;
+	}
+
 	const candidateDirs = [
 		path.join(projectDir, "build", projectName),
 		path.join(projectDir, "build"),
@@ -381,6 +414,35 @@ function assertBuildArtifacts(projectDir, projectName) {
 			);
 		}
 	}
+}
+
+function collectProjectFilePaths(projectDir, fileName) {
+	const pending = [projectDir];
+	const matchedPaths = [];
+
+	while (pending.length > 0) {
+		const currentDir = pending.pop();
+		if (!currentDir) {
+			continue;
+		}
+
+		for (const entry of fs.readdirSync(currentDir, { withFileTypes: true })) {
+			if (entry.name === "node_modules") {
+				continue;
+			}
+
+			const entryPath = path.join(currentDir, entry.name);
+			if (entry.isDirectory()) {
+				pending.push(entryPath);
+				continue;
+			}
+			if (entry.isFile() && entry.name === fileName) {
+				matchedPaths.push(entryPath);
+			}
+		}
+	}
+
+	return matchedPaths.sort();
 }
 
 const blockMetadataFileFields = [
@@ -1007,23 +1069,36 @@ function assertExampleProjectScaffold(projectDir, exampleProject) {
 	const packageJson = readJsonFile(path.join(projectDir, "package.json"));
 	const blockJsonPath = path.join(projectDir, "block.json");
 	const pluginBootstrapPath = path.join(projectDir, `${exampleProject}.php`);
+	const blockSlugs = listSourceBlockSlugs(projectDir);
 
-	if (!fs.existsSync(blockJsonPath)) {
+	if (blockSlugs.length === 0 && !fs.existsSync(blockJsonPath)) {
 		throw new Error(`Expected example project block.json at ${blockJsonPath}`);
 	}
 	if (!fs.existsSync(pluginBootstrapPath)) {
 		throw new Error(`Expected example project bootstrap at ${pluginBootstrapPath}`);
 	}
-	if (typeof packageJson.scripts?.["migration:doctor"] !== "string") {
+	if (
+		exampleProject === "my-typia-block" &&
+		typeof packageJson.scripts?.["migration:doctor"] !== "string"
+	) {
 		throw new Error("Expected example project to expose migration:doctor");
 	}
 
 	assertPluginBootstrapExists(pluginBootstrapPath);
 	assertPluginBootstrapHardening(pluginBootstrapPath);
-	assertNoRawRenderedContentEcho(path.join(projectDir, "render.php"));
+	for (const renderPath of collectProjectFilePaths(projectDir, "render.php")) {
+		assertNoRawRenderedContentEcho(renderPath);
+	}
 	assertBuildArtifacts(projectDir, exampleProject);
 	assertBlockMetadataFileReferences(projectDir);
 	assertGeneratedRuntimeImports(projectDir);
+}
+
+function shouldRunMigrationSmoke(projectDir, packageJson) {
+	return (
+		typeof packageJson.scripts?.["migration:doctor"] === "string" ||
+		fs.existsSync(path.join(projectDir, "src", "migrations", "config.ts"))
+	);
 }
 
 function runExampleProjectSmoke({
@@ -1054,8 +1129,10 @@ function runExampleProjectSmoke({
 	});
 
 	runScaffoldRefreshScripts(exampleDir, packageManager, packageJson);
-	refreshCurrentMigrationSnapshot(exampleDir, runtime);
-	runLocalMigrationDoctor(exampleDir, runtime);
+	if (shouldRunMigrationSmoke(exampleDir, packageJson)) {
+		refreshCurrentMigrationSnapshot(exampleDir, runtime);
+		runLocalMigrationDoctor(exampleDir, runtime);
+	}
 
 	const [buildCommand, buildArgs] = getRunCommand(packageManager);
 	run(buildCommand, buildArgs, { cwd: exampleDir });

--- a/tests/unit/generated-project-smoke-reference-lane.test.ts
+++ b/tests/unit/generated-project-smoke-reference-lane.test.ts
@@ -15,6 +15,10 @@ test("generated project smoke script supports a reference example lane", () => {
 	expect(smokeScript).toContain("runExampleProjectSmoke");
 	expect(smokeScript).toContain("assertExampleProjectScaffold");
 	expect(smokeScript).toContain("ensureCopiedExampleSupportDependencies");
+	expect(smokeScript).toContain("collectProjectFilePaths");
+	expect(smokeScript).toContain("shouldRunMigrationSmoke");
+	expect(smokeScript).toContain('exampleProject === "my-typia-block"');
+	expect(smokeScript).toContain('path.join(projectDir, "build", "blocks", blockSlug)');
 	expect(smokeScript).toContain('devDependencies["bun-types"]');
 	expect(smokeScript).toContain('devDependencies["@types/node"]');
 	expect(smokeScript).toContain(
@@ -24,14 +28,18 @@ test("generated project smoke script supports a reference example lane", () => {
 	expect(smokeScript).toContain('path.resolve(__dirname, "..", "examples", exampleProject)');
 });
 
-test("CI generated smoke matrix includes the reference app lane", () => {
+test("CI generated smoke matrix includes the checked-in example lanes", () => {
 	const ciWorkflow = readFileSync(
 		join(repoRoot, ".github", "workflows", "ci.yml"),
 		"utf8",
 	);
 
 	expect(ciWorkflow).toContain("example_project: my-typia-block");
+	expect(ciWorkflow).toContain("example_project: compound-patterns");
+	expect(ciWorkflow).toContain("example_project: persistence-examples");
 	expect(ciWorkflow).toContain("smoke-reference-my-typia-block-bun");
+	expect(ciWorkflow).toContain("smoke-example-compound-patterns-bun");
+	expect(ciWorkflow).toContain("smoke-example-persistence-examples-bun");
 	expect(ciWorkflow).toContain('if [ -n "${{ matrix.template || \'\' }}" ]; then');
 	expect(ciWorkflow).toContain('args+=(--template "${{ matrix.template }}")');
 	expect(ciWorkflow).toContain('--example-project "${{ matrix.example_project }}"');


### PR DESCRIPTION
## Context
- the generated project smoke lane currently exercises the `my-typia-block` reference app but leaves the other maintained checked-in block examples outside the same release gate
- multi-block examples also need a different artifact assertion path than the single-block reference app, and migration smoke should stay conditional on examples that actually expose migration support

## What Changed
- taught `run-generated-project-smoke.mjs` to distinguish single-block and `src/blocks/*` multi-block example layouts when asserting build artifacts
- made migration smoke conditional so non-migration examples do not fail on `migrate doctor`
- expanded render hardening checks across all `render.php` files in an example project
- added CI matrix lanes for `compound-patterns` and `persistence-examples`
- updated unit coverage to lock the expanded example-lane matrix and helper expectations in place

## Verification
- `bun test tests/unit/generated-project-smoke-reference-lane.test.ts`
- `bun run typecheck`
- `node scripts/run-generated-project-smoke.mjs --runtime bun --example-project compound-patterns --package-manager bun --project-name smoke-example-compound-patterns-bun`
- `node scripts/run-generated-project-smoke.mjs --runtime bun --example-project persistence-examples --package-manager bun --project-name smoke-example-persistence-examples-bun`
- `node scripts/run-generated-project-smoke.mjs --runtime bun --example-project my-typia-block --package-manager bun --project-name smoke-reference-my-typia-block-bun`

Closes #341
