### PR TITLE
Fix post-merge workflow and runtime audit failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,17 +384,17 @@ jobs:
 
       - name: Run generated project smoke
         run: |
-        args=(
-          --runtime "${{ matrix.runtime }}"
-          --package-manager "${{ matrix.package_manager }}"
-          --project-name "${{ matrix.project_name }}"
-        )
-        if [ -n "${{ matrix.template || '' }}" ]; then
-          args+=(--template "${{ matrix.template }}")
-        fi
-        if [ -n "${{ matrix.variant || '' }}" ]; then
-          args+=(--variant "${{ matrix.variant }}")
-        fi
+          args=(
+            --runtime "${{ matrix.runtime }}"
+            --package-manager "${{ matrix.package_manager }}"
+            --project-name "${{ matrix.project_name }}"
+          )
+          if [ -n "${{ matrix.template || '' }}" ]; then
+            args+=(--template "${{ matrix.template }}")
+          fi
+          if [ -n "${{ matrix.variant || '' }}" ]; then
+            args+=(--variant "${{ matrix.variant }}")
+          fi
           if [ -n "${{ matrix.example_project || '' }}" ]; then
             args+=(--example-project "${{ matrix.example_project }}")
           fi

--- a/scripts/lib/typescript-runtime-policy.mjs
+++ b/scripts/lib/typescript-runtime-policy.mjs
@@ -17,6 +17,8 @@ export const TYPESCRIPT_RUNTIME_PACKAGE_POLICIES = [
 		requiredTypeScriptImportFiles: [
 			"src/metadata-analysis.ts",
 			"src/metadata-parser.ts",
+			"src/metadata-parser-symbols.ts",
+			"src/metadata-parser-tags.ts",
 		],
 		runtimeSourceRoots: ["src"],
 		typescriptPlacement: TYPESCRIPT_DEPENDENCY_POLICY.dependency,

--- a/tests/unit/typescript-runtime-dependency-placement.test.ts
+++ b/tests/unit/typescript-runtime-dependency-placement.test.ts
@@ -28,6 +28,8 @@ describe("typescript-runtime-policy", () => {
 
 		expect(importFiles).toContain("src/metadata-analysis.ts");
 		expect(importFiles).toContain("src/metadata-parser.ts");
+		expect(importFiles).toContain("src/metadata-parser-symbols.ts");
+		expect(importFiles).toContain("src/metadata-parser-tags.ts");
 	});
 
 	test("detects side-effect imports but ignores type-only TypeScript imports", () => {


### PR DESCRIPTION
## Context
- recent main-branch follow-up actions started failing in two places after the generated smoke expansion and block-runtime parser split
- the generated project smoke shell block in `.github/workflows/ci.yml` was malformed, and the block-runtime TypeScript runtime placement audit had gone stale

## What Changed
- restored valid shell-block indentation for the generated project smoke step in `ci.yml`
- updated the `@wp-typia/block-runtime` runtime placement policy to include the new metadata parser helper modules
- extended the runtime placement unit test so local validation now expects the expanded audit set

## Verification
- `bun test tests/unit/typescript-runtime-dependency-placement.test.ts`
- `bun run typescript-runtime:validate`
- `bunx prettier --check .github/workflows/ci.yml`

Closes #343


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Fixed CI workflow script indentation to ensure proper execution of smoke test initialization.
  * Updated runtime package validation configuration to include additional source files in dependency verification.

* **Tests**
  * Updated test assertions to verify TypeScript runtime source file validation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->