### PR TITLE
Split cli-add-block runtime boundaries into focused helpers

### DIFF
--- a/.sampo/changesets/issue-347-cli-add-block-boundaries.md
+++ b/.sampo/changesets/issue-347-cli-add-block-boundaries.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Split `cli-add-block` config generation and legacy validator repair into focused runtime helpers while preserving existing workspace add-block behavior.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-block-config.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-block-config.ts
@@ -1,0 +1,178 @@
+import path from "node:path";
+
+import {
+	SHARED_WORKSPACE_TEMPLATE_ROOT,
+} from "./template-registry.js";
+import type { MigrationBlockConfig } from "./migration-types.js";
+import type { ScaffoldTemplateVariables } from "./scaffold.js";
+import {
+	type AddBlockTemplateId,
+	quoteTsString,
+} from "./cli-add-shared.js";
+
+export function buildServerTemplateRoot(
+	persistencePolicy: string | undefined,
+): string {
+	return path.join(
+		SHARED_WORKSPACE_TEMPLATE_ROOT,
+		persistencePolicy === "public" ? "persistence-public" : "persistence-auth",
+	);
+}
+
+function buildSingleBlockConfigEntry(
+	variables: ScaffoldTemplateVariables,
+): string {
+	return [
+		"\t{",
+		`\t\tslug: ${quoteTsString(variables.slugKebabCase)},`,
+		`\t\tattributeTypeName: ${quoteTsString(`${variables.pascalCase}Attributes`)},`,
+		`\t\ttypesFile: ${quoteTsString(`src/blocks/${variables.slugKebabCase}/types.ts`)},`,
+		"\t},",
+	].join("\n");
+}
+
+function buildPersistenceBlockConfigEntry(
+	variables: ScaffoldTemplateVariables,
+): string {
+	return [
+		"\t{",
+		`\t\tapiTypesFile: ${quoteTsString(`src/blocks/${variables.slugKebabCase}/api-types.ts`)},`,
+		`\t\tattributeTypeName: ${quoteTsString(`${variables.pascalCase}Attributes`)},`,
+		"\t\trestManifest: defineEndpointManifest( {",
+		"\t\t\tcontracts: {",
+		"\t\t\t\t'bootstrap-query': {",
+		`\t\t\t\t\tsourceTypeName: ${quoteTsString(`${variables.pascalCase}BootstrapQuery`)},`,
+		"\t\t\t\t},",
+		"\t\t\t\t'bootstrap-response': {",
+		`\t\t\t\t\tsourceTypeName: ${quoteTsString(`${variables.pascalCase}BootstrapResponse`)},`,
+		"\t\t\t\t},",
+		"\t\t\t\t'state-query': {",
+		`\t\t\t\t\tsourceTypeName: ${quoteTsString(`${variables.pascalCase}StateQuery`)},`,
+		"\t\t\t\t},",
+		"\t\t\t\t'state-response': {",
+		`\t\t\t\t\tsourceTypeName: ${quoteTsString(`${variables.pascalCase}StateResponse`)},`,
+		"\t\t\t\t},",
+		"\t\t\t\t'write-state-request': {",
+		`\t\t\t\t\tsourceTypeName: ${quoteTsString(`${variables.pascalCase}WriteStateRequest`)},`,
+		"\t\t\t\t},",
+		"\t\t\t},",
+		"\t\t\tendpoints: [",
+		"\t\t\t\t{",
+		"\t\t\t\t\tauth: 'public',",
+		"\t\t\t\t\tmethod: 'GET',",
+		`\t\t\t\t\toperationId: ${quoteTsString(`get${variables.pascalCase}State`)},`,
+		`\t\t\t\t\tpath: ${quoteTsString(`/${variables.namespace}/v1/${variables.slugKebabCase}/state`)},`,
+		"\t\t\t\t\tqueryContract: 'state-query',",
+		"\t\t\t\t\tresponseContract: 'state-response',",
+		`\t\t\t\t\tsummary: 'Read the current persisted state.',`,
+		`\t\t\t\t\ttags: [ ${quoteTsString(variables.title)} ],`,
+		"\t\t\t\t},",
+		"\t\t\t\t{",
+		`\t\t\t\t\tauth: ${quoteTsString(variables.restWriteAuthIntent)},`,
+		"\t\t\t\t\tbodyContract: 'write-state-request',",
+		"\t\t\t\t\tmethod: 'POST',",
+		`\t\t\t\t\toperationId: ${quoteTsString(`write${variables.pascalCase}State`)},`,
+		`\t\t\t\t\tpath: ${quoteTsString(`/${variables.namespace}/v1/${variables.slugKebabCase}/state`)},`,
+		"\t\t\t\t\tresponseContract: 'state-response',",
+		`\t\t\t\t\tsummary: 'Write the current persisted state.',`,
+		`\t\t\t\t\ttags: [ ${quoteTsString(variables.title)} ],`,
+		"\t\t\t\t\twordpressAuth: {",
+		`\t\t\t\t\t\tmechanism: ${quoteTsString(variables.restWriteAuthMechanism)},`,
+		"\t\t\t\t\t},",
+		"\t\t\t\t},",
+		"\t\t\t\t{",
+		"\t\t\t\t\tauth: 'public',",
+		"\t\t\t\t\tmethod: 'GET',",
+		`\t\t\t\t\toperationId: ${quoteTsString(`get${variables.pascalCase}Bootstrap`)},`,
+		`\t\t\t\t\tpath: ${quoteTsString(`/${variables.namespace}/v1/${variables.slugKebabCase}/bootstrap`)},`,
+		"\t\t\t\t\tqueryContract: 'bootstrap-query',",
+		"\t\t\t\t\tresponseContract: 'bootstrap-response',",
+		`\t\t\t\t\tsummary: 'Read fresh session bootstrap state for the current viewer.',`,
+		`\t\t\t\t\ttags: [ ${quoteTsString(variables.title)} ],`,
+		"\t\t\t\t},",
+		"\t\t\t],",
+		"\t\t\tinfo: {",
+		`\t\t\t\ttitle: ${quoteTsString(`${variables.title} REST API`)},`,
+		"\t\t\t\tversion: '1.0.0',",
+		"\t\t\t},",
+		"\t\t} ),",
+		`\t\topenApiFile: ${quoteTsString(`src/blocks/${variables.slugKebabCase}/api.openapi.json`)},`,
+		`\t\tslug: ${quoteTsString(variables.slugKebabCase)},`,
+		`\t\ttypesFile: ${quoteTsString(`src/blocks/${variables.slugKebabCase}/types.ts`)},`,
+		"\t},",
+	].join("\n");
+}
+
+function buildCompoundChildConfigEntry(
+	variables: ScaffoldTemplateVariables,
+): string {
+	return [
+		"\t{",
+		`\t\tslug: ${quoteTsString(`${variables.slugKebabCase}-item`)},`,
+		`\t\tattributeTypeName: ${quoteTsString(`${variables.pascalCase}ItemAttributes`)},`,
+		`\t\ttypesFile: ${quoteTsString(`src/blocks/${variables.slugKebabCase}-item/types.ts`)},`,
+		"\t},",
+	].join("\n");
+}
+
+export function buildConfigEntries(
+	templateId: AddBlockTemplateId,
+	variables: ScaffoldTemplateVariables,
+): string[] {
+	if (templateId === "basic" || templateId === "interactivity") {
+		return [buildSingleBlockConfigEntry(variables)];
+	}
+
+	if (templateId === "persistence") {
+		return [buildPersistenceBlockConfigEntry(variables)];
+	}
+
+	if (variables.compoundPersistenceEnabled === "true") {
+		return [
+			buildPersistenceBlockConfigEntry(variables),
+			buildCompoundChildConfigEntry(variables),
+		];
+	}
+
+	return [
+		buildSingleBlockConfigEntry(variables),
+		buildCompoundChildConfigEntry(variables),
+	];
+}
+
+export function buildMigrationBlocks(
+	templateId: AddBlockTemplateId,
+	variables: ScaffoldTemplateVariables,
+): MigrationBlockConfig[] {
+	if (templateId === "compound") {
+		return [
+			{
+				blockJsonFile: `src/blocks/${variables.slugKebabCase}/block.json`,
+				blockName: `${variables.namespace}/${variables.slugKebabCase}`,
+				key: variables.slugKebabCase,
+				manifestFile: `src/blocks/${variables.slugKebabCase}/typia.manifest.json`,
+				saveFile: `src/blocks/${variables.slugKebabCase}/save.tsx`,
+				typesFile: `src/blocks/${variables.slugKebabCase}/types.ts`,
+			},
+			{
+				blockJsonFile: `src/blocks/${variables.slugKebabCase}-item/block.json`,
+				blockName: `${variables.namespace}/${variables.slugKebabCase}-item`,
+				key: `${variables.slugKebabCase}-item`,
+				manifestFile: `src/blocks/${variables.slugKebabCase}-item/typia.manifest.json`,
+				saveFile: `src/blocks/${variables.slugKebabCase}-item/save.tsx`,
+				typesFile: `src/blocks/${variables.slugKebabCase}-item/types.ts`,
+			},
+		];
+	}
+
+	return [
+		{
+			blockJsonFile: `src/blocks/${variables.slugKebabCase}/block.json`,
+			blockName: `${variables.namespace}/${variables.slugKebabCase}`,
+			key: variables.slugKebabCase,
+			manifestFile: `src/blocks/${variables.slugKebabCase}/typia.manifest.json`,
+			saveFile: `src/blocks/${variables.slugKebabCase}/save.tsx`,
+			typesFile: `src/blocks/${variables.slugKebabCase}/types.ts`,
+		},
+	];
+}

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-block-legacy-validator.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-block-legacy-validator.ts
@@ -1,0 +1,251 @@
+import fs from "node:fs";
+import { promises as fsp } from "node:fs";
+import path from "node:path";
+
+import { readOptionalFile } from "./cli-add-shared.js";
+
+export const COMPOUND_SHARED_SUPPORT_FILES = [
+	"hooks.ts",
+	"validator-toolkit.ts",
+] as const;
+const LEGACY_ASSERT_PATTERN = /assert:\s*typia\.createAssert</u;
+const LEGACY_MANIFEST_PATTERN = /\r?\n[ \t]*manifest:\s*currentManifest,/u;
+const LEGACY_VALIDATOR_MANIFEST_IMPORT_PATTERN =
+	/^[\uFEFF \t]*import\s+currentManifest\s+from\s*["']\.\/typia\.manifest\.json["'];?$/u;
+const LEGACY_TOOLKIT_CALL_PATTERN =
+	/createTemplateValidatorToolkit<\s*(?<typeName>[A-Za-z0-9_]+)\s*>\s*\(\s*\{/u;
+const LEGACY_VALIDATOR_TOOLKIT_IMPORT_PATTERN =
+	/from\s*["']\.\.\/\.\.\/validator-toolkit["']/u;
+const TYPIA_IMPORT_PATTERN =
+	/^[\uFEFF \t]*import\s+typia\s+from\s*["']typia["'];?/mu;
+const COMPATIBLE_COMPOUND_TOOLKIT_PATTERNS = [
+	/interface\s+TemplateValidatorFunctions\s*<\s*T\s+extends\s+object\s*>\s*\{/u,
+	/\bassert\s*:\s*ScaffoldValidatorToolkitOptions\s*<\s*T\s*>\s*\[\s*["']assert["']\s*\]/u,
+	/\bclone\s*:\s*ScaffoldValidatorToolkitOptions\s*<\s*T\s*>\s*\[\s*["']clone["']\s*\]/u,
+	/\bis\s*:\s*ScaffoldValidatorToolkitOptions\s*<\s*T\s*>\s*\[\s*["']is["']\s*\]/u,
+	/\bprune\s*:\s*ScaffoldValidatorToolkitOptions\s*<\s*T\s*>\s*\[\s*["']prune["']\s*\]/u,
+	/\brandom\s*:\s*ScaffoldValidatorToolkitOptions\s*<\s*T\s*>\s*\[\s*["']random["']\s*\]/u,
+	/\bvalidate\s*:\s*ScaffoldValidatorToolkitOptions\s*<\s*T\s*>\s*\[\s*["']validate["']\s*\]/u,
+	/createTemplateValidatorToolkit\s*<\s*T\s+extends\s+object\s*>\s*\(\s*\{/u,
+] as const;
+
+const REST_MANIFEST_IMPORT_PATTERN =
+	/import\s*\{[^}]*\bdefineEndpointManifest\b[^}]*\}\s*from\s*["']@wp-typia\/block-runtime\/metadata-core["'];?/m;
+
+export function ensureBlockConfigCanAddRestManifests(source: string): string {
+	const importLine =
+		"import { defineEndpointManifest } from '@wp-typia/block-runtime/metadata-core';";
+	if (REST_MANIFEST_IMPORT_PATTERN.test(source)) {
+		return source;
+	}
+	return `${importLine}\n\n${source}`;
+}
+
+function shouldRefreshCompoundValidatorToolkit(source: string | null): boolean {
+	return (
+		source === null ||
+		!COMPATIBLE_COMPOUND_TOOLKIT_PATTERNS.every((pattern) =>
+			pattern.test(source),
+		)
+	);
+}
+
+function isLegacyCompoundValidatorSource(source: string | null): source is string {
+	return (
+		typeof source === "string" &&
+		LEGACY_VALIDATOR_TOOLKIT_IMPORT_PATTERN.test(source) &&
+		!LEGACY_ASSERT_PATTERN.test(source)
+	);
+}
+
+function hasTypiaImport(source: string): boolean {
+	return TYPIA_IMPORT_PATTERN.test(source.replace(/\/\*[\s\S]*?\*\//gu, ""));
+}
+
+function replaceFirstNonCommentLine(
+	source: string,
+	pattern: RegExp,
+	replacement: string,
+): string {
+	const lineEnding = source.includes("\r\n") ? "\r\n" : "\n";
+	const lines = source.split(/\r?\n/);
+	let inBlockComment = false;
+
+	for (let index = 0; index < lines.length; index += 1) {
+		const line = lines[index] ?? "";
+		const trimmed = line.trimStart();
+
+		if (inBlockComment) {
+			if (trimmed.includes("*/")) {
+				inBlockComment = false;
+			}
+			continue;
+		}
+
+		if (trimmed.startsWith("//")) {
+			continue;
+		}
+
+		if (trimmed.startsWith("/*")) {
+			if (!trimmed.includes("*/")) {
+				inBlockComment = true;
+			}
+			continue;
+		}
+
+		if (!pattern.test(line)) {
+			continue;
+		}
+
+		lines[index] = replacement;
+		return lines.join(lineEnding);
+	}
+
+	return source;
+}
+
+function upgradeLegacyCompoundValidatorSource(source: string): string {
+	const typeNameMatch = source.match(LEGACY_TOOLKIT_CALL_PATTERN);
+	const typeName = typeNameMatch?.groups?.typeName;
+	if (!typeName) {
+		throw new Error(
+			"Unable to upgrade a legacy compound validator without a generated type import.",
+		);
+	}
+
+	let nextSource = source;
+	if (!hasTypiaImport(nextSource)) {
+		nextSource = `import typia from 'typia';\n${nextSource}`;
+	}
+
+	nextSource = replaceFirstNonCommentLine(
+		nextSource,
+		LEGACY_VALIDATOR_MANIFEST_IMPORT_PATTERN,
+		"import currentManifest from './manifest-defaults-document';",
+	);
+
+	nextSource = nextSource.replace(
+		LEGACY_TOOLKIT_CALL_PATTERN,
+		[
+			`createTemplateValidatorToolkit< ${typeName} >( {`,
+			`\tassert: typia.createAssert< ${typeName} >(),`,
+			`\tclone: typia.misc.createClone< ${typeName} >() as (`,
+			`\t\tvalue: ${typeName},`,
+			`\t) => ${typeName},`,
+			`\tis: typia.createIs< ${typeName} >(),`,
+		].join("\n") + "\n",
+	);
+
+	const replacedManifest = nextSource.replace(
+		LEGACY_MANIFEST_PATTERN,
+		[
+			"",
+			"\tmanifest: currentManifest,",
+			`\tprune: typia.misc.createPrune< ${typeName} >(),`,
+			`\trandom: typia.createRandom< ${typeName} >() as (`,
+			"\t\t...args: unknown[]",
+			`\t) => ${typeName},`,
+			`\tvalidate: typia.createValidate< ${typeName} >(),`,
+		].join("\n"),
+	);
+	if (replacedManifest === nextSource) {
+		throw new Error(
+			"Unable to upgrade legacy compound validator: manifest anchor not found.",
+		);
+	}
+
+	return replacedManifest;
+}
+
+function renderLegacyManifestDefaultsWrapperSource(): string {
+	return [
+		"import rawCurrentManifest from './typia.manifest.json';",
+		"import { defineManifestDefaultsDocument } from '@wp-typia/block-runtime/defaults';",
+		"",
+		"const currentManifest = defineManifestDefaultsDocument( rawCurrentManifest );",
+		"",
+		"export default currentManifest;",
+		"",
+	].join("\n");
+}
+
+async function ensureLegacyCompoundValidatorManifestDefaultsWrapper(
+	validatorPath: string,
+): Promise<void> {
+	const validatorDir = path.dirname(validatorPath);
+	const wrapperPath = path.join(validatorDir, "manifest-defaults-document.ts");
+	const manifestPath = path.join(validatorDir, "typia.manifest.json");
+	if (fs.existsSync(wrapperPath) || !fs.existsSync(manifestPath)) {
+		return;
+	}
+
+	await fsp.writeFile(
+		wrapperPath,
+		renderLegacyManifestDefaultsWrapperSource(),
+		"utf8",
+	);
+}
+
+export async function collectLegacyCompoundValidatorPaths(
+	projectDir: string,
+): Promise<string[]> {
+	const blocksDir = path.join(projectDir, "src", "blocks");
+	if (!fs.existsSync(blocksDir)) {
+		return [];
+	}
+
+	const blockEntries = await fsp.readdir(blocksDir, { withFileTypes: true });
+	const validatorPaths = await Promise.all(
+		blockEntries
+			.filter((entry) => entry.isDirectory())
+			.map(async (entry) => {
+				const validatorPath = path.join(blocksDir, entry.name, "validators.ts");
+				const validatorSource = await readOptionalFile(validatorPath);
+				return isLegacyCompoundValidatorSource(validatorSource)
+					? validatorPath
+					: null;
+			}),
+	);
+
+	return validatorPaths.filter(
+		(validatorPath): validatorPath is string => validatorPath !== null,
+	);
+}
+
+export async function ensureCompoundWorkspaceSupportFiles(
+	projectDir: string,
+	tempProjectDir: string,
+	legacyValidatorPaths: readonly string[],
+): Promise<void> {
+	for (const fileName of COMPOUND_SHARED_SUPPORT_FILES) {
+		const sourcePath = path.join(tempProjectDir, "src", fileName);
+		if (!fs.existsSync(sourcePath)) {
+			continue;
+		}
+
+		const targetPath = path.join(projectDir, "src", fileName);
+		const currentSource = await readOptionalFile(targetPath);
+		if (
+			fileName === "validator-toolkit.ts"
+				? shouldRefreshCompoundValidatorToolkit(currentSource)
+				: currentSource === null
+		) {
+			await fsp.mkdir(path.dirname(targetPath), { recursive: true });
+			await fsp.copyFile(sourcePath, targetPath);
+		}
+	}
+
+	for (const validatorPath of legacyValidatorPaths) {
+		const currentSource = await readOptionalFile(validatorPath);
+		if (!isLegacyCompoundValidatorSource(currentSource)) {
+			continue;
+		}
+
+		await ensureLegacyCompoundValidatorManifestDefaultsWrapper(validatorPath);
+		await fsp.writeFile(
+			validatorPath,
+			upgradeLegacyCompoundValidatorSource(currentSource),
+			"utf8",
+		);
+	}
+}

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-block.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-block.ts
@@ -23,9 +23,6 @@ import {
 	copyInterpolatedDirectory,
 	listInterpolatedDirectoryOutputs,
 } from "./template-render.js";
-import {
-	SHARED_WORKSPACE_TEMPLATE_ROOT,
-} from "./template-registry.js";
 import type { MigrationBlockConfig } from "./migration-types.js";
 import {
 	appendWorkspaceInventoryEntries,
@@ -40,13 +37,23 @@ import {
 	isAddBlockTemplateId,
 	normalizeBlockSlug,
 	patchFile,
-	quoteTsString,
 	readOptionalFile,
 	type RunAddBlockCommandOptions,
 	rollbackWorkspaceMutation,
 	type WorkspaceMutationSnapshot,
 	snapshotWorkspaceFiles,
 } from "./cli-add-shared.js";
+import {
+	buildConfigEntries,
+	buildMigrationBlocks,
+	buildServerTemplateRoot,
+} from "./cli-add-block-config.js";
+import {
+	COMPOUND_SHARED_SUPPORT_FILES,
+	collectLegacyCompoundValidatorPaths,
+	ensureBlockConfigCanAddRestManifests,
+	ensureCompoundWorkspaceSupportFiles,
+} from "./cli-add-block-legacy-validator.js";
 import {
 	parseTemplateLocator,
 	resolveTemplateSeed,
@@ -59,167 +66,6 @@ import {
 } from "./external-layer-selection.js";
 
 const COLLECTION_IMPORT_LINE = "import '../../collection';";
-const REST_MANIFEST_IMPORT_PATTERN =
-	/import\s*\{[^}]*\bdefineEndpointManifest\b[^}]*\}\s*from\s*["']@wp-typia\/block-runtime\/metadata-core["'];?/m;
-
-function buildServerTemplateRoot(persistencePolicy: string | undefined): string {
-	return path.join(
-		SHARED_WORKSPACE_TEMPLATE_ROOT,
-		persistencePolicy === "public" ? "persistence-public" : "persistence-auth",
-	);
-}
-
-function buildSingleBlockConfigEntry(variables: ScaffoldTemplateVariables): string {
-	return [
-		"\t{",
-		`\t\tslug: ${quoteTsString(variables.slugKebabCase)},`,
-		`\t\tattributeTypeName: ${quoteTsString(`${variables.pascalCase}Attributes`)},`,
-		`\t\ttypesFile: ${quoteTsString(`src/blocks/${variables.slugKebabCase}/types.ts`)},`,
-		"\t},",
-	].join("\n");
-}
-
-function buildPersistenceBlockConfigEntry(variables: ScaffoldTemplateVariables): string {
-	return [
-		"\t{",
-		`\t\tapiTypesFile: ${quoteTsString(`src/blocks/${variables.slugKebabCase}/api-types.ts`)},`,
-		`\t\tattributeTypeName: ${quoteTsString(`${variables.pascalCase}Attributes`)},`,
-		"\t\trestManifest: defineEndpointManifest( {",
-		"\t\t\tcontracts: {",
-		"\t\t\t\t'bootstrap-query': {",
-		`\t\t\t\t\tsourceTypeName: ${quoteTsString(`${variables.pascalCase}BootstrapQuery`)},`,
-		"\t\t\t\t},",
-		"\t\t\t\t'bootstrap-response': {",
-		`\t\t\t\t\tsourceTypeName: ${quoteTsString(`${variables.pascalCase}BootstrapResponse`)},`,
-		"\t\t\t\t},",
-		"\t\t\t\t'state-query': {",
-		`\t\t\t\t\tsourceTypeName: ${quoteTsString(`${variables.pascalCase}StateQuery`)},`,
-		"\t\t\t\t},",
-		"\t\t\t\t'state-response': {",
-		`\t\t\t\t\tsourceTypeName: ${quoteTsString(`${variables.pascalCase}StateResponse`)},`,
-		"\t\t\t\t},",
-		"\t\t\t\t'write-state-request': {",
-		`\t\t\t\t\tsourceTypeName: ${quoteTsString(`${variables.pascalCase}WriteStateRequest`)},`,
-		"\t\t\t\t},",
-		"\t\t\t},",
-		"\t\t\tendpoints: [",
-		"\t\t\t\t{",
-		"\t\t\t\t\tauth: 'public',",
-		"\t\t\t\t\tmethod: 'GET',",
-		`\t\t\t\t\toperationId: ${quoteTsString(`get${variables.pascalCase}State`)},`,
-		`\t\t\t\t\tpath: ${quoteTsString(`/${variables.namespace}/v1/${variables.slugKebabCase}/state`)},`,
-		"\t\t\t\t\tqueryContract: 'state-query',",
-		"\t\t\t\t\tresponseContract: 'state-response',",
-		`\t\t\t\t\tsummary: 'Read the current persisted state.',`,
-		`\t\t\t\t\ttags: [ ${quoteTsString(variables.title)} ],`,
-		"\t\t\t\t},",
-		"\t\t\t\t{",
-		`\t\t\t\t\tauth: ${quoteTsString(variables.restWriteAuthIntent)},`,
-		"\t\t\t\t\tbodyContract: 'write-state-request',",
-		"\t\t\t\t\tmethod: 'POST',",
-		`\t\t\t\t\toperationId: ${quoteTsString(`write${variables.pascalCase}State`)},`,
-		`\t\t\t\t\tpath: ${quoteTsString(`/${variables.namespace}/v1/${variables.slugKebabCase}/state`)},`,
-		"\t\t\t\t\tresponseContract: 'state-response',",
-		`\t\t\t\t\tsummary: 'Write the current persisted state.',`,
-		`\t\t\t\t\ttags: [ ${quoteTsString(variables.title)} ],`,
-		"\t\t\t\t\twordpressAuth: {",
-		`\t\t\t\t\t\tmechanism: ${quoteTsString(variables.restWriteAuthMechanism)},`,
-		"\t\t\t\t\t},",
-		"\t\t\t\t},",
-		"\t\t\t\t{",
-		"\t\t\t\t\tauth: 'public',",
-		"\t\t\t\t\tmethod: 'GET',",
-		`\t\t\t\t\toperationId: ${quoteTsString(`get${variables.pascalCase}Bootstrap`)},`,
-		`\t\t\t\t\tpath: ${quoteTsString(`/${variables.namespace}/v1/${variables.slugKebabCase}/bootstrap`)},`,
-		"\t\t\t\t\tqueryContract: 'bootstrap-query',",
-		"\t\t\t\t\tresponseContract: 'bootstrap-response',",
-		`\t\t\t\t\tsummary: 'Read fresh session bootstrap state for the current viewer.',`,
-		`\t\t\t\t\ttags: [ ${quoteTsString(variables.title)} ],`,
-		"\t\t\t\t},",
-		"\t\t\t],",
-		"\t\t\tinfo: {",
-		`\t\t\t\ttitle: ${quoteTsString(`${variables.title} REST API`)},`,
-		"\t\t\t\tversion: '1.0.0',",
-		"\t\t\t},",
-		"\t\t} ),",
-		`\t\topenApiFile: ${quoteTsString(`src/blocks/${variables.slugKebabCase}/api.openapi.json`)},`,
-		`\t\tslug: ${quoteTsString(variables.slugKebabCase)},`,
-		`\t\ttypesFile: ${quoteTsString(`src/blocks/${variables.slugKebabCase}/types.ts`)},`,
-		"\t},",
-	].join("\n");
-}
-
-function buildCompoundChildConfigEntry(variables: ScaffoldTemplateVariables): string {
-	return [
-		"\t{",
-		`\t\tslug: ${quoteTsString(`${variables.slugKebabCase}-item`)},`,
-		`\t\tattributeTypeName: ${quoteTsString(`${variables.pascalCase}ItemAttributes`)},`,
-		`\t\ttypesFile: ${quoteTsString(`src/blocks/${variables.slugKebabCase}-item/types.ts`)},`,
-		"\t},",
-	].join("\n");
-}
-
-function buildConfigEntries(
-	templateId: AddBlockTemplateId,
-	variables: ScaffoldTemplateVariables,
-): string[] {
-	if (templateId === "basic" || templateId === "interactivity") {
-		return [buildSingleBlockConfigEntry(variables)];
-	}
-
-	if (templateId === "persistence") {
-		return [buildPersistenceBlockConfigEntry(variables)];
-	}
-
-	if (variables.compoundPersistenceEnabled === "true") {
-		return [
-			buildPersistenceBlockConfigEntry(variables),
-			buildCompoundChildConfigEntry(variables),
-		];
-	}
-
-	return [
-		buildSingleBlockConfigEntry(variables),
-		buildCompoundChildConfigEntry(variables),
-	];
-}
-
-function buildMigrationBlocks(
-	templateId: AddBlockTemplateId,
-	variables: ScaffoldTemplateVariables,
-): MigrationBlockConfig[] {
-	if (templateId === "compound") {
-		return [
-			{
-				blockJsonFile: `src/blocks/${variables.slugKebabCase}/block.json`,
-				blockName: `${variables.namespace}/${variables.slugKebabCase}`,
-				key: variables.slugKebabCase,
-				manifestFile: `src/blocks/${variables.slugKebabCase}/typia.manifest.json`,
-				saveFile: `src/blocks/${variables.slugKebabCase}/save.tsx`,
-				typesFile: `src/blocks/${variables.slugKebabCase}/types.ts`,
-			},
-			{
-				blockJsonFile: `src/blocks/${variables.slugKebabCase}-item/block.json`,
-				blockName: `${variables.namespace}/${variables.slugKebabCase}-item`,
-				key: `${variables.slugKebabCase}-item`,
-				manifestFile: `src/blocks/${variables.slugKebabCase}-item/typia.manifest.json`,
-				saveFile: `src/blocks/${variables.slugKebabCase}-item/save.tsx`,
-				typesFile: `src/blocks/${variables.slugKebabCase}-item/types.ts`,
-			},
-		];
-	}
-
-	return [
-		{
-			blockJsonFile: `src/blocks/${variables.slugKebabCase}/block.json`,
-			blockName: `${variables.namespace}/${variables.slugKebabCase}`,
-			key: variables.slugKebabCase,
-			manifestFile: `src/blocks/${variables.slugKebabCase}/typia.manifest.json`,
-			saveFile: `src/blocks/${variables.slugKebabCase}/save.tsx`,
-			typesFile: `src/blocks/${variables.slugKebabCase}/types.ts`,
-		},
-	];
-}
 
 async function ensureCollectionImport(filePath: string): Promise<void> {
 	await patchFile(filePath, (source) => {
@@ -267,15 +113,6 @@ async function addCollectionImportsForTemplate(
 	);
 }
 
-function ensureBlockConfigCanAddRestManifests(source: string): string {
-	const importLine =
-		"import { defineEndpointManifest } from '@wp-typia/block-runtime/metadata-core';";
-	if (REST_MANIFEST_IMPORT_PATTERN.test(source)) {
-		return source;
-	}
-	return `${importLine}\n\n${source}`;
-}
-
 async function appendBlockConfigEntries(
 	projectDir: string,
 	entries: string[],
@@ -295,28 +132,6 @@ async function renderWorkspacePersistenceServerModule(
 	const templateDir = buildServerTemplateRoot(variables.persistencePolicy);
 	await copyInterpolatedDirectory(templateDir, targetDir, variables);
 }
-
-const COMPOUND_SHARED_SUPPORT_FILES = ["hooks.ts", "validator-toolkit.ts"] as const;
-const LEGACY_ASSERT_PATTERN = /assert:\s*typia\.createAssert</u;
-const LEGACY_MANIFEST_PATTERN = /\r?\n[ \t]*manifest:\s*currentManifest,/u;
-const LEGACY_VALIDATOR_MANIFEST_IMPORT_PATTERN =
-	/^[\uFEFF \t]*import\s+currentManifest\s+from\s*["']\.\/typia\.manifest\.json["'];?$/u;
-const LEGACY_TOOLKIT_CALL_PATTERN =
-	/createTemplateValidatorToolkit<\s*(?<typeName>[A-Za-z0-9_]+)\s*>\s*\(\s*\{/u;
-const LEGACY_VALIDATOR_TOOLKIT_IMPORT_PATTERN =
-	/from\s*["']\.\.\/\.\.\/validator-toolkit["']/u;
-const TYPIA_IMPORT_PATTERN =
-	/^[\uFEFF \t]*import\s+typia\s+from\s*["']typia["'];?/mu;
-const COMPATIBLE_COMPOUND_TOOLKIT_PATTERNS = [
-	/interface\s+TemplateValidatorFunctions\s*<\s*T\s+extends\s+object\s*>\s*\{/u,
-	/\bassert\s*:\s*ScaffoldValidatorToolkitOptions\s*<\s*T\s*>\s*\[\s*["']assert["']\s*\]/u,
-	/\bclone\s*:\s*ScaffoldValidatorToolkitOptions\s*<\s*T\s*>\s*\[\s*["']clone["']\s*\]/u,
-	/\bis\s*:\s*ScaffoldValidatorToolkitOptions\s*<\s*T\s*>\s*\[\s*["']is["']\s*\]/u,
-	/\bprune\s*:\s*ScaffoldValidatorToolkitOptions\s*<\s*T\s*>\s*\[\s*["']prune["']\s*\]/u,
-	/\brandom\s*:\s*ScaffoldValidatorToolkitOptions\s*<\s*T\s*>\s*\[\s*["']random["']\s*\]/u,
-	/\bvalidate\s*:\s*ScaffoldValidatorToolkitOptions\s*<\s*T\s*>\s*\[\s*["']validate["']\s*\]/u,
-	/createTemplateValidatorToolkit\s*<\s*T\s+extends\s+object\s*>\s*\(\s*\{/u,
-] as const;
 
 function normalizeExternalLayerOption(value?: string): string | undefined {
 	if (typeof value !== "string") {
@@ -342,208 +157,6 @@ function resolveExternalLayerSourceFromCaller(
 	return path.resolve(callerCwd, source);
 }
 
-function shouldRefreshCompoundValidatorToolkit(source: string | null): boolean {
-	return (
-		source === null ||
-		!COMPATIBLE_COMPOUND_TOOLKIT_PATTERNS.every((pattern) =>
-			pattern.test(source),
-		)
-	);
-}
-
-function isLegacyCompoundValidatorSource(source: string | null): source is string {
-	return (
-		typeof source === "string" &&
-		LEGACY_VALIDATOR_TOOLKIT_IMPORT_PATTERN.test(source) &&
-		!LEGACY_ASSERT_PATTERN.test(source)
-	);
-}
-
-function hasTypiaImport(source: string): boolean {
-	return TYPIA_IMPORT_PATTERN.test(source.replace(/\/\*[\s\S]*?\*\//gu, ""));
-}
-
-function replaceFirstNonCommentLine(
-	source: string,
-	pattern: RegExp,
-	replacement: string,
-): string {
-	const lineEnding = source.includes("\r\n") ? "\r\n" : "\n";
-	const lines = source.split(/\r?\n/);
-	let inBlockComment = false;
-
-	for (let index = 0; index < lines.length; index += 1) {
-		const line = lines[index] ?? "";
-		const trimmed = line.trimStart();
-
-		if (inBlockComment) {
-			if (trimmed.includes("*/")) {
-				inBlockComment = false;
-			}
-			continue;
-		}
-
-		if (trimmed.startsWith("//")) {
-			continue;
-		}
-
-		if (trimmed.startsWith("/*")) {
-			if (!trimmed.includes("*/")) {
-				inBlockComment = true;
-			}
-			continue;
-		}
-
-		if (!pattern.test(line)) {
-			continue;
-		}
-
-		lines[index] = replacement;
-		return lines.join(lineEnding);
-	}
-
-	return source;
-}
-
-function upgradeLegacyCompoundValidatorSource(source: string): string {
-	const typeNameMatch = source.match(LEGACY_TOOLKIT_CALL_PATTERN);
-	const typeName = typeNameMatch?.groups?.typeName;
-	if (!typeName) {
-		throw new Error(
-			"Unable to upgrade a legacy compound validator without a generated type import.",
-		);
-	}
-
-	let nextSource = source;
-	if (!hasTypiaImport(nextSource)) {
-		nextSource = `import typia from 'typia';\n${nextSource}`;
-	}
-
-	nextSource = replaceFirstNonCommentLine(
-		nextSource,
-		LEGACY_VALIDATOR_MANIFEST_IMPORT_PATTERN,
-		"import currentManifest from './manifest-defaults-document';",
-	);
-
-	nextSource = nextSource.replace(
-		LEGACY_TOOLKIT_CALL_PATTERN,
-		[
-			`createTemplateValidatorToolkit< ${typeName} >( {`,
-			`\tassert: typia.createAssert< ${typeName} >(),`,
-			`\tclone: typia.misc.createClone< ${typeName} >() as (`,
-			`\t\tvalue: ${typeName},`,
-			`\t) => ${typeName},`,
-			`\tis: typia.createIs< ${typeName} >(),`,
-		].join("\n") + "\n",
-	);
-
-	const replacedManifest = nextSource.replace(
-		LEGACY_MANIFEST_PATTERN,
-		[
-			"",
-			"\tmanifest: currentManifest,",
-			`\tprune: typia.misc.createPrune< ${typeName} >(),`,
-			`\trandom: typia.createRandom< ${typeName} >() as (`,
-			"\t\t...args: unknown[]",
-			`\t) => ${typeName},`,
-			`\tvalidate: typia.createValidate< ${typeName} >(),`,
-		].join("\n"),
-	);
-	if (replacedManifest === nextSource) {
-		throw new Error(
-			"Unable to upgrade legacy compound validator: manifest anchor not found.",
-		);
-	}
-
-	return replacedManifest;
-}
-
-function renderLegacyManifestDefaultsWrapperSource(): string {
-	return [
-		"import rawCurrentManifest from './typia.manifest.json';",
-		"import { defineManifestDefaultsDocument } from '@wp-typia/block-runtime/defaults';",
-		"",
-		"const currentManifest = defineManifestDefaultsDocument( rawCurrentManifest );",
-		"",
-		"export default currentManifest;",
-		"",
-	].join("\n");
-}
-
-async function ensureLegacyCompoundValidatorManifestDefaultsWrapper(
-	validatorPath: string,
-): Promise<void> {
-	const validatorDir = path.dirname(validatorPath);
-	const wrapperPath = path.join(validatorDir, "manifest-defaults-document.ts");
-	const manifestPath = path.join(validatorDir, "typia.manifest.json");
-	if (fs.existsSync(wrapperPath) || !fs.existsSync(manifestPath)) {
-		return;
-	}
-
-	await fsp.writeFile(
-		wrapperPath,
-		renderLegacyManifestDefaultsWrapperSource(),
-		"utf8",
-	);
-}
-
-async function collectLegacyCompoundValidatorPaths(projectDir: string): Promise<string[]> {
-	const blocksDir = path.join(projectDir, "src", "blocks");
-	if (!fs.existsSync(blocksDir)) {
-		return [];
-	}
-
-	const blockEntries = await fsp.readdir(blocksDir, { withFileTypes: true });
-	const validatorPaths = await Promise.all(
-		blockEntries
-			.filter((entry) => entry.isDirectory())
-			.map(async (entry) => {
-				const validatorPath = path.join(blocksDir, entry.name, "validators.ts");
-				const validatorSource = await readOptionalFile(validatorPath);
-				return isLegacyCompoundValidatorSource(validatorSource) ? validatorPath : null;
-			}),
-	);
-
-	return validatorPaths.filter((validatorPath): validatorPath is string => validatorPath !== null);
-}
-
-async function ensureCompoundWorkspaceSupportFiles(
-	projectDir: string,
-	tempProjectDir: string,
-	legacyValidatorPaths: readonly string[],
-): Promise<void> {
-	for (const fileName of COMPOUND_SHARED_SUPPORT_FILES) {
-		const sourcePath = path.join(tempProjectDir, "src", fileName);
-		if (!fs.existsSync(sourcePath)) {
-			continue;
-		}
-
-		const targetPath = path.join(projectDir, "src", fileName);
-		const currentSource = await readOptionalFile(targetPath);
-		if (
-			fileName === "validator-toolkit.ts"
-				? shouldRefreshCompoundValidatorToolkit(currentSource)
-				: currentSource === null
-		) {
-			await fsp.mkdir(path.dirname(targetPath), { recursive: true });
-			await fsp.copyFile(sourcePath, targetPath);
-		}
-	}
-
-	for (const validatorPath of legacyValidatorPaths) {
-		const currentSource = await readOptionalFile(validatorPath);
-		if (!isLegacyCompoundValidatorSource(currentSource)) {
-			continue;
-		}
-
-		await ensureLegacyCompoundValidatorManifestDefaultsWrapper(validatorPath);
-		await fsp.writeFile(
-			validatorPath,
-			upgradeLegacyCompoundValidatorSource(currentSource),
-			"utf8",
-		);
-	}
-}
 
 async function copyScaffoldedBlockSlice(
 	projectDir: string,

--- a/packages/wp-typia-project-tools/tests/cli-add-block-boundaries.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-add-block-boundaries.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+
+const runtimeRoot = path.join(import.meta.dir, "..", "src", "runtime");
+
+test("cli-add-block delegates config generation and legacy validator repair to focused modules", () => {
+	const addBlockSource = fs.readFileSync(
+		path.join(runtimeRoot, "cli-add-block.ts"),
+		"utf8",
+	);
+	const configSource = fs.readFileSync(
+		path.join(runtimeRoot, "cli-add-block-config.ts"),
+		"utf8",
+	);
+	const legacyValidatorSource = fs.readFileSync(
+		path.join(runtimeRoot, "cli-add-block-legacy-validator.ts"),
+		"utf8",
+	);
+
+	expect(addBlockSource).toContain('from "./cli-add-block-config.js"');
+	expect(addBlockSource).toContain(
+		'from "./cli-add-block-legacy-validator.js"',
+	);
+	expect(addBlockSource).not.toContain("function buildConfigEntries(");
+	expect(addBlockSource).not.toContain("function buildMigrationBlocks(");
+	expect(addBlockSource).not.toContain(
+		"function ensureBlockConfigCanAddRestManifests(",
+	);
+	expect(addBlockSource).not.toContain(
+		"function upgradeLegacyCompoundValidatorSource(",
+	);
+	expect(configSource).toContain("export function buildConfigEntries(");
+	expect(configSource).toContain("export function buildMigrationBlocks(");
+	expect(legacyValidatorSource).toContain(
+		"export function ensureBlockConfigCanAddRestManifests(",
+	);
+	expect(legacyValidatorSource).toContain(
+		"export async function ensureCompoundWorkspaceSupportFiles(",
+	);
+});


### PR DESCRIPTION
## Context
- `cli-add-block.ts` was still carrying block config entry generation and compound legacy validator repair in the main command surface.
- This follow-up keeps the add-block behavior the same while pushing those responsibilities into focused runtime helpers.

## What Changed
- moved add-block block-config entry generation and migration block shape generation into `cli-add-block-config.ts`
- moved REST manifest import patching and legacy compound validator repair into `cli-add-block-legacy-validator.ts`
- added a boundary test that locks the command surface onto the new helper modules
- added a patch changeset for `@wp-typia/project-tools`

## Verification
- `bun test packages/wp-typia-project-tools/tests/cli-add-block-boundaries.test.ts`
- `bun run build` in `packages/wp-typia-project-tools`
- `bun test packages/wp-typia-project-tools/tests/scaffold-compound.test.ts packages/wp-typia-project-tools/tests/workspace-add.test.ts`
- `bun run changesets:validate`

Closes #347
