### PR TITLE
Split scaffold bootstrap and package-manager helpers

### DIFF
--- a/.sampo/changesets/issue-357-scaffold-bootstrap-package-helpers.md
+++ b/.sampo/changesets/issue-357-scaffold-bootstrap-package-helpers.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Split scaffold bootstrap and package-manager normalization helpers into focused runtime modules without changing generated project behavior.

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-bootstrap.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-bootstrap.ts
@@ -1,0 +1,252 @@
+import fs from "node:fs";
+import { promises as fsp } from "node:fs";
+import path from "node:path";
+
+import { formatPackageExecCommand } from "./package-managers.js";
+import type { PackageManagerId } from "./package-managers.js";
+import {
+	ensureMigrationDirectories,
+	writeInitialMigrationScaffold,
+	writeMigrationConfig,
+} from "./migration-project.js";
+import { syncPersistenceRestArtifacts } from "./persistence-rest-artifacts.js";
+import type { ScaffoldTemplateVariables } from "./scaffold.js";
+import { getPackageVersions } from "./package-versions.js";
+import { getStarterManifestFiles, stringifyStarterManifest } from "./starter-manifests.js";
+import {
+	OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE,
+	PROJECT_TOOLS_PACKAGE_ROOT,
+} from "./template-registry.js";
+import type { BuiltInTemplateId } from "./template-registry.js";
+
+const EPHEMERAL_NODE_MODULES_LINK_TYPE = process.platform === "win32" ? "junction" : "dir";
+
+interface GeneratedPackageJson {
+	scripts?: Record<string, string>;
+	wpTypia?: {
+		projectType?: string;
+		templatePackage?: string;
+	};
+}
+
+/**
+ * Ensures the scaffold target directory exists and is empty unless explicitly allowed.
+ *
+ * @param targetDir Absolute project directory that will receive scaffold output.
+ * @param allowExisting Whether an existing non-empty directory should be accepted.
+ * @returns A promise that resolves once the directory precondition is satisfied.
+ */
+export async function ensureScaffoldDirectory(
+	targetDir: string,
+	allowExisting = false,
+): Promise<void> {
+	if (!fs.existsSync(targetDir)) {
+		await fsp.mkdir(targetDir, { recursive: true });
+		return;
+	}
+
+	if (allowExisting) {
+		return;
+	}
+
+	const entries = await fsp.readdir(targetDir);
+	if (entries.length > 0) {
+		throw new Error(`Target directory is not empty: ${targetDir}`);
+	}
+}
+
+/**
+ * Writes built-in starter manifest files into a scaffolded project.
+ *
+ * @param targetDir Absolute scaffold target directory.
+ * @param templateId Built-in template id being scaffolded.
+ * @param variables Resolved scaffold template variables.
+ * @returns A promise that resolves after all starter manifests are written.
+ */
+export async function writeStarterManifestFiles(
+	targetDir: string,
+	templateId: string,
+	variables: ScaffoldTemplateVariables,
+): Promise<void> {
+	const manifests = getStarterManifestFiles(templateId, variables);
+
+	for (const { document, relativePath } of manifests) {
+		const destinationPath = path.join(targetDir, relativePath);
+		await fsp.mkdir(path.dirname(destinationPath), { recursive: true });
+		await fsp.writeFile(destinationPath, stringifyStarterManifest(document), "utf8");
+	}
+}
+
+/**
+ * Seed REST-derived persistence artifacts into a newly scaffolded built-in
+ * project before the first manual `sync-rest` run.
+ *
+ * @param targetDir Absolute scaffold target directory.
+ * @param templateId Built-in template id being scaffolded.
+ * @param variables Resolved scaffold template variables for the project.
+ * @returns A promise that resolves after any required persistence artifacts are generated.
+ */
+export async function seedBuiltInPersistenceArtifacts(
+	targetDir: string,
+	templateId: BuiltInTemplateId,
+	variables: ScaffoldTemplateVariables,
+): Promise<void> {
+	const needsPersistenceArtifacts =
+		templateId === "persistence" ||
+		(templateId === "compound" && variables.compoundPersistenceEnabled === "true");
+
+	if (!needsPersistenceArtifacts) {
+		return;
+	}
+
+	await withEphemeralScaffoldNodeModules(targetDir, async () => {
+		if (templateId === "persistence") {
+			await syncPersistenceRestArtifacts({
+				apiTypesFile: path.join("src", "api-types.ts"),
+				outputDir: "src",
+				projectDir: targetDir,
+				variables,
+			});
+			return;
+		}
+
+		await syncPersistenceRestArtifacts({
+			apiTypesFile: path.join("src", "blocks", variables.slugKebabCase, "api-types.ts"),
+			outputDir: path.join("src", "blocks", variables.slugKebabCase),
+			projectDir: targetDir,
+			variables,
+		});
+	});
+}
+
+/**
+ * Detects whether a scaffolded project is the official workspace template.
+ *
+ * @param projectDir Absolute scaffold target directory.
+ * @returns `true` when the project metadata identifies the official workspace template.
+ */
+export function isOfficialWorkspaceProject(projectDir: string): boolean {
+	const packageJsonPath = path.join(projectDir, "package.json");
+	if (!fs.existsSync(packageJsonPath)) {
+		return false;
+	}
+
+	const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as GeneratedPackageJson;
+	return (
+		packageJson.wpTypia?.projectType === "workspace" &&
+		packageJson.wpTypia?.templatePackage === OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE
+	);
+}
+
+/**
+ * Adds migration scripts and starter workspace files to the official workspace template.
+ *
+ * @param projectDir Absolute scaffold target directory.
+ * @param packageManager Package manager used for generated script commands.
+ * @returns A promise that resolves after scripts and migration starter files are written.
+ */
+export async function applyWorkspaceMigrationCapability(
+	projectDir: string,
+	packageManager: PackageManagerId,
+): Promise<void> {
+	const packageJsonPath = path.join(projectDir, "package.json");
+	const packageJson = JSON.parse(
+		await fsp.readFile(packageJsonPath, "utf8"),
+	) as GeneratedPackageJson;
+	const wpTypiaPackageVersion = getPackageVersions().wpTypiaPackageVersion;
+	const canonicalCliSpecifier =
+		wpTypiaPackageVersion === "^0.0.0"
+			? "wp-typia"
+			: `wp-typia@${wpTypiaPackageVersion.replace(/^[~^]/u, "")}`;
+	const migrationCli = (args: string) =>
+		formatPackageExecCommand(packageManager, canonicalCliSpecifier, `migrate ${args}`);
+
+	packageJson.scripts = {
+		...(packageJson.scripts ?? {}),
+		"migration:init": migrationCli("init --current-migration-version v1"),
+		"migration:snapshot": migrationCli("snapshot"),
+		"migration:diff": migrationCli("diff"),
+		"migration:scaffold": migrationCli("scaffold"),
+		"migration:doctor": migrationCli("doctor --all"),
+		"migration:fixtures": migrationCli("fixtures --all"),
+		"migration:verify": migrationCli("verify --all"),
+		"migration:fuzz": migrationCli("fuzz --all"),
+	};
+
+	await fsp.writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, "\t")}\n`, "utf8");
+
+	writeMigrationConfig(projectDir, {
+		blocks: [],
+		currentMigrationVersion: "v1",
+		snapshotDir: "src/migrations/versions",
+		supportedMigrationVersions: ["v1"],
+	});
+	ensureMigrationDirectories(projectDir, []);
+	writeInitialMigrationScaffold(projectDir, "v1", []);
+}
+
+/**
+ * Locate a node_modules directory containing `typia` relative to the project
+ * tools package root.
+ *
+ * Search order:
+ * 1. `PROJECT_TOOLS_PACKAGE_ROOT/node_modules`
+ * 2. The monorepo root resolved from `PROJECT_TOOLS_PACKAGE_ROOT`
+ * 3. The monorepo root `node_modules`
+ *
+ * @returns The first matching path, or `null` when no candidate contains `typia`.
+ */
+function resolveScaffoldGeneratorNodeModulesPath(): string | null {
+	const candidates = [
+		path.join(PROJECT_TOOLS_PACKAGE_ROOT, "node_modules"),
+		path.resolve(PROJECT_TOOLS_PACKAGE_ROOT, "..", ".."),
+		path.resolve(PROJECT_TOOLS_PACKAGE_ROOT, "..", "..", "node_modules"),
+	];
+
+	for (const candidate of candidates) {
+		if (fs.existsSync(path.join(candidate, "typia", "package.json"))) {
+			return candidate;
+		}
+	}
+
+	return null;
+}
+
+/**
+ * Temporarily symlink a scaffold generator node_modules directory into the
+ * target project while running an async callback.
+ *
+ * The helper resolves the source path via `resolveScaffoldGeneratorNodeModulesPath()`
+ * and uses `EPHEMERAL_NODE_MODULES_LINK_TYPE` for the symlink. The temporary
+ * link is removed in the `finally` block so cleanup still happens if the
+ * callback throws.
+ *
+ * @param targetDir Absolute scaffold target directory.
+ * @param callback Async work that requires a resolvable `node_modules`.
+ * @returns A promise that resolves after the callback and cleanup complete.
+ */
+async function withEphemeralScaffoldNodeModules(
+	targetDir: string,
+	callback: () => Promise<void>,
+): Promise<void> {
+	const targetNodeModulesPath = path.join(targetDir, "node_modules");
+	if (fs.existsSync(targetNodeModulesPath)) {
+		await callback();
+		return;
+	}
+
+	const sourceNodeModulesPath = resolveScaffoldGeneratorNodeModulesPath();
+	if (!sourceNodeModulesPath) {
+		throw new Error(
+			"Unable to resolve a node_modules directory with typia for scaffold-time REST artifact generation.",
+		);
+	}
+
+	await fsp.symlink(sourceNodeModulesPath, targetNodeModulesPath, EPHEMERAL_NODE_MODULES_LINK_TYPE);
+
+	try {
+		await callback();
+	} finally {
+		await fsp.rm(targetNodeModulesPath, { force: true, recursive: true });
+	}
+}

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-package-manager-files.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-package-manager-files.ts
@@ -1,0 +1,124 @@
+import fs from "node:fs";
+import { promises as fsp } from "node:fs";
+import { execSync } from "node:child_process";
+import path from "node:path";
+
+import {
+	formatInstallCommand,
+	getPackageManager,
+	transformPackageManagerText,
+} from "./package-managers.js";
+import type { PackageManagerId } from "./package-managers.js";
+
+const LOCKFILES: Record<PackageManagerId, string[]> = {
+	bun: ["bun.lock", "bun.lockb"],
+	npm: ["package-lock.json"],
+	pnpm: ["pnpm-lock.yaml"],
+	yarn: ["yarn.lock"],
+};
+
+interface GeneratedPackageJson {
+	packageManager?: string;
+	scripts?: Record<string, string>;
+}
+
+/**
+ * Normalizes scaffolded package-manager specific files for the selected toolchain.
+ *
+ * @param targetDir Absolute scaffold target directory.
+ * @param packageManagerId Selected package manager id.
+ * @returns A promise that resolves after any package-manager sidecar files are updated.
+ */
+export async function normalizePackageManagerFiles(
+	targetDir: string,
+	packageManagerId: PackageManagerId,
+): Promise<void> {
+	const yarnRcPath = path.join(targetDir, ".yarnrc.yml");
+
+	if (packageManagerId === "yarn") {
+		await fsp.writeFile(yarnRcPath, "nodeLinker: node-modules\n", "utf8");
+		return;
+	}
+
+	if (fs.existsSync(yarnRcPath)) {
+		await fsp.rm(yarnRcPath, { force: true });
+	}
+}
+
+/**
+ * Rewrites the generated package.json for the selected package manager.
+ *
+ * @param targetDir Absolute scaffold target directory.
+ * @param packageManagerId Selected package manager id.
+ * @returns A promise that resolves after the package.json file is normalized.
+ */
+export async function normalizePackageJson(
+	targetDir: string,
+	packageManagerId: PackageManagerId,
+): Promise<void> {
+	const packageJsonPath = path.join(targetDir, "package.json");
+	if (!fs.existsSync(packageJsonPath)) {
+		return;
+	}
+
+	const packageManager = getPackageManager(packageManagerId);
+	const packageJson = JSON.parse(await fsp.readFile(packageJsonPath, "utf8")) as GeneratedPackageJson;
+	packageJson.packageManager = packageManager.packageManagerField;
+
+	if (packageJson.scripts) {
+		for (const [key, value] of Object.entries(packageJson.scripts)) {
+			if (typeof value === "string") {
+				packageJson.scripts[key] = transformPackageManagerText(value, packageManagerId);
+			}
+		}
+	}
+
+	await fsp.writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, "\t")}\n`, "utf8");
+}
+
+/**
+ * Removes lockfiles that do not match the selected package manager.
+ *
+ * @param targetDir Absolute scaffold target directory.
+ * @param packageManagerId Selected package manager id.
+ * @returns A promise that resolves after stale lockfiles are removed.
+ */
+export async function removeUnexpectedLockfiles(
+	targetDir: string,
+	packageManagerId: PackageManagerId,
+): Promise<void> {
+	const keep = new Set(LOCKFILES[packageManagerId] ?? []);
+	const allLockfiles = Object.values(LOCKFILES).flat();
+
+	await Promise.all(
+		allLockfiles.map(async (filename) => {
+			if (keep.has(filename)) {
+				return;
+			}
+
+			const filePath = path.join(targetDir, filename);
+			if (fs.existsSync(filePath)) {
+				await fsp.rm(filePath, { force: true });
+			}
+		}),
+	);
+}
+
+/**
+ * Installs scaffolded project dependencies with the selected package manager.
+ *
+ * @param options Absolute target directory and selected package manager id.
+ * @returns A promise that resolves after the install command completes.
+ */
+export async function defaultInstallDependencies({
+	projectDir,
+	packageManager,
+}: {
+	projectDir: string;
+	packageManager: PackageManagerId;
+}): Promise<void> {
+	execSync(formatInstallCommand(packageManager), {
+		cwd: projectDir,
+		stdio: "inherit",
+	});
+}

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-package-manager-files.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-package-manager-files.ts
@@ -40,9 +40,7 @@ export async function normalizePackageManagerFiles(
 		return;
 	}
 
-	if (fs.existsSync(yarnRcPath)) {
-		await fsp.rm(yarnRcPath, { force: true });
-	}
+	await fsp.rm(yarnRcPath, { force: true });
 }
 
 /**
@@ -96,10 +94,7 @@ export async function removeUnexpectedLockfiles(
 				return;
 			}
 
-			const filePath = path.join(targetDir, filename);
-			if (fs.existsSync(filePath)) {
-				await fsp.rm(filePath, { force: true });
-			}
+			await fsp.rm(path.join(targetDir, filename), { force: true });
 		}),
 	);
 }

--- a/packages/wp-typia-project-tools/src/runtime/scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold.ts
@@ -5,10 +5,7 @@ import { execSync } from "node:child_process";
 
 import {
 	PACKAGE_MANAGER_IDS,
-	formatPackageExecCommand,
-	formatInstallCommand,
 	getPackageManager,
-	transformPackageManagerText,
 } from "./package-managers.js";
 import type { PackageManagerId } from "./package-managers.js";
 import {
@@ -35,12 +32,18 @@ import {
 import { applyMigrationUiCapability } from "./migration-ui-capability.js";
 import { getPackageVersions } from "./package-versions.js";
 import {
-	ensureMigrationDirectories,
-	writeInitialMigrationScaffold,
-	writeMigrationConfig,
-} from "./migration-project.js";
-import { syncPersistenceRestArtifacts } from "./persistence-rest-artifacts.js";
-import { getStarterManifestFiles, stringifyStarterManifest } from "./starter-manifests.js";
+	applyWorkspaceMigrationCapability,
+	ensureScaffoldDirectory,
+	isOfficialWorkspaceProject,
+	seedBuiltInPersistenceArtifacts,
+	writeStarterManifestFiles,
+} from "./scaffold-bootstrap.js";
+import {
+	defaultInstallDependencies,
+	normalizePackageJson,
+	normalizePackageManagerFiles,
+	removeUnexpectedLockfiles,
+} from "./scaffold-package-manager-files.js";
 import {
 	toPascalCase,
 	toSnakeCase,
@@ -56,12 +59,10 @@ import {
 import { copyInterpolatedDirectory } from "./template-render.js";
 import {
 	OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE,
-	PROJECT_TOOLS_PACKAGE_ROOT,
 	TEMPLATE_IDS,
 	getTemplateById,
 	isBuiltInTemplateId,
 } from "./template-registry.js";
-import type { BuiltInTemplateId } from "./template-registry.js";
 import { resolveTemplateSource } from "./template-source.js";
 import {
 	BlockGeneratorService,
@@ -70,13 +71,6 @@ import {
 } from "./block-generator-service.js";
 
 const WORKSPACE_TEMPLATE_ALIAS = "workspace";
-const EPHEMERAL_NODE_MODULES_LINK_TYPE = process.platform === "win32" ? "junction" : "dir";
-const LOCKFILES: Record<PackageManagerId, string[]> = {
-	bun: ["bun.lock", "bun.lockb"],
-	npm: ["package-lock.json"],
-	pnpm: ["pnpm-lock.yaml"],
-	yarn: ["yarn.lock"],
-};
 
 /**
  * User-facing scaffold answers before template rendering.
@@ -228,15 +222,6 @@ export interface ScaffoldProjectResult {
 	templateId: string;
 	variables: ScaffoldTemplateVariables;
 	warnings: string[];
-}
-
-interface GeneratedPackageJson {
-	dependencies?: Record<string, string>;
-	scripts?: Record<string, string>;
-	wpTypia?: {
-		projectType?: string;
-		templatePackage?: string;
-	};
 }
 export { buildBlockCssClassName } from "./scaffold-identifiers.js";
 
@@ -519,268 +504,6 @@ export function getTemplateVariables(
 	};
 }
 
-async function ensureDirectory(targetDir: string, allowExisting = false): Promise<void> {
-	if (!fs.existsSync(targetDir)) {
-		await fsp.mkdir(targetDir, { recursive: true });
-		return;
-	}
-
-	if (allowExisting) {
-		return;
-	}
-
-	const entries = await fsp.readdir(targetDir);
-	if (entries.length > 0) {
-		throw new Error(`Target directory is not empty: ${targetDir}`);
-	}
-}
-
-async function writeStarterManifestFiles(
-	targetDir: string,
-	templateId: string,
-	variables: ScaffoldTemplateVariables,
-): Promise<void> {
-	const manifests = getStarterManifestFiles(templateId, variables);
-
-	for (const { document, relativePath } of manifests) {
-		const destinationPath = path.join(targetDir, relativePath);
-		await fsp.mkdir(path.dirname(destinationPath), { recursive: true });
-		await fsp.writeFile(destinationPath, stringifyStarterManifest(document), "utf8");
-	}
-}
-
-/**
- * Seed REST-derived persistence artifacts into a newly scaffolded built-in
- * project before the first manual `sync-rest` run.
- *
- * @param targetDir Absolute scaffold target directory.
- * @param templateId Built-in template id being scaffolded.
- * @param variables Resolved scaffold template variables for the project.
- * @returns A promise that resolves after any required persistence artifacts are generated.
- */
-async function seedBuiltInPersistenceArtifacts(
-	targetDir: string,
-	templateId: BuiltInTemplateId,
-	variables: ScaffoldTemplateVariables,
-): Promise<void> {
-	const needsPersistenceArtifacts =
-		templateId === "persistence" ||
-		(templateId === "compound" && variables.compoundPersistenceEnabled === "true");
-
-	if (!needsPersistenceArtifacts) {
-		return;
-	}
-
-	await withEphemeralScaffoldNodeModules(targetDir, async () => {
-		if (templateId === "persistence") {
-			await syncPersistenceRestArtifacts({
-				apiTypesFile: path.join("src", "api-types.ts"),
-				outputDir: "src",
-				projectDir: targetDir,
-				variables,
-			});
-			return;
-		}
-
-		await syncPersistenceRestArtifacts({
-			apiTypesFile: path.join("src", "blocks", variables.slugKebabCase, "api-types.ts"),
-			outputDir: path.join("src", "blocks", variables.slugKebabCase),
-			projectDir: targetDir,
-			variables,
-		});
-	});
-}
-
-/**
- * Locate a node_modules directory containing `typia` relative to the project
- * tools package root.
- *
- * Search order:
- * 1. `PROJECT_TOOLS_PACKAGE_ROOT/node_modules`
- * 2. The monorepo root resolved from `PROJECT_TOOLS_PACKAGE_ROOT`
- * 3. The monorepo root `node_modules`
- *
- * @returns The first matching path, or `null` when no candidate contains `typia`.
- */
-function resolveScaffoldGeneratorNodeModulesPath(): string | null {
-	const candidates = [
-		path.join(PROJECT_TOOLS_PACKAGE_ROOT, "node_modules"),
-		path.resolve(PROJECT_TOOLS_PACKAGE_ROOT, "..", ".."),
-		path.resolve(PROJECT_TOOLS_PACKAGE_ROOT, "..", "..", "node_modules"),
-	];
-
-	for (const candidate of candidates) {
-		if (fs.existsSync(path.join(candidate, "typia", "package.json"))) {
-			return candidate;
-		}
-	}
-
-	return null;
-}
-
-/**
- * Temporarily symlink a scaffold generator node_modules directory into the
- * target project while running an async callback.
- *
- * The helper resolves the source path via `resolveScaffoldGeneratorNodeModulesPath()`
- * and uses `EPHEMERAL_NODE_MODULES_LINK_TYPE` for the symlink. The temporary
- * link is removed in the `finally` block so cleanup still happens if the
- * callback throws.
- *
- * @param targetDir Absolute scaffold target directory.
- * @param callback Async work that requires a resolvable `node_modules`.
- * @returns A promise that resolves after the callback and cleanup complete.
- */
-async function withEphemeralScaffoldNodeModules(
-	targetDir: string,
-	callback: () => Promise<void>,
-): Promise<void> {
-	const targetNodeModulesPath = path.join(targetDir, "node_modules");
-	if (fs.existsSync(targetNodeModulesPath)) {
-		await callback();
-		return;
-	}
-
-	const sourceNodeModulesPath = resolveScaffoldGeneratorNodeModulesPath();
-	if (!sourceNodeModulesPath) {
-		throw new Error(
-			"Unable to resolve a node_modules directory with typia for scaffold-time REST artifact generation.",
-		);
-	}
-
-	await fsp.symlink(sourceNodeModulesPath, targetNodeModulesPath, EPHEMERAL_NODE_MODULES_LINK_TYPE);
-
-	try {
-		await callback();
-	} finally {
-		await fsp.rm(targetNodeModulesPath, { force: true, recursive: true });
-	}
-}
-
-async function normalizePackageManagerFiles(
-	targetDir: string,
-	packageManagerId: PackageManagerId,
-): Promise<void> {
-	const yarnRcPath = path.join(targetDir, ".yarnrc.yml");
-
-	if (packageManagerId === "yarn") {
-		await fsp.writeFile(yarnRcPath, "nodeLinker: node-modules\n", "utf8");
-		return;
-	}
-
-	if (fs.existsSync(yarnRcPath)) {
-		await fsp.rm(yarnRcPath, { force: true });
-	}
-}
-
-async function normalizePackageJson(targetDir: string, packageManagerId: PackageManagerId): Promise<void> {
-	const packageJsonPath = path.join(targetDir, "package.json");
-	if (!fs.existsSync(packageJsonPath)) {
-		return;
-	}
-
-	const packageManager = getPackageManager(packageManagerId);
-	const packageJson = JSON.parse(await fsp.readFile(packageJsonPath, "utf8")) as {
-		packageManager?: string;
-		scripts?: Record<string, string>;
-	};
-	packageJson.packageManager = packageManager.packageManagerField;
-
-	if (packageJson.scripts) {
-		for (const [key, value] of Object.entries(packageJson.scripts)) {
-			if (typeof value === "string") {
-				packageJson.scripts[key] = transformPackageManagerText(value, packageManagerId);
-			}
-		}
-	}
-
-	await fsp.writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, "\t")}\n`, "utf8");
-}
-
-async function removeUnexpectedLockfiles(
-	targetDir: string,
-	packageManagerId: PackageManagerId,
-): Promise<void> {
-	const keep = new Set(LOCKFILES[packageManagerId] ?? []);
-	const allLockfiles = Object.values(LOCKFILES).flat();
-
-	await Promise.all(
-		allLockfiles.map(async (filename) => {
-			if (keep.has(filename)) {
-				return;
-			}
-
-			const filePath = path.join(targetDir, filename);
-			if (fs.existsSync(filePath)) {
-				await fsp.rm(filePath, { force: true });
-			}
-		}),
-	);
-}
-
-async function defaultInstallDependencies({
-	projectDir,
-	packageManager,
-}: InstallDependenciesOptions): Promise<void> {
-	execSync(formatInstallCommand(packageManager), {
-		cwd: projectDir,
-		stdio: "inherit",
-	});
-}
-
-function isOfficialWorkspaceProject(projectDir: string): boolean {
-	const packageJsonPath = path.join(projectDir, "package.json");
-	if (!fs.existsSync(packageJsonPath)) {
-		return false;
-	}
-
-	const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as GeneratedPackageJson;
-	return (
-		packageJson.wpTypia?.projectType === "workspace" &&
-		packageJson.wpTypia?.templatePackage === OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE
-	);
-}
-
-async function applyWorkspaceMigrationCapability(
-	projectDir: string,
-	packageManager: PackageManagerId,
-): Promise<void> {
-	const packageJsonPath = path.join(projectDir, "package.json");
-	const packageJson = JSON.parse(
-		await fsp.readFile(packageJsonPath, "utf8"),
-	) as GeneratedPackageJson;
-	const wpTypiaPackageVersion = getPackageVersions().wpTypiaPackageVersion;
-	const canonicalCliSpecifier =
-		wpTypiaPackageVersion === "^0.0.0"
-			? "wp-typia"
-			: `wp-typia@${wpTypiaPackageVersion.replace(/^[~^]/u, "")}`;
-	const migrationCli = (args: string) =>
-		formatPackageExecCommand(packageManager, canonicalCliSpecifier, `migrate ${args}`);
-
-	packageJson.scripts = {
-		...(packageJson.scripts ?? {}),
-		"migration:init": migrationCli("init --current-migration-version v1"),
-		"migration:snapshot": migrationCli("snapshot"),
-		"migration:diff": migrationCli("diff"),
-		"migration:scaffold": migrationCli("scaffold"),
-		"migration:doctor": migrationCli("doctor --all"),
-		"migration:fixtures": migrationCli("fixtures --all"),
-		"migration:verify": migrationCli("verify --all"),
-		"migration:fuzz": migrationCli("fuzz --all"),
-	};
-
-	await fsp.writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, "\t")}\n`, "utf8");
-
-	writeMigrationConfig(projectDir, {
-		blocks: [],
-		currentMigrationVersion: "v1",
-		snapshotDir: "src/migrations/versions",
-		supportedMigrationVersions: ["v1"],
-	});
-	ensureMigrationDirectories(projectDir, []);
-	writeInitialMigrationScaffold(projectDir, "v1", []);
-}
-
 export async function scaffoldProject({
 	projectDir,
 	templateId,
@@ -866,7 +589,7 @@ export async function scaffoldProject({
 	}
 
 	try {
-		await ensureDirectory(projectDir, allowExistingDir);
+		await ensureScaffoldDirectory(projectDir, allowExistingDir);
 		await copyInterpolatedDirectory(
 			templateSource.templateDir,
 			projectDir,

--- a/packages/wp-typia-project-tools/tests/scaffold-runtime-boundaries.test.ts
+++ b/packages/wp-typia-project-tools/tests/scaffold-runtime-boundaries.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 
 const runtimeRoot = path.join(import.meta.dir, "..", "src", "runtime");
 
-test("scaffold runtime delegates identifier and document helpers to focused modules", () => {
+test("scaffold runtime delegates identifier, document, bootstrap, and package helpers to focused modules", () => {
 	const scaffoldSource = fs.readFileSync(
 		path.join(runtimeRoot, "scaffold.ts"),
 		"utf8",
@@ -17,9 +17,19 @@ test("scaffold runtime delegates identifier and document helpers to focused modu
 		path.join(runtimeRoot, "scaffold-apply-utils.ts"),
 		"utf8",
 	);
+	const bootstrapSource = fs.readFileSync(
+		path.join(runtimeRoot, "scaffold-bootstrap.ts"),
+		"utf8",
+	);
+	const packageManagerFilesSource = fs.readFileSync(
+		path.join(runtimeRoot, "scaffold-package-manager-files.ts"),
+		"utf8",
+	);
 
 	expect(scaffoldSource).toContain('from "./scaffold-identifiers.js"');
 	expect(scaffoldSource).toContain('from "./scaffold-apply-utils.js"');
+	expect(scaffoldSource).toContain('from "./scaffold-bootstrap.js"');
+	expect(scaffoldSource).toContain('from "./scaffold-package-manager-files.js"');
 	expect(scaffoldSource).toContain(
 		'export { buildBlockCssClassName } from "./scaffold-identifiers.js";',
 	);
@@ -29,6 +39,8 @@ test("scaffold runtime delegates identifier and document helpers to focused modu
 	expect(scaffoldSource).not.toContain("function buildReadme(");
 	expect(scaffoldSource).not.toContain("function buildGitignore(");
 	expect(scaffoldSource).not.toContain("function mergeTextLines(");
+	expect(scaffoldSource).not.toContain("async function ensureDirectory(");
+	expect(scaffoldSource).not.toContain("async function normalizePackageJson(");
 	expect(identifiersSource).toContain("export function validateBlockSlug(");
 	expect(identifiersSource).toContain(
 		"export function resolveScaffoldIdentifiers(",
@@ -36,4 +48,8 @@ test("scaffold runtime delegates identifier and document helpers to focused modu
 	expect(applyUtilsSource).toContain("export function buildReadme(");
 	expect(applyUtilsSource).toContain("export function buildGitignore(");
 	expect(applyUtilsSource).toContain("export function mergeTextLines(");
+	expect(bootstrapSource).toContain("export async function ensureScaffoldDirectory(");
+	expect(bootstrapSource).toContain("export async function applyWorkspaceMigrationCapability(");
+	expect(packageManagerFilesSource).toContain("export async function normalizePackageJson(");
+	expect(packageManagerFilesSource).toContain("export async function defaultInstallDependencies(");
 });


### PR DESCRIPTION
## Context

`packages/wp-typia-project-tools/src/runtime/scaffold.ts` was still carrying bootstrap-time helpers and package-manager normalization/install helpers alongside the main scaffold facade.

## What Changed

- extracted scaffold directory/bootstrap helpers into `scaffold-bootstrap.ts`
- extracted package-manager file normalization and install helpers into `scaffold-package-manager-files.ts`
- kept `scaffold.ts` focused on answer/template resolution plus the public `scaffoldProject(...)` facade
- extended scaffold runtime boundary coverage to lock in the new helper split
- added a patch changeset for `@wp-typia/project-tools`

## Verification

- `bun run build` in `packages/wp-typia-project-tools`
- `bun run typecheck`
- `bun test packages/wp-typia-project-tools/tests/scaffold-runtime-boundaries.test.ts packages/wp-typia-project-tools/tests/scaffold-basic.test.ts packages/wp-typia-project-tools/tests/scaffold-compound.test.ts packages/wp-typia-project-tools/tests/scaffold-persistence.test.ts packages/wp-typia-project-tools/tests/workspace-add.test.ts`
- `bun run changesets:validate`

Closes #357


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated scaffolding bootstrap utilities into a dedicated runtime module
  * Separated package-manager normalization utilities into a focused runtime module
  * Restructured internal scaffolding logic for improved maintainability while preserving generated project behavior

* **Tests**
  * Enhanced module boundary tests to verify proper delegation of scaffolding and package-manager functions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->