### PR TITLE
Split migration diff rename and transform helpers

### DIFF
--- a/.sampo/changesets/issue-367-migration-diff-helpers.md
+++ b/.sampo/changesets/issue-367-migration-diff-helpers.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Split migration diff rename and transform helpers into focused runtime modules without changing diff output.

--- a/packages/wp-typia-project-tools/src/runtime/migration-diff-rename.ts
+++ b/packages/wp-typia-project-tools/src/runtime/migration-diff-rename.ts
@@ -1,0 +1,283 @@
+import { isNumber } from "./migration-utils.js";
+import type {
+	FlattenedAttributeDescriptor,
+	ManifestAttribute,
+	RenameCandidate,
+} from "./migration-types.js";
+
+interface CreateRenameCandidatesOptions {
+	addedKeys: string[];
+	isUnionRenameCompatible: (
+		oldAttribute: ManifestAttribute,
+		newAttribute: ManifestAttribute,
+	) => boolean;
+	newAttributes: Record<string, ManifestAttribute>;
+	newLeafAttributes: FlattenedAttributeDescriptor[];
+	oldAttributes: Record<string, ManifestAttribute>;
+	oldLeafAttributes: FlattenedAttributeDescriptor[];
+	removedKeys: string[];
+}
+
+export function createRenameCandidates({
+	addedKeys,
+	isUnionRenameCompatible,
+	newAttributes,
+	newLeafAttributes,
+	oldAttributes,
+	oldLeafAttributes,
+	removedKeys,
+}: CreateRenameCandidatesOptions): RenameCandidate[] {
+	const assessments: RenameCandidate[] = [];
+
+	for (const currentPath of addedKeys) {
+		const nextAttribute = newAttributes[currentPath];
+		if (!nextAttribute) continue;
+		for (const legacyPath of removedKeys) {
+			const previous = oldAttributes[legacyPath];
+			if (!previous) continue;
+			const candidate = assessRenameCandidate(
+				previous,
+				nextAttribute,
+				legacyPath,
+				currentPath,
+				isUnionRenameCompatible,
+			);
+			if (candidate) {
+				assessments.push(candidate);
+			}
+		}
+	}
+
+	const oldLeafMap = new Map(oldLeafAttributes.map((descriptor) => [descriptor.currentPath, descriptor] as const));
+	const newLeafMap = new Map(newLeafAttributes.map((descriptor) => [descriptor.currentPath, descriptor] as const));
+	const removedLeafDescriptors = oldLeafAttributes.filter((descriptor) => !newLeafMap.has(descriptor.currentPath));
+	const addedLeafDescriptors = newLeafAttributes.filter((descriptor) => !oldLeafMap.has(descriptor.currentPath));
+
+	for (const nextDescriptor of addedLeafDescriptors) {
+		if (!nextDescriptor.currentPath.includes(".")) {
+			continue;
+		}
+		for (const previousDescriptor of removedLeafDescriptors) {
+			if (!previousDescriptor.currentPath.includes(".")) {
+				continue;
+			}
+			const candidate = assessRenameCandidate(
+				previousDescriptor.attribute,
+				nextDescriptor.attribute,
+				previousDescriptor.currentPath,
+				nextDescriptor.currentPath,
+				isUnionRenameCompatible,
+			);
+			if (candidate) {
+				assessments.push(candidate);
+			}
+		}
+	}
+
+	return assessments
+		.map((candidate) => {
+			const currentMatches = assessments
+				.filter((item) => item.currentPath === candidate.currentPath)
+				.sort((left, right) => right.score - left.score);
+			const legacyMatches = assessments
+				.filter((item) => item.legacyPath === candidate.legacyPath)
+				.sort((left, right) => right.score - left.score);
+			const currentLeader = currentMatches[0]!;
+			const legacyLeader = legacyMatches[0]!;
+			const currentHasTie =
+				currentMatches.length > 1 && Math.abs((currentMatches[1]?.score ?? 0) - currentLeader.score) < 0.05;
+			const legacyHasTie =
+				legacyMatches.length > 1 && Math.abs((legacyMatches[1]?.score ?? 0) - legacyLeader.score) < 0.05;
+
+			return {
+				...candidate,
+				autoApply:
+					currentLeader.legacyPath === candidate.legacyPath &&
+					legacyLeader.currentPath === candidate.currentPath &&
+					!currentHasTie &&
+					!legacyHasTie &&
+					candidate.score >= 0.6,
+			};
+		})
+		.filter((candidate, index, list) => {
+			const firstMatch = list.findIndex(
+				(item) => item.currentPath === candidate.currentPath && item.legacyPath === candidate.legacyPath,
+			);
+			return firstMatch === index;
+		})
+		.sort((left, right) => right.score - left.score);
+}
+
+export function passesNameSimilarityRule(legacyPath: string, currentPath: string): boolean {
+	return scoreRenameSimilarity(legacyPath, currentPath) >= 0.6;
+}
+
+function isRenameCandidateShapeCompatible(
+	oldAttribute: ManifestAttribute | undefined,
+	newAttribute: ManifestAttribute | undefined,
+	isUnionRenameCompatible: (
+		oldAttribute: ManifestAttribute,
+		newAttribute: ManifestAttribute,
+	) => boolean,
+): boolean {
+	if (!oldAttribute || !newAttribute || oldAttribute.ts.kind !== newAttribute.ts.kind) {
+		return false;
+	}
+
+	if (["string", "number", "boolean"].includes(oldAttribute.ts.kind)) {
+		return hasRenameCompatibleConstraints(oldAttribute, newAttribute);
+	}
+
+	if (oldAttribute.ts.kind === "union") {
+		return isUnionRenameCompatible(oldAttribute, newAttribute);
+	}
+
+	return false;
+}
+
+function assessRenameCandidate(
+	oldAttribute: ManifestAttribute | undefined,
+	newAttribute: ManifestAttribute | undefined,
+	legacyPath: string,
+	currentPath: string,
+	isUnionRenameCompatible: (
+		oldAttribute: ManifestAttribute,
+		newAttribute: ManifestAttribute,
+	) => boolean,
+): RenameCandidate | null {
+	if (!isRenameCandidateShapeCompatible(oldAttribute, newAttribute, isUnionRenameCompatible)) {
+		return null;
+	}
+
+	const baseScore = scoreRenameSimilarity(legacyPath, currentPath);
+	const score =
+		getParentPath(legacyPath) === getParentPath(currentPath) ? Math.max(baseScore, 0.75) : baseScore;
+	return {
+		autoApply: false,
+		currentPath,
+		legacyPath,
+		reason: describeRenameReason(oldAttribute!, legacyPath, currentPath, score),
+		score,
+	};
+}
+
+function hasRenameCompatibleConstraints(
+	oldAttribute: ManifestAttribute,
+	newAttribute: ManifestAttribute,
+): boolean {
+	const oldEnum = oldAttribute.wp.enum ?? null;
+	const nextEnum = newAttribute.wp.enum ?? null;
+
+	if (oldEnum && nextEnum) {
+		const oldIsSubset = oldEnum.every((value) => nextEnum.includes(value));
+		if (!oldIsSubset) {
+			return false;
+		}
+	} else if (oldEnum && !nextEnum) {
+		return false;
+	}
+
+	const oldConstraints = oldAttribute.typia.constraints ?? {};
+	const nextConstraints = newAttribute.typia.constraints ?? {};
+
+	return [
+		compareMinimumBound(oldConstraints.minLength, nextConstraints.minLength),
+		compareMaximumBound(oldConstraints.maxLength, nextConstraints.maxLength),
+		compareMinimumBound(oldConstraints.minimum, nextConstraints.minimum),
+		compareMaximumBound(oldConstraints.maximum, nextConstraints.maximum),
+		comparePatternBound(oldConstraints.pattern, nextConstraints.pattern),
+		comparePatternBound(oldConstraints.format, nextConstraints.format),
+		comparePatternBound(oldConstraints.typeTag, nextConstraints.typeTag),
+	].every(Boolean);
+}
+
+function compareMinimumBound(oldValue: unknown, nextValue: unknown): boolean {
+	if (nextValue === null || nextValue === undefined) return true;
+	if (oldValue === null || oldValue === undefined) return true;
+	return Number(oldValue) <= Number(nextValue);
+}
+
+function compareMaximumBound(oldValue: unknown, nextValue: unknown): boolean {
+	if (nextValue === null || nextValue === undefined) return true;
+	if (oldValue === null || oldValue === undefined) return true;
+	return Number(oldValue) >= Number(nextValue);
+}
+
+function comparePatternBound(oldValue: unknown, nextValue: unknown): boolean {
+	return oldValue === nextValue || oldValue === null || oldValue === undefined;
+}
+
+function scoreRenameSimilarity(legacyPath: string, currentPath: string): number {
+	const legacy = normalizeFieldName(legacyPath);
+	const current = normalizeFieldName(currentPath);
+
+	if (legacy === current) return 1;
+	if (shareAliasGroup(legacy, current)) return 0.9;
+
+	const legacyTokens = tokenizeFieldName(legacy);
+	const currentTokens = tokenizeFieldName(current);
+	const overlap = legacyTokens.filter((token) => currentTokens.includes(token));
+	const jaccard = overlap.length / new Set([...legacyTokens, ...currentTokens]).size;
+
+	if (legacy.includes(current) || current.includes(legacy)) {
+		return Math.max(jaccard, 0.7);
+	}
+	if (
+		legacyTokens.length > 0 &&
+		currentTokens.length > 0 &&
+		legacyTokens[legacyTokens.length - 1] === currentTokens[currentTokens.length - 1]
+	) {
+		return Math.max(jaccard, 0.6);
+	}
+
+	return jaccard;
+}
+
+function normalizeFieldName(name: string): string {
+	return String(name)
+		.replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+		.replace(/[^a-zA-Z0-9]+/g, " ")
+		.trim()
+		.toLowerCase()
+		.replace(/\s+/g, "");
+}
+
+function tokenizeFieldName(name: string): string[] {
+	return String(name)
+		.replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+		.toLowerCase()
+		.split(/[^a-z0-9]+/)
+		.filter(Boolean);
+}
+
+function getParentPath(pathLabel: string): string {
+	const segments = String(pathLabel).split(".");
+	return segments.length <= 1 ? "" : segments.slice(0, -1).join(".");
+}
+
+function shareAliasGroup(left: string, right: string): boolean {
+	const aliasGroups = [
+		["content", "headline", "body", "text", "copy", "message"],
+		["id", "uniqueid", "uuid"],
+		["visible", "isvisible", "show", "shown", "enabled"],
+		["align", "alignment", "textalign"],
+		["count", "clickcount", "counter"],
+		["url", "href", "link"],
+	];
+
+	return aliasGroups.some((group) => group.includes(left) && group.includes(right));
+}
+
+function describeRenameReason(
+	attribute: ManifestAttribute,
+	legacyPath: string,
+	currentPath: string,
+	score: number,
+): string {
+	if (attribute.ts.kind === "union") {
+		return `compatible discriminated union (${legacyPath} → ${currentPath})`;
+	}
+	if (score >= 0.9) return "high-confidence compatible field";
+	if (score >= 0.6) return "name-similar compatible field";
+	return "compatible field requiring review";
+}

--- a/packages/wp-typia-project-tools/src/runtime/migration-diff-transform.ts
+++ b/packages/wp-typia-project-tools/src/runtime/migration-diff-transform.ts
@@ -1,0 +1,157 @@
+import { getAttributeByCurrentPath } from "./migration-manifest.js";
+import { passesNameSimilarityRule } from "./migration-diff-rename.js";
+import type {
+	DiffOutcome,
+	FlattenedAttributeDescriptor,
+	ManifestAttribute,
+	RenameCandidate,
+	TransformSuggestion,
+} from "./migration-types.js";
+
+interface CreateTransformSuggestionsOptions {
+	addedKeys: string[];
+	manualItems: DiffOutcome[];
+	newAttributes: Record<string, ManifestAttribute>;
+	newLeafAttributes: FlattenedAttributeDescriptor[];
+	oldAttributes: Record<string, ManifestAttribute>;
+	oldLeafAttributes: FlattenedAttributeDescriptor[];
+	removedKeys: string[];
+	renameCandidates: RenameCandidate[];
+}
+
+export function createTransformSuggestions({
+	oldAttributes,
+	newAttributes,
+	addedKeys,
+	removedKeys,
+	manualItems,
+	renameCandidates,
+	oldLeafAttributes,
+	newLeafAttributes,
+}: CreateTransformSuggestionsOptions): TransformSuggestion[] {
+	const suggestions: TransformSuggestion[] = [];
+	const activeRenameTargets = new Set(
+		renameCandidates.filter((candidate) => candidate.autoApply).map((candidate) => candidate.currentPath),
+	);
+	const oldLeafMap = new Map(oldLeafAttributes.map((descriptor) => [descriptor.currentPath, descriptor] as const));
+	const newLeafMap = new Map(newLeafAttributes.map((descriptor) => [descriptor.currentPath, descriptor] as const));
+
+	for (const currentPath of [
+		...new Set([
+			...Object.keys(newAttributes),
+			...manualItems.map((item) => item.path),
+			...newLeafAttributes.map((item) => item.currentPath),
+		]),
+	]) {
+		if (activeRenameTargets.has(currentPath)) {
+			continue;
+		}
+
+		const manualItem = manualItems.find(
+			(item) => item.path === currentPath || item.path.startsWith(`${currentPath}.`),
+		);
+		const currentAttribute =
+			newLeafMap.get(currentPath)?.attribute ??
+			getAttributeByCurrentPath(newAttributes, currentPath) ??
+			null;
+		if (!manualItem || !currentAttribute) {
+			continue;
+		}
+
+		const exactLegacy =
+			oldLeafMap.get(currentPath)?.attribute ??
+			getAttributeByCurrentPath(oldAttributes, currentPath) ??
+			null;
+		if (exactLegacy && exactLegacy.ts.kind !== currentAttribute.ts.kind) {
+			suggestions.push({
+				bodyLines: buildTransformBodyLines(currentAttribute, currentPath),
+				attribute: currentAttribute,
+				currentPath,
+				legacyPath: currentPath,
+				reason: `semantic coercion suggested for ${manualItem.kind}`,
+			});
+			continue;
+		}
+
+		const bestRenameCandidate = renameCandidates.find((candidate) => candidate.currentPath === currentPath);
+		if (bestRenameCandidate && !bestRenameCandidate.autoApply) {
+			suggestions.push({
+				bodyLines: buildTransformBodyLines(currentAttribute, bestRenameCandidate.legacyPath),
+				attribute: currentAttribute,
+				currentPath,
+				legacyPath: bestRenameCandidate.legacyPath,
+				reason: `review coercion from ${bestRenameCandidate.legacyPath}`,
+			});
+			continue;
+		}
+
+		const addedCurrent =
+			addedKeys.includes(currentPath) ||
+			(newLeafMap.has(currentPath) && !oldLeafMap.has(currentPath));
+		if (!addedCurrent) {
+			continue;
+		}
+
+		const compatibleLegacyPath = [
+			...removedKeys,
+			...oldLeafAttributes
+				.filter((descriptor) => !newLeafMap.has(descriptor.currentPath))
+				.map((descriptor) => descriptor.currentPath),
+		].find((legacyPath) => passesNameSimilarityRule(legacyPath, currentPath));
+		if (compatibleLegacyPath) {
+			suggestions.push({
+				bodyLines: buildTransformBodyLines(currentAttribute, compatibleLegacyPath),
+				attribute: currentAttribute,
+				currentPath,
+				legacyPath: compatibleLegacyPath,
+				reason: `review coercion from ${compatibleLegacyPath}`,
+			});
+		}
+	}
+
+	return suggestions;
+}
+
+export function describeConstraintChange(
+	oldAttribute: ManifestAttribute,
+	newAttribute: ManifestAttribute,
+): string {
+	const details: string[] = [];
+	const oldConstraints = oldAttribute.typia.constraints;
+	const nextConstraints = newAttribute.typia.constraints;
+
+	if (newAttribute.wp.enum && JSON.stringify(newAttribute.wp.enum) !== JSON.stringify(oldAttribute.wp.enum)) {
+		details.push("enum changed");
+	}
+	for (const key of ["minLength", "maxLength", "minimum", "maximum", "pattern", "format", "typeTag"] as const) {
+		if (oldConstraints[key] !== nextConstraints[key]) {
+			details.push(`${key}: ${oldConstraints[key]} -> ${nextConstraints[key]}`);
+		}
+	}
+
+	return details.join(", ");
+}
+
+function buildTransformBodyLines(
+	attribute: ManifestAttribute,
+	legacyPath: string,
+): string[] {
+	switch (attribute.ts.kind) {
+		case "string":
+			return [`// return typeof legacyValue === "string" ? legacyValue : String(legacyValue ?? "");`];
+		case "number":
+			return [
+				`// const numericValue = typeof legacyValue === "number" ? legacyValue : Number(legacyValue ?? 0);`,
+				`// return Number.isNaN(numericValue) ? undefined : numericValue;`,
+			];
+		case "boolean":
+			return [`// return typeof legacyValue === "boolean" ? legacyValue : Boolean(legacyValue);`];
+		case "union":
+			return [
+				`// const legacyObject = typeof legacyValue === "object" && legacyValue !== null ? legacyValue : {};`,
+				`// return legacyObject; // adjust discriminator / branch fields before verify`,
+			];
+		default:
+			return [`// return legacyValue; // customize migration from ${legacyPath}`];
+	}
+}

--- a/packages/wp-typia-project-tools/src/runtime/migration-diff.ts
+++ b/packages/wp-typia-project-tools/src/runtime/migration-diff.ts
@@ -1,10 +1,14 @@
 import fs from "node:fs";
 import {
 	flattenManifestLeafAttributes,
-	getAttributeByCurrentPath,
 	getManifestDefaultValue,
 	hasManifestDefault,
 } from "./migration-manifest.js";
+import { createRenameCandidates } from "./migration-diff-rename.js";
+import {
+	createTransformSuggestions,
+	describeConstraintChange,
+} from "./migration-diff-transform.js";
 import {
 	createMissingBlockSnapshotMessage,
 	getAvailableSnapshotVersionsForBlock,
@@ -13,27 +17,13 @@ import {
 import { isNumber, readJson } from "./migration-utils.js";
 import type {
 	DiffOutcome,
-	FlattenedAttributeDescriptor,
 	ManifestAttribute,
 	ManifestDocument,
 	MigrationBlockConfig,
 	MigrationDiff,
 	MigrationProjectState,
-	RenameCandidate,
 	ResolvedMigrationBlockTarget,
-	TransformSuggestion,
 } from "./migration-types.js";
-
-interface CreateTransformSuggestionsOptions {
-	addedKeys: string[];
-	manualItems: DiffOutcome[];
-	newAttributes: Record<string, ManifestAttribute>;
-	newLeafAttributes: FlattenedAttributeDescriptor[];
-	oldAttributes: Record<string, ManifestAttribute>;
-	oldLeafAttributes: FlattenedAttributeDescriptor[];
-	removedKeys: string[];
-	renameCandidates: RenameCandidate[];
-}
 
 export function createMigrationDiff(
 	state: MigrationProjectState,
@@ -140,14 +130,16 @@ export function createMigrationDiff(
 		}
 	}
 
-	const renameCandidates = createRenameCandidates(
-		oldAttributes,
-		newAttributes,
-		removedKeys,
+	const renameCandidates = createRenameCandidates({
 		addedKeys,
-		oldLeafAttributes,
+		isUnionRenameCompatible: (oldAttribute, newAttribute) =>
+			compareUnionAttribute(oldAttribute, newAttribute, "$rename").status === "auto",
+		newAttributes,
 		newLeafAttributes,
-	);
+		oldAttributes,
+		oldLeafAttributes,
+		removedKeys,
+	});
 	const activeRenameCandidates = renameCandidates.filter((candidate) => candidate.autoApply);
 
 	for (const candidate of activeRenameCandidates) {
@@ -366,382 +358,6 @@ function hasStricterConstraints(oldAttribute: ManifestAttribute, newAttribute: M
 	}
 
 	return false;
-}
-
-function createRenameCandidates(
-	oldAttributes: Record<string, ManifestAttribute>,
-	newAttributes: Record<string, ManifestAttribute>,
-	removedKeys: string[],
-	addedKeys: string[],
-	oldLeafAttributes: FlattenedAttributeDescriptor[],
-	newLeafAttributes: FlattenedAttributeDescriptor[],
-): RenameCandidate[] {
-	const assessments: RenameCandidate[] = [];
-
-	for (const currentPath of addedKeys) {
-		const nextAttribute = newAttributes[currentPath];
-		if (!nextAttribute) continue;
-		for (const legacyPath of removedKeys) {
-			const previous = oldAttributes[legacyPath];
-			if (!previous) continue;
-			const candidate = assessRenameCandidate(previous, nextAttribute, legacyPath, currentPath);
-			if (candidate) {
-				assessments.push(candidate);
-			}
-		}
-	}
-
-	const oldLeafMap = new Map(oldLeafAttributes.map((descriptor) => [descriptor.currentPath, descriptor] as const));
-	const newLeafMap = new Map(newLeafAttributes.map((descriptor) => [descriptor.currentPath, descriptor] as const));
-	const removedLeafDescriptors = oldLeafAttributes.filter((descriptor) => !newLeafMap.has(descriptor.currentPath));
-	const addedLeafDescriptors = newLeafAttributes.filter((descriptor) => !oldLeafMap.has(descriptor.currentPath));
-
-	for (const nextDescriptor of addedLeafDescriptors) {
-		if (!nextDescriptor.currentPath.includes(".")) {
-			continue;
-		}
-		for (const previousDescriptor of removedLeafDescriptors) {
-			if (!previousDescriptor.currentPath.includes(".")) {
-				continue;
-			}
-			const candidate = assessRenameCandidate(
-				previousDescriptor.attribute,
-				nextDescriptor.attribute,
-				previousDescriptor.currentPath,
-				nextDescriptor.currentPath,
-			);
-			if (candidate) {
-				assessments.push(candidate);
-			}
-		}
-	}
-
-	return assessments
-		.map((candidate) => {
-			const currentMatches = assessments
-				.filter((item) => item.currentPath === candidate.currentPath)
-				.sort((left, right) => right.score - left.score);
-			const legacyMatches = assessments
-				.filter((item) => item.legacyPath === candidate.legacyPath)
-				.sort((left, right) => right.score - left.score);
-			const currentLeader = currentMatches[0]!;
-			const legacyLeader = legacyMatches[0]!;
-			const currentHasTie =
-				currentMatches.length > 1 && Math.abs((currentMatches[1]?.score ?? 0) - currentLeader.score) < 0.05;
-			const legacyHasTie =
-				legacyMatches.length > 1 && Math.abs((legacyMatches[1]?.score ?? 0) - legacyLeader.score) < 0.05;
-
-			return {
-				...candidate,
-				autoApply:
-					currentLeader.legacyPath === candidate.legacyPath &&
-					legacyLeader.currentPath === candidate.currentPath &&
-					!currentHasTie &&
-					!legacyHasTie &&
-					candidate.score >= 0.6,
-			};
-		})
-		.filter((candidate, index, list) => {
-			const firstMatch = list.findIndex(
-				(item) => item.currentPath === candidate.currentPath && item.legacyPath === candidate.legacyPath,
-			);
-			return firstMatch === index;
-		})
-		.sort((left, right) => right.score - left.score);
-}
-
-function createTransformSuggestions({
-	oldAttributes,
-	newAttributes,
-	addedKeys,
-	removedKeys,
-	manualItems,
-	renameCandidates,
-	oldLeafAttributes,
-	newLeafAttributes,
-}: CreateTransformSuggestionsOptions): TransformSuggestion[] {
-	const suggestions: TransformSuggestion[] = [];
-	const activeRenameTargets = new Set(
-		renameCandidates.filter((candidate) => candidate.autoApply).map((candidate) => candidate.currentPath),
-	);
-	const oldLeafMap = new Map(oldLeafAttributes.map((descriptor) => [descriptor.currentPath, descriptor] as const));
-	const newLeafMap = new Map(newLeafAttributes.map((descriptor) => [descriptor.currentPath, descriptor] as const));
-
-	for (const currentPath of [
-		...new Set([
-			...Object.keys(newAttributes),
-			...manualItems.map((item) => item.path),
-			...newLeafAttributes.map((item) => item.currentPath),
-		]),
-	]) {
-		if (activeRenameTargets.has(currentPath)) {
-			continue;
-		}
-
-		const manualItem = manualItems.find(
-			(item) => item.path === currentPath || item.path.startsWith(`${currentPath}.`),
-		);
-		const currentAttribute =
-			newLeafMap.get(currentPath)?.attribute ??
-			getAttributeByCurrentPath(newAttributes, currentPath) ??
-			null;
-		if (!manualItem || !currentAttribute) {
-			continue;
-		}
-
-		const exactLegacy =
-			oldLeafMap.get(currentPath)?.attribute ??
-			getAttributeByCurrentPath(oldAttributes, currentPath) ??
-			null;
-		if (exactLegacy && exactLegacy.ts.kind !== currentAttribute.ts.kind) {
-			suggestions.push({
-				bodyLines: buildTransformBodyLines(currentAttribute, currentPath),
-				attribute: currentAttribute,
-				currentPath,
-				legacyPath: currentPath,
-				reason: `semantic coercion suggested for ${manualItem.kind}`,
-			});
-			continue;
-		}
-
-		const bestRenameCandidate = renameCandidates.find((candidate) => candidate.currentPath === currentPath);
-		if (bestRenameCandidate && !bestRenameCandidate.autoApply) {
-			suggestions.push({
-				bodyLines: buildTransformBodyLines(currentAttribute, bestRenameCandidate.legacyPath),
-				attribute: currentAttribute,
-				currentPath,
-				legacyPath: bestRenameCandidate.legacyPath,
-				reason: `review coercion from ${bestRenameCandidate.legacyPath}`,
-			});
-			continue;
-		}
-
-		const addedCurrent =
-			addedKeys.includes(currentPath) ||
-			(newLeafMap.has(currentPath) && !oldLeafMap.has(currentPath));
-		if (!addedCurrent) {
-			continue;
-		}
-
-		const compatibleLegacyPath = [
-			...removedKeys,
-			...oldLeafAttributes
-				.filter((descriptor) => !newLeafMap.has(descriptor.currentPath))
-				.map((descriptor) => descriptor.currentPath),
-		].find((legacyPath) => passesNameSimilarityRule(legacyPath, currentPath));
-		if (compatibleLegacyPath) {
-			suggestions.push({
-				bodyLines: buildTransformBodyLines(currentAttribute, compatibleLegacyPath),
-				attribute: currentAttribute,
-				currentPath,
-				legacyPath: compatibleLegacyPath,
-				reason: `review coercion from ${compatibleLegacyPath}`,
-			});
-		}
-	}
-
-	return suggestions;
-}
-
-function isRenameCandidateShapeCompatible(
-	oldAttribute: ManifestAttribute | undefined,
-	newAttribute: ManifestAttribute | undefined,
-): boolean {
-	if (!oldAttribute || !newAttribute || oldAttribute.ts.kind !== newAttribute.ts.kind) {
-		return false;
-	}
-
-	if (["string", "number", "boolean"].includes(oldAttribute.ts.kind)) {
-		return hasRenameCompatibleConstraints(oldAttribute, newAttribute);
-	}
-
-	if (oldAttribute.ts.kind === "union") {
-		return compareUnionAttribute(oldAttribute, newAttribute, "$rename").status === "auto";
-	}
-
-	return false;
-}
-
-function assessRenameCandidate(
-	oldAttribute: ManifestAttribute | undefined,
-	newAttribute: ManifestAttribute | undefined,
-	legacyPath: string,
-	currentPath: string,
-): RenameCandidate | null {
-	if (!isRenameCandidateShapeCompatible(oldAttribute, newAttribute)) {
-		return null;
-	}
-
-	const baseScore = scoreRenameSimilarity(legacyPath, currentPath);
-	const score =
-		getParentPath(legacyPath) === getParentPath(currentPath) ? Math.max(baseScore, 0.75) : baseScore;
-	return {
-		autoApply: false,
-		currentPath,
-		legacyPath,
-		reason: describeRenameReason(oldAttribute!, legacyPath, currentPath, score),
-		score,
-	};
-}
-
-function hasRenameCompatibleConstraints(oldAttribute: ManifestAttribute, newAttribute: ManifestAttribute): boolean {
-	const oldEnum = oldAttribute.wp.enum ?? null;
-	const nextEnum = newAttribute.wp.enum ?? null;
-
-	if (oldEnum && nextEnum) {
-		const oldIsSubset = oldEnum.every((value) => nextEnum.includes(value));
-		if (!oldIsSubset) {
-			return false;
-		}
-	} else if (oldEnum && !nextEnum) {
-		return false;
-	}
-
-	const oldConstraints = oldAttribute.typia.constraints ?? {};
-	const nextConstraints = newAttribute.typia.constraints ?? {};
-
-	return [
-		compareMinimumBound(oldConstraints.minLength, nextConstraints.minLength),
-		compareMaximumBound(oldConstraints.maxLength, nextConstraints.maxLength),
-		compareMinimumBound(oldConstraints.minimum, nextConstraints.minimum),
-		compareMaximumBound(oldConstraints.maximum, nextConstraints.maximum),
-		comparePatternBound(oldConstraints.pattern, nextConstraints.pattern),
-		comparePatternBound(oldConstraints.format, nextConstraints.format),
-		comparePatternBound(oldConstraints.typeTag, nextConstraints.typeTag),
-	].every(Boolean);
-}
-
-function compareMinimumBound(oldValue: unknown, nextValue: unknown): boolean {
-	if (nextValue === null || nextValue === undefined) return true;
-	if (oldValue === null || oldValue === undefined) return true;
-	return Number(oldValue) <= Number(nextValue);
-}
-
-function compareMaximumBound(oldValue: unknown, nextValue: unknown): boolean {
-	if (nextValue === null || nextValue === undefined) return true;
-	if (oldValue === null || oldValue === undefined) return true;
-	return Number(oldValue) >= Number(nextValue);
-}
-
-function comparePatternBound(oldValue: unknown, nextValue: unknown): boolean {
-	return oldValue === nextValue || oldValue === null || oldValue === undefined;
-}
-
-function scoreRenameSimilarity(legacyPath: string, currentPath: string): number {
-	const legacy = normalizeFieldName(legacyPath);
-	const current = normalizeFieldName(currentPath);
-
-	if (legacy === current) return 1;
-	if (shareAliasGroup(legacy, current)) return 0.9;
-
-	const legacyTokens = tokenizeFieldName(legacy);
-	const currentTokens = tokenizeFieldName(current);
-	const overlap = legacyTokens.filter((token) => currentTokens.includes(token));
-	const jaccard = overlap.length / new Set([...legacyTokens, ...currentTokens]).size;
-
-	if (legacy.includes(current) || current.includes(legacy)) {
-		return Math.max(jaccard, 0.7);
-	}
-	if (
-		legacyTokens.length > 0 &&
-		currentTokens.length > 0 &&
-		legacyTokens[legacyTokens.length - 1] === currentTokens[currentTokens.length - 1]
-	) {
-		return Math.max(jaccard, 0.6);
-	}
-
-	return jaccard;
-}
-
-function passesNameSimilarityRule(legacyPath: string, currentPath: string): boolean {
-	return scoreRenameSimilarity(legacyPath, currentPath) >= 0.6;
-}
-
-function normalizeFieldName(name: string): string {
-	return String(name)
-		.replace(/([a-z0-9])([A-Z])/g, "$1 $2")
-		.replace(/[^a-zA-Z0-9]+/g, " ")
-		.trim()
-		.toLowerCase()
-		.replace(/\s+/g, "");
-}
-
-function tokenizeFieldName(name: string): string[] {
-	return String(name)
-		.replace(/([a-z0-9])([A-Z])/g, "$1 $2")
-		.toLowerCase()
-		.split(/[^a-z0-9]+/)
-		.filter(Boolean);
-}
-
-function getParentPath(pathLabel: string): string {
-	const segments = String(pathLabel).split(".");
-	return segments.length <= 1 ? "" : segments.slice(0, -1).join(".");
-}
-
-function shareAliasGroup(left: string, right: string): boolean {
-	const aliasGroups = [
-		["content", "headline", "body", "text", "copy", "message"],
-		["id", "uniqueid", "uuid"],
-		["visible", "isvisible", "show", "shown", "enabled"],
-		["align", "alignment", "textalign"],
-		["count", "clickcount", "counter"],
-		["url", "href", "link"],
-	];
-
-	return aliasGroups.some((group) => group.includes(left) && group.includes(right));
-}
-
-function describeRenameReason(
-	attribute: ManifestAttribute,
-	legacyPath: string,
-	currentPath: string,
-	score: number,
-): string {
-	if (attribute.ts.kind === "union") {
-		return `compatible discriminated union (${legacyPath} → ${currentPath})`;
-	}
-	if (score >= 0.9) return "high-confidence compatible field";
-	if (score >= 0.6) return "name-similar compatible field";
-	return "compatible field requiring review";
-}
-
-function buildTransformBodyLines(attribute: ManifestAttribute, legacyPath: string): string[] {
-	switch (attribute.ts.kind) {
-		case "string":
-			return [`// return typeof legacyValue === "string" ? legacyValue : String(legacyValue ?? "");`];
-		case "number":
-			return [
-				`// const numericValue = typeof legacyValue === "number" ? legacyValue : Number(legacyValue ?? 0);`,
-				`// return Number.isNaN(numericValue) ? undefined : numericValue;`,
-			];
-		case "boolean":
-			return [`// return typeof legacyValue === "boolean" ? legacyValue : Boolean(legacyValue);`];
-		case "union":
-			return [
-				`// const legacyObject = typeof legacyValue === "object" && legacyValue !== null ? legacyValue : {};`,
-				`// return legacyObject; // adjust discriminator / branch fields before verify`,
-			];
-		default:
-			return [`// return legacyValue; // customize migration from ${legacyPath}`];
-	}
-}
-
-function describeConstraintChange(oldAttribute: ManifestAttribute, newAttribute: ManifestAttribute): string {
-	const details: string[] = [];
-	const oldConstraints = oldAttribute.typia.constraints;
-	const nextConstraints = newAttribute.typia.constraints;
-
-	if (newAttribute.wp.enum && JSON.stringify(newAttribute.wp.enum) !== JSON.stringify(oldAttribute.wp.enum)) {
-		details.push("enum changed");
-	}
-	for (const key of ["minLength", "maxLength", "minimum", "maximum", "pattern", "format", "typeTag"] as const) {
-		if (oldConstraints[key] !== nextConstraints[key]) {
-			details.push(`${key}: ${oldConstraints[key]} -> ${nextConstraints[key]}`);
-		}
-	}
-
-	return details.join(", ");
 }
 
 function autoOutcome(pathLabel: string, kind: string, detail: string): DiffOutcome {

--- a/packages/wp-typia-project-tools/tests/migration-diff-boundaries.test.ts
+++ b/packages/wp-typia-project-tools/tests/migration-diff-boundaries.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const sourceRoot = resolve(import.meta.dir, "..", "src", "runtime");
+
+test("migration-diff keeps rename and transform helpers in dedicated modules", () => {
+	const migrationDiffSource = readFileSync(
+		resolve(sourceRoot, "migration-diff.ts"),
+		"utf8",
+	);
+	const migrationDiffRenameSource = readFileSync(
+		resolve(sourceRoot, "migration-diff-rename.ts"),
+		"utf8",
+	);
+	const migrationDiffTransformSource = readFileSync(
+		resolve(sourceRoot, "migration-diff-transform.ts"),
+		"utf8",
+	);
+
+	expect(migrationDiffSource).toContain('from "./migration-diff-rename.js"');
+	expect(migrationDiffSource).toContain('from "./migration-diff-transform.js"');
+	expect(migrationDiffSource).not.toContain("function createRenameCandidates(");
+	expect(migrationDiffSource).not.toContain("function assessRenameCandidate(");
+	expect(migrationDiffSource).not.toContain("function createTransformSuggestions(");
+	expect(migrationDiffSource).not.toContain("function buildTransformBodyLines(");
+	expect(migrationDiffRenameSource).toContain("export function createRenameCandidates(");
+	expect(migrationDiffRenameSource).toContain("export function passesNameSimilarityRule(");
+	expect(migrationDiffTransformSource).toContain(
+		"export function createTransformSuggestions(",
+	);
+	expect(migrationDiffTransformSource).toContain(
+		"export function describeConstraintChange(",
+	);
+});


### PR DESCRIPTION
## Context

- `packages/wp-typia-project-tools/src/runtime/migration-diff.ts` still carried rename-candidate and transform-suggestion helper families inline.
- This follow-up keeps `createMigrationDiff(...)` stable while moving those helper clusters into focused runtime modules.

## What Changed

- added `migration-diff-rename.ts` for rename candidate scoring and auto-apply heuristics
- added `migration-diff-transform.ts` for transform suggestion building and constraint change descriptions
- kept `migration-diff.ts` as the orchestration layer and wired it to the new helper modules
- added a dedicated boundary test for the new migration diff split
- added a patch changeset for `@wp-typia/project-tools`

## Verification

- `bun run --filter @wp-typia/project-tools build`
- `bun run --filter wp-typia build`
- `bun test packages/wp-typia-project-tools/tests/migration-diff-boundaries.test.ts`
- `bun test packages/wp-typia-project-tools/tests/migration-scaffold-diff.test.ts`
- `bun run typecheck`
- `bun run changesets:validate`

Closes #367
