### PR TITLE
Tighten create flag defaults and unsupported-option diagnostics

### DIFF
--- a/.sampo/changesets/issue-396-create-flag-contract.md
+++ b/.sampo/changesets/issue-396-create-flag-contract.md
@@ -1,0 +1,6 @@
+---
+npm/wp-typia: patch
+npm/@wp-typia/project-tools: patch
+---
+
+Tighten `wp-typia create` flag handling by defaulting `--yes` scaffolds to npm, rejecting persistence-only flags on non-persistence built-in templates, and surfacing built-in `--variant` misuse earlier.

--- a/packages/wp-typia-project-tools/src/runtime/cli-scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-scaffold.ts
@@ -104,6 +104,33 @@ function templateUsesPersistenceSettings(
 	return Boolean(options.dataStorageMode || options.persistencePolicy);
 }
 
+function templateSupportsPersistenceFlags(templateId: string): boolean {
+	return templateId === "persistence" || templateId === "compound";
+}
+
+function validateCreateFlagContract(options: {
+	dataStorageMode?: string;
+	persistencePolicy?: string;
+	templateId: string;
+	variant?: string;
+}) {
+	const { dataStorageMode, persistencePolicy, templateId, variant } = options;
+	if (
+		(dataStorageMode || persistencePolicy) &&
+		!templateSupportsPersistenceFlags(templateId)
+	) {
+		throw new Error(
+			"`--data-storage` and `--persistence-policy` are supported only for `wp-typia create --template persistence` or `--template compound`.",
+		);
+	}
+
+	if (variant && isBuiltInTemplateId(templateId)) {
+		throw new Error(
+			`--variant is only supported for official external template configs. Received variant "${variant}" for built-in template "${templateId}".`,
+		);
+	}
+}
+
 function parseSelectableValue<T extends string>(
 	label: string,
 	value: string,
@@ -312,6 +339,12 @@ export async function runScaffoldFlow({
 		yes,
 		isInteractive,
 		selectTemplate,
+	});
+	validateCreateFlagContract({
+		dataStorageMode,
+		persistencePolicy,
+		templateId: resolvedTemplateId,
+		variant,
 	});
 	const resolvedExternalLayerSelection =
 		isBuiltInTemplateId(resolvedTemplateId) && isInteractive

--- a/packages/wp-typia-project-tools/src/runtime/scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold.ts
@@ -309,9 +309,7 @@ export async function resolvePackageManagerId({
 	}
 
 	if (yes) {
-		throw new Error(
-			`Package manager is required when using --yes. Use --package-manager <${PACKAGE_MANAGER_IDS.join("|")}>.`,
-		);
+		return "npm";
 	}
 
 	if (!isInteractive || !selectPackageManager) {

--- a/packages/wp-typia-project-tools/tests/cli-entry.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-entry.test.ts
@@ -294,6 +294,38 @@ test("runScaffoldFlow rejects unsupported persistence policies", async () => {
   );
 });
 
+test("runScaffoldFlow rejects persistence-only create flags for non-persistence templates", async () => {
+  await expect(
+    runScaffoldFlow({
+      cwd: tempRoot,
+      dataStorageMode: "custom-table",
+      noInstall: true,
+      packageManager: "npm",
+      projectInput: "demo-basic-invalid-persistence-flags",
+      templateId: "basic",
+      yes: true,
+    })
+  ).rejects.toThrow(
+    "`--data-storage` and `--persistence-policy` are supported only for `wp-typia create --template persistence` or `--template compound`."
+  );
+});
+
+test("runScaffoldFlow rejects built-in variant flags before template rendering", async () => {
+  await expect(
+    runScaffoldFlow({
+      cwd: tempRoot,
+      noInstall: true,
+      packageManager: "npm",
+      projectInput: "demo-basic-invalid-variant",
+      templateId: "basic",
+      variant: "hero",
+      yes: true,
+    })
+  ).rejects.toThrow(
+    '--variant is only supported for official external template configs. Received variant "hero" for built-in template "basic".'
+  );
+});
+
 test("runScaffoldFlow rejects removed built-in template ids", async () => {
   await expect(
     runScaffoldFlow({
@@ -591,23 +623,79 @@ test(
   { timeout: 15_000 }
 );
 
-test("node entry requires --package-manager with --yes", () => {
-  expect(() => {
+test("node entry defaults --yes scaffolds to npm when package manager is omitted", () => {
+  const targetDir = path.join(tempRoot, "demo-default-pm");
+
+  runCli(
+    "node",
+    [
+      entryPath,
+      targetDir,
+      "--template",
+      "basic",
+      "--yes",
+      "--no-install",
+    ],
+    {
+      stdio: "pipe",
+    }
+  );
+
+  const packageJson = JSON.parse(
+    fs.readFileSync(path.join(targetDir, "package.json"), "utf8")
+  );
+
+  expect(packageJson.packageManager).toBe("npm@11.6.1");
+});
+
+test("node entry rejects persistence-only flags for basic create scaffolds", () => {
+  const errorMessage = getCommandErrorMessage(() =>
     runCli(
       "node",
       [
         entryPath,
-        "demo-missing-pm",
+        "demo-basic-invalid-persistence",
         "--template",
         "basic",
+        "--data-storage",
+        "custom-table",
         "--yes",
         "--no-install",
       ],
       {
         stdio: "pipe",
       }
-    );
-  }).toThrow();
+    )
+  );
+
+  expect(errorMessage).toContain(
+    "`--data-storage` and `--persistence-policy` are supported only for `wp-typia create --template persistence` or `--template compound`."
+  );
+});
+
+test("node entry rejects built-in variant flags before scaffolding", () => {
+  const errorMessage = getCommandErrorMessage(() =>
+    runCli(
+      "node",
+      [
+        entryPath,
+        "demo-basic-invalid-variant",
+        "--template",
+        "basic",
+        "--variant",
+        "hero",
+        "--yes",
+        "--no-install",
+      ],
+      {
+        stdio: "pipe",
+      }
+    )
+  );
+
+  expect(errorMessage).toContain(
+    '--variant is only supported for official external template configs. Received variant "hero" for built-in template "basic".'
+  );
 });
 
 test("node entry rejects missing values for identifier override flags", () => {


### PR DESCRIPTION
## Context
- `wp-typia create` still had a few surprising non-interactive flag behaviors
- `--yes` scaffolds still required an explicit package manager
- persistence-only flags and built-in `--variant` mistakes were rejected too late or silently ignored

## What Changed
- default `--yes` create scaffolds to `npm` when no package manager is supplied
- reject `--data-storage` and `--persistence-policy` on non-persistence built-in templates before scaffold generation
- reject built-in `--variant` usage earlier in the create flow
- add create-flow and node-entry regression coverage for the tightened contract
- add a Sampo changeset for `wp-typia` and `@wp-typia/project-tools`

## Verification
- `bun test packages/wp-typia-project-tools/tests/cli-entry.test.ts`
- `bun test packages/wp-typia/tests/cli-package.test.ts`
- `bun run --filter @wp-typia/project-tools build`
- `bun run typecheck`
- `bun run changesets:validate`

Closes #396