### PR TITLE
Harden create project-dir safeguards and positional alias routing

### DIFF
--- a/.sampo/changesets/issue-398-create-invocation-safeguards.md
+++ b/.sampo/changesets/issue-398-create-invocation-safeguards.md
@@ -1,0 +1,6 @@
+---
+npm/wp-typia: patch
+npm/@wp-typia/project-tools: patch
+---
+
+Harden `wp-typia create` project-directory handling by warning on awkward names, rejecting `.` and `..`, and limiting the positional shortcut to unambiguous local paths.

--- a/packages/wp-typia-project-tools/src/runtime/cli-scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-scaffold.ts
@@ -94,7 +94,10 @@ function validateCreateProjectInput(projectInput: string) {
 		);
 	}
 
-	if (normalizedProjectInput === "." || normalizedProjectInput === "..") {
+	const normalizedProjectPath =
+		path.normalize(normalizedProjectInput).replace(/[\\/]+$/u, "") ||
+		path.normalize(normalizedProjectInput);
+	if (normalizedProjectPath === "." || normalizedProjectPath === "..") {
 		throw new Error(
 			"`wp-typia create` requires a new project directory. Use an explicit child directory instead of `.` or `..`.",
 		);

--- a/packages/wp-typia-project-tools/src/runtime/cli-scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-scaffold.ts
@@ -86,6 +86,42 @@ interface RunScaffoldFlowOptions {
 	yes?: boolean;
 }
 
+function validateCreateProjectInput(projectInput: string) {
+	const normalizedProjectInput = projectInput.trim();
+	if (normalizedProjectInput.length === 0) {
+		throw new Error(
+			"Project directory is required. Usage: wp-typia create <project-dir> (or wp-typia <project-dir> when <project-dir> is the only positional argument).",
+		);
+	}
+
+	if (normalizedProjectInput === "." || normalizedProjectInput === "..") {
+		throw new Error(
+			"`wp-typia create` requires a new project directory. Use an explicit child directory instead of `.` or `..`.",
+		);
+	}
+}
+
+function collectProjectDirectoryWarnings(projectDir: string): string[] {
+	const warnings: string[] = [];
+	const projectName = path.basename(projectDir);
+	if (/\s/u.test(projectName)) {
+		warnings.push(
+			`Project directory "${projectName}" contains spaces. The generated next-step commands will be quoted, but a simple kebab-case directory name is usually easier to use with shells and downstream tooling.`,
+		);
+	}
+
+	const shellSensitiveCharacters = Array.from(
+		new Set(projectName.match(/[^A-Za-z0-9._ -]/gu) ?? []),
+	);
+	if (shellSensitiveCharacters.length > 0) {
+		warnings.push(
+			`Project directory "${projectName}" contains shell-sensitive characters (${shellSensitiveCharacters.join(", ")}). Prefer letters, numbers, ".", "_" and "-" when possible.`,
+		);
+	}
+
+	return warnings;
+}
+
 function templateUsesPersistenceSettings(
 	templateId: string,
 	options: {
@@ -328,11 +364,7 @@ export async function runScaffoldFlow({
 			? externalLayerSource.trim()
 			: undefined;
 
-	if (!projectInput) {
-		throw new Error(
-			"Project directory is required. Usage: wp-typia create <project-dir> (or wp-typia <project-dir> when <project-dir> is the only positional argument).",
-		);
-	}
+	validateCreateProjectInput(projectInput);
 
 	const resolvedTemplateId = await resolveTemplateId({
 		templateId,
@@ -476,7 +508,6 @@ export async function runScaffoldFlow({
 			projectDir,
 			projectInput,
 			packageManager: resolvedPackageManager,
-			result,
 			nextSteps: getNextSteps({
 				projectInput,
 				projectDir,
@@ -484,6 +515,10 @@ export async function runScaffoldFlow({
 				noInstall,
 				templateId: resolvedTemplateId,
 			}),
+			result: {
+				...result,
+				warnings: [...result.warnings, ...collectProjectDirectoryWarnings(projectDir)],
+			},
 		};
 	} finally {
 		await resolvedExternalLayerSelection.cleanup?.();

--- a/packages/wp-typia-project-tools/tests/cli-entry.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-entry.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, describe, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { cleanupScaffoldTempRoot, createBlockSubsetFixturePath, createScaffoldTempRoot, entryPath, getCommandErrorMessage, runCli, templateLayerAmbiguousFixturePath, templateLayerFixturePath } from "./helpers/scaffold-test-harness.js";
+import { cleanupScaffoldTempRoot, createBlockSubsetFixturePath, createScaffoldTempRoot, entryPath, getCommandErrorMessage, runCapturedCli, runCli, templateLayerAmbiguousFixturePath, templateLayerFixturePath } from "./helpers/scaffold-test-harness.js";
 import { formatHelpText, getDoctorChecks, getNextSteps, getOptionalOnboarding, runScaffoldFlow } from "../src/runtime/cli-core.js";
 import { collectScaffoldAnswers } from "../src/runtime/scaffold.js";
 
@@ -324,6 +324,26 @@ test("runScaffoldFlow rejects built-in variant flags before template rendering",
   ).rejects.toThrow(
     '--variant is only supported for official external template configs. Received variant "hero" for built-in template "basic".'
   );
+});
+
+test("runScaffoldFlow warns about awkward project directory names", async () => {
+  const projectInput = "my cool block!";
+  const flow = await runScaffoldFlow({
+    cwd: tempRoot,
+    noInstall: true,
+    packageManager: "npm",
+    projectInput,
+    templateId: "basic",
+    yes: true,
+  });
+
+  expect(flow.result.warnings).toContain(
+    'Project directory "my cool block!" contains spaces. The generated next-step commands will be quoted, but a simple kebab-case directory name is usually easier to use with shells and downstream tooling.'
+  );
+  expect(flow.result.warnings).toContain(
+    'Project directory "my cool block!" contains shell-sensitive characters (!). Prefer letters, numbers, ".", "_" and "-" when possible.'
+  );
+  expect(flow.nextSteps[0]).toBe(`cd 'my cool block!'`);
 });
 
 test("runScaffoldFlow rejects removed built-in template ids", async () => {
@@ -695,6 +715,35 @@ test("node entry rejects built-in variant flags before scaffolding", () => {
 
   expect(errorMessage).toContain(
     '--variant is only supported for official external template configs. Received variant "hero" for built-in template "basic".'
+  );
+});
+
+test("node entry rejects create . as an explicit project directory", () => {
+  const errorMessage = getCommandErrorMessage(() =>
+    runCli("node", [entryPath, "create", ".", "--template", "basic", "--yes"], {
+      stdio: "pipe",
+    })
+  );
+
+  expect(errorMessage).toContain(
+    "`wp-typia create` requires a new project directory. Use an explicit child directory instead of `.` or `..`."
+  );
+});
+
+test("node entry warns about awkward project directory names", () => {
+  const targetDir = path.join(tempRoot, "node cool block!");
+  const result = runCapturedCli(
+    "node",
+    [entryPath, "create", targetDir, "--template", "basic", "--yes", "--no-install"],
+    {
+      stdio: "pipe",
+    }
+  );
+
+  expect(result.status).toBe(0);
+  expect(result.stderr).toContain('Project directory "node cool block!" contains spaces.');
+  expect(result.stderr).toContain(
+    'Project directory "node cool block!" contains shell-sensitive characters (!).'
   );
 });
 

--- a/packages/wp-typia-project-tools/tests/cli-entry.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-entry.test.ts
@@ -730,6 +730,18 @@ test("node entry rejects create . as an explicit project directory", () => {
   );
 });
 
+test("node entry rejects create ./ as an explicit project directory", () => {
+  const errorMessage = getCommandErrorMessage(() =>
+    runCli("node", [entryPath, "create", "./", "--template", "basic", "--yes"], {
+      stdio: "pipe",
+    })
+  );
+
+  expect(errorMessage).toContain(
+    "`wp-typia create` requires a new project directory. Use an explicit child directory instead of `.` or `..`."
+  );
+});
+
 test("node entry warns about awkward project directory names", () => {
   const targetDir = path.join(tempRoot, "node cool block!");
   const result = runCapturedCli(

--- a/packages/wp-typia-project-tools/tests/helpers/scaffold-test-environment.ts
+++ b/packages/wp-typia-project-tools/tests/helpers/scaffold-test-environment.ts
@@ -309,6 +309,17 @@ export function getCommandErrorMessage(run: () => string): string {
 	}
 }
 
+export function runCapturedCli(
+	command: string,
+	args: string[],
+	options: Parameters<typeof spawnSync>[2] = {},
+) {
+	return spawnSync(command, args, {
+		...options,
+		encoding: "utf8",
+	});
+}
+
 export function stripPhpFunction(source: string, functionName: string): string {
 	const escapedFunctionName = functionName.replace(
 		/[.*+?^${}()|[\]\\]/gu,

--- a/packages/wp-typia/src/command-contract.ts
+++ b/packages/wp-typia/src/command-contract.ts
@@ -231,6 +231,36 @@ function assertStringOptionValues(argv: string[]): void {
   }
 }
 
+function isWindowsDrivePath(value: string): boolean {
+  return /^[A-Za-z]:([\\/]|$)/.test(value);
+}
+
+function looksLikeStructuredProjectInput(value: string): boolean {
+  if (value.includes('#')) {
+    return true;
+  }
+
+  if (!isWindowsDrivePath(value) && /^[A-Za-z][A-Za-z0-9+.-]*:/u.test(value)) {
+    return true;
+  }
+
+  return value.startsWith('@') && value.includes('/');
+}
+
+function assertPositionalAliasProjectDir(projectDir: string): void {
+  if (projectDir === '.' || projectDir === '..') {
+    throw new Error(
+      `The positional alias does not scaffold into \`${projectDir}\`. Use \`${WP_TYPIA_CANONICAL_CREATE_USAGE}\` with an explicit child directory instead.`,
+    );
+  }
+
+  if (looksLikeStructuredProjectInput(projectDir)) {
+    throw new Error(
+      `The positional alias only accepts unambiguous local project directories. Use \`${WP_TYPIA_CANONICAL_CREATE_USAGE}\` for \`${projectDir}\`.`,
+    );
+  }
+}
+
 export function normalizeWpTypiaArgv(argv: string[]): string[] {
   const positionalIndexes = collectPositionalIndexes(argv);
   const firstPositionalIndex = positionalIndexes[0] ?? -1;
@@ -267,6 +297,8 @@ export function normalizeWpTypiaArgv(argv: string[]): string[] {
       `The positional alias only accepts a single project directory. Use \`${WP_TYPIA_CANONICAL_CREATE_USAGE}\` for scaffold invocations with additional positional arguments, or check the command spelling if you meant another top-level command. Extra positional arguments: ${extraPositionals.map((value) => `\`${value}\``).join(', ')}.`,
     );
   }
+
+  assertPositionalAliasProjectDir(firstPositional);
 
   const normalizedArgv = [
     ...argv.slice(0, firstPositionalIndex),

--- a/packages/wp-typia/src/command-contract.ts
+++ b/packages/wp-typia/src/command-contract.ts
@@ -1,3 +1,5 @@
+import path from 'node:path'
+
 export const WP_TYPIA_CANONICAL_CREATE_USAGE = 'wp-typia create <project-dir>';
 export const WP_TYPIA_POSITIONAL_ALIAS_USAGE = 'wp-typia <project-dir>';
 export const WP_TYPIA_CANONICAL_MIGRATE_USAGE = 'wp-typia migrate <subcommand>';
@@ -248,7 +250,9 @@ function looksLikeStructuredProjectInput(value: string): boolean {
 }
 
 function assertPositionalAliasProjectDir(projectDir: string): void {
-  if (projectDir === '.' || projectDir === '..') {
+  const normalizedProjectDir =
+    path.normalize(projectDir).replace(/[\\/]+$/u, '') || path.normalize(projectDir);
+  if (normalizedProjectDir === '.' || normalizedProjectDir === '..') {
     throw new Error(
       `The positional alias does not scaffold into \`${projectDir}\`. Use \`${WP_TYPIA_CANONICAL_CREATE_USAGE}\` with an explicit child directory instead.`,
     );

--- a/packages/wp-typia/tests/bunli-prep.test.ts
+++ b/packages/wp-typia/tests/bunli-prep.test.ts
@@ -118,6 +118,9 @@ describe("wp-typia Bunli preparation", () => {
 		expect(() => normalizeWpTypiaArgv(["."])).toThrow(
 			/The positional alias does not scaffold into `\.`/,
 		);
+		expect(() => normalizeWpTypiaArgv(["./"])).toThrow(
+			/The positional alias does not scaffold into `\.\/`/,
+		);
 		expect(
 			normalizeWpTypiaArgv([
 				"add",

--- a/packages/wp-typia/tests/bunli-prep.test.ts
+++ b/packages/wp-typia/tests/bunli-prep.test.ts
@@ -112,6 +112,12 @@ describe("wp-typia Bunli preparation", () => {
 		expect(
 			normalizeWpTypiaArgv(["demo-block", "--template", "basic"]),
 		).toEqual(["create", "demo-block", "--template", "basic"]);
+		expect(() => normalizeWpTypiaArgv(["github:acme/template"])).toThrow(
+			/The positional alias only accepts unambiguous local project directories/,
+		);
+		expect(() => normalizeWpTypiaArgv(["."])).toThrow(
+			/The positional alias does not scaffold into `\.`/,
+		);
 		expect(
 			normalizeWpTypiaArgv([
 				"add",


### PR DESCRIPTION
## Context
- `wp-typia create` still allowed awkward project-dir inputs with very little guidance
- the positional `wp-typia <project-dir>` shortcut was still permissive enough to accept structured-looking inputs
- we wanted clearer project-dir feedback without removing the shorthand entirely

## What Changed
- reject `wp-typia create .` and `wp-typia create ..` with an explicit child-directory message
- append create-flow warnings when the target directory name contains spaces or shell-sensitive characters
- keep next-step output quoted for awkward directory names
- restrict the positional `wp-typia <project-dir>` shortcut to unambiguous local paths and reject structured-looking inputs like remote/template specifiers
- add node-entry and alias normalization regression coverage plus a Sampo changeset

## Verification
- `bun run --filter @wp-typia/project-tools build`
- `cd packages/wp-typia && bun run build`
- `bun test packages/wp-typia-project-tools/tests/cli-entry.test.ts packages/wp-typia/tests/bunli-prep.test.ts`
- `bun run typecheck`
- `bun run changesets:validate`

Closes #398

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced `wp-typia create` command with input validation safeguards that reject special directory values (`.`, `..`) with clear error messages.
  * Added warnings for project directories containing spaces or shell-sensitive characters.
  * Positional shortcut now restricts to unambiguous local directory paths, rejecting structured references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->