### PR TITLE
Clarify doctor scope messaging outside workspace roots

### DIFF
--- a/.sampo/changesets/issue-401-doctor-scope-messaging.md
+++ b/.sampo/changesets/issue-401-doctor-scope-messaging.md
@@ -1,0 +1,6 @@
+---
+npm/wp-typia: patch
+npm/@wp-typia/project-tools: patch
+---
+
+Clarify `wp-typia doctor` output outside official workspace roots by surfacing an explicit doctor scope row, environment-only rerun guidance, and earlier invalid-workspace messaging.

--- a/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace.ts
@@ -40,6 +40,13 @@ function createDoctorCheck(
 	return { detail, label, status };
 }
 
+function createDoctorScopeCheck(
+	status: DoctorCheck["status"],
+	detail: string,
+): DoctorCheck {
+	return createDoctorCheck("Doctor scope", status, detail);
+}
+
 function getWorkspaceBootstrapRelativePath(packageName: string): string {
 	const packageBaseName = packageName.split("/").pop() ?? packageName;
 	return `${packageBaseName}.php`;
@@ -384,11 +391,11 @@ function checkMigrationWorkspaceHint(
 /**
  * Collect workspace-scoped doctor checks for the given working directory.
  *
- * When the directory is not an official workspace, the function returns an
- * empty array or a single failing "Workspace package metadata" row describing
- * the reason. When workspace resolution or metadata parsing throws, the
- * corresponding failing row is returned early and the remaining checks are
- * skipped.
+ * When the directory is not an official workspace, the function returns a
+ * "Doctor scope" row explaining that only environment checks ran, plus a
+ * failing workspace metadata row when a nearby candidate workspace is invalid.
+ * When workspace resolution or metadata parsing throws, the corresponding
+ * failing rows are returned early and the remaining checks are skipped.
  *
  * @param cwd Working directory expected to host an official workspace.
  * @returns Ordered workspace check rows ready for CLI rendering.
@@ -403,6 +410,12 @@ export function getWorkspaceDoctorChecks(cwd: string): DoctorCheck[] {
 		workspace = tryResolveWorkspaceProject(cwd);
 	} catch (error) {
 		checks.push(
+			createDoctorScopeCheck(
+				"fail",
+				"Environment checks ran, but workspace discovery could not continue. Fix the nearby workspace package metadata and rerun `wp-typia doctor`.",
+			),
+		);
+		checks.push(
 			createDoctorCheck(
 				"Workspace package metadata",
 				"fail",
@@ -414,10 +427,23 @@ export function getWorkspaceDoctorChecks(cwd: string): DoctorCheck[] {
 	if (!workspace) {
 		if (invalidWorkspaceReason) {
 			checks.push(
+				createDoctorScopeCheck(
+					"fail",
+					"Environment checks ran, but workspace diagnostics could not continue because a nearby wp-typia workspace candidate is invalid. Fix the workspace package metadata and rerun `wp-typia doctor`.",
+				),
+			);
+			checks.push(
 				createDoctorCheck(
 					"Workspace package metadata",
 					"fail",
 					invalidWorkspaceReason,
+				),
+			);
+		} else {
+			checks.push(
+				createDoctorScopeCheck(
+					"pass",
+					"No official wp-typia workspace root was detected, so this run only covered environment readiness. Re-run `wp-typia doctor` from a workspace root if you expected package metadata, inventory, or generated artifact checks.",
 				),
 			);
 		}
@@ -425,10 +451,9 @@ export function getWorkspaceDoctorChecks(cwd: string): DoctorCheck[] {
 	}
 
 	checks.push(
-		createDoctorCheck(
-			"Workspace marker",
+		createDoctorScopeCheck(
 			"pass",
-			`Official workspace detected for ${workspace.workspace.namespace}`,
+			`Official workspace detected for ${workspace.workspace.namespace}; this run covered environment readiness plus workspace metadata, inventory, source-tree drift, and any configured migration hints.`,
 		),
 	);
 

--- a/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace.ts
@@ -396,6 +396,10 @@ function checkMigrationWorkspaceHint(
  * failing workspace metadata row when a nearby candidate workspace is invalid.
  * When workspace resolution or metadata parsing throws, the corresponding
  * failing rows are returned early and the remaining checks are skipped.
+ * When an official workspace is detected, a passing "Doctor scope" row is
+ * emitted first so the remaining package metadata, inventory, source-tree
+ * drift, and optional migration hint rows are clearly framed as workspace
+ * diagnostics for that run.
  *
  * @param cwd Working directory expected to host an official workspace.
  * @returns Ordered workspace check rows ready for CLI rendering.
@@ -453,7 +457,7 @@ export function getWorkspaceDoctorChecks(cwd: string): DoctorCheck[] {
 	checks.push(
 		createDoctorScopeCheck(
 			"pass",
-			`Official workspace detected for ${workspace.workspace.namespace}; this run covered environment readiness plus workspace metadata, inventory, source-tree drift, and any configured migration hints.`,
+			`Official workspace detected for ${workspace.workspace.namespace}; environment readiness checks ran and workspace-scoped diagnostics are enabled for the package metadata, inventory, source-tree drift, and any configured migration hint rows below.`,
 		),
 	);
 

--- a/packages/wp-typia-project-tools/src/runtime/cli-help.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-help.ts
@@ -40,7 +40,7 @@ Notes:
   \`add pattern\` scaffolds a namespaced PHP pattern shell under \`src/patterns/\`.
   \`add binding-source\` scaffolds shared PHP and editor registration under \`src/bindings/\`.
   \`add hooked-block\` patches an existing workspace block's \`block.json\` \`blockHooks\` metadata.
-  \`wp-typia doctor\` checks environment readiness plus workspace inventory and source-tree drift.
+  \`wp-typia doctor\` always checks environment readiness and reports when it only ran environment-level diagnostics; official workspace roots also get inventory and source-tree drift checks.
   \`wp-typia migrate doctor --all\` checks migration target alignment, snapshots, fixtures, and generated migration artifacts.
   \`migrate\` is the canonical migration command; \`migrations\` is no longer supported.`;
 }

--- a/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
@@ -75,6 +75,26 @@ test("doctor reports invalid nearby workspace metadata before workspace checks",
   );
 });
 
+test("doctor reports workspace discovery failures before workspace checks", async () => {
+  const targetDir = path.join(tempRoot, "doctor-workspace-discovery-failure");
+  fs.mkdirSync(targetDir, { recursive: true });
+  fs.writeFileSync(path.join(targetDir, "package.json"), "{\n", "utf8");
+
+  const checks = await getDoctorChecks(targetDir);
+  const scopeCheck = checks.find((check) => check.label === "Doctor scope");
+  const metadataCheck = checks.find(
+    (check) => check.label === "Workspace package metadata"
+  );
+
+  expect(scopeCheck?.status).toBe("fail");
+  expect(scopeCheck?.detail).toContain("workspace discovery could not continue");
+  expect(scopeCheck?.detail).toContain("rerun `wp-typia doctor`");
+  expect(metadataCheck?.status).toBe("fail");
+  expect(metadataCheck?.detail).toContain(
+    "Failed to parse workspace package manifest"
+  );
+});
+
 test("doctor accepts workspaces that keep binding registries in src/bindings/index.js", async () => {
   const targetDir = path.join(
     tempRoot,

--- a/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
@@ -26,6 +26,55 @@ describe("@wp-typia/project-tools workspace doctor", () => {
     cleanupScaffoldTempRoot(tempRoot);
   });
 
+test("doctor reports environment-only scope outside official workspace roots", async () => {
+  const targetDir = path.join(tempRoot, "doctor-environment-only");
+  fs.mkdirSync(targetDir, { recursive: true });
+
+  const checks = await getDoctorChecks(targetDir);
+  const scopeCheck = checks.find((check) => check.label === "Doctor scope");
+
+  expect(scopeCheck?.status).toBe("pass");
+  expect(scopeCheck?.detail).toContain("only covered environment readiness");
+  expect(scopeCheck?.detail).toContain("workspace root");
+  expect(
+    checks.some((check) => check.label === "Workspace package metadata")
+  ).toBe(false);
+});
+
+test("doctor reports invalid nearby workspace metadata before workspace checks", async () => {
+  const targetDir = path.join(tempRoot, "doctor-invalid-workspace-metadata");
+  fs.mkdirSync(targetDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(targetDir, "package.json"),
+    `${JSON.stringify(
+      {
+        name: "invalid-workspace-metadata",
+        private: true,
+        wpTypia: {
+          projectType: "workspace",
+        },
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+
+  const checks = await getDoctorChecks(targetDir);
+  const scopeCheck = checks.find((check) => check.label === "Doctor scope");
+  const metadataCheck = checks.find(
+    (check) => check.label === "Workspace package metadata"
+  );
+
+  expect(scopeCheck?.status).toBe("fail");
+  expect(scopeCheck?.detail).toContain("workspace diagnostics could not continue");
+  expect(scopeCheck?.detail).toContain("rerun `wp-typia doctor`");
+  expect(metadataCheck?.status).toBe("fail");
+  expect(metadataCheck?.detail).toContain(
+    "Invalid wp-typia workspace metadata"
+  );
+});
+
 test("doctor accepts workspaces that keep binding registries in src/bindings/index.js", async () => {
   const targetDir = path.join(
     tempRoot,

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -576,11 +576,36 @@ describe("wp-typia package", () => {
 			});
 
 			expect(result.status).toBe(1);
+			expect(result.stdout).toContain("FAIL Doctor scope:");
+			expect(result.stdout).toContain(
+				"workspace diagnostics could not continue because a nearby wp-typia workspace candidate is invalid.",
+			);
 			expect(result.stdout).toContain("FAIL Workspace package metadata:");
 			expect(result.stdout).toContain("FAIL wp-typia doctor summary:");
 			expect(result.stderr).toContain("Error: wp-typia doctor failed");
 			expect(result.stderr).toContain("Summary: One or more doctor checks failed.");
+			expect(result.stderr).toContain("- Doctor scope:");
 			expect(result.stderr).toContain("- Workspace package metadata:");
+		} finally {
+			fs.rmSync(fixtureRoot, { force: true, recursive: true });
+		}
+	});
+
+	test("prints an explicit environment-only doctor scope outside workspace roots", () => {
+		const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "wp-typia-doctor-scope-"));
+
+		try {
+			const result = runCapturedCommand("node", [entryPath, "doctor"], {
+				cwd: fixtureRoot,
+				env: withoutAIAgentEnv(),
+			});
+
+			expect(result.status).toBe(0);
+			expect(result.stdout).toContain("PASS Doctor scope:");
+			expect(result.stdout).toContain("only covered environment readiness");
+			expect(result.stdout).toContain("workspace root");
+			expect(result.stdout).toContain("PASS wp-typia doctor summary:");
+			expect(result.stderr).toBe("");
 		} finally {
 			fs.rmSync(fixtureRoot, { force: true, recursive: true });
 		}


### PR DESCRIPTION
## Context
- `wp-typia doctor` can pass outside official workspace roots, but the output did not clearly say when only environment checks ran
- invalid nearby workspace metadata also surfaced as a package metadata failure without first clarifying that workspace diagnostics were unavailable

## What Changed
- add a dedicated `Doctor scope` row so every doctor run explains whether it covered environment-only diagnostics or full workspace checks
- add rerun guidance for environment-only runs and earlier invalid-workspace messaging before the package metadata failure details
- document the clarified behavior in CLI help and add regression coverage for both generic-directory and invalid-workspace cases

## Verification
- `bun run packages:build`
- `bun test packages/wp-typia-project-tools/tests/workspace-doctor.test.ts -t "doctor reports"`
- `bun test packages/wp-typia/tests/cli-package.test.ts -t "doctor"`
- `bun run typecheck`
- `bun run changesets:validate`

Closes #401


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added "Doctor scope" indicator to `wp-typia doctor` output, clarifying whether diagnostics cover environment-only or full workspace checks.
  * Improved error messaging when the command is invoked outside official workspace roots with clearer guidance.
  * Enhanced detection and messaging for invalid workspace metadata scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->