### PR TITLE
Improve CLI diagnostic readability in narrow terminals

### DIFF
--- a/.sampo/changesets/issue-402-cli-diagnostic-readability.md
+++ b/.sampo/changesets/issue-402-cli-diagnostic-readability.md
@@ -1,0 +1,6 @@
+---
+npm/wp-typia: patch
+npm/@wp-typia/project-tools: patch
+---
+
+Wrap human-readable `wp-typia` CLI diagnostic and doctor output more readably in narrow terminals without changing structured output.

--- a/packages/wp-typia-project-tools/src/runtime/cli-diagnostics.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-diagnostics.ts
@@ -38,6 +38,31 @@ function resolveCliWrapColumns(streamColumns: number | undefined): number | null
 			: null);
 }
 
+function wrapCliText(text: string, maxWidth: number): string[] {
+	const words = text.trim().split(/\s+/u).filter((word) => word.length > 0);
+
+	if (words.length === 0) {
+		return [""];
+	}
+
+	const lines: string[] = [];
+	let currentLine = words[0] ?? "";
+
+	for (const word of words.slice(1)) {
+		const nextLine = `${currentLine} ${word}`;
+		if (nextLine.length <= maxWidth) {
+			currentLine = nextLine;
+			continue;
+		}
+
+		lines.push(currentLine);
+		currentLine = word;
+	}
+
+	lines.push(currentLine);
+	return lines;
+}
+
 function formatWrappedPrefixedLine(
 	prefix: string,
 	text: string,
@@ -54,9 +79,18 @@ function formatWrappedPrefixedLine(
 		return [prefix.trimEnd()];
 	}
 
+	const continuationWidth = Math.max(1, columns - continuationIndent.length);
+	const firstLineWidth = columns - prefix.length;
+	if (firstLineWidth <= 0 || (words[0]?.length ?? 0) > firstLineWidth) {
+		return [
+			prefix.trimEnd(),
+			...wrapCliText(text, continuationWidth).map((line) => `${continuationIndent}${line}`),
+		];
+	}
+
 	const lines: string[] = [];
 	let currentPrefix = prefix;
-	let currentWidth = Math.max(10, columns - currentPrefix.length);
+	let currentWidth = Math.max(1, columns - currentPrefix.length);
 	let currentLine = words[0] ?? "";
 
 	for (const word of words.slice(1)) {
@@ -68,7 +102,7 @@ function formatWrappedPrefixedLine(
 
 		lines.push(`${currentPrefix}${currentLine}`);
 		currentPrefix = continuationIndent;
-		currentWidth = Math.max(10, columns - currentPrefix.length);
+		currentWidth = continuationWidth;
 		currentLine = word;
 	}
 

--- a/packages/wp-typia-project-tools/src/runtime/cli-diagnostics.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-diagnostics.ts
@@ -38,31 +38,6 @@ function resolveCliWrapColumns(streamColumns: number | undefined): number | null
 			: null);
 }
 
-function wrapCliText(text: string, maxWidth: number): string[] {
-	const words = text.trim().split(/\s+/u).filter((word) => word.length > 0);
-
-	if (words.length === 0) {
-		return [""];
-	}
-
-	const lines: string[] = [];
-	let currentLine = words[0] ?? "";
-
-	for (const word of words.slice(1)) {
-		const nextLine = `${currentLine} ${word}`;
-		if (nextLine.length <= maxWidth) {
-			currentLine = nextLine;
-			continue;
-		}
-
-		lines.push(currentLine);
-		currentLine = word;
-	}
-
-	lines.push(currentLine);
-	return lines;
-}
-
 function formatWrappedPrefixedLine(
 	prefix: string,
 	text: string,
@@ -74,14 +49,31 @@ function formatWrappedPrefixedLine(
 		return [singleLine];
 	}
 
-	const availableWidth = Math.max(
-		MIN_CLI_WRAP_COLUMNS - continuationIndent.length,
-		columns - continuationIndent.length,
-	);
-	const wrappedLines = wrapCliText(text, availableWidth);
-	return wrappedLines.map((line, index) =>
-		index === 0 ? `${prefix}${line}` : `${continuationIndent}${line}`,
-	);
+	const words = text.trim().split(/\s+/u).filter((word) => word.length > 0);
+	if (words.length === 0) {
+		return [prefix.trimEnd()];
+	}
+
+	const lines: string[] = [];
+	let currentPrefix = prefix;
+	let currentWidth = Math.max(10, columns - currentPrefix.length);
+	let currentLine = words[0] ?? "";
+
+	for (const word of words.slice(1)) {
+		const nextLine = `${currentLine} ${word}`;
+		if (nextLine.length <= currentWidth) {
+			currentLine = nextLine;
+			continue;
+		}
+
+		lines.push(`${currentPrefix}${currentLine}`);
+		currentPrefix = continuationIndent;
+		currentWidth = Math.max(10, columns - currentPrefix.length);
+		currentLine = word;
+	}
+
+	lines.push(`${currentPrefix}${currentLine}`);
+	return lines;
 }
 
 function formatCliDiagnosticBlock(message: CliDiagnosticMessage): string {

--- a/packages/wp-typia-project-tools/src/runtime/cli-diagnostics.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-diagnostics.ts
@@ -20,13 +20,81 @@ const DEFAULT_CLI_FAILURE_SUMMARIES: Record<string, string> = {
 	migrate: "Unable to complete the requested migration command.",
 };
 
+const MIN_CLI_WRAP_COLUMNS = 32;
+
+function parseCliColumns(value: string | undefined): number | null {
+	if (typeof value !== "string" || value.trim().length === 0) {
+		return null;
+	}
+
+	const parsed = Number.parseInt(value, 10);
+	return Number.isFinite(parsed) && parsed >= MIN_CLI_WRAP_COLUMNS ? parsed : null;
+}
+
+function resolveCliWrapColumns(streamColumns: number | undefined): number | null {
+	return parseCliColumns(process.env.COLUMNS) ??
+		(typeof streamColumns === "number" && streamColumns >= MIN_CLI_WRAP_COLUMNS
+			? streamColumns
+			: null);
+}
+
+function wrapCliText(text: string, maxWidth: number): string[] {
+	const words = text.trim().split(/\s+/u).filter((word) => word.length > 0);
+
+	if (words.length === 0) {
+		return [""];
+	}
+
+	const lines: string[] = [];
+	let currentLine = words[0] ?? "";
+
+	for (const word of words.slice(1)) {
+		const nextLine = `${currentLine} ${word}`;
+		if (nextLine.length <= maxWidth) {
+			currentLine = nextLine;
+			continue;
+		}
+
+		lines.push(currentLine);
+		currentLine = word;
+	}
+
+	lines.push(currentLine);
+	return lines;
+}
+
+function formatWrappedPrefixedLine(
+	prefix: string,
+	text: string,
+	columns: number | null,
+	continuationIndent = "  ",
+): string[] {
+	const singleLine = `${prefix}${text}`;
+	if (columns === null || singleLine.length <= columns) {
+		return [singleLine];
+	}
+
+	const availableWidth = Math.max(
+		MIN_CLI_WRAP_COLUMNS - continuationIndent.length,
+		columns - continuationIndent.length,
+	);
+	const wrappedLines = wrapCliText(text, availableWidth);
+	return wrappedLines.map((line, index) =>
+		index === 0 ? `${prefix}${line}` : `${continuationIndent}${line}`,
+	);
+}
+
 function formatCliDiagnosticBlock(message: CliDiagnosticMessage): string {
-	const lines = [`wp-typia ${message.command} failed`, `Summary: ${message.summary}`];
+	const columns = resolveCliWrapColumns(process.stderr.columns);
+	const lines = [
+		`wp-typia ${message.command} failed`,
+		...formatWrappedPrefixedLine("Summary: ", message.summary, columns),
+	];
 
 	if (message.detailLines.length > 0) {
 		lines.push("Details:");
 		for (const detailLine of message.detailLines) {
-			lines.push(`- ${detailLine}`);
+			lines.push(...formatWrappedPrefixedLine("- ", detailLine, columns));
 		}
 	}
 
@@ -123,7 +191,11 @@ export function formatCliDiagnosticError(error: unknown): string {
  * Format one human-readable doctor check row.
  */
 export function formatDoctorCheckLine(check: DoctorCheckLike): string {
-	return `${check.status === "pass" ? "PASS" : "FAIL"} ${check.label}: ${check.detail}`;
+	return formatWrappedPrefixedLine(
+		`${check.status === "pass" ? "PASS" : "FAIL"} ${check.label}: `,
+		check.detail,
+		resolveCliWrapColumns(process.stdout.columns),
+	).join("\n");
 }
 
 /**
@@ -140,7 +212,11 @@ export function getFailingDoctorChecks<TCheck extends DoctorCheckLike>(
  */
 export function formatDoctorSummaryLine(checks: readonly DoctorCheckLike[]): string {
 	const failedChecks = getFailingDoctorChecks(checks);
-	return `${failedChecks.length === 0 ? "PASS" : "FAIL"} wp-typia doctor summary: ${checks.length - failedChecks.length}/${checks.length} checks passed`;
+	return formatWrappedPrefixedLine(
+		`${failedChecks.length === 0 ? "PASS" : "FAIL"} wp-typia doctor summary: `,
+		`${checks.length - failedChecks.length}/${checks.length} checks passed`,
+		resolveCliWrapColumns(process.stdout.columns),
+	).join("\n");
 }
 
 /**

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -611,6 +611,37 @@ describe("wp-typia package", () => {
 		}
 	});
 
+	test("wraps doctor scope guidance in narrow terminals", () => {
+		const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "wp-typia-doctor-narrow-"));
+
+		try {
+			const result = runCapturedCommand("node", [entryPath, "doctor"], {
+				cwd: fixtureRoot,
+				env: {
+					...withoutAIAgentEnv(),
+					COLUMNS: "54",
+				},
+			});
+
+			expect(result.status).toBe(0);
+			expect(result.stdout).toContain(
+				[
+					"PASS Doctor scope: No official wp-typia workspace root was detected, so",
+					"  this run only covered environment readiness. Re-run",
+				].join("\n"),
+			);
+			expect(result.stdout).toContain(
+				[
+					"  `wp-typia doctor` from a workspace root if you",
+					"  expected package metadata, inventory, or generated",
+				].join("\n"),
+			);
+			expect(result.stdout).toContain("PASS wp-typia doctor summary:");
+		} finally {
+			fs.rmSync(fixtureRoot, { force: true, recursive: true });
+		}
+	});
+
 	test("prints migrate help through the canonical verb", () => {
 		const helpOutput = runUtf8Command("node", [entryPath, "migrate"]);
 		expect(helpOutput).toContain("wp-typia migrate init");

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -626,14 +626,14 @@ describe("wp-typia package", () => {
 			expect(result.status).toBe(0);
 			expect(result.stdout).toContain(
 				[
-					"PASS Doctor scope: No official wp-typia workspace root was detected, so",
-					"  this run only covered environment readiness. Re-run",
+					"PASS Doctor scope: No official wp-typia workspace root",
+					"  was detected, so this run only covered environment",
 				].join("\n"),
 			);
 			expect(result.stdout).toContain(
 				[
-					"  `wp-typia doctor` from a workspace root if you",
-					"  expected package metadata, inventory, or generated",
+					"  readiness. Re-run `wp-typia doctor` from a workspace",
+					"  root if you expected package metadata, inventory, or",
 				].join("\n"),
 			);
 			expect(result.stdout).toContain("PASS wp-typia doctor summary:");

--- a/packages/wp-typia/tests/tui-lifecycle.test.ts
+++ b/packages/wp-typia/tests/tui-lifecycle.test.ts
@@ -79,6 +79,43 @@ describe("alternate-buffer TUI lifecycle", () => {
 		);
 	});
 
+	test("wraps shared CLI diagnostic blocks in narrow terminals", () => {
+		const originalColumns = process.env.COLUMNS;
+		process.env.COLUMNS = "48";
+
+		try {
+			expect(
+				formatCliDiagnosticError(
+					createCliCommandError({
+						command: "create",
+						detailLines: [
+							"Run `wp-typia create demo-block --template workspace` from a writable directory and retry the scaffold flow.",
+						],
+						summary:
+							"Unable to complete the requested create workflow because the target directory already exists.",
+					}),
+				),
+			).toBe(
+				[
+					"wp-typia create failed",
+					"Summary: Unable to complete the requested create",
+					"  workflow because the target directory already",
+					"  exists.",
+					"Details:",
+					"- Run `wp-typia create demo-block --template",
+					"  workspace` from a writable directory and retry",
+					"  the scaffold flow.",
+				].join("\n"),
+			);
+		} finally {
+			if (originalColumns === undefined) {
+				delete process.env.COLUMNS;
+			} else {
+				process.env.COLUMNS = originalColumns;
+			}
+		}
+	});
+
 	test("reports failures and exits immediately", () => {
 		const messages: string[] = [];
 		const events: string[] = [];

--- a/packages/wp-typia/tests/tui-lifecycle.test.ts
+++ b/packages/wp-typia/tests/tui-lifecycle.test.ts
@@ -4,6 +4,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import {
 	createCliCommandError,
 	formatCliDiagnosticError,
+	formatDoctorSummaryLine,
 } from "@wp-typia/project-tools/cli-diagnostics";
 
 import { addCommand } from "../src/commands/add";
@@ -105,6 +106,31 @@ describe("alternate-buffer TUI lifecycle", () => {
 					"- Run `wp-typia create demo-block --template",
 					"  workspace` from a writable directory and retry",
 					"  the scaffold flow.",
+				].join("\n"),
+			);
+		} finally {
+			if (originalColumns === undefined) {
+				delete process.env.COLUMNS;
+			} else {
+				process.env.COLUMNS = originalColumns;
+			}
+		}
+	});
+
+	test("keeps doctor summaries within very narrow terminal widths", () => {
+		const originalColumns = process.env.COLUMNS;
+		process.env.COLUMNS = "32";
+
+		try {
+			expect(
+				formatDoctorSummaryLine([
+					{ detail: "ready", label: "Doctor scope", status: "pass" as const },
+					{ detail: "ready", label: "Bun", status: "pass" as const },
+				]),
+			).toBe(
+				[
+					"PASS wp-typia doctor summary:",
+					"  2/2 checks passed",
 				].join("\n"),
 			);
 		} finally {


### PR DESCRIPTION
## Context
- long human-readable `wp-typia` diagnostics still read awkwardly in narrow terminals because summary and guidance lines stay on one dense line
- structured output should remain unchanged, so the readability fix needs to stay inside the human-readable diagnostic layer

## What Changed
- teach the shared CLI diagnostic formatter to wrap summary and detail lines against terminal width when `COLUMNS` or stream width is narrow
- apply the same wrapping behavior to streamed doctor rows and the doctor summary line without changing structured output paths
- add regression coverage for wrapped diagnostic blocks and wrapped doctor scope guidance in narrow-terminal runs

## Verification
- `bun run packages:build`
- `bun test packages/wp-typia/tests/tui-lifecycle.test.ts -t "wraps shared CLI diagnostic blocks"`
- `bun test packages/wp-typia/tests/cli-package.test.ts -t "wraps doctor scope guidance in narrow terminals|prints an explicit environment-only doctor scope outside workspace roots|formats doctor failures"`
- `bun run typecheck`
- `bun run changesets:validate`

Closes #402


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved CLI diagnostic and doctor output formatting to wrap text readably for narrow terminal widths, ensuring better readability without breaking structured output behavior.

* **Tests**
  * Added integration tests validating CLI output wrapping with constrained terminal widths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->