### PR TITLE
Improve scaffold onboarding output and README guidance

### DIFF
--- a/.sampo/changesets/issue-397-scaffold-onboarding-guidance.md
+++ b/.sampo/changesets/issue-397-scaffold-onboarding-guidance.md
@@ -1,0 +1,6 @@
+---
+npm/wp-typia: patch
+npm/@wp-typia/project-tools: patch
+---
+
+Split scaffold onboarding into clearer quick-start, advanced sync, and first-commit guidance across the CLI completion output and generated README content.

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-apply-utils.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-apply-utils.ts
@@ -21,8 +21,11 @@ import {
 } from "./persistence-rest-artifacts.js";
 import {
 	getCompoundExtensionWorkflowSection,
+	getInitialCommitCommands,
+	getInitialCommitNote,
 	getOptionalOnboardingNote,
 	getOptionalOnboardingSteps,
+	getQuickStartWorkflowNote,
 	getPhpRestExtensionPointsSection,
 	getTemplateSourceOfTruthNote,
 } from "./scaffold-onboarding.js";
@@ -113,6 +116,7 @@ export function buildReadme(
 	const optionalOnboardingSteps = getOptionalOnboardingSteps(packageManager, templateId, {
 		compoundPersistenceEnabled: variables.compoundPersistenceEnabled === "true",
 	});
+	const initialCommitCommands = getInitialCommitCommands();
 	const sourceOfTruthNote = getTemplateSourceOfTruthNote(templateId, {
 		compoundPersistenceEnabled: variables.compoundPersistenceEnabled === "true",
 	});
@@ -148,20 +152,26 @@ ${variables.description}
 
 ${templateId}
 
-## Development
+## Quick Start
 
 \`\`\`bash
 ${formatInstallCommand(packageManager)}
 ${formatRunScript(packageManager, developmentScript)}
+${formatRunScript(packageManager, "start")}
 \`\`\`
 
-## Build
+${getQuickStartWorkflowNote(packageManager, templateId, {
+		compoundPersistenceEnabled,
+	})}
+
+## Build and Verify
 
 \`\`\`bash
 ${formatRunScript(packageManager, "build")}
+${formatRunScript(packageManager, "typecheck")}
 \`\`\`
 
-## Optional First Sync
+## Advanced Sync
 
 \`\`\`bash
 ${optionalOnboardingSteps.join("\n")}
@@ -170,6 +180,14 @@ ${optionalOnboardingSteps.join("\n")}
 ${getOptionalOnboardingNote(packageManager, templateId, {
 		compoundPersistenceEnabled,
 	})}
+
+## Before First Commit
+
+\`\`\`bash
+${initialCommitCommands.join("\n")}
+\`\`\`
+
+${getInitialCommitNote()}
 
 ${sourceOfTruthNote}${publicPersistencePolicyNote ? `\n\n${publicPersistencePolicyNote}` : ""}${migrationSection ? `\n\n${migrationSection}` : ""}${compoundExtensionWorkflowSection ? `\n\n${compoundExtensionWorkflowSection}` : ""}${wpEnvSection ? `\n\n${wpEnvSection}` : ""}${testPresetSection ? `\n\n${testPresetSection}` : ""}${phpRestExtensionPointsSection ? `\n\n${phpRestExtensionPointsSection}` : ""}
 `;

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-apply-utils.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-apply-utils.ts
@@ -99,6 +99,15 @@ export async function ensureDirectory(targetDir: string, allowExisting = false):
 	}
 }
 
+/**
+ * Builds the generated README markdown for one scaffolded project.
+ *
+ * @param templateId Scaffold template family or template identifier.
+ * @param variables Interpolated scaffold variables used in generated content.
+ * @param packageManager Package manager used to format install and script commands.
+ * @param options Optional README sections enabled by scaffold presets.
+ * @returns Markdown README content for the generated project root.
+ */
 export function buildReadme(
 	templateId: string,
 	variables: ScaffoldTemplateVariables,
@@ -157,7 +166,6 @@ ${templateId}
 \`\`\`bash
 ${formatInstallCommand(packageManager)}
 ${formatRunScript(packageManager, developmentScript)}
-${formatRunScript(packageManager, "start")}
 \`\`\`
 
 ${getQuickStartWorkflowNote(packageManager, templateId, {

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-onboarding.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-onboarding.ts
@@ -23,6 +23,12 @@ interface PhpRestSectionOptions {
 	transportPath: string;
 }
 
+const INITIAL_COMMIT_COMMANDS = [
+	"git init",
+	"git add .",
+	'git commit -m "Initial scaffold"',
+] as const;
+
 function templateHasPersistenceSync(
 	templateId: string,
 	{ compoundPersistenceEnabled = false }: SyncOnboardingOptions = {},
@@ -70,6 +76,29 @@ export function getOptionalOnboardingSteps(
 	return getOptionalSyncScriptNames(templateId, options).map((scriptName) =>
 		formatRunScript(packageManager, scriptName),
 	);
+}
+
+/**
+ * Returns the quick-start note explaining the scaffold's primary local loop.
+ */
+export function getQuickStartWorkflowNote(
+	packageManager: PackageManagerId,
+	templateId = "basic",
+	options: SyncOnboardingOptions = {},
+): string {
+	const developmentScript = getPrimaryDevelopmentScript(templateId);
+	const devCommand = formatRunScript(packageManager, developmentScript);
+	const startCommand = formatRunScript(packageManager, "start");
+
+	if (developmentScript !== "dev") {
+		return `${devCommand} is the primary local entry point for this template. Use ${startCommand} when you want the scaffold's one-shot startup flow instead of the watch-oriented workflow.`;
+	}
+
+	if (templateHasPersistenceSync(templateId, options)) {
+		return `${devCommand} keeps the editor, type-derived artifacts, and REST-derived artifacts moving together during local development. Use ${startCommand} when you want a one-shot sync plus editor startup without the long-running watch loop.`;
+	}
+
+	return `${devCommand} keeps the editor and type-derived artifacts moving together during local development. Use ${startCommand} when you want a one-shot sync plus editor startup without the long-running watch loop.`;
 }
 
 /**
@@ -123,11 +152,21 @@ export function getOptionalOnboardingNote(
 		return fallbackCustomTemplateNote;
 	}
 
-	return `${formatRunScript(packageManager, developmentScript)} ${
-		developmentScript === "dev"
-			? "watches the relevant sync scripts during local development."
-			: "remains the primary local entry point."
-	} ${formatRunScript(packageManager, "start")} still runs one-shot syncs before starting, while ${formatRunScript(packageManager, "build")} and ${typecheckCommand} verify that generated metadata/schema artifacts are already current through ${syncCheckCommand}. Run ${syncCommand} manually when you want to refresh generated artifacts before build, typecheck, or commit. ${syncTypesCommand} stays warn-only by default; use \`${failOnLossySyncCommand}\` to fail only on lossy WordPress projections, or \`${strictSyncCommand}\` for a CI-friendly JSON report that fails on all warnings.${advancedPersistenceNote} They do not create migration history.`;
+	return `You usually do not need to run ${syncCommand} during a normal ${formatRunScript(packageManager, developmentScript)} session. Run ${syncCommand} manually when you want a reviewable artifact refresh before ${formatRunScript(packageManager, "build")}, ${typecheckCommand}, or your first commit. ${syncTypesCommand} stays warn-only by default; use \`${failOnLossySyncCommand}\` to fail only on lossy WordPress projections, or \`${strictSyncCommand}\` for the stricter CI-oriented report.${advancedPersistenceNote} They do not create migration history. If this directory is new, create your first Git commit after that refresh.`;
+}
+
+/**
+ * Returns the recommended version-control commands for a fresh scaffold.
+ */
+export function getInitialCommitCommands(): string[] {
+	return [...INITIAL_COMMIT_COMMANDS];
+}
+
+/**
+ * Returns the version-control note shown after the initial scaffold.
+ */
+export function getInitialCommitNote(): string {
+	return "Skip `git init` if this directory already lives inside an existing repository. If you want generated artifacts refreshed before the first checkpoint, run your manual sync step first and then create the commit.";
 }
 
 /**

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-onboarding.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-onboarding.ts
@@ -90,6 +90,10 @@ export function getQuickStartWorkflowNote(
 	const devCommand = formatRunScript(packageManager, developmentScript);
 	const startCommand = formatRunScript(packageManager, "start");
 
+	if (developmentScript === "start") {
+		return `${startCommand} is the primary local entry point for this template. If the template also exposes a dedicated watch mode or alternate editor workflow, follow that template-specific documentation alongside the generated project scripts.`;
+	}
+
 	if (developmentScript !== "dev") {
 		return `${devCommand} is the primary local entry point for this template. Use ${startCommand} when you want the scaffold's one-shot startup flow instead of the watch-oriented workflow.`;
 	}
@@ -140,16 +144,22 @@ export function getOptionalOnboardingNote(
 	const advancedPersistenceNote = templateHasPersistenceSync(templateId, options)
 		? ` ${syncRestCommand} remains available for advanced REST-only refreshes, but it now fails fast when type-derived artifacts are stale; run \`${syncCommand}\` or \`${syncTypesCommand}\` first.`
 		: "";
+	const isCustomTemplate =
+		!isBuiltInTemplateId(templateId) &&
+		templateId !== OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE;
 	const fallbackCustomTemplateNote =
 		!hasUnifiedSync &&
 		syncSteps.length > 0 &&
-		!isBuiltInTemplateId(templateId) &&
-		templateId !== OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE
+		isCustomTemplate
 			? `Run ${syncSteps.join(" then ")} manually before build, typecheck, or commit. ${syncCheckCommand} verifies the current type-derived artifacts without rewriting them.${optionalSyncScripts.includes("sync-rest") ? ` ${syncRestCommand} remains available for REST-only refreshes after ${syncTypesCommand}.` : ""}`
 			: null;
 
 	if (fallbackCustomTemplateNote) {
 		return fallbackCustomTemplateNote;
+	}
+
+	if (isCustomTemplate && syncSteps.length === 0) {
+		return "No optional sync command was detected for this custom template. Follow the template's own artifact-refresh guidance before build, typecheck, or your first commit.";
 	}
 
 	return `You usually do not need to run ${syncCommand} during a normal ${formatRunScript(packageManager, developmentScript)} session. Run ${syncCommand} manually when you want a reviewable artifact refresh before ${formatRunScript(packageManager, "build")}, ${typecheckCommand}, or your first commit. ${syncTypesCommand} stays warn-only by default; use \`${failOnLossySyncCommand}\` to fail only on lossy WordPress projections, or \`${strictSyncCommand}\` for the stricter CI-oriented report.${advancedPersistenceNote} They do not create migration history. If this directory is new, create your first Git commit after that refresh.`;

--- a/packages/wp-typia-project-tools/tests/cli-entry.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-entry.test.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 import { cleanupScaffoldTempRoot, createBlockSubsetFixturePath, createScaffoldTempRoot, entryPath, getCommandErrorMessage, runCapturedCli, runCli, templateLayerAmbiguousFixturePath, templateLayerFixturePath } from "./helpers/scaffold-test-harness.js";
 import { formatHelpText, getDoctorChecks, getNextSteps, getOptionalOnboarding, runScaffoldFlow } from "../src/runtime/cli-core.js";
 import { collectScaffoldAnswers } from "../src/runtime/scaffold.js";
+import { getQuickStartWorkflowNote } from "../src/runtime/scaffold-onboarding.js";
 
 describe("@wp-typia/project-tools scaffold CLI flow", () => {
   const tempRoot = createScaffoldTempRoot("wp-typia-scaffold-cli-");
@@ -274,6 +275,28 @@ test("optional onboarding derives sync steps from available custom-template scri
     "npm run sync-types -- --check verifies the current type-derived artifacts without rewriting them."
   );
   expect(onboarding.note).not.toContain("npm run sync -- --check");
+});
+
+test("optional onboarding avoids synthesized sync commands for custom templates without sync scripts", () => {
+  const onboarding = getOptionalOnboarding({
+    availableScripts: [],
+    packageManager: "npm",
+    templateId: "/tmp/custom-template",
+  });
+
+  expect(onboarding.steps).toEqual([]);
+  expect(onboarding.note).toContain(
+    "No optional sync command was detected for this custom template."
+  );
+  expect(onboarding.note).not.toContain("npm run sync");
+  expect(onboarding.note).not.toContain("npm run sync-types");
+});
+
+test("quick-start guidance handles start-only templates without repeating the same command", () => {
+  const note = getQuickStartWorkflowNote("npm", "/tmp/custom-template");
+
+  expect(note).toContain("npm run start is the primary local entry point");
+  expect(note).not.toContain("Use npm run start");
 });
 
 test("runScaffoldFlow rejects unsupported persistence policies", async () => {

--- a/packages/wp-typia-project-tools/tests/scaffold-basic.test.ts
+++ b/packages/wp-typia-project-tools/tests/scaffold-basic.test.ts
@@ -294,7 +294,10 @@ describe('@wp-typia/project-tools scaffold core', () => {
       expect(readme).toContain('npm install');
       expect(readme).toContain('npm run dev');
       expect(readme).toContain('npm run start');
-      expect(readme).toContain('## Optional First Sync');
+      expect(readme).toContain('## Quick Start');
+      expect(readme).toContain('## Build and Verify');
+      expect(readme).toContain('## Advanced Sync');
+      expect(readme).toContain('## Before First Commit');
       expect(readme).toContain('npm run sync');
       expect(readme).toContain('npm run sync-types');
       expect(readme).toContain('-- --fail-on-lossy');
@@ -304,9 +307,12 @@ describe('@wp-typia/project-tools scaffold core', () => {
         '`src/render.php` is only an opt-in server placeholder',
       );
       expect(readme).toContain(
-        'watches the relevant sync scripts during local development',
+        'keeps the editor and type-derived artifacts moving together during local development',
       );
       expect(readme).toContain('do not create migration history');
+      expect(readme).toContain('git init');
+      expect(readme).toContain('git add .');
+      expect(readme).toContain('Initial scaffold');
       expect(readme).not.toContain('## PHP REST Extension Points');
 
       typecheckGeneratedProject(targetDir);

--- a/packages/wp-typia-project-tools/tests/scaffold-compound.test.ts
+++ b/packages/wp-typia-project-tools/tests/scaffold-compound.test.ts
@@ -393,10 +393,14 @@ describe('@wp-typia/project-tools scaffold compound', () => {
       expect(readme).toContain('npm run sync-types');
       expect(readme).not.toContain('npm run sync-rest');
       expect(readme).toContain('npm run dev');
+      expect(readme).toContain('## Quick Start');
+      expect(readme).toContain('## Advanced Sync');
+      expect(readme).toContain('## Before First Commit');
       expect(readme).toContain('src/blocks/*/types.ts');
       expect(readme).toContain(
         'npm run add-child -- --slug faq-item --title "FAQ Item"',
       );
+      expect(readme).toContain('git init');
       expect(readme).not.toContain('## PHP REST Extension Points');
       expect(blockConfig).not.toContain('restManifest');
 
@@ -971,11 +975,15 @@ describe('@wp-typia/project-tools scaffold compound', () => {
       expect(readme).toContain('npm run dev');
       expect(readme).toContain('npm run sync');
       expect(readme).toContain('npm run sync-rest');
+      expect(readme).toContain('## Quick Start');
+      expect(readme).toContain('## Advanced Sync');
+      expect(readme).toContain('## Before First Commit');
       expect(readme).toContain('src/blocks/*/api-types.ts');
       expect(readme).toContain('src/blocks/*/transport.ts');
       expect(readme).toContain(
         'npm run add-child -- --slug faq-item --title "FAQ Item"',
       );
+      expect(readme).toContain('git commit -m "Initial scaffold"');
       expect(readme).toContain('## PHP REST Extension Points');
       expect(readme).toContain(
         'Edit `src/blocks/demo-compound-storage/transport.ts` when you need to switch between direct WordPress REST and a contract-compatible proxy or BFF',

--- a/packages/wp-typia-project-tools/tests/scaffold-persistence.test.ts
+++ b/packages/wp-typia-project-tools/tests/scaffold-persistence.test.ts
@@ -385,6 +385,9 @@ test(
     expect(readme).toContain("npm run sync");
     expect(readme).toContain("npm run sync-types");
     expect(readme).toContain("npm run sync-rest");
+    expect(readme).toContain("## Quick Start");
+    expect(readme).toContain("## Advanced Sync");
+    expect(readme).toContain("## Before First Commit");
     expect(readme).toContain("src/api-types.ts");
     expect(readme).toContain(
       "`src/render.php` is the canonical frontend entry"
@@ -397,6 +400,7 @@ test(
       "per-request ids, and coarse rate limiting by default"
     );
     expect(readme).toContain("## PHP REST Extension Points");
+    expect(readme).toContain('git commit -m "Initial scaffold"');
     expect(readme).toContain("Edit `demo-persistence-public.php`");
     expect(readme).toContain(
       "Edit `src/transport.ts` when you need to switch between direct WordPress REST and a contract-compatible proxy or BFF"
@@ -713,6 +717,9 @@ test(
   expect(generatedSave).toContain("intentionally server-rendered");
   expect(generatedSave).toContain("return null;");
   expect(readme).toContain("npm run dev");
+  expect(readme).toContain("## Quick Start");
+  expect(readme).toContain("## Advanced Sync");
+  expect(readme).toContain("## Before First Commit");
   expect(readme).toContain("## PHP REST Extension Points");
   expect(readme).toContain("Edit `demo-persistence-authenticated.php`");
   expect(readme).toContain(

--- a/packages/wp-typia/src/runtime-bridge-output.ts
+++ b/packages/wp-typia/src/runtime-bridge-output.ts
@@ -90,7 +90,7 @@ export function buildCreateCompletionPayload(flow: {
 		optionalNote:
 			flow.optionalOnboarding.steps.length > 0 ? flow.optionalOnboarding.note : undefined,
 		optionalTitle:
-			flow.optionalOnboarding.steps.length > 0 ? "Optional before first commit:" : undefined,
+			flow.optionalOnboarding.steps.length > 0 ? "Advanced sync (optional):" : undefined,
 		preambleLines: flow.result.selectedVariant
 			? [`Template variant: ${flow.result.selectedVariant}`]
 			: undefined,

--- a/packages/wp-typia/tests/completion-output.test.ts
+++ b/packages/wp-typia/tests/completion-output.test.ts
@@ -28,7 +28,7 @@ describe("alternate-buffer completion output helpers", () => {
 		expect(payload.preambleLines).toEqual(["Template variant: hero"]);
 		expect(payload.warningLines).toEqual(["This template enables optional migration UI."]);
 		expect(payload.nextSteps).toEqual(["cd demo-block", "npm install", "npm run dev"]);
-		expect(payload.optionalTitle).toBe("Optional before first commit:");
+		expect(payload.optionalTitle).toBe("Advanced sync (optional):");
 		expect(payload.optionalLines).toEqual(["npm run sync"]);
 		expect(payload.optionalNote).toContain("npm run sync");
 	});
@@ -42,7 +42,7 @@ describe("alternate-buffer completion output helpers", () => {
 				nextSteps: ["cd demo-block", "npm install"],
 				optionalLines: ["npm run sync"],
 				optionalNote: "Review the generated metadata before first commit.",
-				optionalTitle: "Optional before first commit:",
+				optionalTitle: "Advanced sync (optional):",
 				preambleLines: ["Template variant: hero"],
 				summaryLines: ["Project directory: /tmp/demo-block"],
 				title: "✅ Created Demo Block in /tmp/demo-block",
@@ -62,7 +62,7 @@ describe("alternate-buffer completion output helpers", () => {
 			"Next steps:",
 			"  cd demo-block",
 			"  npm install",
-			"\nOptional before first commit:",
+			"\nAdvanced sync (optional):",
 			"  npm run sync",
 			"Note: Review the generated metadata before first commit.",
 		]);

--- a/packages/wp-typia/tests/tui-lifecycle.test.ts
+++ b/packages/wp-typia/tests/tui-lifecycle.test.ts
@@ -358,7 +358,7 @@ describe("alternate-buffer TUI lifecycle", () => {
 					nextSteps: ["cd demo-block", "npm install", "npm run dev"],
 					optionalLines: ["npm run sync"],
 					optionalNote: "Review the generated metadata before first commit.",
-					optionalTitle: "Optional before first commit:",
+					optionalTitle: "Advanced sync (optional):",
 					preambleLines: ["Template variant: hero"],
 					summaryLines: ["Project directory: /tmp/demo-block"],
 					title: "✅ Created Demo Block in /tmp/demo-block",
@@ -372,7 +372,7 @@ describe("alternate-buffer TUI lifecycle", () => {
 		expect(rendered).toContain("✅ Created Demo Block in /tmp/demo-block");
 		expect(rendered).toContain("Next steps:");
 		expect(rendered).toContain("cd demo-block");
-		expect(rendered).toContain("Optional before first commit:");
+		expect(rendered).toContain("Advanced sync (optional):");
 		expect(rendered).toContain("Review the generated metadata before first commit.");
 		expect(rendered).toContain("PgUp/PgDn");
 		expect(rendered).toContain("Home/End");


### PR DESCRIPTION
## Context
- scaffold completion output and generated READMEs still mixed quick-start, advanced sync, and first-commit guidance together too densely
- template-specific `dev` versus `start` expectations were present, but not separated clearly enough for first-run users

## What Changed
- split generated README guidance into `Quick Start`, `Build and Verify`, `Advanced Sync`, and `Before First Commit` sections
- add template-aware quick-start notes that explain how `dev` differs from `start` for the selected scaffold family
- rename the CLI completion optional section to `Advanced sync (optional)` and keep the sync note shorter while still pointing first-run users toward an initial Git checkpoint

## Verification
- `bun run --filter @wp-typia/project-tools build`
- `bun run --filter wp-typia build`
- `bun test packages/wp-typia-project-tools/tests/cli-entry.test.ts`
- `bun test packages/wp-typia-project-tools/tests/scaffold-basic.test.ts packages/wp-typia-project-tools/tests/scaffold-compound.test.ts packages/wp-typia-project-tools/tests/scaffold-persistence.test.ts`
- `bun test packages/wp-typia/tests/completion-output.test.ts packages/wp-typia/tests/tui-lifecycle.test.ts`
- `bun run typecheck`
- `bun run changesets:validate`

Closes #397


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Restructured scaffold onboarding guidance into three clearer sections: Quick Start, Advanced Sync, and Before First Commit
  * Added explicit git initialization and first commit instructions to generated project README
  * Renamed "Development" to "Quick Start" and "Optional First Sync" to "Advanced Sync" for improved clarity

* **Documentation**
  * Updated CLI completion messaging to reflect revised onboarding section labels

<!-- end of auto-generated comment: release notes by coderabbit.ai -->