### PR TITLE
Deprecate archived create-wp-typia entrypoint explicitly

### DIFF
--- a/apps/docs/src/content/docs/maintainers/package-graduation.md
+++ b/apps/docs/src/content/docs/maintainers/package-graduation.md
@@ -51,3 +51,15 @@ Kept in `@wp-typia/block-runtime`:
 `@wp-typia/create` remains publishable so npm deprecation and migration
 messaging can point somewhere stable, but it is no longer the supported home
 for runtime imports or orchestration code.
+
+## Archived npm entrypoints
+
+`create-wp-typia` remains in-repo only as an archived npm-facing redirect.
+
+- keep its source manifest private so future releases do not accidentally
+  republish it
+- keep its README and manifest description aligned with the canonical
+  `wp-typia create` install path
+- after a release, use `bun run archived-entrypoints:plan` to print the
+  expected npm deprecation command, or `bun run archived-entrypoints:deprecate`
+  from an npm-authenticated shell to apply it

--- a/apps/docs/src/content/docs/maintainers/package-manifest-policy.md
+++ b/apps/docs/src/content/docs/maintainers/package-manifest-policy.md
@@ -52,6 +52,17 @@ No other publishable runtime package should use `workspace:` protocol dependenci
 
 Private manifests, including the repo root, may still use `workspace:*` where that improves monorepo ergonomics. The publish-time coupling rules above apply only to publishable workspace packages.
 
+## Archived npm entrypoint manifests
+
+Archived npm-facing redirect packages use a stricter source-manifest policy:
+
+- keep the source manifest `private` to block accidental republishes
+- keep the manifest description explicit about the supported
+  `wp-typia create <project-dir>` path
+- keep the registry deprecation message sourced from the shared archived
+  entrypoint policy helper so README, package metadata, and npm guidance stay
+  aligned
+
 ## When Touching Package Metadata
 
 When a PR edits package manifests:

--- a/package.json
+++ b/package.json
@@ -79,6 +79,8 @@
     "publish:dry-run": "bun run packages:build && DRY_RUN=1 bun run publish:oidc",
     "publish:oidc": "bash scripts/publish-oidc.sh",
     "publish:validate": "node scripts/validate-publish-oidc-packages.mjs",
+    "archived-entrypoints:plan": "node scripts/deprecate-archived-npm-entrypoints.mjs",
+    "archived-entrypoints:deprecate": "node scripts/deprecate-archived-npm-entrypoints.mjs --apply",
     "manifest-policy:validate": "node scripts/validate-package-manifest-policy.mjs",
     "runtime-coupling:validate": "node scripts/validate-runtime-package-coupling.mjs",
     "sampo:add": "sampo add",

--- a/packages/create-wp-typia/README.md
+++ b/packages/create-wp-typia/README.md
@@ -6,9 +6,13 @@ This package is no longer a supported installation path for new projects.
 
 Use these commands instead:
 
-- `npx wp-typia my-block`
-- `bunx wp-typia my-block`
+- `npx wp-typia create my-block`
+- `bunx wp-typia create my-block`
 
 `@wp-typia/project-tools` is the canonical programmatic package for scaffold,
 add, migrate, template, and doctor orchestration. `@wp-typia/create` is the
 deprecated legacy package shell and no longer owns the CLI install surface.
+
+If this archived package remains published on npm for migration purposes, its
+registry deprecation message should point to the same `wp-typia create`
+commands.

--- a/packages/create-wp-typia/package.json
+++ b/packages/create-wp-typia/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-wp-typia",
   "version": "1.3.9",
-  "description": "Archived wp-typia initializer package kept only for repository history",
+  "description": "Archived npm entrypoint for wp-typia. Use npx wp-typia create <project-dir> or bunx wp-typia create <project-dir> instead.",
   "packageManager": "bun@1.3.11",
   "private": true,
   "type": "module",
@@ -12,6 +12,15 @@
     "bin/",
     "README.md",
     "package.json"
+  ],
+  "keywords": [
+    "wordpress",
+    "gutenberg",
+    "typia",
+    "archived",
+    "deprecated",
+    "legacy",
+    "initializer"
   ],
   "author": "imjlk",
   "license": "GPL-2.0-or-later",

--- a/scripts/deprecate-archived-npm-entrypoints.d.mts
+++ b/scripts/deprecate-archived-npm-entrypoints.d.mts
@@ -1,0 +1,5 @@
+export declare function runCli(options?: {
+	argv?: string[];
+	stdout?: { write(chunk: string): unknown };
+	stderr?: { write(chunk: string): unknown };
+}): number;

--- a/scripts/deprecate-archived-npm-entrypoints.mjs
+++ b/scripts/deprecate-archived-npm-entrypoints.mjs
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
 import { execFileSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import {
 	ARCHIVED_NPM_ENTRYPOINTS,
@@ -23,7 +25,11 @@ function parseArgs(argv) {
 		}
 
 		if (argument === "--package") {
-			packageName = argv[index + 1] ?? null;
+			const nextArgument = argv[index + 1];
+			if (!nextArgument || nextArgument.startsWith("-")) {
+				throw new Error("--package requires an archived npm entrypoint name.");
+			}
+			packageName = nextArgument;
 			index += 1;
 			continue;
 		}
@@ -91,4 +97,9 @@ export function runCli({
 	}
 }
 
-process.exitCode = runCli();
+const currentFilePath = fileURLToPath(import.meta.url);
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : "";
+
+if (invokedPath === currentFilePath) {
+	process.exitCode = runCli();
+}

--- a/scripts/deprecate-archived-npm-entrypoints.mjs
+++ b/scripts/deprecate-archived-npm-entrypoints.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+
+import {
+	ARCHIVED_NPM_ENTRYPOINTS,
+	getArchivedNpmEntrypoint,
+	renderArchivedNpmDeprecationCommand,
+	renderArchivedNpmDeprecationMessage,
+	renderArchivedNpmDeprecationPlan,
+} from "./lib/archived-package-policy.mjs";
+
+function parseArgs(argv) {
+	let apply = false;
+	let packageName = null;
+
+	for (let index = 0; index < argv.length; index += 1) {
+		const argument = argv[index];
+
+		if (argument === "--apply") {
+			apply = true;
+			continue;
+		}
+
+		if (argument === "--package") {
+			packageName = argv[index + 1] ?? null;
+			index += 1;
+			continue;
+		}
+
+		throw new Error(
+			`Unknown argument: ${argument}. Supported flags: --apply, --package <name>.`,
+		);
+	}
+
+	return { apply, packageName };
+}
+
+function selectEntries(packageName) {
+	if (!packageName) {
+		return ARCHIVED_NPM_ENTRYPOINTS;
+	}
+
+	const entry = getArchivedNpmEntrypoint(packageName);
+	if (!entry) {
+		throw new Error(
+			`Unknown archived npm entrypoint: ${packageName}. Supported values: ${ARCHIVED_NPM_ENTRYPOINTS.map(({ packageName: name }) => name).join(", ")}.`,
+		);
+	}
+
+	return [entry];
+}
+
+export function runCli({
+	argv = process.argv.slice(2),
+	stdout = process.stdout,
+	stderr = process.stderr,
+} = {}) {
+	try {
+		const { apply, packageName } = parseArgs(argv);
+		const entries = selectEntries(packageName);
+
+		if (!apply) {
+			stdout.write(`${renderArchivedNpmDeprecationPlan(entries)}\n`);
+			stdout.write(
+				"\nRun again with --apply from an npm-authenticated shell to execute the commands.\n",
+			);
+			return 0;
+		}
+
+		for (const entry of entries) {
+			execFileSync(
+				"npm",
+				[
+					"deprecate",
+					`${entry.packageName}@${entry.deprecationRange}`,
+					renderArchivedNpmDeprecationMessage(entry),
+				],
+				{
+					stdio: "inherit",
+				},
+			);
+			stdout.write(`Applied: ${renderArchivedNpmDeprecationCommand(entry)}\n`);
+		}
+
+		return 0;
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		stderr.write(`${message}\n`);
+		return 1;
+	}
+}
+
+process.exitCode = runCli();

--- a/scripts/lib/archived-package-policy.d.mts
+++ b/scripts/lib/archived-package-policy.d.mts
@@ -1,0 +1,27 @@
+export interface ArchivedNpmEntrypoint {
+	deprecationRange: string;
+	description: string;
+	keywords: readonly string[];
+	packageDir: string;
+	packageName: string;
+	private: boolean;
+	replacementCommands: readonly [string, string];
+}
+
+export declare const ARCHIVED_NPM_ENTRYPOINTS: readonly ArchivedNpmEntrypoint[];
+
+export declare function getArchivedNpmEntrypoint(
+	packageName: string,
+): ArchivedNpmEntrypoint | null;
+
+export declare function renderArchivedNpmDeprecationMessage(
+	entry: ArchivedNpmEntrypoint,
+): string;
+
+export declare function renderArchivedNpmDeprecationCommand(
+	entry: ArchivedNpmEntrypoint,
+): string;
+
+export declare function renderArchivedNpmDeprecationPlan(
+	entries?: readonly ArchivedNpmEntrypoint[],
+): string;

--- a/scripts/lib/archived-package-policy.mjs
+++ b/scripts/lib/archived-package-policy.mjs
@@ -1,0 +1,53 @@
+export const ARCHIVED_NPM_ENTRYPOINTS = Object.freeze([
+	{
+		deprecationRange: "*",
+		description:
+			"Archived npm entrypoint for wp-typia. Use npx wp-typia create <project-dir> or bunx wp-typia create <project-dir> instead.",
+		keywords: Object.freeze([
+			"wordpress",
+			"gutenberg",
+			"typia",
+			"archived",
+			"deprecated",
+			"legacy",
+			"initializer",
+		]),
+		packageDir: "packages/create-wp-typia",
+		packageName: "create-wp-typia",
+		private: true,
+		replacementCommands: Object.freeze([
+			"npx wp-typia create <project-dir>",
+			"bunx wp-typia create <project-dir>",
+		]),
+	},
+]);
+
+export function getArchivedNpmEntrypoint(packageName) {
+	return (
+		ARCHIVED_NPM_ENTRYPOINTS.find((entry) => entry.packageName === packageName) ?? null
+	);
+}
+
+export function renderArchivedNpmDeprecationMessage(entry) {
+	const [primaryCommand, secondaryCommand] = entry.replacementCommands;
+
+	return `${entry.packageName} is archived. Use \`${primaryCommand}\` or \`${secondaryCommand}\` instead.`;
+}
+
+export function renderArchivedNpmDeprecationCommand(entry) {
+	return `npm deprecate ${entry.packageName}@${JSON.stringify(entry.deprecationRange)} ${JSON.stringify(renderArchivedNpmDeprecationMessage(entry))}`;
+}
+
+export function renderArchivedNpmDeprecationPlan(
+	entries = ARCHIVED_NPM_ENTRYPOINTS,
+) {
+	const lines = ["Archived npm entrypoint deprecation plan:"];
+
+	for (const entry of entries) {
+		lines.push("");
+		lines.push(`- ${entry.packageName}`);
+		lines.push(`  ${renderArchivedNpmDeprecationCommand(entry)}`);
+	}
+
+	return lines.join("\n");
+}

--- a/scripts/lib/archived-package-policy.mjs
+++ b/scripts/lib/archived-package-policy.mjs
@@ -34,8 +34,14 @@ export function renderArchivedNpmDeprecationMessage(entry) {
 	return `${entry.packageName} is archived. Use \`${primaryCommand}\` or \`${secondaryCommand}\` instead.`;
 }
 
+function shellQuote(value) {
+	return `'${String(value).replaceAll("'", `'\\''`)}'`;
+}
+
 export function renderArchivedNpmDeprecationCommand(entry) {
-	return `npm deprecate ${entry.packageName}@${JSON.stringify(entry.deprecationRange)} ${JSON.stringify(renderArchivedNpmDeprecationMessage(entry))}`;
+	const packageSpec = `${entry.packageName}@${entry.deprecationRange}`;
+
+	return `npm deprecate ${shellQuote(packageSpec)} ${shellQuote(renderArchivedNpmDeprecationMessage(entry))}`;
 }
 
 export function renderArchivedNpmDeprecationPlan(

--- a/scripts/validate-package-manifest-policy.mjs
+++ b/scripts/validate-package-manifest-policy.mjs
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { ARCHIVED_NPM_ENTRYPOINTS } from "./lib/archived-package-policy.mjs";
 import { findPublishablePackages } from "./lib/sampo-changesets.mjs";
 import {
 	RUNTIME_PACKAGE_NAMES,
@@ -131,6 +132,38 @@ function validateBlockTypesRegistrationPeerPolicy(repoRoot, runtimePackages, err
 	}
 }
 
+function validateArchivedEntrypointManifestPolicy(repoRoot, errors) {
+	for (const entry of ARCHIVED_NPM_ENTRYPOINTS) {
+		const manifestPath = path.join(repoRoot, entry.packageDir, "package.json");
+		if (!fs.existsSync(manifestPath)) {
+			errors.push(`${entry.packageDir}/package.json is missing.`);
+			continue;
+		}
+
+		const manifest = readJson(manifestPath);
+		const relativePath = toRelativePath(repoRoot, manifestPath);
+
+		if (manifest.private !== entry.private) {
+			errors.push(
+				`${relativePath} must declare private=${JSON.stringify(entry.private)} for archived npm entrypoints, found ${JSON.stringify(manifest.private ?? null)}.`,
+			);
+		}
+
+		if (manifest.description !== entry.description) {
+			errors.push(
+				`${relativePath} must declare description=${JSON.stringify(entry.description)} for archived npm entrypoints, found ${JSON.stringify(manifest.description ?? null)}.`,
+			);
+		}
+
+		const actualKeywords = Array.isArray(manifest.keywords) ? manifest.keywords : [];
+		if (JSON.stringify(actualKeywords) !== JSON.stringify(entry.keywords)) {
+			errors.push(
+				`${relativePath} must declare keywords=${JSON.stringify(entry.keywords)} for archived npm entrypoints, found ${JSON.stringify(actualKeywords)}.`,
+			);
+		}
+	}
+}
+
 function validateRuntimeDependencyPolicy(repoRoot, runtimePackages, errors) {
 	const exceptionSet = new Set(
 		WORKSPACE_PROTOCOL_POLICY_EXCEPTIONS.map(
@@ -235,6 +268,7 @@ export function validatePackageManifestPolicy(repoRoot = DEFAULT_REPO_ROOT) {
 	validateRuntimeDependencyPolicy(repoRoot, runtimePackages, errors);
 	validateUnusedDevDependencyPolicy(runtimePackages, errors);
 	validateBlockTypesRegistrationPeerPolicy(repoRoot, runtimePackages, errors);
+	validateArchivedEntrypointManifestPolicy(repoRoot, errors);
 
 	return {
 		errors,

--- a/tests/unit/archived-package-policy.test.ts
+++ b/tests/unit/archived-package-policy.test.ts
@@ -16,7 +16,7 @@ describe("archived-package-policy", () => {
 
 	test("renders copy-pastable npm deprecate commands for archived entrypoints", () => {
 		expect(renderArchivedNpmDeprecationCommand(ARCHIVED_NPM_ENTRYPOINTS[0])).toBe(
-			'npm deprecate create-wp-typia@"*" "create-wp-typia is archived. Use `npx wp-typia create <project-dir>` or `bunx wp-typia create <project-dir>` instead."',
+			"npm deprecate 'create-wp-typia@*' 'create-wp-typia is archived. Use `npx wp-typia create <project-dir>` or `bunx wp-typia create <project-dir>` instead.'",
 		);
 	});
 
@@ -25,7 +25,7 @@ describe("archived-package-policy", () => {
 			"Archived npm entrypoint deprecation plan:",
 		);
 		expect(renderArchivedNpmDeprecationPlan()).toContain(
-			'npm deprecate create-wp-typia@"*" "create-wp-typia is archived. Use `npx wp-typia create <project-dir>` or `bunx wp-typia create <project-dir>` instead."',
+			"npm deprecate 'create-wp-typia@*' 'create-wp-typia is archived. Use `npx wp-typia create <project-dir>` or `bunx wp-typia create <project-dir>` instead.'",
 		);
 	});
 });

--- a/tests/unit/archived-package-policy.test.ts
+++ b/tests/unit/archived-package-policy.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+	ARCHIVED_NPM_ENTRYPOINTS,
+	renderArchivedNpmDeprecationCommand,
+	renderArchivedNpmDeprecationMessage,
+	renderArchivedNpmDeprecationPlan,
+} from "../../scripts/lib/archived-package-policy.mjs";
+
+describe("archived-package-policy", () => {
+	test("renders the archived npm entrypoint deprecation message with the supported migration path", () => {
+		expect(renderArchivedNpmDeprecationMessage(ARCHIVED_NPM_ENTRYPOINTS[0])).toBe(
+			"create-wp-typia is archived. Use `npx wp-typia create <project-dir>` or `bunx wp-typia create <project-dir>` instead.",
+		);
+	});
+
+	test("renders copy-pastable npm deprecate commands for archived entrypoints", () => {
+		expect(renderArchivedNpmDeprecationCommand(ARCHIVED_NPM_ENTRYPOINTS[0])).toBe(
+			'npm deprecate create-wp-typia@"*" "create-wp-typia is archived. Use `npx wp-typia create <project-dir>` or `bunx wp-typia create <project-dir>` instead."',
+		);
+	});
+
+	test("renders a maintainer-facing deprecation plan", () => {
+		expect(renderArchivedNpmDeprecationPlan()).toContain(
+			"Archived npm entrypoint deprecation plan:",
+		);
+		expect(renderArchivedNpmDeprecationPlan()).toContain(
+			'npm deprecate create-wp-typia@"*" "create-wp-typia is archived. Use `npx wp-typia create <project-dir>` or `bunx wp-typia create <project-dir>` instead."',
+		);
+	});
+});

--- a/tests/unit/deprecate-archived-npm-entrypoints.test.ts
+++ b/tests/unit/deprecate-archived-npm-entrypoints.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+
+import { runCli } from "../../scripts/deprecate-archived-npm-entrypoints.mjs";
+
+function createBufferWriter() {
+	let value = "";
+
+	return {
+		writer: {
+			write(chunk: string) {
+				value += chunk;
+			},
+		},
+		read() {
+			return value;
+		},
+	};
+}
+
+describe("deprecate-archived-npm-entrypoints", () => {
+	test("rejects --package when the archived entrypoint name is missing", () => {
+		const stdout = createBufferWriter();
+		const stderr = createBufferWriter();
+
+		expect(
+			runCli({
+				argv: ["--package"],
+				stdout: stdout.writer,
+				stderr: stderr.writer,
+			}),
+		).toBe(1);
+		expect(stdout.read()).toBe("");
+		expect(stderr.read()).toContain(
+			"--package requires an archived npm entrypoint name.",
+		);
+	});
+
+	test("prints a package-scoped plan without executing npm", () => {
+		const stdout = createBufferWriter();
+		const stderr = createBufferWriter();
+
+		expect(
+			runCli({
+				argv: ["--package", "create-wp-typia"],
+				stdout: stdout.writer,
+				stderr: stderr.writer,
+			}),
+		).toBe(0);
+		expect(stderr.read()).toBe("");
+		expect(stdout.read()).toContain("Archived npm entrypoint deprecation plan:");
+		expect(stdout.read()).toContain(
+			"npm deprecate 'create-wp-typia@*' 'create-wp-typia is archived. Use `npx wp-typia create <project-dir>` or `bunx wp-typia create <project-dir>` instead.'",
+		);
+	});
+});

--- a/tests/unit/package-manifest-policy.test.ts
+++ b/tests/unit/package-manifest-policy.test.ts
@@ -38,12 +38,23 @@ function createManifestRepo() {
 	});
 
 	writeJson(path.join(repoRoot, "packages/create-wp-typia/package.json"), {
+		description:
+			"Archived npm entrypoint for wp-typia. Use npx wp-typia create <project-dir> or bunx wp-typia create <project-dir> instead.",
 		dependencies: {},
 		engines: {
 			bun: ">=1.3.11",
 			node: ">=20.0.0",
 			npm: ">=10.0.0",
 		},
+		keywords: [
+			"wordpress",
+			"gutenberg",
+			"typia",
+			"archived",
+			"deprecated",
+			"legacy",
+			"initializer",
+		],
 		name: "create-wp-typia",
 		packageManager: "bun@1.3.11",
 		private: true,
@@ -243,6 +254,29 @@ describe("validatePackageManifestPolicy", () => {
 		expect(result.valid).toBe(false);
 		expect(result.errors).toContain(
 			"packages/wp-typia-rest/package.json depends on workspace protocol rewriting but scripts/publish-manifest.mjs does not delegate to the shared publish-manifest helper.",
+		);
+	});
+
+	test("fails when the archived npm entrypoint manifest drifts from the supported redirect policy", () => {
+		const repoRoot = createManifestRepo();
+		const packageJsonPath = path.join(repoRoot, "packages/create-wp-typia/package.json");
+		const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+		packageJson.description = "Archived package with stale guidance";
+		packageJson.keywords = ["wordpress"];
+		packageJson.private = false;
+		writeJson(packageJsonPath, packageJson);
+
+		const result = validatePackageManifestPolicy(repoRoot);
+
+		expect(result.valid).toBe(false);
+		expect(result.errors).toContain(
+			'packages/create-wp-typia/package.json must declare private=true for archived npm entrypoints, found false.',
+		);
+		expect(result.errors).toContain(
+			'packages/create-wp-typia/package.json must declare description="Archived npm entrypoint for wp-typia. Use npx wp-typia create <project-dir> or bunx wp-typia create <project-dir> instead." for archived npm entrypoints, found "Archived package with stale guidance".',
+		);
+		expect(result.errors).toContain(
+			'packages/create-wp-typia/package.json must declare keywords=["wordpress","gutenberg","typia","archived","deprecated","legacy","initializer"] for archived npm entrypoints, found ["wordpress"].',
 		);
 	});
 });


### PR DESCRIPTION
## Context

`create-wp-typia` is already archived in-repo, but the npm-facing entrypoint still needs one canonical migration path and a maintainer-owned deprecation workflow.

## What Changed

- aligned `packages/create-wp-typia` package metadata and README with the supported `wp-typia create <project-dir>` install path
- added a shared archived-entrypoint policy helper plus `archived-entrypoints:plan` / `archived-entrypoints:deprecate` scripts so maintainers can print or apply the exact `npm deprecate` command after release
- extended package manifest policy validation and unit coverage so archived entrypoint metadata cannot drift away from the supported redirect policy
- documented the archived npm entrypoint policy in the maintainer docs

## Verification

- `bun test tests/unit/archived-package-policy.test.ts tests/unit/package-manifest-policy.test.ts`
- `bun run manifest-policy:validate`
- `node scripts/deprecate-archived-npm-entrypoints.mjs`
- `bun run typecheck`
- `bun run docs:build:site`

Closes #399


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Established policies and guidance for managing archived npm entrypoints, including procedures for package deprecation and metadata management.
  * Updated `create-wp-typia` with new installation guidance directing users to use `wp-typia create <project-dir>` instead.

* **Chores**
  * Added tooling to automate npm package deprecation and validate archived package configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->