### PR TITLE
Improve Node-side fallback prompt UX

### DIFF
--- a/.sampo/changesets/issue-400-node-fallback-prompt-ux.md
+++ b/.sampo/changesets/issue-400-node-fallback-prompt-ux.md
@@ -1,0 +1,6 @@
+---
+npm/wp-typia: patch
+npm/@wp-typia/project-tools: patch
+---
+
+Improve the Node-side fallback prompt UX for `wp-typia` by making numbered selections easier to reuse, redrawing choices on demand, and documenting the lighter readline prompt model relative to the Bun/OpenTUI path.

--- a/apps/docs/src/content/docs/maintainers/bunli-cli-migration.md
+++ b/apps/docs/src/content/docs/maintainers/bunli-cli-migration.md
@@ -43,6 +43,22 @@ Published runtime support model:
 Shorthand references like `npx wp-typia` and `bunx wp-typia` should still map
 to the canonical `create` surface in docs and review notes.
 
+## Node fallback prompt model
+
+- Bun/OpenTUI remains the canonical rich interactive surface for `create`,
+  `add`, and `migrate`.
+- The Node fallback should stay readline-based and intentionally lighter, but
+  it must no longer feel like a bare escape hatch.
+- The fallback prompt contract is:
+  - render numbered options with explicit defaults
+  - accept option numbers, labels, and raw values
+  - support `?`, `help`, and `list` to redraw the current option set
+  - retry validation inline with direct guidance instead of dropping the user
+    back into an opaque loop
+- Business logic, defaults, and validation rules should stay shared with the
+  Bun/TUI path through `@wp-typia/project-tools`; only the prompt presentation
+  should differ.
+
 ## Non-negotiable ownership boundary
 
 - `wp-typia` must remain the only CLI-owning package.

--- a/packages/wp-typia-project-tools/src/runtime/cli-prompt.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-prompt.ts
@@ -103,14 +103,14 @@ export function createReadlinePromptWithInterface(
 					return options[resolvedDefaultIndex].value;
 				}
 
-				if (isPromptHelpToken(answer)) {
-					renderSelectPrompt(message, options, resolvedDefaultIndex);
-					continue;
-				}
-
 				const selection = resolvePromptSelection(options, answer);
 				if (selection) {
 					return selection.value;
+				}
+
+				if (isPromptHelpToken(answer)) {
+					renderSelectPrompt(message, options, resolvedDefaultIndex);
+					continue;
 				}
 
 				console.error(formatInvalidSelectionError(answer, options, resolvedDefaultIndex));

--- a/packages/wp-typia-project-tools/src/runtime/cli-prompt.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-prompt.ts
@@ -1,6 +1,7 @@
 import readline from "node:readline";
 
 type ValidateInput = (value: string) => boolean | string;
+type PromptQuestion = (query: string) => Promise<string>;
 
 interface PromptOption<T extends string> {
 	hint?: string;
@@ -59,19 +60,21 @@ export function createReadlinePrompt(): ReadlinePrompt {
 export function createReadlinePromptWithInterface(
 	rl: ReadlineQuestionAdapter,
 ): ReadlinePrompt {
+	const askQuestion: PromptQuestion = (query) =>
+		new Promise<string>((resolve) => {
+			rl.question(query, resolve);
+		});
+
 	return {
 		async text(message: string, defaultValue: string, validate?: ValidateInput): Promise<string> {
-			const suffix = defaultValue ? ` (${defaultValue})` : "";
 			while (true) {
-				const answer = await new Promise<string>((resolve) => {
-					rl.question(`${message}${suffix}: `, resolve);
-				});
-
-				const value = String(answer).trim() || defaultValue;
+				const value = normalizePromptAnswer(
+					await askQuestion(formatTextPrompt(message, defaultValue)),
+				) || defaultValue;
 				if (validate) {
 					const result = validate(value);
 					if (result !== true) {
-						console.error(`❌ ${typeof result === "string" ? result : "Invalid input"}`);
+						console.error(formatValidationError(message, result, defaultValue));
 						continue;
 					}
 				}
@@ -88,29 +91,126 @@ export function createReadlinePromptWithInterface(
 				throw new Error(`select() requires at least one option for prompt: ${message}`);
 			}
 
-			console.log(message);
-			options.forEach((option, index) => {
-				const hint = option.hint ? ` - ${option.hint}` : "";
-				console.log(`  ${index + 1}. ${option.label}${hint}`);
-			});
+			const resolvedDefaultIndex = getResolvedDefaultIndex(options, defaultValue);
+			renderSelectPrompt(message, options, resolvedDefaultIndex);
 
 			while (true) {
-				const answer = await this.text("Choice", String(defaultValue));
-				const numericChoice = Number(answer);
-				if (!Number.isNaN(numericChoice) && options[numericChoice - 1]) {
-					return options[numericChoice - 1].value;
+				const answer = normalizePromptAnswer(
+					await askQuestion(formatChoicePrompt(resolvedDefaultIndex)),
+				);
+
+				if (answer.length === 0) {
+					return options[resolvedDefaultIndex].value;
 				}
 
-				const directChoice = options.find((option) => option.value === answer);
-				if (directChoice) {
-					return directChoice.value;
+				if (isPromptHelpToken(answer)) {
+					renderSelectPrompt(message, options, resolvedDefaultIndex);
+					continue;
 				}
 
-				console.error(`❌ Invalid selection: ${answer}`);
+				const selection = resolvePromptSelection(options, answer);
+				if (selection) {
+					return selection.value;
+				}
+
+				console.error(formatInvalidSelectionError(answer, options, resolvedDefaultIndex));
 			}
 		},
 		close(): void {
 			rl.close();
 		},
 	};
+}
+
+function normalizePromptAnswer(value: string): string {
+	return String(value).trim();
+}
+
+function normalizePromptToken(value: string): string {
+	return value.trim().toLowerCase();
+}
+
+function getResolvedDefaultIndex<T extends string>(
+	options: PromptOption<T>[],
+	defaultValue: number,
+): number {
+	const candidateIndex = Number.isInteger(defaultValue) ? defaultValue - 1 : -1;
+	return options[candidateIndex] ? candidateIndex : 0;
+}
+
+function formatTextPrompt(message: string, defaultValue: string): string {
+	const suffix = defaultValue.length > 0 ? ` [default: ${defaultValue}]` : "";
+	return `${message}${suffix}: `;
+}
+
+function formatValidationError(
+	message: string,
+	result: boolean | string,
+	defaultValue: string,
+): string {
+	const detail = typeof result === "string" ? result : "Invalid input";
+	const retryHint =
+		defaultValue.length > 0 ? ` Press Enter to keep "${defaultValue}".` : "";
+	return `❌ ${message}: ${detail}.${retryHint}`;
+}
+
+function formatChoicePrompt(defaultIndex: number): string {
+	return `Choice [default: ${defaultIndex + 1}, ? for options]: `;
+}
+
+function renderSelectPrompt<T extends string>(
+	message: string,
+	options: PromptOption<T>[],
+	defaultIndex: number,
+): void {
+	console.log(message);
+	console.log(
+		"  Enter a number, option label, or option value. Press Enter to keep the default, or type ? to list choices again.",
+	);
+	options.forEach((option, index) => {
+		const defaultMarker = index === defaultIndex ? " (default)" : "";
+		const valueHint =
+			normalizePromptToken(option.label) === normalizePromptToken(option.value)
+				? ""
+				: ` [${option.value}]`;
+		console.log(`  ${index + 1}. ${option.label}${valueHint}${defaultMarker}`);
+		if (option.hint) {
+			console.log(`     ${option.hint}`);
+		}
+	});
+}
+
+function isPromptHelpToken(answer: string): boolean {
+	const normalized = normalizePromptToken(answer);
+	return normalized === "?" || normalized === "help" || normalized === "list";
+}
+
+function resolvePromptSelection<T extends string>(
+	options: PromptOption<T>[],
+	answer: string,
+): PromptOption<T> | undefined {
+	const numericChoice = Number(answer);
+	if (!Number.isNaN(numericChoice) && options[numericChoice - 1]) {
+		return options[numericChoice - 1];
+	}
+
+	const normalizedAnswer = normalizePromptToken(answer);
+	return options.find((option) => {
+		const normalizedLabel = normalizePromptToken(option.label);
+		const normalizedValue = normalizePromptToken(option.value);
+		return normalizedAnswer === normalizedLabel || normalizedAnswer === normalizedValue;
+	});
+}
+
+function formatInvalidSelectionError<T extends string>(
+	answer: string,
+	options: PromptOption<T>[],
+	defaultIndex: number,
+): string {
+	const optionValues = options.map((option) => option.value).join(", ");
+	return [
+		`❌ Invalid selection: ${answer}.`,
+		`Enter 1-${options.length}, one of: ${optionValues},`,
+		`or press Enter for "${options[defaultIndex].label}".`,
+	].join(" ");
 }

--- a/packages/wp-typia-project-tools/tests/cli-prompt.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-prompt.test.ts
@@ -99,7 +99,7 @@ describe("@wp-typia/project-tools cli prompt", () => {
 	});
 
 	test("select accepts help tokens and case-insensitive labels", async () => {
-		const stub = createStubInterface(["?", "storage persistence"]);
+		const stub = createStubInterface(["?", "help", "list", "storage persistence"]);
 		const logs: string[] = [];
 		const originalLog = console.log;
 		console.log = (...args: unknown[]) => {
@@ -116,6 +116,18 @@ describe("@wp-typia/project-tools cli prompt", () => {
 
 			expect(value).toBe("persistence");
 			expect(logs).toEqual([
+				"Template",
+				"  Enter a number, option label, or option value. Press Enter to keep the default, or type ? to list choices again.",
+				"  1. Basic (default)",
+				"     Starter block",
+				"  2. Storage Persistence [persistence]",
+				"     Storage helpers",
+				"Template",
+				"  Enter a number, option label, or option value. Press Enter to keep the default, or type ? to list choices again.",
+				"  1. Basic (default)",
+				"     Starter block",
+				"  2. Storage Persistence [persistence]",
+				"     Storage helpers",
 				"Template",
 				"  Enter a number, option label, or option value. Press Enter to keep the default, or type ? to list choices again.",
 				"  1. Basic (default)",

--- a/packages/wp-typia-project-tools/tests/cli-prompt.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-prompt.test.ts
@@ -46,10 +46,10 @@ describe("@wp-typia/project-tools cli prompt", () => {
 
 			expect(value).toBe("valid-name");
 			expect(stub.prompts).toEqual([
-				"Project name (demo): ",
-				"Project name (demo): ",
+				"Project name [default: demo]: ",
+				"Project name [default: demo]: ",
 			]);
-			expect(errors).toEqual(["❌ Too short"]);
+			expect(errors).toEqual(["❌ Project name: Too short. Press Enter to keep \"demo\"."]);
 			expect(stub.closeCalls).toBe(1);
 		} finally {
 			console.error = originalError;
@@ -79,18 +79,57 @@ describe("@wp-typia/project-tools cli prompt", () => {
 
 			expect(value).toBe("persistence");
 			expect(stub.prompts).toEqual([
-				"Choice (1): ",
-				"Choice (1): ",
+				"Choice [default: 1, ? for options]: ",
+				"Choice [default: 1, ? for options]: ",
 			]);
 			expect(logs).toEqual([
 				"Template",
-				"  1. Basic",
+				"  Enter a number, option label, or option value. Press Enter to keep the default, or type ? to list choices again.",
+				"  1. Basic (default)",
 				"  2. Persistence",
 			]);
-			expect(errors).toEqual(["❌ Invalid selection: 9"]);
+			expect(errors).toEqual([
+				"❌ Invalid selection: 9. Enter 1-2, one of: basic, persistence, or press Enter for \"Basic\".",
+			]);
 			expect(stub.closeCalls).toBe(1);
 		} finally {
 			console.error = originalError;
+			console.log = originalLog;
+		}
+	});
+
+	test("select accepts help tokens and case-insensitive labels", async () => {
+		const stub = createStubInterface(["?", "storage persistence"]);
+		const logs: string[] = [];
+		const originalLog = console.log;
+		console.log = (...args: unknown[]) => {
+			logs.push(args.join(" "));
+		};
+
+		try {
+			const prompt = createReadlinePromptWithInterface(stub.adapter);
+			const value = await prompt.select("Template", [
+				{ label: "Basic", value: "basic", hint: "Starter block" },
+				{ label: "Storage Persistence", value: "persistence", hint: "Storage helpers" },
+			]);
+			prompt.close();
+
+			expect(value).toBe("persistence");
+			expect(logs).toEqual([
+				"Template",
+				"  Enter a number, option label, or option value. Press Enter to keep the default, or type ? to list choices again.",
+				"  1. Basic (default)",
+				"     Starter block",
+				"  2. Storage Persistence [persistence]",
+				"     Storage helpers",
+				"Template",
+				"  Enter a number, option label, or option value. Press Enter to keep the default, or type ? to list choices again.",
+				"  1. Basic (default)",
+				"     Starter block",
+				"  2. Storage Persistence [persistence]",
+				"     Storage helpers",
+			]);
+		} finally {
 			console.log = originalLog;
 		}
 	});

--- a/packages/wp-typia/README.md
+++ b/packages/wp-typia/README.md
@@ -19,6 +19,7 @@ Compatibility notes:
 
 - `@wp-typia/project-tools` is the canonical programmatic project orchestration package
 - the published CLI now ships built `dist-bunli` runtimes, and the canonical Node bin uses a Node-safe fallback runtime for non-TUI `create`/`add`/`migrate`, `doctor`, `sync`, `--version`, `--help`, and template inspection without requiring a locally installed Bun binary
+- when that Node fallback prompts interactively, it intentionally stays lighter than the Bun/OpenTUI flow: numbered lists, option label/value matching, inline validation retries, and `?` to reprint the current choices
 - Bunli-specific command surfaces such as `skills`, `completions`, and `mcp` still run through the built `dist-bunli/cli.js` artifact and require Bun; if you need the full Bunli/OpenTUI runtime story, prefer `bunx wp-typia` or install Bun locally
 - any future `curl`-style installer should reuse the same published `dist-bunli` runtime instead of reintroducing a Bun bootstrap path
 - internal runtime-bridge helper modules are implementation details; integrations

--- a/packages/wp-typia/README.md
+++ b/packages/wp-typia/README.md
@@ -19,7 +19,7 @@ Compatibility notes:
 
 - `@wp-typia/project-tools` is the canonical programmatic project orchestration package
 - the published CLI now ships built `dist-bunli` runtimes, and the canonical Node bin uses a Node-safe fallback runtime for non-TUI `create`/`add`/`migrate`, `doctor`, `sync`, `--version`, `--help`, and template inspection without requiring a locally installed Bun binary
-- when that Node fallback prompts interactively, it intentionally stays lighter than the Bun/OpenTUI flow: numbered lists, option label/value matching, inline validation retries, and `?` to reprint the current choices
+- when that Node fallback prompts interactively, it intentionally stays lighter than the Bun/OpenTUI flow: numbered lists, option label/value matching, inline validation retries, and redraw commands for the current choices: `?` for the short reprint shortcut, `help` for the explicit redraw command, and `list` for users who expect option listing semantics
 - Bunli-specific command surfaces such as `skills`, `completions`, and `mcp` still run through the built `dist-bunli/cli.js` artifact and require Bun; if you need the full Bunli/OpenTUI runtime story, prefer `bunx wp-typia` or install Bun locally
 - any future `curl`-style installer should reuse the same published `dist-bunli` runtime instead of reintroducing a Bun bootstrap path
 - internal runtime-bridge helper modules are implementation details; integrations


### PR DESCRIPTION
## Context

`wp-typia` now has a real Bun-free fallback path, so the readline prompt flow is no longer just an escape hatch. This PR gives the Node-side interactive path a clearer, deliberate prompt model without trying to duplicate the full Bun/OpenTUI experience.

## What Changed

- upgraded `createReadlinePrompt()` so fallback prompts show explicit defaults, accept numbers plus label/value matches, and support `?` / `help` / `list` to redraw the current options
- tightened retry messaging for validation failures and invalid selections so the user gets direct guidance instead of a bare loop
- expanded `cli-prompt` coverage to lock the new selection/help behavior in place
- documented the lighter Node fallback prompt model relative to the Bun/OpenTUI path in the maintainer docs and CLI README
- added a changeset for `wp-typia` and `@wp-typia/project-tools`

## Verification

- `bun run packages:build`
- `bun test packages/wp-typia-project-tools/tests/cli-prompt.test.ts packages/wp-typia-project-tools/tests/cli-entry.test.ts packages/wp-typia-project-tools/tests/workspace-add.test.ts packages/wp-typia-project-tools/tests/migration-plan-wizard.test.ts`
- `bun run typecheck`
- `bun run changesets:validate`
- `bun run docs:build:site`

Closes #400


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced interactive command-line prompts with numbered selection options and explicit default values
  * Added `?` command support to redisplay available choices
  * Improved validation feedback with inline error guidance
  * Enabled case-insensitive option label and value matching

* **Documentation**
  * Added Node fallback prompt model specification and behavior documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->