### PR TITLE
Fix scaffold runtime coverage boundary test

### DIFF
--- a/packages/wp-typia-project-tools/tests/scaffold-runtime-boundaries.test.ts
+++ b/packages/wp-typia-project-tools/tests/scaffold-runtime-boundaries.test.ts
@@ -49,9 +49,10 @@ test("scaffold runtime delegates identifier, document, bootstrap, and package he
 	expect(identifiersSource).toContain(
 		"export function resolveScaffoldIdentifiers(",
 	);
-	expect(applyUtilsSource).toContain(
-		'export {\n\tbuildGitignore,\n\tbuildReadme,\n\tmergeTextLines,\n} from "./scaffold-documents.js";',
-	);
+	expect(applyUtilsSource).toContain('from "./scaffold-documents.js"');
+	expect(applyUtilsSource).toContain("buildGitignore");
+	expect(applyUtilsSource).toContain("buildReadme");
+	expect(applyUtilsSource).toContain("mergeTextLines");
 	expect(documentsSource).toContain("export function buildReadme(");
 	expect(documentsSource).toContain("export function buildGitignore(");
 	expect(documentsSource).toContain("export function mergeTextLines(");

--- a/packages/wp-typia-project-tools/tests/scaffold-runtime-boundaries.test.ts
+++ b/packages/wp-typia-project-tools/tests/scaffold-runtime-boundaries.test.ts
@@ -29,6 +29,8 @@ test("scaffold runtime delegates identifier, document, bootstrap, and package he
 		path.join(runtimeRoot, "scaffold-package-manager-files.ts"),
 		"utf8",
 	);
+	const documentsReExportPattern =
+		/export\s*\{(?=[^}]*\bbuildGitignore\b)(?=[^}]*\bbuildReadme\b)(?=[^}]*\bmergeTextLines\b)[^}]*\}\s*from\s*"\.\/scaffold-documents\.js";/u;
 
 	expect(scaffoldSource).toContain('from "./scaffold-identifiers.js"');
 	expect(scaffoldSource).toContain('from "./scaffold-apply-utils.js"');
@@ -49,10 +51,7 @@ test("scaffold runtime delegates identifier, document, bootstrap, and package he
 	expect(identifiersSource).toContain(
 		"export function resolveScaffoldIdentifiers(",
 	);
-	expect(applyUtilsSource).toContain('from "./scaffold-documents.js"');
-	expect(applyUtilsSource).toContain("buildGitignore");
-	expect(applyUtilsSource).toContain("buildReadme");
-	expect(applyUtilsSource).toContain("mergeTextLines");
+	expect(documentsReExportPattern.test(applyUtilsSource)).toBe(true);
 	expect(documentsSource).toContain("export function buildReadme(");
 	expect(documentsSource).toContain("export function buildGitignore(");
 	expect(documentsSource).toContain("export function mergeTextLines(");

--- a/packages/wp-typia-project-tools/tests/scaffold-runtime-boundaries.test.ts
+++ b/packages/wp-typia-project-tools/tests/scaffold-runtime-boundaries.test.ts
@@ -17,6 +17,10 @@ test("scaffold runtime delegates identifier, document, bootstrap, and package he
 		path.join(runtimeRoot, "scaffold-apply-utils.ts"),
 		"utf8",
 	);
+	const documentsSource = fs.readFileSync(
+		path.join(runtimeRoot, "scaffold-documents.ts"),
+		"utf8",
+	);
 	const bootstrapSource = fs.readFileSync(
 		path.join(runtimeRoot, "scaffold-bootstrap.ts"),
 		"utf8",
@@ -45,9 +49,12 @@ test("scaffold runtime delegates identifier, document, bootstrap, and package he
 	expect(identifiersSource).toContain(
 		"export function resolveScaffoldIdentifiers(",
 	);
-	expect(applyUtilsSource).toContain("export function buildReadme(");
-	expect(applyUtilsSource).toContain("export function buildGitignore(");
-	expect(applyUtilsSource).toContain("export function mergeTextLines(");
+	expect(applyUtilsSource).toContain(
+		'export {\n\tbuildGitignore,\n\tbuildReadme,\n\tmergeTextLines,\n} from "./scaffold-documents.js";',
+	);
+	expect(documentsSource).toContain("export function buildReadme(");
+	expect(documentsSource).toContain("export function buildGitignore(");
+	expect(documentsSource).toContain("export function mergeTextLines(");
 	expect(bootstrapSource).toContain("export async function ensureScaffoldDirectory(");
 	expect(bootstrapSource).toContain("export async function applyWorkspaceMigrationCapability(");
 	expect(packageManagerFilesSource).toContain("export async function normalizePackageJson(");


### PR DESCRIPTION
## Context
`main` failed in `Project Tools Coverage` after the scaffold helper split because `scaffold-runtime-boundaries.test.ts` still expected `buildReadme`, `buildGitignore`, and `mergeTextLines` to be defined in `scaffold-apply-utils.ts`.

## What Changed
- updated `scaffold-runtime-boundaries.test.ts` to read `scaffold-documents.ts`
- kept the facade assertion on `scaffold-apply-utils.ts` as a re-export boundary check
- aligned the coverage boundary test with the current scaffold helper ownership split

## Verification
- `bun test packages/wp-typia-project-tools/tests/scaffold-runtime-boundaries.test.ts`
- `bun run test:coverage:project-tools`
- `bun run changesets:validate`

Closes #425


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reorganized test structure for runtime module validation, improving test organization and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->