### PR TITLE
Add connected Query Loop layout presets

### DIFF
--- a/.sampo/changesets/query-loop-pattern-presets.md
+++ b/.sampo/changesets/query-loop-pattern-presets.md
@@ -1,0 +1,7 @@
+---
+npm/@wp-typia/project-tools: minor
+npm/wp-typia: minor
+---
+
+Add connected Query Loop layout preset scaffolds so `wp-typia create --template query-loop`
+now seeds pattern-backed grid and list layouts alongside the inline variation fallback.

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ The `compound` template creates a parent/child block structure with hidden imple
 
 ### 5. Query Loop variations get a first-class scaffold
 
-The `query-loop` template scaffolds an editor-facing `core/query` variation plugin instead of a standalone block, so you can ship a branded inserter entry with stable namespace identity, default query settings, allowed inspector controls, and inline starter `innerBlocks` without rebuilding the full Query Loop setup flow by hand.
+The `query-loop` template scaffolds an editor-facing `core/query` variation plugin instead of a standalone block, so you can ship a branded inserter entry with stable namespace identity, default query settings, allowed inspector controls, and inline starter `innerBlocks` without rebuilding the full Query Loop setup flow by hand. It also includes connected `src/patterns/*.php` presets so richer editorial layouts can live in pattern files while `src/index.ts` stays focused on variation identity and query defaults.
 
 ## Example flows
 

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-onboarding.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-onboarding.ts
@@ -91,7 +91,7 @@ export function getQuickStartWorkflowNote(
 	options: SyncOnboardingOptions = {},
 ): string {
 	if (templateId === "query-loop") {
-		return `${formatRunScript(packageManager, "start")} runs the editor build/watch loop that registers your Query Loop variation in the block editor. This scaffold is editor-facing by design: update \`src/index.ts\` when you want to change the variation namespace, default query, allowed controls, or starter layout.`;
+		return `${formatRunScript(packageManager, "start")} runs the editor build/watch loop that registers your Query Loop variation in the block editor. This scaffold is editor-facing by design: update \`src/index.ts\` when you want to change the variation namespace, default query, allowed controls, or the minimal inline starter layout, and update \`src/patterns/*.php\` when you want richer connected layout presets in the inserter.`;
 	}
 
 	const developmentScript = getPrimaryDevelopmentScript(templateId);
@@ -122,7 +122,7 @@ export function getOptionalOnboardingNote(
 	options: SyncOnboardingOptions = {},
 ): string {
 	if (templateId === "query-loop") {
-		return `This scaffold does not generate \`block.json\` or Typia manifests. Edit \`src/index.ts\` to change the variation contract, then rerun ${formatRunScript(packageManager, "build")}, ${formatRunScript(packageManager, "start")}, or ${formatRunScript(packageManager, "typecheck")} as needed.`;
+		return `This scaffold does not generate \`block.json\` or Typia manifests. Edit \`src/index.ts\` to change the variation contract, and edit \`src/patterns/*.php\` when you want richer connected layouts beyond the inline fallback. Then rerun ${formatRunScript(packageManager, "build")}, ${formatRunScript(packageManager, "start")}, or ${formatRunScript(packageManager, "typecheck")} as needed.`;
 	}
 
 	const optionalSyncScripts = getOptionalSyncScriptNames(templateId, options);
@@ -199,7 +199,7 @@ export function getTemplateSourceOfTruthNote(
 	{ compoundPersistenceEnabled = false }: SyncOnboardingOptions = {},
 ): string {
 	if (templateId === "query-loop") {
-		return "`src/index.ts` remains the source of truth for the Query Loop variation name, default query attributes, `allowedControls`, and inline starter `innerBlocks`. The generated plugin bootstrap only enqueues the built editor asset and should stay focused on script registration unless you intentionally add frontend/runtime glue in later follow-ups.";
+		return "`src/index.ts` remains the source of truth for the Query Loop variation name, default query attributes, `allowedControls`, and the minimal inline starter `innerBlocks`. Use `src/patterns/*.php` for richer connected layout presets that stay tied to the same variation namespace. The generated plugin bootstrap should stay focused on script registration and pattern loading unless you intentionally add frontend/runtime glue in later follow-ups.";
 	}
 
 	if (templateId === "compound") {

--- a/packages/wp-typia-project-tools/src/runtime/template-registry.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-registry.ts
@@ -95,9 +95,9 @@ export const TEMPLATE_REGISTRY = Object.freeze<TemplateDefinition[]>([
 	},
 	{
 		id: "query-loop",
-		description: "A Query Loop block variation scaffold with stable namespace-based identity and inline starter layout",
+		description: "A Query Loop block variation scaffold with stable namespace-based identity, inline starter layout, and connected pattern presets",
 		defaultCategory: getBuiltInTemplateMetadataDefaults("query-loop").category,
-		features: ["core/query variation", "Default innerBlocks", "Allowed controls"],
+		features: ["core/query variation", "Default innerBlocks", "Connected patterns", "Allowed controls"],
 		templateDir: path.join(TEMPLATE_ROOT, "query-loop"),
 	},
 	{

--- a/packages/wp-typia-project-tools/templates/query-loop/src/patterns/grid.php.mustache
+++ b/packages/wp-typia-project-tools/templates/query-loop/src/patterns/grid.php.mustache
@@ -1,0 +1,49 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$content = sprintf(
+	<<<'HTML'
+<!-- wp:query {"namespace":"{{namespace}}/{{slug}}","query":{"inherit":false,"postType":"{{queryPostType}}","perPage":6,"order":"desc","orderBy":"date"},"displayLayout":{"type":"grid","columns":3}} -->
+<div class="wp-block-query">
+	<!-- wp:post-template -->
+	<!-- wp:group {"style":{"spacing":{"blockGap":"0.75rem","padding":{"top":"1rem","right":"1rem","bottom":"1rem","left":"1rem"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group" style="padding-top:1rem;padding-right:1rem;padding-bottom:1rem;padding-left:1rem">
+		<!-- wp:post-featured-image /-->
+		<!-- wp:post-title {"isLink":true} /-->
+		<!-- wp:post-excerpt /-->
+	</div>
+	<!-- /wp:group -->
+	<!-- /wp:post-template -->
+
+	<!-- wp:query-pagination -->
+	<!-- wp:query-pagination-previous /-->
+	<!-- wp:query-pagination-numbers /-->
+	<!-- wp:query-pagination-next /-->
+	<!-- /wp:query-pagination -->
+
+	<!-- wp:query-no-results -->
+	<!-- wp:paragraph -->
+	<p>%s</p>
+	<!-- /wp:paragraph -->
+	<!-- /wp:query-no-results -->
+</div>
+<!-- /wp:query -->
+HTML,
+	esc_html__( 'No items matched this preset yet.', '{{textDomain}}' )
+);
+
+register_block_pattern(
+	'{{namespace}}/{{slug}}-grid',
+	array(
+		'title'         => __( '{{title}} Grid', '{{textDomain}}' ),
+		'description'   => __( 'A connected grid layout preset for the {{title}} Query Loop variation.', '{{textDomain}}' ),
+		'categories'    => array( '{{slug}}-query-loop' ),
+		'blockTypes'    => array( 'core/query' ),
+		'postTypes'     => array( '{{queryPostType}}' ),
+		'inserter'      => true,
+		'viewportWidth' => 1280,
+		'content'       => $content,
+	)
+);

--- a/packages/wp-typia-project-tools/templates/query-loop/src/patterns/list.php.mustache
+++ b/packages/wp-typia-project-tools/templates/query-loop/src/patterns/list.php.mustache
@@ -1,0 +1,48 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$content = sprintf(
+	<<<'HTML'
+<!-- wp:query {"namespace":"{{namespace}}/{{slug}}","query":{"inherit":false,"postType":"{{queryPostType}}","perPage":4,"order":"desc","orderBy":"date"}} -->
+<div class="wp-block-query">
+	<!-- wp:post-template -->
+	<!-- wp:group {"style":{"spacing":{"blockGap":"1rem","padding":{"top":"1.25rem","bottom":"1.25rem"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group" style="padding-top:1.25rem;padding-bottom:1.25rem">
+		<!-- wp:post-title {"isLink":true} /-->
+		<!-- wp:post-date /-->
+		<!-- wp:post-excerpt {"moreText":"Continue reading"} /-->
+	</div>
+	<!-- /wp:group -->
+	<!-- /wp:post-template -->
+
+	<!-- wp:query-pagination -->
+	<!-- wp:query-pagination-previous /-->
+	<!-- wp:query-pagination-next /-->
+	<!-- /wp:query-pagination -->
+
+	<!-- wp:query-no-results -->
+	<!-- wp:paragraph -->
+	<p>%s</p>
+	<!-- /wp:paragraph -->
+	<!-- /wp:query-no-results -->
+</div>
+<!-- /wp:query -->
+HTML,
+	esc_html__( 'No items matched this preset yet.', '{{textDomain}}' )
+);
+
+register_block_pattern(
+	'{{namespace}}/{{slug}}-list',
+	array(
+		'title'         => __( '{{title}} List', '{{textDomain}}' ),
+		'description'   => __( 'A connected list layout preset for the {{title}} Query Loop variation.', '{{textDomain}}' ),
+		'categories'    => array( '{{slug}}-query-loop' ),
+		'blockTypes'    => array( 'core/query' ),
+		'postTypes'     => array( '{{queryPostType}}' ),
+		'inserter'      => true,
+		'viewportWidth' => 1280,
+		'content'       => $content,
+	)
+);

--- a/packages/wp-typia-project-tools/templates/query-loop/{{slugKebabCase}}.php.mustache
+++ b/packages/wp-typia-project-tools/templates/query-loop/{{slugKebabCase}}.php.mustache
@@ -25,6 +25,29 @@ function {{phpPrefix}}_load_textdomain() {
 	);
 }
 
+function {{phpPrefix}}_register_query_loop_pattern_category() {
+	if ( ! function_exists( 'register_block_pattern_category' ) ) {
+		return;
+	}
+
+	register_block_pattern_category(
+		'{{slug}}-query-loop',
+		array(
+			'label' => __( '{{title}} Query Loop', '{{textDomain}}' ),
+		)
+	);
+}
+
+function {{phpPrefix}}_register_query_loop_patterns() {
+	if ( ! function_exists( 'register_block_pattern' ) ) {
+		return;
+	}
+
+	foreach ( glob( __DIR__ . '/src/patterns/*.php' ) ?: array() as $pattern_module ) {
+		require $pattern_module;
+	}
+}
+
 function {{phpPrefix}}_register_query_loop_variation_script() {
 	$script_path      = __DIR__ . '/build/index.js';
 	$script_asset_path = __DIR__ . '/build/index.asset.php';
@@ -52,4 +75,6 @@ function {{phpPrefix}}_enqueue_query_loop_variation_script() {
 }
 
 add_action( 'init', '{{phpPrefix}}_load_textdomain' );
+add_action( 'init', '{{phpPrefix}}_register_query_loop_pattern_category' );
+add_action( 'init', '{{phpPrefix}}_register_query_loop_patterns', 20 );
 add_action( 'enqueue_block_editor_assets', '{{phpPrefix}}_enqueue_query_loop_variation_script' );

--- a/packages/wp-typia-project-tools/tests/scaffold-query-loop.test.ts
+++ b/packages/wp-typia-project-tools/tests/scaffold-query-loop.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
@@ -52,6 +53,14 @@ describe("@wp-typia/project-tools scaffold query-loop", () => {
 				path.join(targetDir, "demo-query-loop.php"),
 				"utf8",
 			);
+			const gridPatternSource = fs.readFileSync(
+				path.join(targetDir, "src", "patterns", "grid.php"),
+				"utf8",
+			);
+			const listPatternSource = fs.readFileSync(
+				path.join(targetDir, "src", "patterns", "list.php"),
+				"utf8",
+			);
 
 			expect(packageJson.devDependencies["@wp-typia/block-types"]).toBe(
 				blockTypesPackageVersion,
@@ -77,7 +86,14 @@ describe("@wp-typia/project-tools scaffold query-loop", () => {
 			expect(variationSource).toMatch(/['"]core\/post-template['"]/);
 			expect(pluginBootstrap).toMatch(/enqueue_block_editor_assets/);
 			expect(pluginBootstrap).toMatch(/wp_register_script\s*\(/);
+			expect(pluginBootstrap).toContain("register_block_pattern_category");
+			expect(pluginBootstrap).toContain("/src/patterns/*.php");
 			expect(pluginBootstrap).not.toContain("register_block_type");
+			expect(gridPatternSource).toContain("demo-space/demo-query-loop-grid");
+			expect(gridPatternSource).toContain('"namespace":"demo-space/demo-query-loop"');
+			expect(gridPatternSource).toContain('"postType":"book"');
+			expect(listPatternSource).toContain("demo-space/demo-query-loop-list");
+			expect(listPatternSource).toContain('"namespace":"demo-space/demo-query-loop"');
 			expect(readme).toContain("## Artifact Refresh");
 			expect(readme).toContain(
 				"This scaffold does not generate `block.json` or Typia manifests.",
@@ -85,6 +101,16 @@ describe("@wp-typia/project-tools scaffold query-loop", () => {
 			expect(readme).toContain(
 				"`src/index.ts` remains the source of truth for the Query Loop variation name",
 			);
+			expect(readme).toContain("Use `src/patterns/*.php` for richer connected layout presets");
+			execFileSync("php", ["-l", path.join(targetDir, "demo-query-loop.php")], {
+				stdio: "ignore",
+			});
+			execFileSync("php", ["-l", path.join(targetDir, "src", "patterns", "grid.php")], {
+				stdio: "ignore",
+			});
+			execFileSync("php", ["-l", path.join(targetDir, "src", "patterns", "list.php")], {
+				stdio: "ignore",
+			});
 
 			typecheckGeneratedProject(targetDir);
 			buildGeneratedProject(targetDir);

--- a/tests/unit/template-registry.test.ts
+++ b/tests/unit/template-registry.test.ts
@@ -86,7 +86,7 @@ describe("template registry runtime helpers", () => {
 				value: "compound",
 			},
 			{
-				hint: "core/query variation, Default innerBlocks, Allowed controls",
+				hint: "core/query variation, Default innerBlocks, Connected patterns, Allowed controls",
 				label: "query-loop",
 				value: "query-loop",
 			},


### PR DESCRIPTION
## Context

Query Loop MVP scaffolds already ship a usable inline `core/query` variation, but they did not yet provide a first-class place for richer layout presets. This follow-up adds connected pattern scaffolds so layout presets can evolve independently from the variation's identity and default query contract.

## What Changed

- register a query-loop-specific pattern category and loader in the generated PHP bootstrap
- seed `src/patterns/grid.php` and `src/patterns/list.php` connected presets that stay tied to the generated variation namespace
- update query-loop onboarding, template registry metadata, and top-level docs so `src/index.ts` owns variation identity/default query while `src/patterns/*.php` owns richer layout presets
- harden the query-loop scaffold test to verify pattern generation, bootstrap wiring, generated README guidance, and PHP syntax validity for the scaffolded PHP files
- add a changeset for the new query-loop preset scaffolds

## Verification

- `bun test packages/wp-typia-project-tools/tests/scaffold-query-loop.test.ts`
- `bun test tests/unit/template-registry.test.ts`
- `bun run --filter @wp-typia/project-tools build`
- `bun run typecheck`
- `bun run format:check`
- `bun run changesets:validate`

Closes #422
