### PR TITLE
Add Query Loop custom query extension seams

### DIFF
--- a/.sampo/changesets/query-loop-custom-query-hooks.md
+++ b/.sampo/changesets/query-loop-custom-query-hooks.md
@@ -1,0 +1,8 @@
+---
+npm/@wp-typia/project-tools: minor
+npm/wp-typia: minor
+---
+
+Add Query Loop custom query extension seams so `wp-typia create --template query-loop`
+now seeds a dedicated `src/query-extension.ts` authoring surface for variation-
+specific query params and optional editor hook registration.

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ The `compound` template creates a parent/child block structure with hidden imple
 
 ### 5. Query Loop variations get a first-class scaffold
 
-The `query-loop` template scaffolds an editor-facing `core/query` variation plugin instead of a standalone block, so you can ship a branded inserter entry with stable namespace identity, default query settings, allowed inspector controls, and inline starter `innerBlocks` without rebuilding the full Query Loop setup flow by hand. It also includes connected `src/patterns/*.php` presets so richer editorial layouts can live in pattern files while `src/index.ts` stays focused on variation identity and query defaults.
+The `query-loop` template scaffolds an editor-facing `core/query` variation plugin instead of a standalone block, so you can ship a branded inserter entry with stable namespace identity, default query settings, allowed inspector controls, and inline starter `innerBlocks` without rebuilding the full Query Loop setup flow by hand. It also includes connected `src/patterns/*.php` presets so richer editorial layouts can live in pattern files while `src/index.ts` stays focused on variation identity and query defaults, plus a dedicated `src/query-extension.ts` seam for custom query params and optional editor-side hook registration.
 
 ## Example flows
 

--- a/packages/wp-typia-project-tools/src/runtime/built-in-block-code-templates/query-loop.ts
+++ b/packages/wp-typia-project-tools/src/runtime/built-in-block-code-templates/query-loop.ts
@@ -1,6 +1,11 @@
 export const QUERY_LOOP_INDEX_TEMPLATE = `import { registerBlockVariation } from '@wordpress/blocks';
 import type { BlockVariation } from '@wp-typia/block-types/blocks/registration';
 import { __ } from '@wordpress/i18n';
+import {
+  getQueryLoopCustomAllowedControls,
+  getQueryLoopCustomQuerySeed,
+  registerQueryLoopEditorExtensions,
+} from './query-extension';
 
 type QueryLoopVariationAttributes = {
   namespace?: string;
@@ -10,6 +15,7 @@ type QueryLoopVariationAttributes = {
     orderBy?: string;
     perPage?: number;
     postType?: string;
+    [key: string]: unknown;
   };
 };
 
@@ -18,6 +24,11 @@ type QueryLoopVariation = BlockVariation<QueryLoopVariationAttributes> & {
 };
 
 const VARIATION_NAME = {{queryVariationNamespaceJson}};
+const DEFAULT_ALLOWED_CONTROLS = {{queryAllowedControlsJson}};
+const customQuerySeed = getQueryLoopCustomQuerySeed();
+const allowedControls = Array.from(
+  new Set([...DEFAULT_ALLOWED_CONTROLS, ...getQueryLoopCustomAllowedControls()]),
+);
 
 const queryLoopVariation = {
   name: VARIATION_NAME,
@@ -33,9 +44,10 @@ const queryLoopVariation = {
       orderBy: 'date',
       perPage: 6,
       postType: {{queryPostTypeJson}},
+      ...customQuerySeed,
     },
   },
-  allowedControls: {{queryAllowedControlsJson}},
+  allowedControls,
   innerBlocks: [
     [
       'core/post-template',
@@ -52,4 +64,5 @@ const queryLoopVariation = {
 } satisfies QueryLoopVariation;
 
 registerBlockVariation('core/query', queryLoopVariation);
+registerQueryLoopEditorExtensions({ variationName: VARIATION_NAME });
 `;

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-onboarding.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-onboarding.ts
@@ -91,7 +91,7 @@ export function getQuickStartWorkflowNote(
 	options: SyncOnboardingOptions = {},
 ): string {
 	if (templateId === "query-loop") {
-		return `${formatRunScript(packageManager, "start")} runs the editor build/watch loop that registers your Query Loop variation in the block editor. This scaffold is editor-facing by design: update \`src/index.ts\` when you want to change the variation namespace, default query, allowed controls, or the minimal inline starter layout, and update \`src/patterns/*.php\` when you want richer connected layout presets in the inserter.`;
+		return `${formatRunScript(packageManager, "start")} runs the editor build/watch loop that registers your Query Loop variation in the block editor. This scaffold is editor-facing by design: update \`src/index.ts\` when you want to change the variation namespace, default query, allowed controls, or the minimal inline starter layout, update \`src/patterns/*.php\` when you want richer connected layout presets in the inserter, and use \`src/query-extension.ts\` when the variation needs custom query params or optional editor-side hooks.`;
 	}
 
 	const developmentScript = getPrimaryDevelopmentScript(templateId);
@@ -122,7 +122,7 @@ export function getOptionalOnboardingNote(
 	options: SyncOnboardingOptions = {},
 ): string {
 	if (templateId === "query-loop") {
-		return `This scaffold does not generate \`block.json\` or Typia manifests. Edit \`src/index.ts\` to change the variation contract, and edit \`src/patterns/*.php\` when you want richer connected layouts beyond the inline fallback. Then rerun ${formatRunScript(packageManager, "build")}, ${formatRunScript(packageManager, "start")}, or ${formatRunScript(packageManager, "typecheck")} as needed.`;
+		return `This scaffold does not generate \`block.json\` or Typia manifests. Edit \`src/index.ts\` to change the variation contract, edit \`src/patterns/*.php\` when you want richer connected layouts beyond the inline fallback, and edit \`src/query-extension.ts\` when you need variation-specific query params or custom editor hooks. Then rerun ${formatRunScript(packageManager, "build")}, ${formatRunScript(packageManager, "start")}, or ${formatRunScript(packageManager, "typecheck")} as needed.`;
 	}
 
 	const optionalSyncScripts = getOptionalSyncScriptNames(templateId, options);
@@ -199,7 +199,7 @@ export function getTemplateSourceOfTruthNote(
 	{ compoundPersistenceEnabled = false }: SyncOnboardingOptions = {},
 ): string {
 	if (templateId === "query-loop") {
-		return "`src/index.ts` remains the source of truth for the Query Loop variation name, default query attributes, `allowedControls`, and the minimal inline starter `innerBlocks`. Use `src/patterns/*.php` for richer connected layout presets that stay tied to the same variation namespace. The generated plugin bootstrap should stay focused on script registration and pattern loading unless you intentionally add frontend/runtime glue in later follow-ups.";
+		return "`src/index.ts` remains the source of truth for the Query Loop variation name, default query attributes, `allowedControls`, and the minimal inline starter `innerBlocks`. Use `src/patterns/*.php` for richer connected layout presets that stay tied to the same variation namespace, and use `src/query-extension.ts` for custom query seed values or optional editor-only hook registration. The generated plugin bootstrap should stay focused on script registration and pattern loading unless you intentionally add frontend/runtime glue in later follow-ups.";
 	}
 
 	if (templateId === "compound") {

--- a/packages/wp-typia-project-tools/src/runtime/template-registry.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-registry.ts
@@ -95,9 +95,9 @@ export const TEMPLATE_REGISTRY = Object.freeze<TemplateDefinition[]>([
 	},
 	{
 		id: "query-loop",
-		description: "A Query Loop block variation scaffold with stable namespace-based identity, inline starter layout, and connected pattern presets",
+		description: "A Query Loop block variation scaffold with stable namespace-based identity, inline starter layout, connected pattern presets, and custom query seams",
 		defaultCategory: getBuiltInTemplateMetadataDefaults("query-loop").category,
-		features: ["core/query variation", "Default innerBlocks", "Connected patterns", "Allowed controls"],
+		features: ["core/query variation", "Default innerBlocks", "Connected patterns", "Custom query hooks", "Allowed controls"],
 		templateDir: path.join(TEMPLATE_ROOT, "query-loop"),
 	},
 	{

--- a/packages/wp-typia-project-tools/templates/query-loop/src/query-extension.ts.mustache
+++ b/packages/wp-typia-project-tools/templates/query-loop/src/query-extension.ts.mustache
@@ -1,0 +1,38 @@
+export type QueryLoopEditorExtensionContext = {
+  variationName: string;
+};
+
+export type QueryLoopCustomQuerySeed = Record<string, unknown>;
+
+/**
+ * Extend the generated Query Loop variation with variation-specific query params.
+ *
+ * Add custom keys here only when the variation should always seed them. Runtime
+ * parity hooks can read the same keys later from the Query Loop `query` object.
+ */
+export function getQueryLoopCustomQuerySeed(): QueryLoopCustomQuerySeed {
+  return {};
+}
+
+/**
+ * Add extra inspector controls by key when your custom query seed needs them.
+ *
+ * Keep the generated defaults in `src/index.ts` and return only the additional
+ * control ids that your variation-specific query params rely on.
+ */
+export function getQueryLoopCustomAllowedControls(): string[] {
+  return [];
+}
+
+/**
+ * Register optional editor-only extension hooks for custom Query Loop params.
+ *
+ * This stays a no-op by default. When you need custom inspector UI, add your
+ * `editor.BlockEdit` filters or other editor hooks here so `src/index.ts` can
+ * keep variation registration focused on identity and default query values.
+ */
+export function registerQueryLoopEditorExtensions(
+  _context: QueryLoopEditorExtensionContext,
+): void {
+  // Add optional editor hooks here when this variation introduces custom query UI.
+}

--- a/packages/wp-typia-project-tools/tests/scaffold-query-loop.test.ts
+++ b/packages/wp-typia-project-tools/tests/scaffold-query-loop.test.ts
@@ -49,6 +49,10 @@ describe("@wp-typia/project-tools scaffold query-loop", () => {
 				path.join(targetDir, "src", "index.ts"),
 				"utf8",
 			);
+			const queryExtensionSource = fs.readFileSync(
+				path.join(targetDir, "src", "query-extension.ts"),
+				"utf8",
+			);
 			const pluginBootstrap = fs.readFileSync(
 				path.join(targetDir, "demo-query-loop.php"),
 				"utf8",
@@ -76,14 +80,24 @@ describe("@wp-typia/project-tools scaffold query-loop", () => {
 			expect(variationSource).toMatch(
 				/registerBlockVariation\('core\/query', queryLoopVariation\);/,
 			);
+			expect(variationSource).toContain("from './query-extension'");
 			expect(variationSource).toMatch(
 				/const VARIATION_NAME = ["']demo-space\/demo-query-loop["'];/,
 			);
 			expect(variationSource).toMatch(/namespace:\s*VARIATION_NAME/);
 			expect(variationSource).toMatch(/postType:\s*["']book["']/);
+			expect(variationSource).toContain(
+				"const customQuerySeed = getQueryLoopCustomQuerySeed();",
+			);
+			expect(variationSource).toContain("...customQuerySeed");
+			expect(variationSource).toContain("registerQueryLoopEditorExtensions({ variationName: VARIATION_NAME })");
 			expect(variationSource).toContain("allowedControls:");
 			expect(variationSource).toMatch(/isActive:\s*\[\s*['"]namespace['"]\s*\]/);
 			expect(variationSource).toMatch(/['"]core\/post-template['"]/);
+			expect(queryExtensionSource).toContain("export function getQueryLoopCustomQuerySeed()");
+			expect(queryExtensionSource).toContain(
+				"export function registerQueryLoopEditorExtensions",
+			);
 			expect(pluginBootstrap).toMatch(/enqueue_block_editor_assets/);
 			expect(pluginBootstrap).toMatch(/wp_register_script\s*\(/);
 			expect(pluginBootstrap).toContain("register_block_pattern_category");
@@ -102,6 +116,7 @@ describe("@wp-typia/project-tools scaffold query-loop", () => {
 				"`src/index.ts` remains the source of truth for the Query Loop variation name",
 			);
 			expect(readme).toContain("Use `src/patterns/*.php` for richer connected layout presets");
+			expect(readme).toContain("use `src/query-extension.ts` for custom query seed values");
 			execFileSync("php", ["-l", path.join(targetDir, "demo-query-loop.php")], {
 				stdio: "ignore",
 			});

--- a/tests/unit/template-registry.test.ts
+++ b/tests/unit/template-registry.test.ts
@@ -86,7 +86,7 @@ describe("template registry runtime helpers", () => {
 				value: "compound",
 			},
 			{
-				hint: "core/query variation, Default innerBlocks, Connected patterns, Allowed controls",
+				hint: "core/query variation, Default innerBlocks, Connected patterns, Custom query hooks, Allowed controls",
 				label: "query-loop",
 				value: "query-loop",
 			},


### PR DESCRIPTION
## Context

The Query Loop scaffold now has a clean pattern-backed layout lane, but custom variation-specific query params still had no dedicated authoring surface. This follow-up adds a small extension seam so the generated scaffold can intentionally layer custom query seeds and optional editor-only hooks without making the default variation registration harder to read.

## What Changed

- add a generated `src/query-extension.ts` file for custom query seeds, extra allowed controls, and optional editor-only hook registration
- update the query-loop variation source to consume the custom query seed, merge extra allowed controls, and call the editor extension registration hook
- widen the generated query attribute typing so custom query params can live alongside the default Query Loop contract
- update query-loop onboarding docs and template metadata so the scaffold clearly separates variation identity, connected patterns, and custom query extension ownership
- extend the query-loop scaffold test to verify the new extension file, variation wiring, README guidance, and generated project outputs
- add a changeset for the new query extension seam

## Verification

- `bun test packages/wp-typia-project-tools/tests/scaffold-query-loop.test.ts`
- `bun test tests/unit/template-registry.test.ts`
- `bun run --filter @wp-typia/project-tools build`
- `bun run typecheck`
- `bun run format:check`
- `bun run changesets:validate`

Closes #417
