### PR TITLE
Fix generated-project smoke CI failure visibility and cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,7 +277,7 @@ jobs:
         run: bun run test:publish-install-smoke
 
   generated-smoke:
-    name: Generated Project Smoke (${{ matrix.package_manager }})
+    name: Generated Project Smoke (${{ matrix.project_name || matrix.example_project }})
     runs-on: ubuntu-latest
     needs: [build, publish-install-smoke]
     strategy:

--- a/scripts/lib/generated-project-smoke-assertions.mjs
+++ b/scripts/lib/generated-project-smoke-assertions.mjs
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { execFileSync } from "node:child_process";
 
 import {
 	hasPhpBinary,
@@ -249,9 +250,22 @@ function lintPhpArtifact(filePath) {
 		return;
 	}
 
-	run("php", ["-l", filePath], {
-		stdio: "ignore",
-	});
+	try {
+		execFileSync("php", ["-l", filePath], {
+			encoding: "utf8",
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+	} catch (error) {
+		const detail =
+			typeof error?.stderr === "string" && error.stderr.trim().length > 0
+				? error.stderr.trim()
+				: typeof error?.stdout === "string" && error.stdout.trim().length > 0
+					? error.stdout.trim()
+					: error instanceof Error
+						? error.message
+						: String(error);
+		throw new Error(`PHP lint failed for ${filePath}:\n${detail}`);
+	}
 }
 
 function assertPluginBootstrapHardening(filePath) {

--- a/scripts/lib/generated-project-smoke-core.mjs
+++ b/scripts/lib/generated-project-smoke-core.mjs
@@ -41,6 +41,15 @@ export function run(command, args, options = {}) {
 	});
 }
 
+export function cleanupTemporaryProjectRoot(tempRoot) {
+	fs.rmSync(tempRoot, {
+		force: true,
+		maxRetries: 5,
+		recursive: true,
+		retryDelay: 100,
+	});
+}
+
 export function getPackageManager(packageManager) {
 	const manager = PACKAGE_MANAGERS[packageManager];
 	if (!manager) {

--- a/scripts/run-generated-project-smoke.mjs
+++ b/scripts/run-generated-project-smoke.mjs
@@ -4,14 +4,13 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-
+import { assertGeneratedProjectScaffold } from "./lib/generated-project-smoke-assertions.mjs";
 import {
 	cleanupTemporaryProjectRoot,
 	ensureCorepackPackageManager,
 	getInstallCommand,
 	getPackageManager,
 	getRunCommand,
-	normalizeBlockSlug,
 	refreshCurrentMigrationSnapshot,
 	rewriteWorkspaceDependencies,
 	run,
@@ -19,12 +18,7 @@ import {
 	runLocalMigrationDoctor,
 	runScaffoldRefreshScripts,
 } from "./lib/generated-project-smoke-core.mjs";
-import {
-	assertGeneratedProjectScaffold,
-} from "./lib/generated-project-smoke-assertions.mjs";
-import {
-	runExampleProjectSmoke,
-} from "./lib/generated-project-smoke-example.mjs";
+import { runExampleProjectSmoke } from "./lib/generated-project-smoke-example.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -273,14 +267,17 @@ function main() {
 		!runtime ||
 		!packageManager ||
 		!projectName ||
-		((!template && !exampleProject) || (template && exampleProject))
+		(!template && !exampleProject) ||
+		(template && exampleProject)
 	) {
 		throw new Error(
 			"Usage: node scripts/run-generated-project-smoke.mjs --runtime <node|bun> (--template <id> | --example-project <slug>) [--variant <name>] [--namespace <value>] [--text-domain <value>] [--php-prefix <value>] [--data-storage <post-meta|custom-table>] [--persistence-policy <authenticated|public>] [--with-migration-ui] [--add-block-name <name> --add-template <basic|interactivity|persistence|compound> [--add-data-storage <post-meta|custom-table>] [--add-persistence-policy <authenticated|public>]] [--add-variation-name <name> --add-variation-block <block-slug>] [--add-pattern-name <name>] [--add-binding-source-name <name>] [--add-hooked-block-slug <block-slug> --add-hooked-block-anchor <anchor-block-name> --add-hooked-block-position <before|after|firstChild|lastChild>] --package-manager <id> --project-name <name>",
 		);
 	}
 
-	const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "wp-typia-generated-smoke-"));
+	const tempRoot = fs.mkdtempSync(
+		path.join(os.tmpdir(), "wp-typia-generated-smoke-"),
+	);
 	const projectDir = path.join(tempRoot, projectName);
 	let primaryError = null;
 
@@ -317,7 +314,8 @@ function main() {
 
 		const packageJsonPath = path.join(projectDir, "package.json");
 		const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
-		const expectedPackageManager = getPackageManager(packageManager).packageManagerField;
+		const expectedPackageManager =
+			getPackageManager(packageManager).packageManagerField;
 		if (packageJson.packageManager !== expectedPackageManager) {
 			throw new Error(
 				`Expected packageManager ${expectedPackageManager}, received ${packageJson.packageManager}`,
@@ -342,30 +340,38 @@ function main() {
 
 		if (addBlockName) {
 			if (!addTemplate) {
-				throw new Error("--add-template is required when --add-block-name is provided.");
+				throw new Error(
+					"--add-template is required when --add-block-name is provided.",
+				);
 			}
 
-			run(runtime, [
-				entryPath,
-				"add",
-				"block",
-				addBlockName,
-				"--template",
-				addTemplate,
-				...(addDataStorage ? ["--data-storage", addDataStorage] : []),
-				...(addPersistencePolicy
-					? ["--persistence-policy", addPersistencePolicy]
-					: []),
-			], {
-				cwd: projectDir,
-			});
+			run(
+				runtime,
+				[
+					entryPath,
+					"add",
+					"block",
+					addBlockName,
+					"--template",
+					addTemplate,
+					...(addDataStorage ? ["--data-storage", addDataStorage] : []),
+					...(addPersistencePolicy
+						? ["--persistence-policy", addPersistencePolicy]
+						: []),
+				],
+				{
+					cwd: projectDir,
+				},
+			);
 
 			runScaffoldRefreshScripts(projectDir, packageManager, packageJson);
 		}
 
 		if (addVariationName) {
 			if (!addVariationBlock) {
-				throw new Error("--add-variation-block is required when --add-variation-name is provided.");
+				throw new Error(
+					"--add-variation-block is required when --add-variation-name is provided.",
+				);
 			}
 
 			run(
@@ -397,7 +403,11 @@ function main() {
 		}
 
 		if (addHookedBlockSlug || addHookedBlockAnchor || addHookedBlockPosition) {
-			if (!addHookedBlockSlug || !addHookedBlockAnchor || !addHookedBlockPosition) {
+			if (
+				!addHookedBlockSlug ||
+				!addHookedBlockAnchor ||
+				!addHookedBlockPosition
+			) {
 				throw new Error(
 					"--add-hooked-block-slug, --add-hooked-block-anchor, and --add-hooked-block-position must be provided together.",
 				);
@@ -429,7 +439,10 @@ function main() {
 			runLocalDoctor(projectDir, runtime);
 		}
 
-		if (withMigrationUi && typeof packageJson.scripts?.["migration:doctor"] === "string") {
+		if (
+			withMigrationUi &&
+			typeof packageJson.scripts?.["migration:doctor"] === "string"
+		) {
 			refreshCurrentMigrationSnapshot(projectDir, runtime);
 			runLocalMigrationDoctor(projectDir, runtime);
 		}
@@ -467,7 +480,10 @@ function main() {
 					`Warning: failed to remove temporary smoke directory ${tempRoot}: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`,
 				);
 			} else {
-				throw cleanupError;
+				console.error(
+					`Failed to remove temporary smoke directory ${tempRoot}: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`,
+				);
+				process.exitCode = 1;
 			}
 		}
 	}

--- a/scripts/run-generated-project-smoke.mjs
+++ b/scripts/run-generated-project-smoke.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
+	cleanupTemporaryProjectRoot,
 	ensureCorepackPackageManager,
 	getInstallCommand,
 	getPackageManager,
@@ -281,6 +282,7 @@ function main() {
 
 	const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "wp-typia-generated-smoke-"));
 	const projectDir = path.join(tempRoot, projectName);
+	let primaryError = null;
 
 	try {
 		ensureCanonicalCliReady();
@@ -453,8 +455,21 @@ function main() {
 			projectName,
 			template,
 		});
+	} catch (error) {
+		primaryError = error;
+		throw error;
 	} finally {
-		fs.rmSync(tempRoot, { force: true, recursive: true });
+		try {
+			cleanupTemporaryProjectRoot(tempRoot);
+		} catch (cleanupError) {
+			if (primaryError) {
+				console.warn(
+					`Warning: failed to remove temporary smoke directory ${tempRoot}: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`,
+				);
+			} else {
+				throw cleanupError;
+			}
+		}
 	}
 }
 

--- a/tests/unit/generated-project-smoke-reference-lane.test.ts
+++ b/tests/unit/generated-project-smoke-reference-lane.test.ts
@@ -36,12 +36,17 @@ test("generated project smoke script supports a reference example lane", () => {
 	expect(assertionHelper).toContain("assertExampleProjectScaffold");
 	expect(assertionHelper).toContain("collectProjectFilePaths");
 	expect(assertionHelper).toContain("PHP lint failed for");
+	expect(assertionHelper).toContain("${filePath}");
+	expect(assertionHelper).toContain("error?.stderr");
+	expect(assertionHelper).toContain("error?.stdout");
 	expect(assertionHelper).toContain('exampleProject === "my-typia-block"');
 	expect(assertionHelper).toContain('path.join(projectDir, "build", "blocks", blockSlug)');
 	expect(coreHelper).toContain(
 		'Expected ${configPath} to declare currentMigrationVersion in a supported format'
 	);
 	expect(coreHelper).toContain("cleanupTemporaryProjectRoot");
+	expect(coreHelper).toContain("maxRetries: 5");
+	expect(coreHelper).toContain("retryDelay: 100");
 	expect(exampleHelper).toContain('Missing "typecheck" script in');
 	expect(exampleHelper).toContain('path.resolve(repoRoot, "examples", exampleProject)');
 });

--- a/tests/unit/generated-project-smoke-reference-lane.test.ts
+++ b/tests/unit/generated-project-smoke-reference-lane.test.ts
@@ -35,11 +35,13 @@ test("generated project smoke script supports a reference example lane", () => {
 	expect(exampleHelper).toContain('devDependencies["@types/node"]');
 	expect(assertionHelper).toContain("assertExampleProjectScaffold");
 	expect(assertionHelper).toContain("collectProjectFilePaths");
+	expect(assertionHelper).toContain("PHP lint failed for");
 	expect(assertionHelper).toContain('exampleProject === "my-typia-block"');
 	expect(assertionHelper).toContain('path.join(projectDir, "build", "blocks", blockSlug)');
 	expect(coreHelper).toContain(
 		'Expected ${configPath} to declare currentMigrationVersion in a supported format'
 	);
+	expect(coreHelper).toContain("cleanupTemporaryProjectRoot");
 	expect(exampleHelper).toContain('Missing "typecheck" script in');
 	expect(exampleHelper).toContain('path.resolve(repoRoot, "examples", exampleProject)');
 });
@@ -56,6 +58,9 @@ test("CI generated smoke matrix includes the checked-in example lanes", () => {
 	expect(ciWorkflow).toContain("smoke-reference-my-typia-block-bun");
 	expect(ciWorkflow).toContain("smoke-example-compound-patterns-bun");
 	expect(ciWorkflow).toContain("smoke-example-persistence-examples-bun");
+	expect(ciWorkflow).toContain(
+		"Generated Project Smoke (${{ matrix.project_name || matrix.example_project }})",
+	);
 	expect(ciWorkflow).toContain('if [ -n "${{ matrix.template || \'\' }}" ]; then');
 	expect(ciWorkflow).toContain('args+=(--template "${{ matrix.template }}")');
 	expect(ciWorkflow).toContain('--example-project "${{ matrix.example_project }}"');


### PR DESCRIPTION
## Context
`main` is failing in `Generated Project Smoke (bun)` before the pending release PR can merge cleanly. The failing lane was reaching a successful compound scaffold build, but the workflow still surfaced only a generic exit code, which made the failure hard to debug and left the smoke cleanup path brittle.

## What Changed
- add retry-aware temporary smoke project cleanup so transient recursive remove races do not fail the step immediately
- make generated PHP lint failures include the exact file path and stderr output instead of exiting silently
- rename generated smoke matrix jobs to include the concrete `project_name` or `example_project` so future failures point at the exact lane
- extend generated smoke boundary coverage to pin the new cleanup helper and CI job naming

## Verification
- `bun test tests/unit/generated-project-smoke-reference-lane.test.ts`
- `node scripts/run-generated-project-smoke.mjs --runtime bun --package-manager bun --project-name smoke-compound-bun-postfix --template compound`
- `bun run typecheck`
- `bun run changesets:validate`

Closes #432

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PHP linting failures now report detailed diagnostic information to help identify issues.
  * Cleanup operations improved to better preserve primary error messages when failures occur.

* **Improvements**
  * CI workflow job names now include more relevant project information for enhanced visibility and debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->