### PR TITLE
Polish Node fallback version output and create/add preflights

### DIFF
--- a/.sampo/changesets/node-fallback-preflight-polish.md
+++ b/.sampo/changesets/node-fallback-preflight-polish.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Make the Node fallback CLI print a normal human-readable `--version` line by default, add earlier create/add preflight diagnostics for mistyped built-in templates and non-empty target directories, and fail `wp-typia add block` with install guidance before workspace dependency resolution errors.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-block.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-block.ts
@@ -62,10 +62,14 @@ import {
 	resolveExternalTemplateLayers,
 } from "./template-layers.js";
 import {
+	formatInstallCommand,
+} from "./package-managers.js";
+import {
 	resolveOptionalInteractiveExternalLayerId,
 } from "./external-layer-selection.js";
 
 const COLLECTION_IMPORT_LINE = "import '../../collection';";
+const WORKSPACE_INSTALL_MARKERS = ["node_modules", ".pnp.cjs", ".pnp.loader.mjs"] as const;
 
 async function ensureCollectionImport(filePath: string): Promise<void> {
 	await patchFile(filePath, (source) => {
@@ -155,6 +159,25 @@ function resolveExternalLayerSourceFromCaller(
 	}
 
 	return path.resolve(callerCwd, source);
+}
+
+function hasInstalledWorkspaceDependencies(projectDir: string): boolean {
+	return WORKSPACE_INSTALL_MARKERS.some((marker) =>
+		fs.existsSync(path.join(projectDir, marker)),
+	);
+}
+
+function assertWorkspaceDependenciesInstalled(workspace: {
+	packageManager: "bun" | "npm" | "pnpm" | "yarn";
+	projectDir: string;
+}): void {
+	if (hasInstalledWorkspaceDependencies(workspace.projectDir)) {
+		return;
+	}
+
+	throw new Error(
+		`Workspace dependencies have not been installed yet. Run \`${formatInstallCommand(workspace.packageManager)}\` from the workspace root before using \`wp-typia add block ...\`.`,
+	);
 }
 
 
@@ -495,6 +518,7 @@ export async function runAddBlockCommand({
 	assertPersistenceFlagsAllowed(resolvedTemplateId, { dataStorageMode, persistencePolicy });
 
 	const workspace = resolveWorkspaceProject(cwd);
+	assertWorkspaceDependenciesInstalled(workspace);
 	const normalizedExternalLayerId = normalizeExternalLayerOption(externalLayerId);
 	const normalizedExternalLayerSource = resolveExternalLayerSourceFromCaller(
 		normalizeExternalLayerOption(externalLayerSource),

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-block.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-block.ts
@@ -69,6 +69,11 @@ import {
 } from "./external-layer-selection.js";
 
 const COLLECTION_IMPORT_LINE = "import '../../collection';";
+// This is a lightweight preflight heuristic for the common install layouts:
+// node_modules for npm/pnpm/bun/yarn-classic and Yarn PnP marker files.
+// It intentionally favors fast user guidance over exhaustive detection, so
+// stale node_modules or hoisted installs outside the workspace root can still
+// fall through to deeper resolver errors.
 const WORKSPACE_INSTALL_MARKERS = ["node_modules", ".pnp.cjs", ".pnp.loader.mjs"] as const;
 
 async function ensureCollectionImport(filePath: string): Promise<void> {
@@ -491,7 +496,8 @@ export async function seedWorkspaceMigrationProject(
  * succeeds.
  * @throws {Error} When the template id is unknown, persistence flags are used
  * with unsupported templates, the command runs outside an official workspace,
- * or target block paths already exist.
+ * workspace dependencies have not been installed yet, or target block paths
+ * already exist.
  */
 export async function runAddBlockCommand({
 	blockName,

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-answer-resolution.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-answer-resolution.ts
@@ -1,3 +1,5 @@
+import { execSync } from 'node:child_process';
+
 import {
   PACKAGE_MANAGER_IDS,
   getPackageManager,
@@ -31,6 +33,11 @@ import type {
 } from './scaffold.js';
 
 const WORKSPACE_TEMPLATE_ALIAS = 'workspace';
+const TEMPLATE_SELECTION_HINT = `--template <${[
+  ...TEMPLATE_IDS,
+  WORKSPACE_TEMPLATE_ALIAS,
+].join('|')}|./path|github:owner/repo/path[#ref]|npm-package>`;
+const TEMPLATE_SUGGESTION_IDS = [...TEMPLATE_IDS, WORKSPACE_TEMPLATE_ALIAS] as const;
 
 /**
  * Detect the current author name from local Git config.
@@ -109,6 +116,84 @@ function normalizeTemplateSelection(templateId: string): string {
     : templateId;
 }
 
+function looksLikeExplicitExternalTemplateLocator(templateId: string): boolean {
+  return (
+    templateId.startsWith('./') ||
+    templateId.startsWith('../') ||
+    templateId.startsWith('/') ||
+    templateId.startsWith('@') ||
+    templateId.startsWith('github:') ||
+    templateId.includes('/')
+  );
+}
+
+function getEditDistance(left: string, right: string): number {
+  const previous = Array.from({ length: right.length + 1 }, (_, index) => index);
+  const current = new Array<number>(right.length + 1);
+
+  for (let leftIndex = 0; leftIndex < left.length; leftIndex += 1) {
+    current[0] = leftIndex + 1;
+
+    for (let rightIndex = 0; rightIndex < right.length; rightIndex += 1) {
+      const substitutionCost = left[leftIndex] === right[rightIndex] ? 0 : 1;
+      current[rightIndex + 1] = Math.min(
+        current[rightIndex] + 1,
+        previous[rightIndex + 1] + 1,
+        previous[rightIndex] + substitutionCost,
+      );
+    }
+
+    for (let index = 0; index < current.length; index += 1) {
+      previous[index] = current[index] as number;
+    }
+  }
+
+  return previous[right.length] as number;
+}
+
+function findMistypedBuiltInTemplateSuggestion(templateId: string): string | null {
+  const normalizedTemplateId = templateId.trim().toLowerCase();
+  if (
+    normalizedTemplateId.length === 0 ||
+    looksLikeExplicitExternalTemplateLocator(normalizedTemplateId)
+  ) {
+    return null;
+  }
+
+  let bestCandidate: { distance: number; id: string } | null = null;
+
+  for (const candidateId of TEMPLATE_SUGGESTION_IDS) {
+    const distance = getEditDistance(normalizedTemplateId, candidateId);
+    if (
+      bestCandidate === null ||
+      distance < bestCandidate.distance
+    ) {
+      bestCandidate = {
+        distance,
+        id: candidateId,
+      };
+    }
+  }
+
+  return bestCandidate && bestCandidate.distance <= 2
+    ? bestCandidate.id
+    : null;
+}
+
+function getMistypedBuiltInTemplateMessage(templateId: string): string | null {
+  const suggestion = findMistypedBuiltInTemplateSuggestion(templateId);
+  if (!suggestion) {
+    return null;
+  }
+
+  const suggestionDescription =
+    suggestion === WORKSPACE_TEMPLATE_ALIAS
+      ? 'official workspace scaffold'
+      : 'built-in scaffold';
+
+  return `Unknown template "${templateId}". Did you mean "${suggestion}"? Use \`--template ${suggestion}\` for the ${suggestionDescription}, or pass a local path, \`github:owner/repo/path[#ref]\`, or an npm package spec for an external template.`;
+}
+
 /**
  * Resolve the scaffold template id from flags, defaults, and interactive selection.
  *
@@ -126,8 +211,15 @@ export async function resolveTemplateId({
     if (isRemovedBuiltInTemplateId(templateId)) {
       throw new Error(getRemovedBuiltInTemplateMessage(templateId));
     }
+    if (normalizedTemplateId === OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE) {
+      return normalizedTemplateId;
+    }
     if (isBuiltInTemplateId(normalizedTemplateId)) {
       return getTemplateById(normalizedTemplateId).id;
+    }
+    const mistypedBuiltInTemplateMessage = getMistypedBuiltInTemplateMessage(templateId);
+    if (mistypedBuiltInTemplateMessage) {
+      throw new Error(mistypedBuiltInTemplateMessage);
     }
     return normalizedTemplateId;
   }
@@ -138,7 +230,7 @@ export async function resolveTemplateId({
 
   if (!isInteractive || !selectTemplate) {
     throw new Error(
-      `Template is required in non-interactive mode. Use --template <${TEMPLATE_IDS.join('|')}|./path|github:owner/repo/path[#ref]|npm-package>.`,
+      `Template is required in non-interactive mode. Use ${TEMPLATE_SELECTION_HINT}.`,
     );
   }
 
@@ -246,4 +338,3 @@ export async function collectScaffoldAnswers({
     title: await promptText('Block title', toTitleCase(identifiers.slug)),
   };
 }
-import { execSync } from 'node:child_process';

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-apply-utils.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-apply-utils.ts
@@ -28,6 +28,9 @@ import {
 	stringifyStarterManifest,
 } from "./starter-manifests.js";
 import {
+	formatNonEmptyTargetDirectoryError,
+} from "./scaffold-bootstrap.js";
+import {
 	stringifyBuiltInBlockJsonDocument,
 	type BuiltInBlockArtifact,
 } from "./built-in-block-artifacts.js";
@@ -94,7 +97,7 @@ export async function ensureDirectory(targetDir: string, allowExisting = false):
 
 	const entries = await fsp.readdir(targetDir);
 	if (entries.length > 0) {
-		throw new Error(`Target directory is not empty: ${targetDir}`);
+		throw new Error(formatNonEmptyTargetDirectoryError(targetDir));
 	}
 }
 

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-bootstrap.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-bootstrap.ts
@@ -55,6 +55,13 @@ export async function ensureScaffoldDirectory(
 	}
 }
 
+/**
+ * Format the actionable error message used when a scaffold target directory
+ * already exists and is not empty.
+ *
+ * @param targetDir Absolute path to the target directory being evaluated.
+ * @returns A human-readable error string with next-step guidance.
+ */
 export function formatNonEmptyTargetDirectoryError(targetDir: string): string {
 	return `Target directory is not empty: ${targetDir}. Choose a new project directory, or empty this directory before rerunning the scaffold.`;
 }

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-bootstrap.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-bootstrap.ts
@@ -51,8 +51,12 @@ export async function ensureScaffoldDirectory(
 
 	const entries = await fsp.readdir(targetDir);
 	if (entries.length > 0) {
-		throw new Error(`Target directory is not empty: ${targetDir}`);
+		throw new Error(formatNonEmptyTargetDirectoryError(targetDir));
 	}
+}
+
+export function formatNonEmptyTargetDirectoryError(targetDir: string): string {
+	return `Target directory is not empty: ${targetDir}. Choose a new project directory, or empty this directory before rerunning the scaffold.`;
 }
 
 /**

--- a/packages/wp-typia-project-tools/tests/cli-entry.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-entry.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, describe, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { cleanupScaffoldTempRoot, createBlockSubsetFixturePath, createScaffoldTempRoot, entryPath, getCommandErrorMessage, runCapturedCli, runCli, templateLayerAmbiguousFixturePath, templateLayerFixturePath } from "./helpers/scaffold-test-harness.js";
+import { cleanupScaffoldTempRoot, createBlockSubsetFixturePath, createScaffoldTempRoot, entryPath, getCommandErrorMessage, runCapturedCli, runCli, scaffoldOfficialWorkspace, templateLayerAmbiguousFixturePath, templateLayerFixturePath } from "./helpers/scaffold-test-harness.js";
 import { formatHelpText, getDoctorChecks, getNextSteps, getOptionalOnboarding, runScaffoldFlow } from "../src/runtime/cli-core.js";
 import { collectScaffoldAnswers } from "../src/runtime/scaffold.js";
 import { getQuickStartWorkflowNote } from "../src/runtime/scaffold-onboarding.js";
@@ -414,6 +414,21 @@ test("runScaffoldFlow rejects removed built-in template ids", async () => {
   );
 });
 
+test("runScaffoldFlow rejects mistyped built-in template ids before external lookup noise", async () => {
+  await expect(
+    runScaffoldFlow({
+      cwd: tempRoot,
+      noInstall: true,
+      packageManager: "npm",
+      projectInput: "demo-mistyped-template",
+      templateId: "basicc",
+      yes: true,
+    })
+  ).rejects.toThrow(
+    'Unknown template "basicc". Did you mean "basic"? Use `--template basic` for the built-in scaffold'
+  );
+});
+
 test("runScaffoldFlow rejects external layers for non-built-in templates", async () => {
   await expect(
     runScaffoldFlow({
@@ -815,6 +830,43 @@ test("node entry warns about awkward project directory names", () => {
   expect(result.stderr).toContain(
     'Project directory "node cool block!" contains shell-sensitive characters (!).'
   );
+});
+
+test("node entry rejects non-empty target directories with actionable guidance", () => {
+  const targetDir = path.join(tempRoot, "node-non-empty-target");
+  fs.mkdirSync(targetDir, { recursive: true });
+  fs.writeFileSync(path.join(targetDir, "existing.txt"), "already here\n", "utf8");
+
+  const errorMessage = getCommandErrorMessage(() =>
+    runCli("node", [entryPath, "create", targetDir, "--template", "basic", "--yes"], {
+      stdio: "pipe",
+    })
+  );
+
+  expect(errorMessage).toContain(`Target directory is not empty: ${targetDir}.`);
+  expect(errorMessage).toContain("Choose a new project directory");
+  expect(errorMessage).toContain("empty this directory before rerunning the scaffold");
+});
+
+test("node entry rejects add block before workspace dependencies are installed", async () => {
+  const targetDir = path.join(tempRoot, "node-workspace-add-without-install");
+
+  await scaffoldOfficialWorkspace(targetDir);
+
+  const errorMessage = getCommandErrorMessage(() =>
+    runCli(
+      "node",
+      [entryPath, "add", "block", "counter-card", "--template", "basic"],
+      {
+        cwd: targetDir,
+        stdio: "pipe",
+      }
+    )
+  );
+
+  expect(errorMessage).toContain("Workspace dependencies have not been installed yet.");
+  expect(errorMessage).toContain("Run `npm install` from the workspace root");
+  expect(errorMessage).toContain("`wp-typia add block ...`");
 });
 
 test("node entry rejects missing values for identifier override flags", () => {

--- a/packages/wp-typia-project-tools/tests/cli-entry.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-entry.test.ts
@@ -838,9 +838,13 @@ test("node entry rejects non-empty target directories with actionable guidance",
   fs.writeFileSync(path.join(targetDir, "existing.txt"), "already here\n", "utf8");
 
   const errorMessage = getCommandErrorMessage(() =>
-    runCli("node", [entryPath, "create", targetDir, "--template", "basic", "--yes"], {
-      stdio: "pipe",
-    })
+    runCli(
+      "node",
+      [entryPath, "create", targetDir, "--template", "basic", "--yes", "--no-install"],
+      {
+        stdio: "pipe",
+      }
+    )
   );
 
   expect(errorMessage).toContain(`Target directory is not empty: ${targetDir}.`);

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -348,21 +348,28 @@ function renderAddHelp() {
 	]);
 }
 
-function renderVersion() {
-	printLine(
-		JSON.stringify(
-			{
-				ok: true,
-				data: {
-					type: "version",
-					name: packageJson.name,
-					version: packageJson.version,
+function renderVersion(options: {
+	format?: string;
+} = {}) {
+	if (options.format === "json") {
+		printLine(
+			JSON.stringify(
+				{
+					ok: true,
+					data: {
+						type: "version",
+						name: packageJson.name,
+						version: packageJson.version,
+					},
 				},
-			},
-			null,
-			2,
-		),
-	);
+				null,
+				2,
+			),
+		);
+		return;
+	}
+
+	printLine(`wp-typia ${packageJson.version}`);
 }
 
 function renderTemplatesJson(flags: GlobalFlags, subcommand: string) {
@@ -469,7 +476,9 @@ export async function runNodeCli(argv = process.argv.slice(2)): Promise<void> {
 	}
 
 	if (versionRequested) {
-		renderVersion();
+		renderVersion({
+			format: typeof rawMergedFlags.format === "string" ? rawMergedFlags.format : undefined,
+		});
 		return;
 	}
 

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -199,8 +199,14 @@ describe("wp-typia package", () => {
 		expect(addHelpOutput).toContain("--external-layer-id");
 	});
 
-	test("returns structured version output through the canonical bin", () => {
+	test("renders a human-readable version line through the canonical bin", () => {
 		const output = runUtf8Command("node", [entryPath, "--version"]);
+
+		expect(output.trim()).toBe(`wp-typia ${packageManifest.version}`);
+	});
+
+	test("keeps structured version output opt-in through --format json", () => {
+		const output = runUtf8Command("node", [entryPath, "--version", "--format", "json"]);
 		const parsed = parseJsonObjectFromOutput<{
 			data?: { name?: string; type?: string; version?: string };
 			ok?: boolean;
@@ -212,21 +218,14 @@ describe("wp-typia package", () => {
 		expect(parsed.data?.version).toBe(packageManifest.version);
 	});
 
-	test("runs the published version path without requiring a local Bun binary", () => {
+	test("runs the published human-readable version path without requiring a local Bun binary", () => {
 		const result = runCapturedCommand(process.execPath, [entryPath, "--version"], {
 			env: withoutLocalBunEnv(),
 		});
 
 		expect(result.status).toBe(0);
 		expect(result.stderr).toBe("");
-		const parsed = parseJsonObjectFromOutput<{
-			data?: { name?: string; type?: string; version?: string };
-			ok?: boolean;
-		}>(result.stdout);
-		expect(parsed.ok).toBe(true);
-		expect(parsed.data?.type).toBe("version");
-		expect(parsed.data?.name).toBe("wp-typia");
-		expect(parsed.data?.version).toBe(packageManifest.version);
+		expect(result.stdout.trim()).toBe(`wp-typia ${packageManifest.version}`);
 	});
 
 	test("renders general and command help without requiring a local Bun binary", () => {

--- a/scripts/run-publish-install-smoke.mjs
+++ b/scripts/run-publish-install-smoke.mjs
@@ -217,11 +217,23 @@ withTempDir("wp-typia-publish-install-smoke-", (tempRoot) => {
 		cwd: projectDir,
 		env: createNodeOnlyEnv(),
 	}).trim();
+	if (!versionOutput.startsWith("wp-typia ")) {
+		throw new Error(`Unexpected human-readable wp-typia --version output: ${versionOutput}`);
+	}
+
+	const versionJsonOutput = run(
+		process.execPath,
+		[cliPath, "--version", "--format", "json"],
+		{
+			cwd: projectDir,
+			env: createNodeOnlyEnv(),
+		},
+	).trim();
 	let parsed;
 	try {
-		parsed = JSON.parse(versionOutput);
+		parsed = JSON.parse(versionJsonOutput);
 	} catch {
-		throw new Error(`wp-typia --version did not return JSON: ${versionOutput}`);
+		throw new Error(`wp-typia --version --format json did not return JSON: ${versionJsonOutput}`);
 	}
 
 	if (
@@ -230,7 +242,7 @@ withTempDir("wp-typia-publish-install-smoke-", (tempRoot) => {
 		parsed.data?.type !== "version" ||
 		typeof parsed.data.version !== "string"
 	) {
-		throw new Error(`Unexpected wp-typia --version output: ${versionOutput}`);
+		throw new Error(`Unexpected wp-typia --version --format json output: ${versionJsonOutput}`);
 	}
 
 	const completionsOutput = run(process.execPath, [cliPath, "completions", "bash"], {


### PR DESCRIPTION
## Context

This bundles #443 and #444 together because both changes live on the Node fallback and early create/add diagnostic surface.

The first half fixes the default npm/Node-first CLI experience so `wp-typia --version` behaves like a normal human-readable command instead of defaulting to structured JSON. The second half tightens create/add preflight failures so users get actionable guidance before they fall through into lower-level lookup or module-resolution noise.

## What Changed

- made the Node fallback print `wp-typia <version>` for the default `--version` path while preserving `--format json` as the explicit machine-readable version mode
- updated the published-install smoke and package tests to lock both the human-readable default and JSON opt-in behavior
- rejected mistyped built-in template ids like `--template basicc` earlier with a direct suggestion before external template lookup kicks in
- improved non-empty target-directory failures so scaffold runs tell users to choose a new directory or empty the existing one first
- added an early `wp-typia add block` install preflight so fresh workspaces fail with `npm install` guidance instead of deeper dependency-resolution errors
- added a patch changeset for `@wp-typia/project-tools` and `wp-typia`

## Verification

- `bun run --filter @wp-typia/project-tools build`
- `bun run --filter wp-typia build`
- `bun test packages/wp-typia/tests/cli-package.test.ts`
- `bun test packages/wp-typia-project-tools/tests/cli-entry.test.ts`
- `bun run typecheck`
- `bun run changesets:validate`
- `node scripts/run-publish-install-smoke.mjs`

Closes #443
Closes #444


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Machine-readable version output now available with `--format json` flag

* **Bug Fixes**
  * Default `--version` output now displays human-readable format
  * Preflight validation runs earlier with improved error messages
  * Added "Did you mean..." suggestions for mistyped template names
  * `add block` command fails early with installation guidance when workspace dependencies are missing
  * Clearer messaging when target directory is non-empty

<!-- end of auto-generated comment: release notes by coderabbit.ai -->