### PR TITLE
Improve template discovery output and inspect ergonomics

### DIFF
--- a/.sampo/changesets/template-discovery-ergonomics.md
+++ b/.sampo/changesets/template-discovery-ergonomics.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Improve human-readable `templates list` and `templates inspect` output with clearer flag capability hints, workspace alias discoverability, and logical layer summaries that do not expose raw internal template paths by default.

--- a/packages/wp-typia-project-tools/src/runtime/cli-templates.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-templates.ts
@@ -1,11 +1,13 @@
-import { getBuiltInTemplateLayerDirs } from "./template-builtins.js";
 import {
+	OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE,
 	getTemplateById,
 	getTemplateSelectOptions,
 	isBuiltInTemplateId,
 	listTemplates,
 } from "./template-registry.js";
 import type { TemplateDefinition } from "./template-registry.js";
+
+const WORKSPACE_TEMPLATE_ALIAS = "workspace";
 
 /**
  * Format one line of template list output for a built-in template.
@@ -18,65 +20,114 @@ export function formatTemplateSummary(template: TemplateDefinition): string {
 }
 
 /**
- * Format the feature hint line shown under a template summary.
+ * Format the feature and capability hint lines shown under a template summary.
  *
  * @param template Template metadata including the `features` list.
- * @returns Indented feature text for CLI list output.
+ * @returns Indented feature and capability text for CLI list output.
  */
 export function formatTemplateFeatures(template: TemplateDefinition): string {
-	return `  ${template.features.join(" • ")}`;
+	const lines = [`  Features: ${template.features.join(" • ")}`];
+	const capabilityHints = getTemplateCapabilityHints(template);
+	if (capabilityHints.length > 0) {
+		lines.push(`  Supports: ${capabilityHints.join(" • ")}`);
+	}
+	if (template.id === OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE) {
+		lines.push(
+			`  Alias: ${WORKSPACE_TEMPLATE_ALIAS} (\`--template ${WORKSPACE_TEMPLATE_ALIAS}\`)`,
+		);
+	}
+	return lines.join("\n");
 }
 
 /**
  * Format the detailed template description for `templates inspect`.
  *
  * This expands special layer combinations for the `persistence` and `compound`
- * templates and returns a multi-line block including category, overlay path,
- * resolved layers, and feature labels.
+ * templates and returns a multi-line block centered on human-facing identity,
+ * capabilities, and logical layer composition.
  *
  * @param template Template metadata including `id`, `defaultCategory`,
  * `templateDir`, and `features`.
  * @returns Multi-line template details text for CLI output.
  */
 export function formatTemplateDetails(template: TemplateDefinition): string {
-	if (!isBuiltInTemplateId(template.id)) {
-		return [
-			template.id,
-			template.description,
-			`Category: ${template.defaultCategory}`,
-			`Overlay path: ${template.templateDir}`,
-			"Layers: workspace package scaffold",
-			`Features: ${template.features.join(", ")}`,
-		].join("\n");
+	const detailLines = [
+		template.id,
+		`Summary: ${template.description}`,
+		...getTemplateIdentityLines(template),
+		`Category: ${template.defaultCategory}`,
+	];
+	const capabilityHints = getTemplateCapabilityHints(template);
+	if (capabilityHints.length > 0) {
+		detailLines.push("Capabilities:");
+		for (const capabilityHint of capabilityHints) {
+			detailLines.push(`  - ${capabilityHint}`);
+		}
+	}
+	detailLines.push("Logical layers:");
+	for (const logicalLayer of getTemplateLogicalLayerSummaries(template)) {
+		detailLines.push(`  - ${logicalLayer}`);
+	}
+	detailLines.push(`Features: ${template.features.join(", ")}`);
+
+	return detailLines.join("\n");
+}
+
+function getTemplateCapabilityHints(template: TemplateDefinition): string[] {
+	if (template.id === "persistence" || template.id === "compound") {
+		return ["--data-storage", "--persistence-policy", "external layers"];
+	}
+	if (template.id === "query-loop") {
+		return ["--query-post-type", "external layers"];
+	}
+	if (isBuiltInTemplateId(template.id)) {
+		return ["external layers"];
 	}
 
-	const layers =
-		template.id === "persistence"
-			? [
-					`authenticated: ${getBuiltInTemplateLayerDirs(template.id, { persistencePolicy: "authenticated" }).join(" -> ")}`,
-					`public: ${getBuiltInTemplateLayerDirs(template.id, { persistencePolicy: "public" }).join(" -> ")}`,
-				]
-			: template.id === "compound"
-				? [
-						`pure: ${getBuiltInTemplateLayerDirs(template.id).join(" -> ")}`,
-						`authenticated+persistence: ${getBuiltInTemplateLayerDirs(template.id, {
-							persistenceEnabled: true,
-							persistencePolicy: "authenticated",
-						}).join(" -> ")}`,
-						`public+persistence: ${getBuiltInTemplateLayerDirs(template.id, {
-							persistenceEnabled: true,
-							persistencePolicy: "public",
-						}).join(" -> ")}`,
-					]
-				: [getBuiltInTemplateLayerDirs(template.id).join(" -> ")];
+	return [];
+}
+
+function getTemplateIdentityLines(template: TemplateDefinition): string[] {
+	if (template.id === OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE) {
+		return [
+			"Identity:",
+			`  - Official package: ${OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE}`,
+			`  - Alias: ${WORKSPACE_TEMPLATE_ALIAS} (\`--template ${WORKSPACE_TEMPLATE_ALIAS}\`)`,
+			"Type: official workspace scaffold",
+		];
+	}
+
 	return [
-		template.id,
-		template.description,
-		`Category: ${template.defaultCategory}`,
-		`Overlay path: ${template.templateDir}`,
-		`Layers: ${layers.join("\n")}`,
-		`Features: ${template.features.join(", ")}`,
-	].join("\n");
+		"Identity:",
+		`  - Built-in template id: ${template.id}`,
+		"Type: built-in block scaffold",
+	];
+}
+
+function getTemplateLogicalLayerSummaries(template: TemplateDefinition): string[] {
+	if (!isBuiltInTemplateId(template.id)) {
+		return ["workspace package scaffold"];
+	}
+
+	if (template.id === "persistence") {
+		return [
+			"authenticated write policy: shared/base -> rest helpers (shared) -> persistence core -> authenticated write policy -> persistence overlay",
+			"public write policy: shared/base -> rest helpers (shared) -> persistence core -> public write policy -> persistence overlay",
+		];
+	}
+
+	if (template.id === "compound") {
+		return [
+			"pure block family: shared/base -> compound core -> compound overlay",
+			"authenticated persistence: shared/base -> compound core -> rest helpers (shared) -> compound persistence core -> authenticated write policy -> compound overlay",
+			"public persistence: shared/base -> compound core -> rest helpers (shared) -> compound persistence core -> public write policy -> compound overlay",
+		];
+	}
+
+	const overlayName = template.id === "query-loop" ? "query-loop overlay" : `${template.id} overlay`;
+	return [
+		`shared/base -> ${overlayName}`,
+	];
 }
 
 export { getTemplateById, getTemplateSelectOptions, listTemplates };

--- a/packages/wp-typia-project-tools/tests/cli-templates.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-templates.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+	formatTemplateDetails,
+	formatTemplateFeatures,
+	getTemplateById,
+} from "../src/runtime/cli-templates.js";
+
+describe("@wp-typia/project-tools template discovery formatting", () => {
+	test("list output surfaces flag hints for persistence and query-loop templates", () => {
+		expect(formatTemplateFeatures(getTemplateById("persistence"))).toContain(
+			"Supports: --data-storage • --persistence-policy • external layers",
+		);
+		expect(formatTemplateFeatures(getTemplateById("query-loop"))).toContain(
+			"Supports: --query-post-type • external layers",
+		);
+	});
+
+	test("workspace template discovery surfaces the workspace alias", () => {
+		expect(
+			formatTemplateFeatures(getTemplateById("@wp-typia/create-workspace-template")),
+		).toContain("Alias: workspace (`--template workspace`)");
+	});
+
+	test("inspect output prefers logical layer summaries over raw overlay paths", () => {
+		const basicDetails = formatTemplateDetails(getTemplateById("basic"));
+		const workspaceDetails = formatTemplateDetails(
+			getTemplateById("@wp-typia/create-workspace-template"),
+		);
+
+		expect(basicDetails).toContain("Identity:");
+		expect(basicDetails).toContain("Built-in template id: basic");
+		expect(basicDetails).toContain("Logical layers:");
+		expect(basicDetails).toContain("shared/base -> basic overlay");
+		expect(basicDetails).not.toContain("Overlay path:");
+		expect(basicDetails).not.toContain("/templates/basic");
+
+		expect(workspaceDetails).toContain("Official package: @wp-typia/create-workspace-template");
+		expect(workspaceDetails).toContain("Alias: workspace (`--template workspace`)");
+		expect(workspaceDetails).toContain("workspace package scaffold");
+		expect(workspaceDetails).not.toContain("Overlay path:");
+	});
+});

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -812,6 +812,39 @@ describe("wp-typia package", () => {
 		).toBe(true);
 	});
 
+	test("renders human-readable template discovery hints for flags and workspace aliasing", () => {
+		const output = runUtf8Command("node", [entryPath, "templates", "list"]);
+
+		expect(output).toContain(
+			"Supports: --data-storage • --persistence-policy • external layers",
+		);
+		expect(output).toContain("Supports: --query-post-type • external layers");
+		expect(output).toContain("Alias: workspace (`--template workspace`)");
+	});
+
+	test("keeps human-readable template inspect output focused on logical layers", () => {
+		const basicOutput = runUtf8Command("node", [entryPath, "templates", "inspect", "basic"]);
+		const workspaceOutput = runUtf8Command("node", [
+			entryPath,
+			"templates",
+			"inspect",
+			"@wp-typia/create-workspace-template",
+		]);
+
+		expect(basicOutput).toContain("Identity:");
+		expect(basicOutput).toContain("Built-in template id: basic");
+		expect(basicOutput).toContain("Logical layers:");
+		expect(basicOutput).toContain("shared/base -> basic overlay");
+		expect(basicOutput).not.toContain("Overlay path:");
+		expect(basicOutput).not.toContain("/templates/basic");
+
+		expect(workspaceOutput).toContain(
+			"Official package: @wp-typia/create-workspace-template",
+		);
+		expect(workspaceOutput).toContain("Alias: workspace (`--template workspace`)");
+		expect(workspaceOutput).not.toContain("Overlay path:");
+	});
+
 	test("stops parsing global flags after -- in the Node fallback", () => {
 		const parsed = parseGlobalFlags(["templates", "list", "--", "--format"]);
 


### PR DESCRIPTION
## Context

This closes #445 by tightening the human-facing `templates list` and `templates inspect` output.

The previous discovery surface exposed raw overlay paths too directly and still made it harder than necessary to answer three practical questions from the terminal alone:

- which template families support persistence-only or query-loop-only flags
- how the official workspace package relates to the `workspace` shorthand
- what the logical template/layer shape looks like without reading internal file-system paths

## What Changed

- updated human-readable `templates list` output so each template now shows `Features:` plus capability hints such as `--data-storage`, `--persistence-policy`, `--query-post-type`, and external-layer support where relevant
- made the official workspace template surface its alias directly in discovery output as `workspace (--template workspace)`
- rewrote human-readable `templates inspect` output around `Summary`, `Identity`, `Capabilities`, and `Logical layers` instead of raw overlay-path-first output
- kept the machine-readable JSON discovery path unchanged so existing structured consumers still see the raw registry objects
- added direct `cli-templates` helper coverage plus canonical CLI regression coverage for the new human-readable discovery output
- added a patch changeset for `@wp-typia/project-tools` and `wp-typia`

## Verification

- `bun run --filter @wp-typia/project-tools build`
- `bun run --filter wp-typia build`
- `bun test packages/wp-typia-project-tools/tests/cli-templates.test.ts packages/wp-typia/tests/cli-package.test.ts`
- `bun run typecheck`
- `bun run changesets:validate`

Closes #445
