### PR TITLE
Add scaffold progress reporting for long-running create flows

### DIFF
--- a/.sampo/changesets/scaffold-progress-status-reporting.md
+++ b/.sampo/changesets/scaffold-progress-status-reporting.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Add user-visible progress reporting for longer `wp-typia create` scaffold phases so fallback CLI runs and alternate-buffer create flows more clearly show template resolution, file generation, artifact seeding, finalization, and dependency installation work while scaffolding is in progress.

--- a/packages/wp-typia-project-tools/src/runtime/block-generator-service-core.ts
+++ b/packages/wp-typia-project-tools/src/runtime/block-generator-service-core.ts
@@ -359,6 +359,7 @@ export class BlockGeneratorService {
 	async apply({
 		rendered,
 		installDependencies,
+		onProgress,
 	}: ApplyBlockInput): Promise<ScaffoldProjectResult> {
 		const cachedArtifacts = renderedArtifactCache.get(rendered);
 		const currentVariablesFingerprint = createVariablesFingerprint(
@@ -388,6 +389,7 @@ export class BlockGeneratorService {
 				codeArtifacts,
 				installDependencies,
 				noInstall: rendered.target.noInstall,
+				onProgress,
 				packageManager: rendered.target.packageManager,
 				projectDir: rendered.target.projectDir,
 				repositoryReference: rendered.target.repositoryReference,

--- a/packages/wp-typia-project-tools/src/runtime/block-generator-service-spec.ts
+++ b/packages/wp-typia-project-tools/src/runtime/block-generator-service-spec.ts
@@ -23,6 +23,7 @@ import type {
 	DataStorageMode,
 	PersistencePolicy,
 	ScaffoldAnswers,
+	ScaffoldProgressEvent,
 	ScaffoldTemplateVariables,
 } from "./scaffold.js";
 
@@ -138,6 +139,7 @@ export interface RenderBlockResult extends ValidateBlockResult {
 export interface ApplyBlockInput {
 	rendered: RenderBlockResult;
 	installDependencies?: ((options: InstallDependenciesOptions) => Promise<void>) | undefined;
+	onProgress?: ((event: ScaffoldProgressEvent) => void | Promise<void>) | undefined;
 }
 
 function getBuiltInPersistenceSpec({

--- a/packages/wp-typia-project-tools/src/runtime/cli-scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-scaffold.ts
@@ -15,7 +15,11 @@ import {
 	formatInstallCommand,
 	formatRunScript,
 } from "./package-managers.js";
-import type { DataStorageMode, PersistencePolicy } from "./scaffold.js";
+import type {
+	DataStorageMode,
+	PersistencePolicy,
+	ScaffoldProgressEvent,
+} from "./scaffold.js";
 import type { PackageManagerId } from "./package-managers.js";
 import { getPrimaryDevelopmentScript } from "./local-dev-presets.js";
 import {
@@ -62,6 +66,7 @@ interface RunScaffoldFlowOptions {
 	isInteractive?: boolean;
 	namespace?: string;
 	noInstall?: boolean;
+	onProgress?: ((event: ScaffoldProgressEvent) => void | Promise<void>) | undefined;
 	packageManager?: string;
 	phpPrefix?: string;
 	projectInput: string;
@@ -342,6 +347,7 @@ export async function runScaffoldFlow({
 	queryPostType,
 	yes = false,
 	noInstall = false,
+	onProgress,
 	isInteractive = false,
 	allowExistingDir = false,
 	selectTemplate,
@@ -475,6 +481,7 @@ export async function runScaffoldFlow({
 			externalLayerSourceLabel: normalizedExternalLayerSource,
 			installDependencies,
 			noInstall,
+			onProgress,
 			packageManager: resolvedPackageManager,
 			persistencePolicy: resolvedPersistencePolicy,
 			projectDir,

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-apply-utils.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-apply-utils.ts
@@ -52,6 +52,7 @@ import {
 	resolveScaffoldRepositoryReference,
 } from "./scaffold-repository-reference.js";
 import type {
+	ScaffoldProgressEvent,
 	ScaffoldTemplateVariables,
 } from "./scaffold.js";
 
@@ -64,6 +65,15 @@ export {
 export interface InstallDependenciesOptions {
 	packageManager: PackageManagerId;
 	projectDir: string;
+}
+
+async function reportScaffoldProgress(
+	onProgress:
+		| ((event: ScaffoldProgressEvent) => void | Promise<void>)
+		| undefined,
+	event: ScaffoldProgressEvent,
+): Promise<void> {
+	await onProgress?.(event);
 }
 
 interface GeneratedPackageJson {
@@ -427,6 +437,7 @@ export async function applyBuiltInScaffoldProjectFiles({
 	noInstall = false,
 	installDependencies,
 	repositoryReference,
+	onProgress,
 }: {
 	projectDir: string;
 	templateDir: string;
@@ -444,8 +455,14 @@ export async function applyBuiltInScaffoldProjectFiles({
 	noInstall?: boolean;
 	installDependencies?: ((options: InstallDependenciesOptions) => Promise<void>) | undefined;
 	repositoryReference?: string;
+	onProgress?: ((event: ScaffoldProgressEvent) => void | Promise<void>) | undefined;
 }): Promise<void> {
 	await ensureDirectory(projectDir, allowExistingDir);
+	await reportScaffoldProgress(onProgress, {
+		detail: "Copying built-in template files and writing generated source modules.",
+		phase: "generate-files",
+		title: "Generating project files",
+	});
 	await copyInterpolatedDirectory(templateDir, projectDir, variables);
 	if (codeArtifacts && codeArtifacts.length > 0) {
 		await writeBuiltInCodeArtifacts(projectDir, codeArtifacts);
@@ -453,6 +470,11 @@ export async function applyBuiltInScaffoldProjectFiles({
 	if (artifacts && artifacts.length > 0) {
 		await writeBuiltInStructuralArtifacts(projectDir, artifacts);
 	}
+	await reportScaffoldProgress(onProgress, {
+		detail: "Writing starter manifests, local presets, and seeded template artifacts.",
+		phase: "seed-artifacts",
+		title: "Seeding scaffold artifacts",
+	});
 	await writeStarterManifestFiles(projectDir, templateId, variables, artifacts);
 	await seedBuiltInPersistenceArtifacts(projectDir, templateId, variables);
 	await applyLocalDevPresetFiles({
@@ -470,6 +492,11 @@ export async function applyBuiltInScaffoldProjectFiles({
 		});
 	}
 
+	await reportScaffoldProgress(onProgress, {
+		detail: "Writing README, normalizing package metadata, and aligning package-manager files.",
+		phase: "finalize-project",
+		title: "Finalizing scaffold output",
+	});
 	const readmePath = path.join(projectDir, "README.md");
 	if (!fs.existsSync(readmePath)) {
 		await fsp.writeFile(
@@ -509,6 +536,11 @@ export async function applyBuiltInScaffoldProjectFiles({
 	});
 
 	if (!noInstall) {
+		await reportScaffoldProgress(onProgress, {
+			detail: "Installing project dependencies with the selected package manager.",
+			phase: "install-dependencies",
+			title: "Installing dependencies",
+		});
 		const installer = installDependencies ?? defaultInstallDependencies;
 		await installer({
 			projectDir,

--- a/packages/wp-typia-project-tools/src/runtime/scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold.ts
@@ -180,6 +180,17 @@ interface InstallDependenciesOptions {
 	projectDir: string;
 }
 
+export interface ScaffoldProgressEvent {
+	detail: string;
+	phase:
+		| "finalize-project"
+		| "generate-files"
+		| "install-dependencies"
+		| "resolve-template"
+		| "seed-artifacts";
+	title: string;
+}
+
 interface ScaffoldProjectOptions {
 	allowExistingDir?: boolean;
 	answers: ScaffoldAnswers;
@@ -190,6 +201,7 @@ interface ScaffoldProjectOptions {
 	externalLayerSourceLabel?: string;
 	installDependencies?: ((options: InstallDependenciesOptions) => Promise<void>) | undefined;
 	noInstall?: boolean;
+	onProgress?: ((event: ScaffoldProgressEvent) => void | Promise<void>) | undefined;
 	packageManager: PackageManagerId;
 	persistencePolicy?: PersistencePolicy;
 	projectDir: string;
@@ -233,6 +245,13 @@ function normalizeTemplateSelection(templateId: string): string {
 		: templateId;
 }
 
+async function reportScaffoldProgress(
+	onProgress: ScaffoldProjectOptions["onProgress"],
+	event: ScaffoldProgressEvent,
+): Promise<void> {
+	await onProgress?.(event);
+}
+
 export async function scaffoldProject({
 	projectDir,
 	templateId,
@@ -248,6 +267,7 @@ export async function scaffoldProject({
 	allowExistingDir = false,
 	noInstall = false,
 	installDependencies = undefined,
+	onProgress = undefined,
 	variant,
 	withMigrationUi = false,
 	withTestPreset = false,
@@ -265,6 +285,11 @@ export async function scaffoldProject({
 
 	if (isBuiltInTemplate) {
 		const blockGeneratorService = new BlockGeneratorService();
+		await reportScaffoldProgress(onProgress, {
+			detail: "Preparing template layers, variants, and generated artifact plans.",
+			phase: "resolve-template",
+			title: "Resolving scaffold template",
+		});
 		const plan = await blockGeneratorService.plan({
 			allowExistingDir,
 			answers,
@@ -288,6 +313,7 @@ export async function scaffoldProject({
 		const rendered = await blockGeneratorService.render({ validated });
 		return blockGeneratorService.apply({
 			installDependencies,
+			onProgress,
 			rendered,
 		});
 	}
@@ -302,6 +328,11 @@ export async function scaffoldProject({
 		...answers,
 		dataStorageMode: dataStorageMode ?? answers.dataStorageMode,
 		persistencePolicy: persistencePolicy ?? answers.persistencePolicy,
+	});
+	await reportScaffoldProgress(onProgress, {
+		detail: "Loading template files, variants, and external package metadata when needed.",
+		phase: "resolve-template",
+		title: "Resolving scaffold template",
 	});
 	const templateSource = await resolveTemplateSource(
 		resolvedTemplateId,
@@ -318,6 +349,11 @@ export async function scaffoldProject({
 	}
 
 	try {
+		await reportScaffoldProgress(onProgress, {
+			detail: "Copying scaffold files into the target project directory.",
+			phase: "generate-files",
+			title: "Generating project files",
+		});
 		await ensureScaffoldDirectory(projectDir, allowExistingDir);
 		await copyInterpolatedDirectory(
 			templateSource.templateDir,
@@ -331,6 +367,11 @@ export async function scaffoldProject({
 	}
 	const isOfficialWorkspace = isOfficialWorkspaceProject(projectDir);
 	if (isBuiltInTemplate) {
+		await reportScaffoldProgress(onProgress, {
+			detail: "Writing starter manifests, local presets, and template-specific generated artifacts.",
+			phase: "seed-artifacts",
+			title: "Seeding scaffold artifacts",
+		});
 		await writeStarterManifestFiles(projectDir, resolvedTemplateId, variables);
 		await seedBuiltInPersistenceArtifacts(projectDir, resolvedTemplateId, variables);
 		await applyLocalDevPresetFiles({
@@ -349,8 +390,18 @@ export async function scaffoldProject({
 		}
 		await removeQueryLoopPlaceholderFiles(projectDir, resolvedTemplateId);
 	} else if (withMigrationUi && isOfficialWorkspace) {
+		await reportScaffoldProgress(onProgress, {
+			detail: "Initializing workspace migration scripts and starter migration files.",
+			phase: "seed-artifacts",
+			title: "Seeding scaffold artifacts",
+		});
 		await applyWorkspaceMigrationCapability(projectDir, resolvedPackageManager);
 	}
+	await reportScaffoldProgress(onProgress, {
+		detail: "Writing README, normalizing package metadata, and aligning package-manager files.",
+		phase: "finalize-project",
+		title: "Finalizing scaffold output",
+	});
 	const readmePath = path.join(projectDir, "README.md");
 	if (!fs.existsSync(readmePath)) {
 		await fsp.writeFile(
@@ -391,6 +442,11 @@ export async function scaffoldProject({
 	});
 
 	if (!noInstall) {
+		await reportScaffoldProgress(onProgress, {
+			detail: "Installing project dependencies with the selected package manager.",
+			phase: "install-dependencies",
+			title: "Installing dependencies",
+		});
 		const installer = installDependencies ?? defaultInstallDependencies;
 		await installer({
 			projectDir,

--- a/packages/wp-typia/src/runtime-bridge-output.ts
+++ b/packages/wp-typia/src/runtime-bridge-output.ts
@@ -2,6 +2,11 @@ import type { AlternateBufferCompletionPayload } from "./ui/alternate-buffer-lif
 
 type PrintLine = (line: string) => void;
 
+export type CreateProgressPayload = {
+	detail: string;
+	title: string;
+};
+
 type ExternalLayerSelectOption = {
 	description?: string;
 	extends: string[];
@@ -60,6 +65,16 @@ export function printCompletionPayload(
 	if (payload.optionalNote) {
 		printLine(`Note: ${payload.optionalNote}`);
 	}
+}
+
+/**
+ * Formats a lightweight create-progress line for fallback CLI output.
+ *
+ * @param payload User-facing scaffold progress payload.
+ * @returns A single readable status line.
+ */
+export function formatCreateProgressLine(payload: CreateProgressPayload): string {
+	return `⏳ ${payload.title}: ${payload.detail}`;
 }
 
 /**

--- a/packages/wp-typia/src/runtime-bridge.ts
+++ b/packages/wp-typia/src/runtime-bridge.ts
@@ -4,6 +4,7 @@ import {
 	buildAddCompletionPayload,
 	buildCreateCompletionPayload,
 	buildMigrationCompletionPayload,
+	formatCreateProgressLine,
 	printBlock,
 	printCompletionPayload,
 	toExternalLayerPromptOptions,
@@ -11,9 +12,15 @@ import {
 export {
 	buildCreateCompletionPayload,
 	buildMigrationCompletionPayload,
+	formatCreateProgressLine,
 	printCompletionPayload,
 } from "./runtime-bridge-output";
 export { executeSyncCommand } from "./runtime-bridge-sync";
+
+type CreateProgressPayload = {
+	detail: string;
+	title: string;
+};
 
 type CreateExecutionInput = {
 	projectDir: string;
@@ -21,6 +28,7 @@ type CreateExecutionInput = {
 	emitOutput?: boolean;
 	flags: Record<string, unknown>;
 	interactive?: boolean;
+	onProgress?: (payload: CreateProgressPayload) => void;
 	printLine?: PrintLine;
 	prompt?: ReadlinePrompt;
 	warnLine?: PrintLine;
@@ -153,6 +161,7 @@ export async function executeCreateCommand({
 	emitOutput = true,
 	flags,
 	interactive,
+	onProgress,
 	printLine = console.log as PrintLine,
 	prompt,
 	warnLine = console.warn as PrintLine,
@@ -185,6 +194,16 @@ export async function executeCreateCommand({
 			persistencePolicy: readOptionalLooseStringFlag(flags, "persistence-policy"),
 			phpPrefix: readOptionalLooseStringFlag(flags, "php-prefix"),
 			projectInput: projectDir,
+			onProgress: async (progress) => {
+				const payload = {
+					detail: progress.detail,
+					title: progress.title,
+				};
+				onProgress?.(payload);
+				if (emitOutput) {
+					printLine(formatCreateProgressLine(payload));
+				}
+			},
 			promptText: activePrompt
 				? (message, defaultValue, validate) => activePrompt.text(message, defaultValue, validate)
 				: undefined,

--- a/packages/wp-typia/src/ui/alternate-buffer-lifecycle.ts
+++ b/packages/wp-typia/src/ui/alternate-buffer-lifecycle.ts
@@ -20,6 +20,11 @@ export type AlternateBufferCompletionPayload = {
 	warningLines?: string[];
 };
 
+export type AlternateBufferProgressPayload = {
+	description?: string;
+	title: string;
+};
+
 type AlternateBufferFailureOptions = {
 	context: string;
 	error: unknown;
@@ -163,10 +168,13 @@ export function useAlternateBufferLifecycle(
 	handleCancel: () => void;
 	handleFailure: (error: unknown) => void;
 	handleSubmit: (action: () => Promise<AlternateBufferCompletionPayload | void>) => Promise<void>;
+	progress: AlternateBufferProgressPayload | null;
+	reportProgress: (payload: AlternateBufferProgressPayload) => void;
 	status: AlternateBufferLifecycleStatus;
 } {
 	const runtime = useRuntime();
 	const [completion, setCompletion] = useState<AlternateBufferCompletionPayload | null>(null);
+	const [progress, setProgress] = useState<AlternateBufferProgressPayload | null>(null);
 	const [status, setStatus] = useState<AlternateBufferLifecycleStatus>("editing");
 	const exit = useCallback(() => {
 		runtime.exit();
@@ -184,6 +192,7 @@ export function useAlternateBufferLifecycle(
 
 	const handleCancel = useCallback(() => {
 		setCompletion(null);
+		setProgress(null);
 		setStatus("editing");
 		exit();
 	}, [exit]);
@@ -191,6 +200,7 @@ export function useAlternateBufferLifecycle(
 	const handleFailure = useCallback(
 		(error: unknown) => {
 			setCompletion(null);
+			setProgress(null);
 			setStatus("editing");
 			reportAlternateBufferFailure({
 				context,
@@ -204,12 +214,14 @@ export function useAlternateBufferLifecycle(
 	const handleSubmit = useCallback(
 		async (action: () => Promise<AlternateBufferCompletionPayload | void>) => {
 			setCompletion(null);
+			setProgress(null);
 			setStatus("submitting");
 
 			try {
 				const result = await action();
 				if (isAlternateBufferCompletionPayload(result)) {
 					setCompletion(result);
+					setProgress(null);
 					setStatus("completed");
 					return;
 				}
@@ -217,6 +229,7 @@ export function useAlternateBufferLifecycle(
 				exit();
 			} catch (error) {
 				setCompletion(null);
+				setProgress(null);
 				setStatus("editing");
 				reportAlternateBufferFailure({
 					context,
@@ -228,11 +241,17 @@ export function useAlternateBufferLifecycle(
 		[context, exit],
 	);
 
+	const reportProgress = useCallback((payload: AlternateBufferProgressPayload) => {
+		setProgress(payload);
+	}, []);
+
 	return {
 		completion,
 		handleCancel,
 		handleFailure,
 		handleSubmit,
+		progress,
+		reportProgress,
 		status,
 	};
 }

--- a/packages/wp-typia/src/ui/create-flow.tsx
+++ b/packages/wp-typia/src/ui/create-flow.tsx
@@ -72,7 +72,13 @@ type CreateSelectFieldName = {
 	[K in keyof CreateFlowValues]-?: CreateFlowValues[K] extends string | undefined ? K : never;
 }[keyof CreateFlowValues];
 
-function CreateFlowFields() {
+function CreateFlowFields({
+	progressDescription,
+	progressTitle,
+}: {
+	progressDescription?: string;
+	progressTitle?: string;
+}) {
 	const { activeFieldName, isSubmitting, values } = useFormContext();
 	const { height: terminalHeight = 24 } = useTerminalDimensions();
 	const createValues = values as Partial<CreateFlowValues>;
@@ -95,8 +101,9 @@ function CreateFlowFields() {
 		{
 			isSubmitting,
 			scrollTop,
-			submittingDescription: "Preparing your wp-typia project files...",
-			submittingTitle: "Creating project...",
+			submittingDescription:
+				progressDescription ?? "Preparing your wp-typia project files...",
+			submittingTitle: progressTitle ?? "Creating project...",
 			viewportHeight,
 		},
 		[
@@ -178,7 +185,8 @@ function CreateFlowFields() {
 }
 
 export function CreateFlow({ cwd, initialValues }: CreateFlowProps) {
-	const { completion, handleCancel, handleSubmit, status } = useAlternateBufferLifecycle(
+	const { completion, handleCancel, handleSubmit, progress, reportProgress, status } =
+		useAlternateBufferLifecycle(
 		"wp-typia create failed",
 	);
 	const { height: terminalHeight = 24 } = useTerminalDimensions();
@@ -212,6 +220,11 @@ export function CreateFlow({ cwd, initialValues }: CreateFlowProps) {
 						emitOutput: false,
 						flags,
 						interactive: true,
+						onProgress: ({ detail, title }) =>
+							reportProgress({
+								description: detail,
+								title,
+							}),
 						projectDir: values["project-dir"],
 						prompt: defaultPrompt,
 					});
@@ -220,7 +233,10 @@ export function CreateFlow({ cwd, initialValues }: CreateFlowProps) {
 			schema={createFlowSchema}
 			title="Create a wp-typia project"
 		>
-			<CreateFlowFields />
+			<CreateFlowFields
+				progressDescription={progress?.description}
+				progressTitle={progress?.title}
+			/>
 		</Form>
 	);
 }

--- a/packages/wp-typia/tests/completion-output.test.ts
+++ b/packages/wp-typia/tests/completion-output.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
 	buildCreateCompletionPayload,
+	formatCreateProgressLine,
 	buildMigrationCompletionPayload,
 	printCompletionPayload,
 } from "../src/runtime-bridge";
@@ -126,5 +127,16 @@ describe("alternate-buffer completion output helpers", () => {
 			"Next steps:",
 			"  wp-typia migrate scaffold --from-migration-version v1",
 		]);
+	});
+
+	test("create progress formatter keeps fallback status lines readable", () => {
+		expect(
+			formatCreateProgressLine({
+				detail: "Copying scaffold files into the target project directory.",
+				title: "Generating project files",
+			}),
+		).toBe(
+			"⏳ Generating project files: Copying scaffold files into the target project directory.",
+		);
 	});
 });

--- a/packages/wp-typia/tests/create-command.test.ts
+++ b/packages/wp-typia/tests/create-command.test.ts
@@ -57,4 +57,36 @@ test("keeps ambiguous external layers fail-fast when a synthetic prompt is suppl
 			"External layer package defines multiple selectable layers (acme/internal-base, acme/alpha, acme/beta). Pass an explicit externalLayerId or rerun through the interactive CLI selector.",
 		);
 	});
+
+	test("reports scaffold progress during create flows", async () => {
+		const progress: string[] = [];
+
+		await executeCreateCommand({
+			cwd: tempRoot,
+			emitOutput: false,
+			flags: {
+				"no-install": true,
+				"package-manager": "npm",
+				template: "basic",
+				yes: true,
+			},
+			interactive: false,
+			onProgress: ({ detail, title }) => {
+				progress.push(`${title}: ${detail}`);
+			},
+			projectDir: "demo-progress-reporting",
+		});
+
+		expect(progress[0]).toContain("Resolving scaffold template");
+		expect(progress).toContain(
+			"Generating project files: Copying built-in template files and writing generated source modules.",
+		);
+		expect(progress).toContain(
+			"Seeding scaffold artifacts: Writing starter manifests, local presets, and seeded template artifacts.",
+		);
+		expect(progress).toContain(
+			"Finalizing scaffold output: Writing README, normalizing package metadata, and aligning package-manager files.",
+		);
+		expect(progress.some((line) => line.startsWith("Installing dependencies:"))).toBe(false);
+	});
 });


### PR DESCRIPTION
## Context

`wp-typia create` could still feel hung during longer scaffold runs because there was no user-visible status reporting while template resolution, generation, artifact seeding, or dependency installation were in flight.

## What Changed

- added scaffold progress events across template resolution, file generation, artifact seeding, finalization, and dependency installation
- wired fallback CLI output to print lightweight progress lines during create flows
- wired the alternate-buffer create flow to reuse the same progress events for live submitting titles and descriptions
- added bridge/output tests to lock the new status reporting behavior

## Verification

- `bun run --filter @wp-typia/api-client build && bun run --filter @wp-typia/block-runtime build && bun run --filter @wp-typia/project-tools build && bun run --filter wp-typia build`
- `bun test packages/wp-typia/tests/create-command.test.ts packages/wp-typia/tests/completion-output.test.ts packages/wp-typia/tests/tui-lifecycle.test.ts packages/wp-typia-project-tools/tests/cli-entry.test.ts`
- `bun run typecheck`
- `bun run changesets:validate`

Closes #447