### PR TITLE
Fix npm scaffold expectations in generated smoke

### DIFF
--- a/scripts/run-generated-project-smoke.mjs
+++ b/scripts/run-generated-project-smoke.mjs
@@ -248,6 +248,25 @@ function ensureCanonicalCliReady() {
 	});
 }
 
+function assertScaffoldPackageManagerField(packageJson, packageManager) {
+	if (packageManager === "npm") {
+		if (packageJson.packageManager !== undefined) {
+			throw new Error(
+				`Expected npm scaffolds to omit packageManager, received ${packageJson.packageManager}`,
+			);
+		}
+		return;
+	}
+
+	const expectedPackageManager =
+		getPackageManager(packageManager).packageManagerField;
+	if (packageJson.packageManager !== expectedPackageManager) {
+		throw new Error(
+			`Expected packageManager ${expectedPackageManager}, received ${packageJson.packageManager}`,
+		);
+	}
+}
+
 function main() {
 	const {
 		runtime,
@@ -328,13 +347,7 @@ function main() {
 
 		const packageJsonPath = path.join(projectDir, "package.json");
 		const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
-		const expectedPackageManager =
-			getPackageManager(packageManager).packageManagerField;
-		if (packageJson.packageManager !== expectedPackageManager) {
-			throw new Error(
-				`Expected packageManager ${expectedPackageManager}, received ${packageJson.packageManager}`,
-			);
-		}
+		assertScaffoldPackageManagerField(packageJson, packageManager);
 
 		rewriteWorkspaceDependencies(projectDir, packageManager);
 		ensureCorepackPackageManager(packageManager);

--- a/tests/unit/generated-project-smoke-reference-lane.test.ts
+++ b/tests/unit/generated-project-smoke-reference-lane.test.ts
@@ -28,6 +28,9 @@ test("generated project smoke script supports a reference example lane", () => {
 	expect(smokeScript).toContain('./lib/generated-project-smoke-assertions.mjs');
 	expect(smokeScript).toContain("runExampleProjectSmoke");
 	expect(smokeScript).toContain("assertGeneratedProjectScaffold");
+	expect(smokeScript).toContain("assertScaffoldPackageManagerField");
+	expect(smokeScript).toContain('packageManager === "npm"');
+	expect(smokeScript).toContain("Expected npm scaffolds to omit packageManager");
 	expect(exampleHelper).toContain("ensureCopiedExampleSupportDependencies");
 	expect(exampleHelper).toContain("runExampleProjectSmoke");
 	expect(exampleHelper).toContain("shouldRunMigrationSmoke");


### PR DESCRIPTION
## Context

`main` CI started failing in generated project smoke after npm-based scaffolds intentionally stopped writing a `packageManager` field. The smoke harness was still treating the old npm field as required.

## What Changed

- updated the generated smoke script so npm scaffolds expect an omitted `packageManager` field while non-npm scaffolds still require the pinned field
- added a regression assertion in the smoke reference lane unit test so the npm special-case stays documented and covered

## Verification

- `bun test tests/unit/generated-project-smoke-reference-lane.test.ts`
- `node scripts/run-generated-project-smoke.mjs --runtime node --template workspace --package-manager npm --project-name smoke-workspace-add-pattern-npm --add-pattern-name hero-layout`
- `node scripts/run-generated-project-smoke.mjs --runtime node --template workspace --package-manager npm --project-name smoke-workspace-add-binding-source-npm --add-binding-source-name hero-data`
- `node scripts/run-generated-project-smoke.mjs --runtime node --template compound --package-manager npm --project-name smoke-compound-public-post-meta-npm --data-storage post-meta --persistence-policy public`

Closes #456

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced validation for generated project configurations to ensure correct package manager field handling in `package.json` across different package managers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->