### PR TITLE
Fix bunli runtime rebuild fallback for linked examples

### DIFF
--- a/packages/wp-typia/scripts/build-bunli-runtime.ts
+++ b/packages/wp-typia/scripts/build-bunli-runtime.ts
@@ -16,6 +16,7 @@ const generatedMetadataEntrypoint = path.resolve(packageRoot, ".bunli", "command
 const nodeRuntimeEntrypoint = path.resolve(packageRoot, "src", "node-cli.ts");
 const outdir = path.resolve(packageRoot, buildConfig.outdir);
 const generatedMetadataOutdir = path.join(outdir, ".bunli");
+const repoRoot = path.resolve(packageRoot, "..", "..");
 const projectToolsPackageRoot = path.resolve(packageRoot, "..", "wp-typia-project-tools");
 const projectToolsRuntimeDir = path.resolve(
 	packageRoot,
@@ -25,6 +26,8 @@ const projectToolsRuntimeDir = path.resolve(
 	"runtime",
 );
 const apiClientDistDir = path.resolve(packageRoot, "..", "wp-typia-api-client", "dist");
+const bunExecutable =
+	typeof Bun !== "undefined" ? (Bun.which("bun") ?? process.execPath) : process.execPath;
 const PROJECT_TOOLS_ALIASES = {
 	"@wp-typia/api-client/runtime-primitives": path.join(
 		apiClientDistDir,
@@ -72,6 +75,41 @@ const WP_TYPIA_EXTERNALS = [
 	"@wp-typia/rest/*",
 ];
 
+interface RuntimeDependencyBuildStep {
+	args: string[];
+	cwd: string;
+	label: string;
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+	try {
+		await fs.access(filePath);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function getRuntimeDependencyBuildSteps(): RuntimeDependencyBuildStep[] {
+	return [
+		{
+			args: ["run", "--filter", "@wp-typia/api-client", "build"],
+			cwd: repoRoot,
+			label: "@wp-typia/api-client",
+		},
+		{
+			args: ["run", "--filter", "@wp-typia/block-runtime", "build"],
+			cwd: repoRoot,
+			label: "@wp-typia/block-runtime",
+		},
+		{
+			args: ["run", "--filter", "@wp-typia/project-tools", "build"],
+			cwd: repoRoot,
+			label: "@wp-typia/project-tools",
+		},
+	];
+}
+
 async function ensureRuntimeBuildDependencies() {
 	const requiredArtifacts = [...new Set(Object.values(PROJECT_TOOLS_ALIASES))];
 	const missingArtifacts: string[] = [];
@@ -88,15 +126,30 @@ async function ensureRuntimeBuildDependencies() {
 		return;
 	}
 
-	const buildResult = spawnSync(process.execPath, ["run", "build"], {
-		cwd: projectToolsPackageRoot,
-		env: process.env,
-		stdio: "inherit",
-	});
+	const buildSteps =
+		(await fileExists(path.join(repoRoot, "package.json")))
+			? getRuntimeDependencyBuildSteps()
+			: [
+					{
+						args: ["run", "build"],
+						cwd: projectToolsPackageRoot,
+						label: "@wp-typia/project-tools",
+					},
+				];
 
-	if (buildResult.status !== 0) {
+	for (const buildStep of buildSteps) {
+		const buildResult = spawnSync(bunExecutable, buildStep.args, {
+			cwd: buildStep.cwd,
+			env: process.env,
+			stdio: "inherit",
+		});
+
+		if (buildResult.status === 0) {
+			continue;
+		}
+
 		throw new Error(
-			`Failed to build @wp-typia/project-tools for wp-typia runtime aliases: ${missingArtifacts.join(", ")}`,
+			`Failed to build ${buildStep.label} while recovering wp-typia runtime aliases: ${missingArtifacts.join(", ")}`,
 		);
 	}
 

--- a/packages/wp-typia/tests/bunli-prep.test.ts
+++ b/packages/wp-typia/tests/bunli-prep.test.ts
@@ -44,6 +44,20 @@ describe("wp-typia Bunli preparation", () => {
 		expect(fs.existsSync(path.join(packageRoot, ".bunli", "commands.gen.ts"))).toBe(true);
 	});
 
+	test("runtime rebuild fallback targets linked workspace packages from the repo root", () => {
+		const runtimeBuildScript = fs.readFileSync(
+			path.join(packageRoot, "scripts", "build-bunli-runtime.ts"),
+			"utf8",
+		);
+
+		expect(runtimeBuildScript).toContain('const repoRoot = path.resolve(packageRoot, "..", "..");');
+		expect(runtimeBuildScript).toContain('Bun.which("bun") ?? process.execPath');
+		expect(runtimeBuildScript).toContain('@wp-typia/api-client');
+		expect(runtimeBuildScript).toContain('@wp-typia/block-runtime');
+		expect(runtimeBuildScript).toContain('@wp-typia/project-tools');
+		expect(runtimeBuildScript).toContain('Failed to build ${buildStep.label}');
+	});
+
 	test("future Bunli command tree preserves the reserved top-level taxonomy", async () => {
 		expect(WP_TYPIA_FUTURE_COMMAND_TREE.map((command) => command.name)).toEqual(
 			Array.from(WP_TYPIA_TOP_LEVEL_COMMAND_NAMES),


### PR DESCRIPTION
## Context

`main` CI regressed after #457 in `Generated Project Smoke (smoke-reference-my-typia-block-bun)`.
The failing lane hit `wp-typia`'s Bunli runtime rebuild fallback while running `migration:snapshot` from a workspace-linked example on a clean checkout.

## What Changed

- switched `build-bunli-runtime.ts` to rebuild missing linked runtime artifacts from the repo root instead of only shelling into `@wp-typia/project-tools`
- made the fallback run explicit `@wp-typia/api-client`, `@wp-typia/block-runtime`, and `@wp-typia/project-tools` builds with the Bun executable
- kept a package-local fallback for non-workspace contexts
- added a Bunli prep boundary test that locks the repo-root rebuild strategy into source

## Verification

- `bun test packages/wp-typia/tests/bunli-prep.test.ts`
- `rm -rf packages/wp-typia-project-tools/dist packages/wp-typia-api-client/dist && node scripts/run-generated-project-smoke.mjs --runtime bun --example-project my-typia-block --package-manager bun --project-name smoke-reference-my-typia-block-bun-fix`
- `bun run changesets:validate`
- `bun run --filter wp-typia build`

Closes #458
