### PR TITLE
Build linked runtime dependencies from sibling roots

### DIFF
--- a/packages/wp-typia-rest/tests/react.test.tsx
+++ b/packages/wp-typia-rest/tests/react.test.tsx
@@ -528,12 +528,13 @@ describe("@wp-typia/rest/react", () => {
 		});
 
 		client.invalidate(endpoint, request);
+		await flush();
 		resolveFirstFetch({ count: 1 });
 
 		await waitForAssertion(() => {
 			expect(fetchCount).toBe(2);
 			expect(rendered.current.data).toEqual({ count: 2 });
-		});
+		}, 5_000);
 
 		await rendered.unmount();
 	});

--- a/packages/wp-typia/scripts/build-bunli-runtime.ts
+++ b/packages/wp-typia/scripts/build-bunli-runtime.ts
@@ -16,7 +16,8 @@ const generatedMetadataEntrypoint = path.resolve(packageRoot, ".bunli", "command
 const nodeRuntimeEntrypoint = path.resolve(packageRoot, "src", "node-cli.ts");
 const outdir = path.resolve(packageRoot, buildConfig.outdir);
 const generatedMetadataOutdir = path.join(outdir, ".bunli");
-const repoRoot = path.resolve(packageRoot, "..", "..");
+const apiClientPackageRoot = path.resolve(packageRoot, "..", "wp-typia-api-client");
+const blockRuntimePackageRoot = path.resolve(packageRoot, "..", "wp-typia-block-runtime");
 const projectToolsPackageRoot = path.resolve(packageRoot, "..", "wp-typia-project-tools");
 const projectToolsRuntimeDir = path.resolve(
 	packageRoot,
@@ -93,18 +94,18 @@ async function fileExists(filePath: string): Promise<boolean> {
 function getRuntimeDependencyBuildSteps(): RuntimeDependencyBuildStep[] {
 	return [
 		{
-			args: ["run", "--filter", "@wp-typia/api-client", "build"],
-			cwd: repoRoot,
+			args: ["run", "build"],
+			cwd: apiClientPackageRoot,
 			label: "@wp-typia/api-client",
 		},
 		{
-			args: ["run", "--filter", "@wp-typia/block-runtime", "build"],
-			cwd: repoRoot,
+			args: ["run", "build"],
+			cwd: blockRuntimePackageRoot,
 			label: "@wp-typia/block-runtime",
 		},
 		{
-			args: ["run", "--filter", "@wp-typia/project-tools", "build"],
-			cwd: repoRoot,
+			args: ["run", "build"],
+			cwd: projectToolsPackageRoot,
 			label: "@wp-typia/project-tools",
 		},
 	];
@@ -127,15 +128,15 @@ async function ensureRuntimeBuildDependencies() {
 	}
 
 	const buildSteps =
-		(await fileExists(path.join(repoRoot, "package.json")))
+		(await fileExists(projectToolsPackageRoot))
 			? getRuntimeDependencyBuildSteps()
-			: [
-					{
-						args: ["run", "build"],
-						cwd: projectToolsPackageRoot,
-						label: "@wp-typia/project-tools",
-					},
-				];
+			: [];
+
+	if (buildSteps.length === 0) {
+		throw new Error(
+			`Unable to locate linked wp-typia sibling packages while recovering runtime aliases: ${missingArtifacts.join(", ")}`,
+		);
+	}
 
 	for (const buildStep of buildSteps) {
 		const buildResult = spawnSync(bunExecutable, buildStep.args, {

--- a/packages/wp-typia/scripts/build-bunli-runtime.ts
+++ b/packages/wp-typia/scripts/build-bunli-runtime.ts
@@ -127,10 +127,13 @@ async function ensureRuntimeBuildDependencies() {
 		return;
 	}
 
-	const buildSteps =
-		(await fileExists(projectToolsPackageRoot))
-			? getRuntimeDependencyBuildSteps()
-			: [];
+	const siblingRoots = [
+		apiClientPackageRoot,
+		blockRuntimePackageRoot,
+		projectToolsPackageRoot,
+	];
+	const siblingRootsExist = await Promise.all(siblingRoots.map((rootPath) => fileExists(rootPath)));
+	const buildSteps = siblingRootsExist.every(Boolean) ? getRuntimeDependencyBuildSteps() : [];
 
 	if (buildSteps.length === 0) {
 		throw new Error(
@@ -150,7 +153,9 @@ async function ensureRuntimeBuildDependencies() {
 		}
 
 		throw new Error(
-			`Failed to build ${buildStep.label} while recovering wp-typia runtime aliases: ${missingArtifacts.join(", ")}`,
+			`Failed to build ${buildStep.label} while recovering wp-typia runtime aliases: ${missingArtifacts.join(", ")}${
+				buildResult.error ? ` (${buildResult.error.message})` : ""
+			}`,
 		);
 	}
 

--- a/packages/wp-typia/tests/bunli-prep.test.ts
+++ b/packages/wp-typia/tests/bunli-prep.test.ts
@@ -44,17 +44,28 @@ describe("wp-typia Bunli preparation", () => {
 		expect(fs.existsSync(path.join(packageRoot, ".bunli", "commands.gen.ts"))).toBe(true);
 	});
 
-	test("runtime rebuild fallback targets linked workspace packages from the repo root", () => {
+	test("runtime rebuild fallback targets sibling linked packages directly", () => {
 		const runtimeBuildScript = fs.readFileSync(
 			path.join(packageRoot, "scripts", "build-bunli-runtime.ts"),
 			"utf8",
 		);
 
-		expect(runtimeBuildScript).toContain('const repoRoot = path.resolve(packageRoot, "..", "..");');
+		expect(runtimeBuildScript).toContain(
+			'const apiClientPackageRoot = path.resolve(packageRoot, "..", "wp-typia-api-client");',
+		);
+		expect(runtimeBuildScript).toContain(
+			'const blockRuntimePackageRoot = path.resolve(packageRoot, "..", "wp-typia-block-runtime");',
+		);
+		expect(runtimeBuildScript).toContain(
+			'const projectToolsPackageRoot = path.resolve(packageRoot, "..", "wp-typia-project-tools");',
+		);
 		expect(runtimeBuildScript).toContain('Bun.which("bun") ?? process.execPath');
 		expect(runtimeBuildScript).toContain('@wp-typia/api-client');
 		expect(runtimeBuildScript).toContain('@wp-typia/block-runtime');
 		expect(runtimeBuildScript).toContain('@wp-typia/project-tools');
+		expect(runtimeBuildScript).toContain(
+			"Unable to locate linked wp-typia sibling packages while recovering runtime aliases",
+		);
 		expect(runtimeBuildScript).toContain('Failed to build ${buildStep.label}');
 	});
 


### PR DESCRIPTION
## Context

`main` still regressed after #459 in `Generated Project Smoke (smoke-reference-my-typia-block-bun)`.
The previous fallback assumed a workspace-style repo root, but the failing Bun-linked example executes from a copied `.bun/.../node_modules/*` tree where no monorepo root exists.

## What Changed

- switched `build-bunli-runtime.ts` to rebuild missing runtime artifacts from each sibling package root directly
- removed the repo-root workspace-filter assumption for `@wp-typia/api-client`, `@wp-typia/block-runtime`, and `@wp-typia/project-tools`
- kept the error messaging focused on linked sibling package recovery
- updated the Bunli prep boundary test to lock the sibling-root rebuild strategy

## Verification

- `bun test packages/wp-typia/tests/bunli-prep.test.ts`
- `rm -rf packages/wp-typia-project-tools/dist packages/wp-typia-api-client/dist && node scripts/run-generated-project-smoke.mjs --runtime bun --example-project my-typia-block --package-manager bun --project-name smoke-reference-my-typia-block-bun-fix-2`
- `bun run changesets:validate`

Closes #460


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored runtime dependency build process for improved explicit package handling.
  * Enhanced error handling with clearer reporting when dependencies cannot be located.

* **Tests**
  * Updated test validation for new build fallback strategy.

**Note:** These are internal infrastructure improvements with no direct impact on end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->