### PR TITLE
Resolve linked package roots for Bun runtime recovery

### DIFF
--- a/packages/wp-typia/scripts/build-bunli-runtime.ts
+++ b/packages/wp-typia/scripts/build-bunli-runtime.ts
@@ -44,10 +44,22 @@ const projectToolsRuntimeDir = path.resolve(
   'runtime',
 );
 const apiClientDistDir = path.resolve(apiClientPackageRoot, 'dist');
-const bunExecutable =
-  typeof Bun !== 'undefined'
-    ? (Bun.which('bun') ?? process.execPath)
-    : process.execPath;
+const bunExecutable = (() => {
+  if (typeof Bun === 'undefined') {
+    throw new Error(
+      'wp-typia Bun runtime recovery requires Bun to be available.',
+    );
+  }
+
+  const resolvedBunExecutable = Bun.which('bun');
+  if (!resolvedBunExecutable) {
+    throw new Error(
+      'wp-typia Bun runtime recovery could not locate the `bun` executable.',
+    );
+  }
+
+  return resolvedBunExecutable;
+})();
 const PROJECT_TOOLS_ALIASES = {
   '@wp-typia/api-client/runtime-primitives': path.join(
     apiClientDistDir,
@@ -112,6 +124,7 @@ const WP_TYPIA_EXTERNALS = [
 
 interface RuntimeDependencyBuildStep {
   cwd: string;
+  dependencies: string[];
   label: string;
   outdir: string;
   tsconfig: string;
@@ -130,18 +143,21 @@ function getRuntimeDependencyBuildSteps(): RuntimeDependencyBuildStep[] {
   return [
     {
       cwd: apiClientPackageRoot,
+      dependencies: [],
       label: '@wp-typia/api-client',
       outdir: path.join(apiClientPackageRoot, 'dist'),
       tsconfig: 'tsconfig.build.json',
     },
     {
       cwd: blockRuntimePackageRoot,
+      dependencies: ['@wp-typia/api-client'],
       label: '@wp-typia/block-runtime',
       outdir: path.join(blockRuntimePackageRoot, 'dist'),
       tsconfig: 'tsconfig.build.json',
     },
     {
       cwd: projectToolsPackageRoot,
+      dependencies: ['@wp-typia/api-client', '@wp-typia/block-runtime'],
       label: '@wp-typia/project-tools',
       outdir: path.join(projectToolsPackageRoot, 'dist'),
       tsconfig: 'tsconfig.runtime.json',
@@ -151,13 +167,17 @@ function getRuntimeDependencyBuildSteps(): RuntimeDependencyBuildStep[] {
 
 async function ensureRuntimeBuildDependencies() {
   const requiredArtifacts = [...new Set(Object.values(PROJECT_TOOLS_ALIASES))];
-  const missingArtifacts: string[] = [];
+  const missingArtifacts: Array<{
+    absolutePath: string;
+    relativePath: string;
+  }> = [];
 
   for (const artifactPath of requiredArtifacts) {
-    try {
-      await fs.access(artifactPath);
-    } catch {
-      missingArtifacts.push(path.relative(packageRoot, artifactPath));
+    if (!(await fileExists(artifactPath))) {
+      missingArtifacts.push({
+        absolutePath: artifactPath,
+        relativePath: path.relative(packageRoot, artifactPath),
+      });
     }
   }
 
@@ -166,16 +186,67 @@ async function ensureRuntimeBuildDependencies() {
   }
 
   const buildSteps = getRuntimeDependencyBuildSteps();
-  const siblingRootsExist = await Promise.all(
-    buildSteps.map((step) => fileExists(step.cwd)),
+  const buildStepByLabel = new Map(
+    buildSteps.map((buildStep) => [buildStep.label, buildStep]),
   );
-  if (!siblingRootsExist.every(Boolean)) {
+  const selectedBuildStepLabels = new Set(
+    buildSteps
+      .filter((buildStep) =>
+        missingArtifacts.some(({ absolutePath }) => {
+          const relativeToOutdir = path.relative(
+            buildStep.outdir,
+            absolutePath,
+          );
+          return (
+            relativeToOutdir.length > 0 &&
+            !relativeToOutdir.startsWith('..') &&
+            !path.isAbsolute(relativeToOutdir)
+          );
+        }),
+      )
+      .map((buildStep) => buildStep.label),
+  );
+
+  const queue = [...selectedBuildStepLabels];
+  while (queue.length > 0) {
+    const nextLabel = queue.shift();
+    if (!nextLabel) {
+      continue;
+    }
+
+    const buildStep = buildStepByLabel.get(nextLabel);
+    if (!buildStep) {
+      continue;
+    }
+
+    for (const dependencyLabel of buildStep.dependencies) {
+      if (selectedBuildStepLabels.has(dependencyLabel)) {
+        continue;
+      }
+      selectedBuildStepLabels.add(dependencyLabel);
+      queue.push(dependencyLabel);
+    }
+  }
+
+  const stepsToRebuild = buildSteps.filter((buildStep) =>
+    selectedBuildStepLabels.has(buildStep.label),
+  );
+  if (stepsToRebuild.length === 0) {
     throw new Error(
-      `Unable to locate linked wp-typia sibling packages while recovering runtime aliases: ${missingArtifacts.join(', ')}`,
+      `Unable to match missing wp-typia runtime alias artifacts to rebuild steps: ${missingArtifacts
+        .map(({ relativePath }) => relativePath)
+        .join(', ')}`,
     );
   }
 
-  for (const buildStep of buildSteps) {
+  for (const buildStep of stepsToRebuild) {
+    const tsconfigPath = path.join(buildStep.cwd, buildStep.tsconfig);
+    if (!(await fileExists(tsconfigPath))) {
+      throw new Error(
+        `Missing ${buildStep.tsconfig} for ${buildStep.label} while recovering wp-typia runtime aliases.`,
+      );
+    }
+
     await fs.rm(buildStep.outdir, { force: true, recursive: true });
     const buildResult = spawnSync(
       bunExecutable,
@@ -192,14 +263,24 @@ async function ensureRuntimeBuildDependencies() {
     }
 
     throw new Error(
-      `Failed to build ${buildStep.label} while recovering wp-typia runtime aliases: ${missingArtifacts.join(', ')}${
+      `Failed to build ${buildStep.label} while recovering wp-typia runtime aliases: ${missingArtifacts
+        .map(({ relativePath }) => relativePath)
+        .join(', ')}${
         buildResult.error ? ` (${buildResult.error.message})` : ''
       }`,
     );
   }
 
+  const stillMissing: string[] = [];
   for (const artifactPath of requiredArtifacts) {
-    await fs.access(artifactPath);
+    if (!(await fileExists(artifactPath))) {
+      stillMissing.push(path.relative(packageRoot, artifactPath));
+    }
+  }
+  if (stillMissing.length > 0) {
+    throw new Error(
+      `wp-typia runtime alias artifacts still missing after rebuild: ${stillMissing.join(', ')}`,
+    );
   }
 }
 

--- a/packages/wp-typia/scripts/build-bunli-runtime.ts
+++ b/packages/wp-typia/scripts/build-bunli-runtime.ts
@@ -1,225 +1,264 @@
-import { spawnSync } from "node:child_process";
-import fs from "node:fs/promises";
-import path from "node:path";
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import path from 'node:path';
 
-import { bunliConfig } from "../bunli.config";
+import { bunliConfig } from '../bunli.config';
 
-const packageRoot = path.resolve(import.meta.dir, "..");
+const packageRoot = path.resolve(import.meta.dir, '..');
 const buildConfig = bunliConfig.build;
 
 if (!buildConfig?.entry || !buildConfig?.outdir) {
-	throw new Error("wp-typia bunli.config.ts is missing build.entry or build.outdir.");
+  throw new Error(
+    'wp-typia bunli.config.ts is missing build.entry or build.outdir.',
+  );
 }
 
 const fullRuntimeEntrypoint = path.resolve(packageRoot, buildConfig.entry);
-const generatedMetadataEntrypoint = path.resolve(packageRoot, ".bunli", "commands.gen.ts");
-const nodeRuntimeEntrypoint = path.resolve(packageRoot, "src", "node-cli.ts");
-const outdir = path.resolve(packageRoot, buildConfig.outdir);
-const generatedMetadataOutdir = path.join(outdir, ".bunli");
-const apiClientPackageRoot = path.resolve(packageRoot, "..", "wp-typia-api-client");
-const blockRuntimePackageRoot = path.resolve(packageRoot, "..", "wp-typia-block-runtime");
-const projectToolsPackageRoot = path.resolve(packageRoot, "..", "wp-typia-project-tools");
-const projectToolsRuntimeDir = path.resolve(
-	packageRoot,
-	"..",
-	"wp-typia-project-tools",
-	"dist",
-	"runtime",
+const generatedMetadataEntrypoint = path.resolve(
+  packageRoot,
+  '.bunli',
+  'commands.gen.ts',
 );
-const apiClientDistDir = path.resolve(packageRoot, "..", "wp-typia-api-client", "dist");
+const nodeRuntimeEntrypoint = path.resolve(packageRoot, 'src', 'node-cli.ts');
+const outdir = path.resolve(packageRoot, buildConfig.outdir);
+const generatedMetadataOutdir = path.join(outdir, '.bunli');
+const requireFromWpTypia = createRequire(
+  path.join(packageRoot, 'package.json'),
+);
+const projectToolsPackageRoot = path.dirname(
+  requireFromWpTypia.resolve('@wp-typia/project-tools/package.json'),
+);
+const apiClientPackageRoot = path.dirname(
+  requireFromWpTypia.resolve('@wp-typia/api-client/package.json'),
+);
+const requireFromProjectTools = createRequire(
+  path.join(projectToolsPackageRoot, 'package.json'),
+);
+const blockRuntimePackageRoot = path.dirname(
+  requireFromProjectTools.resolve('@wp-typia/block-runtime/package.json'),
+);
+const projectToolsRuntimeDir = path.resolve(
+  projectToolsPackageRoot,
+  'dist',
+  'runtime',
+);
+const apiClientDistDir = path.resolve(apiClientPackageRoot, 'dist');
 const bunExecutable =
-	typeof Bun !== "undefined" ? (Bun.which("bun") ?? process.execPath) : process.execPath;
+  typeof Bun !== 'undefined'
+    ? (Bun.which('bun') ?? process.execPath)
+    : process.execPath;
 const PROJECT_TOOLS_ALIASES = {
-	"@wp-typia/api-client/runtime-primitives": path.join(
-		apiClientDistDir,
-		"runtime-primitives.js",
-	),
-	"@wp-typia/api-client/internal/runtime-primitives": path.join(
-		apiClientDistDir,
-		"internal",
-		"runtime-primitives.js",
-	),
-	"@wp-typia/project-tools/cli-add": path.join(projectToolsRuntimeDir, "cli-add.js"),
-	"@wp-typia/project-tools/cli-diagnostics": path.join(
-		projectToolsRuntimeDir,
-		"cli-diagnostics.js",
-	),
-	"@wp-typia/project-tools/cli-doctor": path.join(projectToolsRuntimeDir, "cli-doctor.js"),
-	"@wp-typia/project-tools/cli-prompt": path.join(projectToolsRuntimeDir, "cli-prompt.js"),
-	"@wp-typia/project-tools/cli-scaffold": path.join(projectToolsRuntimeDir, "cli-scaffold.js"),
-	"@wp-typia/project-tools/cli-templates": path.join(
-		projectToolsRuntimeDir,
-		"cli-templates.js",
-	),
-	"@wp-typia/project-tools/hooked-blocks": path.join(
-		projectToolsRuntimeDir,
-		"hooked-blocks.js",
-	),
-	"@wp-typia/project-tools/migrations": path.join(projectToolsRuntimeDir, "migrations.js"),
-	"@wp-typia/project-tools/package-managers": path.join(
-		projectToolsRuntimeDir,
-		"package-managers.js",
-	),
-	"@wp-typia/project-tools/workspace-project": path.join(
-		projectToolsRuntimeDir,
-		"workspace-project.js",
-	),
+  '@wp-typia/api-client/runtime-primitives': path.join(
+    apiClientDistDir,
+    'runtime-primitives.js',
+  ),
+  '@wp-typia/api-client/internal/runtime-primitives': path.join(
+    apiClientDistDir,
+    'internal',
+    'runtime-primitives.js',
+  ),
+  '@wp-typia/project-tools/cli-add': path.join(
+    projectToolsRuntimeDir,
+    'cli-add.js',
+  ),
+  '@wp-typia/project-tools/cli-diagnostics': path.join(
+    projectToolsRuntimeDir,
+    'cli-diagnostics.js',
+  ),
+  '@wp-typia/project-tools/cli-doctor': path.join(
+    projectToolsRuntimeDir,
+    'cli-doctor.js',
+  ),
+  '@wp-typia/project-tools/cli-prompt': path.join(
+    projectToolsRuntimeDir,
+    'cli-prompt.js',
+  ),
+  '@wp-typia/project-tools/cli-scaffold': path.join(
+    projectToolsRuntimeDir,
+    'cli-scaffold.js',
+  ),
+  '@wp-typia/project-tools/cli-templates': path.join(
+    projectToolsRuntimeDir,
+    'cli-templates.js',
+  ),
+  '@wp-typia/project-tools/hooked-blocks': path.join(
+    projectToolsRuntimeDir,
+    'hooked-blocks.js',
+  ),
+  '@wp-typia/project-tools/migrations': path.join(
+    projectToolsRuntimeDir,
+    'migrations.js',
+  ),
+  '@wp-typia/project-tools/package-managers': path.join(
+    projectToolsRuntimeDir,
+    'package-managers.js',
+  ),
+  '@wp-typia/project-tools/workspace-project': path.join(
+    projectToolsRuntimeDir,
+    'workspace-project.js',
+  ),
 };
 const WP_TYPIA_EXTERNALS = [
-	"@wp-typia/api-client",
-	"@wp-typia/api-client/*",
-	"@wp-typia/block-runtime",
-	"@wp-typia/block-runtime/*",
-	"@wp-typia/block-types",
-	"@wp-typia/block-types/*",
-	"@wp-typia/rest",
-	"@wp-typia/rest/*",
+  '@wp-typia/api-client',
+  '@wp-typia/api-client/*',
+  '@wp-typia/block-runtime',
+  '@wp-typia/block-runtime/*',
+  '@wp-typia/block-types',
+  '@wp-typia/block-types/*',
+  '@wp-typia/rest',
+  '@wp-typia/rest/*',
 ];
 
 interface RuntimeDependencyBuildStep {
-	args: string[];
-	cwd: string;
-	label: string;
+  cwd: string;
+  label: string;
+  outdir: string;
+  tsconfig: string;
 }
 
 async function fileExists(filePath: string): Promise<boolean> {
-	try {
-		await fs.access(filePath);
-		return true;
-	} catch {
-		return false;
-	}
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function getRuntimeDependencyBuildSteps(): RuntimeDependencyBuildStep[] {
-	return [
-		{
-			args: ["run", "build"],
-			cwd: apiClientPackageRoot,
-			label: "@wp-typia/api-client",
-		},
-		{
-			args: ["run", "build"],
-			cwd: blockRuntimePackageRoot,
-			label: "@wp-typia/block-runtime",
-		},
-		{
-			args: ["run", "build"],
-			cwd: projectToolsPackageRoot,
-			label: "@wp-typia/project-tools",
-		},
-	];
+  return [
+    {
+      cwd: apiClientPackageRoot,
+      label: '@wp-typia/api-client',
+      outdir: path.join(apiClientPackageRoot, 'dist'),
+      tsconfig: 'tsconfig.build.json',
+    },
+    {
+      cwd: blockRuntimePackageRoot,
+      label: '@wp-typia/block-runtime',
+      outdir: path.join(blockRuntimePackageRoot, 'dist'),
+      tsconfig: 'tsconfig.build.json',
+    },
+    {
+      cwd: projectToolsPackageRoot,
+      label: '@wp-typia/project-tools',
+      outdir: path.join(projectToolsPackageRoot, 'dist'),
+      tsconfig: 'tsconfig.runtime.json',
+    },
+  ];
 }
 
 async function ensureRuntimeBuildDependencies() {
-	const requiredArtifacts = [...new Set(Object.values(PROJECT_TOOLS_ALIASES))];
-	const missingArtifacts: string[] = [];
+  const requiredArtifacts = [...new Set(Object.values(PROJECT_TOOLS_ALIASES))];
+  const missingArtifacts: string[] = [];
 
-	for (const artifactPath of requiredArtifacts) {
-		try {
-			await fs.access(artifactPath);
-		} catch {
-			missingArtifacts.push(path.relative(packageRoot, artifactPath));
-		}
-	}
+  for (const artifactPath of requiredArtifacts) {
+    try {
+      await fs.access(artifactPath);
+    } catch {
+      missingArtifacts.push(path.relative(packageRoot, artifactPath));
+    }
+  }
 
-	if (missingArtifacts.length === 0) {
-		return;
-	}
+  if (missingArtifacts.length === 0) {
+    return;
+  }
 
-	const siblingRoots = [
-		apiClientPackageRoot,
-		blockRuntimePackageRoot,
-		projectToolsPackageRoot,
-	];
-	const siblingRootsExist = await Promise.all(siblingRoots.map((rootPath) => fileExists(rootPath)));
-	const buildSteps = siblingRootsExist.every(Boolean) ? getRuntimeDependencyBuildSteps() : [];
+  const buildSteps = getRuntimeDependencyBuildSteps();
+  const siblingRootsExist = await Promise.all(
+    buildSteps.map((step) => fileExists(step.cwd)),
+  );
+  if (!siblingRootsExist.every(Boolean)) {
+    throw new Error(
+      `Unable to locate linked wp-typia sibling packages while recovering runtime aliases: ${missingArtifacts.join(', ')}`,
+    );
+  }
 
-	if (buildSteps.length === 0) {
-		throw new Error(
-			`Unable to locate linked wp-typia sibling packages while recovering runtime aliases: ${missingArtifacts.join(", ")}`,
-		);
-	}
+  for (const buildStep of buildSteps) {
+    await fs.rm(buildStep.outdir, { force: true, recursive: true });
+    const buildResult = spawnSync(
+      bunExecutable,
+      ['x', 'tsc', '-p', buildStep.tsconfig],
+      {
+        cwd: buildStep.cwd,
+        env: process.env,
+        stdio: 'inherit',
+      },
+    );
 
-	for (const buildStep of buildSteps) {
-		const buildResult = spawnSync(bunExecutable, buildStep.args, {
-			cwd: buildStep.cwd,
-			env: process.env,
-			stdio: "inherit",
-		});
+    if (buildResult.status === 0) {
+      continue;
+    }
 
-		if (buildResult.status === 0) {
-			continue;
-		}
+    throw new Error(
+      `Failed to build ${buildStep.label} while recovering wp-typia runtime aliases: ${missingArtifacts.join(', ')}${
+        buildResult.error ? ` (${buildResult.error.message})` : ''
+      }`,
+    );
+  }
 
-		throw new Error(
-			`Failed to build ${buildStep.label} while recovering wp-typia runtime aliases: ${missingArtifacts.join(", ")}${
-				buildResult.error ? ` (${buildResult.error.message})` : ""
-			}`,
-		);
-	}
-
-	for (const artifactPath of requiredArtifacts) {
-		await fs.access(artifactPath);
-	}
+  for (const artifactPath of requiredArtifacts) {
+    await fs.access(artifactPath);
+  }
 }
 
 async function buildFullBunliRuntime() {
-	const result = await Bun.build({
-		alias: PROJECT_TOOLS_ALIASES,
-		entrypoints: [fullRuntimeEntrypoint],
-		external: WP_TYPIA_EXTERNALS,
-		format: "esm",
-		outdir,
-		sourcemap: buildConfig.sourcemap ? "external" : "none",
-		splitting: true,
-		target: "bun",
-	});
+  const result = await Bun.build({
+    alias: PROJECT_TOOLS_ALIASES,
+    entrypoints: [fullRuntimeEntrypoint],
+    external: WP_TYPIA_EXTERNALS,
+    format: 'esm',
+    outdir,
+    sourcemap: buildConfig.sourcemap ? 'external' : 'none',
+    splitting: true,
+    target: 'bun',
+  });
 
-	if (!result.success) {
-		for (const log of result.logs) {
-			console.error(log);
-		}
-		process.exit(1);
-	}
+  if (!result.success) {
+    for (const log of result.logs) {
+      console.error(log);
+    }
+    process.exit(1);
+  }
 }
 
 async function buildGeneratedMetadataRuntime() {
-	const result = await Bun.build({
-		alias: PROJECT_TOOLS_ALIASES,
-		entrypoints: [generatedMetadataEntrypoint],
-		external: WP_TYPIA_EXTERNALS,
-		format: "esm",
-		outdir: generatedMetadataOutdir,
-		sourcemap: buildConfig.sourcemap ? "external" : "none",
-		splitting: false,
-		target: "bun",
-	});
+  const result = await Bun.build({
+    alias: PROJECT_TOOLS_ALIASES,
+    entrypoints: [generatedMetadataEntrypoint],
+    external: WP_TYPIA_EXTERNALS,
+    format: 'esm',
+    outdir: generatedMetadataOutdir,
+    sourcemap: buildConfig.sourcemap ? 'external' : 'none',
+    splitting: false,
+    target: 'bun',
+  });
 
-	if (!result.success) {
-		for (const log of result.logs) {
-			console.error(log);
-		}
-		process.exit(1);
-	}
+  if (!result.success) {
+    for (const log of result.logs) {
+      console.error(log);
+    }
+    process.exit(1);
+  }
 }
 
 async function buildNodeFallbackRuntime() {
-	const result = await Bun.build({
-		entrypoints: [nodeRuntimeEntrypoint],
-		format: "esm",
-		outdir,
-		packages: "external",
-		sourcemap: buildConfig.sourcemap ? "external" : "none",
-		target: "node",
-	});
+  const result = await Bun.build({
+    entrypoints: [nodeRuntimeEntrypoint],
+    format: 'esm',
+    outdir,
+    packages: 'external',
+    sourcemap: buildConfig.sourcemap ? 'external' : 'none',
+    target: 'node',
+  });
 
-	if (!result.success) {
-		for (const log of result.logs) {
-			console.error(log);
-		}
-		process.exit(1);
-	}
+  if (!result.success) {
+    for (const log of result.logs) {
+      console.error(log);
+    }
+    process.exit(1);
+  }
 }
 
 await ensureRuntimeBuildDependencies();
@@ -230,6 +269,6 @@ await buildFullBunliRuntime();
 await buildGeneratedMetadataRuntime();
 await buildNodeFallbackRuntime();
 
-await fs.access(path.join(outdir, "cli.js"));
-await fs.access(path.join(generatedMetadataOutdir, "commands.gen.js"));
-await fs.access(path.join(outdir, "node-cli.js"));
+await fs.access(path.join(outdir, 'cli.js'));
+await fs.access(path.join(generatedMetadataOutdir, 'commands.gen.js'));
+await fs.access(path.join(outdir, 'node-cli.js'));

--- a/packages/wp-typia/tests/bunli-prep.test.ts
+++ b/packages/wp-typia/tests/bunli-prep.test.ts
@@ -84,14 +84,26 @@ describe('wp-typia Bunli preparation', () => {
       "requireFromProjectTools.resolve('@wp-typia/block-runtime/package.json')",
     );
     expect(runtimeBuildScript).toContain(
+      'wp-typia Bun runtime recovery requires Bun to be available.',
+    );
+    expect(runtimeBuildScript).toContain(
       "['x', 'tsc', '-p', buildStep.tsconfig]",
+    );
+    expect(runtimeBuildScript).toContain(
+      "dependencies: ['@wp-typia/api-client'",
+    );
+    expect(runtimeBuildScript).toContain(
+      "dependencies: ['@wp-typia/api-client', '@wp-typia/block-runtime']",
     );
     expect(runtimeBuildScript).toContain('tsconfig.runtime.json');
     expect(runtimeBuildScript).toContain('tsconfig.build.json');
     expect(runtimeBuildScript).toContain(
-      'Unable to locate linked wp-typia sibling packages while recovering runtime aliases',
+      'Unable to match missing wp-typia runtime alias artifacts to rebuild steps',
     );
     expect(runtimeBuildScript).toContain('Failed to build ${buildStep.label}');
+    expect(runtimeBuildScript).toContain(
+      'wp-typia runtime alias artifacts still missing after rebuild',
+    );
   });
 
   test('future Bunli command tree preserves the reserved top-level taxonomy', async () => {

--- a/packages/wp-typia/tests/bunli-prep.test.ts
+++ b/packages/wp-typia/tests/bunli-prep.test.ts
@@ -1,174 +1,203 @@
-import { describe, expect, test } from "bun:test";
-import fs from "node:fs";
-import path from "node:path";
+import { describe, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
 
 import {
-	WP_TYPIA_BUNLI_MIGRATION_DOC,
-	WP_TYPIA_CANONICAL_CREATE_USAGE,
-	WP_TYPIA_CANONICAL_MIGRATE_USAGE,
-	WP_TYPIA_FUTURE_COMMAND_TREE,
-	WP_TYPIA_POSITIONAL_ALIAS_USAGE,
-	WP_TYPIA_TOP_LEVEL_COMMAND_NAMES,
-	normalizeWpTypiaArgv,
-} from "../src/command-contract";
-import { wpTypiaCommands } from "../src/command-list";
+  WP_TYPIA_BUNLI_MIGRATION_DOC,
+  WP_TYPIA_CANONICAL_CREATE_USAGE,
+  WP_TYPIA_CANONICAL_MIGRATE_USAGE,
+  WP_TYPIA_FUTURE_COMMAND_TREE,
+  WP_TYPIA_POSITIONAL_ALIAS_USAGE,
+  WP_TYPIA_TOP_LEVEL_COMMAND_NAMES,
+  normalizeWpTypiaArgv,
+} from '../src/command-contract';
+import { wpTypiaCommands } from '../src/command-list';
 
-const packageRoot = path.resolve(import.meta.dir, "..");
-const repoRoot = path.resolve(packageRoot, "../..");
+const packageRoot = path.resolve(import.meta.dir, '..');
+const repoRoot = path.resolve(packageRoot, '../..');
 const packageManifest = JSON.parse(
-	fs.readFileSync(path.join(packageRoot, "package.json"), "utf8"),
+  fs.readFileSync(path.join(packageRoot, 'package.json'), 'utf8'),
 );
 
-describe("wp-typia Bunli preparation", () => {
-	test("checks in the Bunli prep tree while promoting a built CLI runtime", () => {
-		expect(packageManifest.bin["wp-typia"]).toBe("bin/wp-typia.js");
-		expect(packageManifest.files).toContain("dist-bunli/");
-		expect(packageManifest.files).toContain("bunli.config.ts");
-		expect(packageManifest.scripts["bunli:build"]).toBe("bun run build");
-		expect(packageManifest.scripts["bunli:dev"]).toBe("bun src/cli.ts");
-		expect(packageManifest.scripts["bunli:test"]).toBe("bun test tests/*.test.ts");
-		expect(packageManifest.scripts.prepack).toBe("bun run build");
-		expect(packageManifest.engines.bun).toBe(">=1.3.11");
-		expect(packageManifest.devDependencies.bunli).toBe("0.9.0");
-		expect(packageManifest.dependencies["@bunli/core"]).toBe("0.9.0");
-		expect(packageManifest.devDependencies["@bunli/test"]).toBe("0.6.0");
-		expect(fs.existsSync(path.join(packageRoot, "bunli.config.ts"))).toBe(true);
-		expect(fs.existsSync(path.join(packageRoot, "src", "cli.ts"))).toBe(true);
-		expect(fs.existsSync(path.join(packageRoot, "src", "commands", "create.ts"))).toBe(true);
-		expect(fs.existsSync(path.join(packageRoot, "src", "commands", "sync.ts"))).toBe(true);
-		expect(fs.existsSync(path.join(packageRoot, "src", "commands", "add.ts"))).toBe(true);
-		expect(fs.existsSync(path.join(packageRoot, "src", "commands", "templates.ts"))).toBe(true);
-		expect(fs.existsSync(path.join(packageRoot, "src", "commands", "migrate.ts"))).toBe(true);
-		expect(fs.existsSync(path.join(packageRoot, "src", "commands", "mcp.ts"))).toBe(true);
-		expect(fs.existsSync(path.join(packageRoot, "src", "commands", "doctor.ts"))).toBe(true);
-		expect(fs.existsSync(path.join(packageRoot, ".bunli", "commands.gen.ts"))).toBe(true);
-	});
+describe('wp-typia Bunli preparation', () => {
+  test('checks in the Bunli prep tree while promoting a built CLI runtime', () => {
+    expect(packageManifest.bin['wp-typia']).toBe('bin/wp-typia.js');
+    expect(packageManifest.files).toContain('dist-bunli/');
+    expect(packageManifest.files).toContain('bunli.config.ts');
+    expect(packageManifest.scripts['bunli:build']).toBe('bun run build');
+    expect(packageManifest.scripts['bunli:dev']).toBe('bun src/cli.ts');
+    expect(packageManifest.scripts['bunli:test']).toBe(
+      'bun test tests/*.test.ts',
+    );
+    expect(packageManifest.scripts.prepack).toBe('bun run build');
+    expect(packageManifest.engines.bun).toBe('>=1.3.11');
+    expect(packageManifest.devDependencies.bunli).toBe('0.9.0');
+    expect(packageManifest.dependencies['@bunli/core']).toBe('0.9.0');
+    expect(packageManifest.devDependencies['@bunli/test']).toBe('0.6.0');
+    expect(fs.existsSync(path.join(packageRoot, 'bunli.config.ts'))).toBe(true);
+    expect(fs.existsSync(path.join(packageRoot, 'src', 'cli.ts'))).toBe(true);
+    expect(
+      fs.existsSync(path.join(packageRoot, 'src', 'commands', 'create.ts')),
+    ).toBe(true);
+    expect(
+      fs.existsSync(path.join(packageRoot, 'src', 'commands', 'sync.ts')),
+    ).toBe(true);
+    expect(
+      fs.existsSync(path.join(packageRoot, 'src', 'commands', 'add.ts')),
+    ).toBe(true);
+    expect(
+      fs.existsSync(path.join(packageRoot, 'src', 'commands', 'templates.ts')),
+    ).toBe(true);
+    expect(
+      fs.existsSync(path.join(packageRoot, 'src', 'commands', 'migrate.ts')),
+    ).toBe(true);
+    expect(
+      fs.existsSync(path.join(packageRoot, 'src', 'commands', 'mcp.ts')),
+    ).toBe(true);
+    expect(
+      fs.existsSync(path.join(packageRoot, 'src', 'commands', 'doctor.ts')),
+    ).toBe(true);
+    expect(
+      fs.existsSync(path.join(packageRoot, '.bunli', 'commands.gen.ts')),
+    ).toBe(true);
+  });
 
-	test("runtime rebuild fallback targets sibling linked packages directly", () => {
-		const runtimeBuildScript = fs.readFileSync(
-			path.join(packageRoot, "scripts", "build-bunli-runtime.ts"),
-			"utf8",
-		);
+  test('runtime rebuild fallback targets sibling linked packages directly', () => {
+    const runtimeBuildScript = fs.readFileSync(
+      path.join(packageRoot, 'scripts', 'build-bunli-runtime.ts'),
+      'utf8',
+    );
 
-		expect(runtimeBuildScript).toContain(
-			'const apiClientPackageRoot = path.resolve(packageRoot, "..", "wp-typia-api-client");',
-		);
-		expect(runtimeBuildScript).toContain(
-			'const blockRuntimePackageRoot = path.resolve(packageRoot, "..", "wp-typia-block-runtime");',
-		);
-		expect(runtimeBuildScript).toContain(
-			'const projectToolsPackageRoot = path.resolve(packageRoot, "..", "wp-typia-project-tools");',
-		);
-		expect(runtimeBuildScript).toContain('Bun.which("bun") ?? process.execPath');
-		expect(runtimeBuildScript).toContain('@wp-typia/api-client');
-		expect(runtimeBuildScript).toContain('@wp-typia/block-runtime');
-		expect(runtimeBuildScript).toContain('@wp-typia/project-tools');
-		expect(runtimeBuildScript).toContain(
-			"Unable to locate linked wp-typia sibling packages while recovering runtime aliases",
-		);
-		expect(runtimeBuildScript).toContain('Failed to build ${buildStep.label}');
-	});
+    expect(runtimeBuildScript).toContain(
+      'const requireFromWpTypia = createRequire(',
+    );
+    expect(runtimeBuildScript).toContain(
+      "path.join(packageRoot, 'package.json')",
+    );
+    expect(runtimeBuildScript).toContain(
+      "requireFromWpTypia.resolve('@wp-typia/project-tools/package.json')",
+    );
+    expect(runtimeBuildScript).toContain(
+      "requireFromWpTypia.resolve('@wp-typia/api-client/package.json')",
+    );
+    expect(runtimeBuildScript).toContain(
+      "requireFromProjectTools.resolve('@wp-typia/block-runtime/package.json')",
+    );
+    expect(runtimeBuildScript).toContain(
+      "['x', 'tsc', '-p', buildStep.tsconfig]",
+    );
+    expect(runtimeBuildScript).toContain('tsconfig.runtime.json');
+    expect(runtimeBuildScript).toContain('tsconfig.build.json');
+    expect(runtimeBuildScript).toContain(
+      'Unable to locate linked wp-typia sibling packages while recovering runtime aliases',
+    );
+    expect(runtimeBuildScript).toContain('Failed to build ${buildStep.label}');
+  });
 
-	test("future Bunli command tree preserves the reserved top-level taxonomy", async () => {
-		expect(WP_TYPIA_FUTURE_COMMAND_TREE.map((command) => command.name)).toEqual(
-			Array.from(WP_TYPIA_TOP_LEVEL_COMMAND_NAMES),
-		);
-		expect(wpTypiaCommands.map((command) => command.name)).toEqual(
-			Array.from(WP_TYPIA_TOP_LEVEL_COMMAND_NAMES),
-		);
-		expect(fs.readFileSync(path.join(packageRoot, "src", "cli.ts"), "utf8")).toContain(
-			"createCLI(",
-		);
-	});
+  test('future Bunli command tree preserves the reserved top-level taxonomy', async () => {
+    expect(WP_TYPIA_FUTURE_COMMAND_TREE.map((command) => command.name)).toEqual(
+      Array.from(WP_TYPIA_TOP_LEVEL_COMMAND_NAMES),
+    );
+    expect(wpTypiaCommands.map((command) => command.name)).toEqual(
+      Array.from(WP_TYPIA_TOP_LEVEL_COMMAND_NAMES),
+    );
+    expect(
+      fs.readFileSync(path.join(packageRoot, 'src', 'cli.ts'), 'utf8'),
+    ).toContain('createCLI(');
+  });
 
-	test("maintainer docs keep wp-typia as the only CLI owner", () => {
-		const migrationDocSourcePath = path.join(
-			repoRoot,
-			"apps",
-			"docs",
-			"src",
-			"content",
-			"docs",
-			"maintainers",
-			"bunli-cli-migration.md",
-		);
-		const migrationDoc = fs.readFileSync(
-			migrationDocSourcePath,
-			"utf8",
-		);
+  test('maintainer docs keep wp-typia as the only CLI owner', () => {
+    const migrationDocSourcePath = path.join(
+      repoRoot,
+      'apps',
+      'docs',
+      'src',
+      'content',
+      'docs',
+      'maintainers',
+      'bunli-cli-migration.md',
+    );
+    const migrationDoc = fs.readFileSync(migrationDocSourcePath, 'utf8');
 
-		expect(WP_TYPIA_BUNLI_MIGRATION_DOC).toBe(
-			"https://imjlk.github.io/wp-typia/maintainers/bunli-cli-migration/",
-		);
-		expect(migrationDoc).toContain("`@wp-typia/project-tools` must remain non-CLI");
-		expect(migrationDoc).toContain("`npx wp-typia`");
-		expect(migrationDoc).toContain("`bunx wp-typia`");
-		expect(migrationDoc).toContain("`dist-bunli/cli.js`");
-		expect(migrationDoc).toContain("`>=1.3.11`");
-		expect(migrationDoc).toContain(`\`${WP_TYPIA_CANONICAL_CREATE_USAGE}\``);
-		expect(migrationDoc).toContain(`\`${WP_TYPIA_CANONICAL_MIGRATE_USAGE}\``);
-		expect(migrationDoc).toContain(`\`${WP_TYPIA_POSITIONAL_ALIAS_USAGE}\``);
-		expect(migrationDoc).not.toContain("`@wp-typia/create`");
-		expect(fs.existsSync(path.join(repoRoot, "packages", "create"))).toBe(false);
-	});
+    expect(WP_TYPIA_BUNLI_MIGRATION_DOC).toBe(
+      'https://imjlk.github.io/wp-typia/maintainers/bunli-cli-migration/',
+    );
+    expect(migrationDoc).toContain(
+      '`@wp-typia/project-tools` must remain non-CLI',
+    );
+    expect(migrationDoc).toContain('`npx wp-typia`');
+    expect(migrationDoc).toContain('`bunx wp-typia`');
+    expect(migrationDoc).toContain('`dist-bunli/cli.js`');
+    expect(migrationDoc).toContain('`>=1.3.11`');
+    expect(migrationDoc).toContain(`\`${WP_TYPIA_CANONICAL_CREATE_USAGE}\``);
+    expect(migrationDoc).toContain(`\`${WP_TYPIA_CANONICAL_MIGRATE_USAGE}\``);
+    expect(migrationDoc).toContain(`\`${WP_TYPIA_POSITIONAL_ALIAS_USAGE}\``);
+    expect(migrationDoc).not.toContain('`@wp-typia/create`');
+    expect(fs.existsSync(path.join(repoRoot, 'packages', 'create'))).toBe(
+      false,
+    );
+  });
 
-	test("alias normalization ignores option values before the first command positional", () => {
-		expect(
-			normalizeWpTypiaArgv(["--template", "basic", "demo-block"]),
-		).toEqual(["--template", "basic", "create", "demo-block"]);
-		expect(
-			normalizeWpTypiaArgv(["--format", "json", "templates", "list"]),
-		).toEqual(["--format", "json", "templates", "list"]);
-		expect(
-			normalizeWpTypiaArgv(["-t", "basic", "demo-block"]),
-		).toEqual(["-t", "basic", "create", "demo-block"]);
-		expect(
-			normalizeWpTypiaArgv(["--config", "./custom.json", "templates", "list"]),
-		).toEqual(["--config", "./custom.json", "templates", "list"]);
-		expect(
-			normalizeWpTypiaArgv(["-c", "./custom.json", "templates", "list"]),
-		).toEqual(["-c", "./custom.json", "templates", "list"]);
-		expect(normalizeWpTypiaArgv(["help"])).toEqual(["help"]);
-		expect(normalizeWpTypiaArgv(["version"])).toEqual(["version"]);
-		expect(
-			normalizeWpTypiaArgv(["demo-block", "--template", "basic"]),
-		).toEqual(["create", "demo-block", "--template", "basic"]);
-		expect(() => normalizeWpTypiaArgv(["github:acme/template"])).toThrow(
-			/The positional alias only accepts unambiguous local project directories/,
-		);
-		expect(() => normalizeWpTypiaArgv(["."])).toThrow(
-			/The positional alias does not scaffold into `\.`/,
-		);
-		expect(() => normalizeWpTypiaArgv(["./"])).toThrow(
-			/The positional alias does not scaffold into `\.\/`/,
-		);
-		expect(
-			normalizeWpTypiaArgv([
-				"add",
-				"hooked-block",
-				"promo-card",
-				"--anchor",
-				"core/post-content",
-				"--position",
-				"after",
-			]),
-		).toEqual([
-			"add",
-			"hooked-block",
-			"promo-card",
-			"--anchor",
-			"core/post-content",
-			"--position",
-			"after",
-		]);
-		expect(() => normalizeWpTypiaArgv(["templates", "inspect", "--id"])).toThrow(
-			/`--id` requires a value\./,
-		);
-		expect(() => normalizeWpTypiaArgv(["mcp", "sync", "--output-dir"])).toThrow(
-			/`--output-dir` requires a value\./,
-		);
-		expect(() => normalizeWpTypiaArgv(["temlates", "list"])).toThrow(
-			/only accepts a single project directory.*check the command spelling.*`list`/s,
-		);
-	});
+  test('alias normalization ignores option values before the first command positional', () => {
+    expect(normalizeWpTypiaArgv(['--template', 'basic', 'demo-block'])).toEqual(
+      ['--template', 'basic', 'create', 'demo-block'],
+    );
+    expect(
+      normalizeWpTypiaArgv(['--format', 'json', 'templates', 'list']),
+    ).toEqual(['--format', 'json', 'templates', 'list']);
+    expect(normalizeWpTypiaArgv(['-t', 'basic', 'demo-block'])).toEqual([
+      '-t',
+      'basic',
+      'create',
+      'demo-block',
+    ]);
+    expect(
+      normalizeWpTypiaArgv(['--config', './custom.json', 'templates', 'list']),
+    ).toEqual(['--config', './custom.json', 'templates', 'list']);
+    expect(
+      normalizeWpTypiaArgv(['-c', './custom.json', 'templates', 'list']),
+    ).toEqual(['-c', './custom.json', 'templates', 'list']);
+    expect(normalizeWpTypiaArgv(['help'])).toEqual(['help']);
+    expect(normalizeWpTypiaArgv(['version'])).toEqual(['version']);
+    expect(normalizeWpTypiaArgv(['demo-block', '--template', 'basic'])).toEqual(
+      ['create', 'demo-block', '--template', 'basic'],
+    );
+    expect(() => normalizeWpTypiaArgv(['github:acme/template'])).toThrow(
+      /The positional alias only accepts unambiguous local project directories/,
+    );
+    expect(() => normalizeWpTypiaArgv(['.'])).toThrow(
+      /The positional alias does not scaffold into `\.`/,
+    );
+    expect(() => normalizeWpTypiaArgv(['./'])).toThrow(
+      /The positional alias does not scaffold into `\.\/`/,
+    );
+    expect(
+      normalizeWpTypiaArgv([
+        'add',
+        'hooked-block',
+        'promo-card',
+        '--anchor',
+        'core/post-content',
+        '--position',
+        'after',
+      ]),
+    ).toEqual([
+      'add',
+      'hooked-block',
+      'promo-card',
+      '--anchor',
+      'core/post-content',
+      '--position',
+      'after',
+    ]);
+    expect(() =>
+      normalizeWpTypiaArgv(['templates', 'inspect', '--id']),
+    ).toThrow(/`--id` requires a value\./);
+    expect(() => normalizeWpTypiaArgv(['mcp', 'sync', '--output-dir'])).toThrow(
+      /`--output-dir` requires a value\./,
+    );
+    expect(() => normalizeWpTypiaArgv(['temlates', 'list'])).toThrow(
+      /only accepts a single project directory.*check the command spelling.*`list`/s,
+    );
+  });
 });


### PR DESCRIPTION
## Context

The Bun-linked `my-typia-block` generated smoke lane still fails on `main` after merge because `packages/wp-typia/scripts/build-bunli-runtime.ts` guesses sibling package directories relative to `wp-typia`. That breaks inside copied Bun package trees under `node_modules/.bun/...`, where the linked sibling packages are only reliably discoverable through installed package metadata.

## What Changed

- resolve linked `@wp-typia/project-tools` and `@wp-typia/api-client` package roots from the installed `wp-typia` package with `createRequire(...).resolve(.../package.json)`
- resolve `@wp-typia/block-runtime` from the linked `@wp-typia/project-tools` package root instead of guessing another sibling path
- rebuild missing runtime dependencies with direct package-local TypeScript builds (`bun x tsc -p ...`) so copied Bun package trees do not depend on monorepo filter scripts
- update `bunli-prep.test.ts` to lock the new resolution/build strategy behind boundary assertions

## Verification

- `bun test packages/wp-typia/tests/bunli-prep.test.ts`
- `bun run changesets:validate`
- `rm -rf packages/wp-typia-project-tools/dist packages/wp-typia-api-client/dist packages/wp-typia-block-runtime/dist && node scripts/run-generated-project-smoke.mjs --runtime bun --example-project my-typia-block --package-manager bun --project-name smoke-reference-my-typia-block-bun-fix-3`

Closes #462


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored the build process to improve dependency resolution and ensure consistent artifact generation across packages.
  * Updated build verification tests to validate the new build step handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->