### PR TITLE
Fix Linux Bunli asset naming collisions in reference smoke

### DIFF
--- a/.sampo/changesets/linux-reference-smoke-bunli-assets.md
+++ b/.sampo/changesets/linux-reference-smoke-bunli-assets.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Keep the split `wp-typia` Bunli runtime compatible with Linux reference-project migration smoke runs by using collision-safe asset names for the full runtime rebuild without regressing local help and skills command loading.

--- a/packages/wp-typia/scripts/build-bunli-runtime.ts
+++ b/packages/wp-typia/scripts/build-bunli-runtime.ts
@@ -291,9 +291,8 @@ async function buildFullBunliRuntime() {
     external: WP_TYPIA_EXTERNALS,
     format: 'esm',
     naming: {
-      asset: '[name]-[hash].[ext]',
+      asset: '[dir]/[name]-[hash].[ext]',
       chunk: '[name]-[hash].[ext]',
-      entry: '[name].[ext]',
     },
     outdir,
     sourcemap: buildConfig.sourcemap ? 'external' : 'none',

--- a/packages/wp-typia/tests/bunli-prep.test.ts
+++ b/packages/wp-typia/tests/bunli-prep.test.ts
@@ -105,9 +105,8 @@ describe('wp-typia Bunli preparation', () => {
       'wp-typia runtime alias artifacts still missing after rebuild',
     );
     expect(runtimeBuildScript).toContain("naming: {");
-    expect(runtimeBuildScript).toContain("asset: '[name]-[hash].[ext]'");
+    expect(runtimeBuildScript).toContain("asset: '[dir]/[name]-[hash].[ext]'");
     expect(runtimeBuildScript).toContain("chunk: '[name]-[hash].[ext]'");
-    expect(runtimeBuildScript).toContain("entry: '[name].[ext]'");
     expect(runtimeBuildScript).toContain('splitting: true');
   });
 


### PR DESCRIPTION
## Context

`main` still fails after #466 in `Generated Project Smoke (smoke-reference-my-typia-block-bun)` on Linux during `wp-typia migrate snapshot`. The full Bunli runtime rebuild needs collision-safe asset output names, but the previous broader naming change regressed local help/skills loading.

## What Changed

- keep the full Bunli runtime split build in place
- narrow the naming override to collision-prone assets while leaving chunk naming on the working path
- lock the new naming contract in `bunli-prep.test.ts`
- add a patch changeset for the `wp-typia` CLI package

## Verification

- `bun run --filter wp-typia build`
- `node packages/wp-typia/bin/wp-typia.js --help`
- `node packages/wp-typia/bin/wp-typia.js skills list`
- `node scripts/run-generated-project-smoke.mjs --runtime bun --example-project my-typia-block --package-manager bun --project-name smoke-reference-my-typia-block-bun-linux-followup`
- `bun run changesets:validate`

Closes #468

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed compatibility issue affecting Linux reference-project migration smoke runs by ensuring collision-safe asset naming during runtime rebuilds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->