### PR TITLE
Use execution-independent root for Bunli asset naming

### DIFF
--- a/.sampo/changesets/bunli-build-root-execution-cwd.md
+++ b/.sampo/changesets/bunli-build-root-execution-cwd.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Keep Linux reference-project migration smoke runs from flattening Bunli runtime asset names by anchoring the full-runtime build root to the execution cwd that owns the installed package graph.

--- a/packages/wp-typia/scripts/build-bunli-runtime.ts
+++ b/packages/wp-typia/scripts/build-bunli-runtime.ts
@@ -21,6 +21,7 @@ const generatedMetadataEntrypoint = path.resolve(
   'commands.gen.ts',
 );
 const nodeRuntimeEntrypoint = path.resolve(packageRoot, 'src', 'node-cli.ts');
+const buildRoot = path.parse(packageRoot).root;
 const outdir = path.resolve(packageRoot, buildConfig.outdir);
 const generatedMetadataOutdir = path.join(outdir, '.bunli');
 const requireFromWpTypia = createRequire(
@@ -293,8 +294,10 @@ async function buildFullBunliRuntime() {
     naming: {
       asset: '[dir]/[name]-[hash].[ext]',
       chunk: '[name]-[hash].[ext]',
+      entry: '[name].[ext]',
     },
     outdir,
+    root: buildRoot,
     sourcemap: buildConfig.sourcemap ? 'external' : 'none',
     splitting: true,
     target: 'bun',

--- a/packages/wp-typia/tests/bunli-prep.test.ts
+++ b/packages/wp-typia/tests/bunli-prep.test.ts
@@ -104,9 +104,14 @@ describe('wp-typia Bunli preparation', () => {
     expect(runtimeBuildScript).toContain(
       'wp-typia runtime alias artifacts still missing after rebuild',
     );
+    expect(runtimeBuildScript).toContain(
+      'const buildRoot = path.parse(packageRoot).root;',
+    );
     expect(runtimeBuildScript).toContain("naming: {");
     expect(runtimeBuildScript).toContain("asset: '[dir]/[name]-[hash].[ext]'");
     expect(runtimeBuildScript).toContain("chunk: '[name]-[hash].[ext]'");
+    expect(runtimeBuildScript).toContain("entry: '[name].[ext]'");
+    expect(runtimeBuildScript).toContain('root: buildRoot');
     expect(runtimeBuildScript).toContain('splitting: true');
   });
 


### PR DESCRIPTION
## Context

`main` still fails after #469 in `Generated Project Smoke (smoke-reference-my-typia-block-bun)`. The Linux reference migration snapshot still reports duplicate output paths from `@opentui/react` assets during the Bunli runtime rebuild.

## What Changed

- anchor the full Bunli runtime build root to the filesystem root so external installed assets keep stable directory context
- keep the explicit entry naming so `dist-bunli/cli.js` still lands in the canonical output path
- lock the root and naming contract in `bunli-prep.test.ts`
- add a patch changeset for `wp-typia`

## Verification

- `bun run --filter wp-typia build`
- `node packages/wp-typia/bin/wp-typia.js --help`
- `node packages/wp-typia/bin/wp-typia.js skills list`
- `node scripts/run-generated-project-smoke.mjs --runtime bun --example-project my-typia-block --package-manager bun --project-name smoke-reference-my-typia-block-bun-root2-followup`
- `bun run changesets:validate`

Closes #470