### PR TITLE
Support multi-child and nested compound scaffold specs

### DIFF
--- a/.sampo/changesets/compound-multi-child-nested-scaffold.md
+++ b/.sampo/changesets/compound-multi-child-nested-scaffold.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/project-tools: minor
+---
+
+Support multi-child and nested compound scaffold growth through the generated `add-compound-child` workflow.

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Use it for:
 
 ### 4. Compound blocks are scaffolded as a system
 
-The `compound` template creates a parent/child block structure with hidden implementation children, so complex `InnerBlocks` patterns start from a maintainable project shape rather than a one-off setup.
+The `compound` template creates a parent/child block structure with hidden implementation children, and the generated `add-child` workflow can now grow that into visible container children plus nested ancestor chains for richer document-style `InnerBlocks` hierarchies.
 
 ### 5. Query Loop variations get a first-class scaffold
 

--- a/apps/docs/src/content/docs/reference/api.md
+++ b/apps/docs/src/content/docs/reference/api.md
@@ -643,10 +643,14 @@ be scaffolded on demand:
 
 ```bash
 npm run add-child -- --slug faq-item --title "FAQ Item"
+npm run add-child -- --slug section --title "Section" --container --inserter visible
+npm run add-child -- --slug clause --title "Clause" --ancestor section
 ```
 
 That command updates `scripts/block-config.ts` plus `src/blocks/<parent>/children.ts`
-without changing the parent block's default seeded template.
+without changing the parent block's default seeded template for hidden child
+extensions, and it also supports visible container children plus nested ancestor
+chains for richer document-style layouts.
 
 Official workspaces also support first-class variation, pattern, binding-source, and hooked-block expansion:
 

--- a/packages/wp-typia-project-tools/src/runtime/built-in-block-artifacts.ts
+++ b/packages/wp-typia-project-tools/src/runtime/built-in-block-artifacts.ts
@@ -154,6 +154,7 @@ function buildCompoundParentArtifact(
 			icon: variables.icon,
 			description: variables.description,
 			example: {},
+			allowedBlocks: [`${variables.namespace}/${variables.slugKebabCase}-item`],
 			supports: persistenceEnabled
 				? {
 					html: false,

--- a/packages/wp-typia-project-tools/src/runtime/built-in-block-code-templates/compound-child.ts
+++ b/packages/wp-typia-project-tools/src/runtime/built-in-block-code-templates/compound-child.ts
@@ -1,8 +1,14 @@
 export const COMPOUND_CHILD_EDIT_TEMPLATE = `import type { BlockEditProps } from '@wp-typia/block-types/blocks/registration';
-import { RichText, useBlockProps } from '@wordpress/block-editor';
+import { InnerBlocks, RichText, useBlockProps } from '@wordpress/block-editor';
 import { Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
+import metadata from './block-metadata';
+import {
+\tgetChildAllowedBlocks,
+\tgetChildTemplate,
+\thasNestedChildBlocks,
+} from '../{{slugKebabCase}}/children';
 import { useTypiaValidation } from './hooks';
 import type { {{pascalCase}}ItemAttributes } from './types';
 import {
@@ -21,6 +27,9 @@ export default function Edit( {
 \t\tattributes,
 \t\tvalidate{{pascalCase}}ItemAttributes
 \t);
+\tconst nestedAllowedBlocks = getChildAllowedBlocks( metadata.name );
+\tconst nestedTemplate = getChildTemplate( metadata.name );
+\tconst showsNestedChildren = hasNestedChildBlocks( metadata.name );
 
 \treturn (
 \t\t<div { ...useBlockProps( { className: '{{compoundChildCssClassName}}' } ) }>
@@ -45,13 +54,25 @@ export default function Edit( {
 \t\t\t\t\t</ul>
 \t\t\t\t</Notice>
 \t\t\t) }
+\t\t\t{ showsNestedChildren && (
+\t\t\t\t<div className="{{compoundChildCssClassName}}__children">
+\t\t\t\t\t<InnerBlocks
+\t\t\t\t\t\tallowedBlocks={ nestedAllowedBlocks }
+\t\t\t\t\t\trenderAppender={ InnerBlocks.ButtonBlockAppender }
+\t\t\t\t\t\ttemplate={ nestedTemplate }
+\t\t\t\t\t\ttemplateLock={ false }
+\t\t\t\t\t/>
+\t\t\t\t</div>
+\t\t\t) }
 \t\t</div>
 \t);
 }
 `;
 
-export const COMPOUND_CHILD_SAVE_TEMPLATE = `import { RichText, useBlockProps } from '@wordpress/block-editor';
+export const COMPOUND_CHILD_SAVE_TEMPLATE = `import { InnerBlocks, RichText, useBlockProps } from '@wordpress/block-editor';
 
+import metadata from './block-metadata';
+import { hasNestedChildBlocks } from '../{{slugKebabCase}}/children';
 import type { {{pascalCase}}ItemAttributes } from './types';
 
 export default function Save( {
@@ -59,6 +80,8 @@ export default function Save( {
 }: {
 \tattributes: {{pascalCase}}ItemAttributes;
 } ) {
+\tconst showsNestedChildren = hasNestedChildBlocks( metadata.name );
+
 \treturn (
 \t\t<div { ...useBlockProps.save( { className: '{{compoundChildCssClassName}}' } ) }>
 \t\t\t<RichText.Content
@@ -71,6 +94,11 @@ export default function Save( {
 \t\t\t\tclassName="{{compoundChildCssClassName}}__body"
 \t\t\t\tvalue={ attributes.body }
 \t\t\t/>
+\t\t\t{ showsNestedChildren && (
+\t\t\t\t<div className="{{compoundChildCssClassName}}__children">
+\t\t\t\t\t<InnerBlocks.Content />
+\t\t\t\t</div>
+\t\t\t) }
 \t\t</div>
 \t);
 }

--- a/packages/wp-typia-project-tools/src/runtime/built-in-block-code-templates/compound-parent.ts
+++ b/packages/wp-typia-project-tools/src/runtime/built-in-block-code-templates/compound-parent.ts
@@ -208,25 +208,145 @@ export const COMPOUND_CHILDREN_TEMPLATE = `import type { BlockTemplate } from '@
 
 export const DEFAULT_CHILD_BLOCK_NAME = '{{namespace}}/{{slugKebabCase}}-item';
 
-export const ALLOWED_CHILD_BLOCKS = [
-\tDEFAULT_CHILD_BLOCK_NAME,
-\t// add-child: insert new allowed child block names here
+export interface CompoundChildSpec {
+\tancestorKeys: string[];
+\tblockName: string;
+\tbodyPlaceholder: string;
+\tcontainer: boolean;
+\tfolderSlug: string;
+\tkey: string;
+\tplacement: 'nested' | 'root';
+\tsupportsInserter: boolean;
+\ttemplateInstances: Array< Record< string, unknown > >;
+\ttitle: string;
+}
+
+const ROOT_BLOCK_NAME = '{{namespace}}/{{slugKebabCase}}';
+
+export const COMPOUND_CHILD_SPECS: CompoundChildSpec[] = [
+\t{
+\t\tancestorKeys: [],
+\t\tblockName: DEFAULT_CHILD_BLOCK_NAME,
+\t\tbodyPlaceholder: 'Add supporting details for this internal item.',
+\t\tcontainer: false,
+\t\tfolderSlug: '{{slugKebabCase}}-item',
+\t\tkey: 'item',
+\t\tplacement: 'root',
+\t\tsupportsInserter: false,
+\t\ttemplateInstances: [
+\t\t\t{
+\t\t\t\tbody: 'Add supporting details for the first internal item.',
+\t\t\t\ttitle: 'First Item',
+\t\t\t},
+\t\t\t{
+\t\t\t\tbody: 'Add supporting details for the second internal item.',
+\t\t\t\ttitle: 'Second Item',
+\t\t\t},
+\t\t],
+\t\ttitle: '{{compoundChildTitle}}',
+\t},
+\t// add-child: insert new child specs here
 ];
 
-export const DEFAULT_CHILD_TEMPLATE: BlockTemplate = [
-\t[
-\t\tDEFAULT_CHILD_BLOCK_NAME,
-\t\t{
-\t\t\tbody: 'Add supporting details for the first internal item.',
-\t\t\ttitle: 'First Item',
-\t\t},
-\t],
-\t[
-\t\tDEFAULT_CHILD_BLOCK_NAME,
-\t\t{
-\t\t\tbody: 'Add supporting details for the second internal item.',
-\t\t\ttitle: 'Second Item',
-\t\t},
-\t],
-];
+function getChildSpecByKey( key: string ): CompoundChildSpec | undefined {
+\treturn COMPOUND_CHILD_SPECS.find( ( spec ) => spec.key === key );
+}
+
+function buildTemplateEntriesForSpec( spec: CompoundChildSpec ): BlockTemplate {
+\tconst nestedTemplate = buildNestedTemplateForKey( spec.key );
+
+\treturn spec.templateInstances.map( ( attributes ) =>
+\t\tnestedTemplate.length > 0
+\t\t\t? [ spec.blockName, attributes, nestedTemplate ]
+\t\t\t: [ spec.blockName, attributes ]
+\t);
+}
+
+function buildNestedTemplateForKey( key: string ): BlockTemplate {
+\treturn COMPOUND_CHILD_SPECS.filter(
+\t\t( spec ) =>
+\t\t\tspec.placement === 'nested' &&
+\t\t\tspec.ancestorKeys[ spec.ancestorKeys.length - 1 ] === key
+\t).flatMap( ( spec ) => buildTemplateEntriesForSpec( spec ) );
+}
+
+export const ALLOWED_CHILD_BLOCKS = COMPOUND_CHILD_SPECS.filter(
+\t( spec ) => spec.placement === 'root'
+).map( ( spec ) => spec.blockName );
+
+export const DEFAULT_CHILD_TEMPLATE: BlockTemplate =
+\tCOMPOUND_CHILD_SPECS.filter( ( spec ) => spec.placement === 'root' ).flatMap(
+\t\t( spec ) => buildTemplateEntriesForSpec( spec )
+\t);
+
+export function getChildSpec( blockName: string ): CompoundChildSpec | undefined {
+\treturn COMPOUND_CHILD_SPECS.find( ( spec ) => spec.blockName === blockName );
+}
+
+export function getChildAllowedBlocks(
+\tblockName: string
+): string[] | undefined {
+\tconst childSpec = getChildSpec( blockName );
+\tif ( ! childSpec ) {
+\t\treturn undefined;
+\t}
+
+\tconst directDescendants = COMPOUND_CHILD_SPECS.filter(
+\t\t( spec ) =>
+\t\t\tspec.placement === 'nested' &&
+\t\t\tspec.ancestorKeys[ spec.ancestorKeys.length - 1 ] === childSpec.key
+\t).map( ( spec ) => spec.blockName );
+
+\tif ( directDescendants.length > 0 ) {
+\t\treturn directDescendants;
+\t}
+
+\treturn childSpec.container ? [] : undefined;
+}
+
+export function getChildAncestorBlockNames(
+\tblockName: string
+): string[] | undefined {
+\tconst childSpec = getChildSpec( blockName );
+\tif ( ! childSpec || childSpec.ancestorKeys.length === 0 ) {
+\t\treturn undefined;
+\t}
+
+\treturn childSpec.ancestorKeys.flatMap( ( key ) => {
+\t\tconst ancestorSpec = getChildSpecByKey( key );
+\t\treturn ancestorSpec ? [ ancestorSpec.blockName ] : [];
+\t} );
+}
+
+export function getChildTemplate(
+\tblockName: string
+): BlockTemplate | undefined {
+\tconst childSpec = getChildSpec( blockName );
+\tif ( ! childSpec ) {
+\t\treturn undefined;
+\t}
+
+\tconst nestedTemplate = buildNestedTemplateForKey( childSpec.key );
+\tif ( nestedTemplate.length > 0 ) {
+\t\treturn nestedTemplate;
+\t}
+
+\treturn childSpec.container ? [] : undefined;
+}
+
+export function hasNestedChildBlocks( blockName: string ): boolean {
+\tconst childSpec = getChildSpec( blockName );
+\tif ( ! childSpec ) {
+\t\treturn false;
+\t}
+
+\treturn childSpec.container || buildNestedTemplateForKey( childSpec.key ).length > 0;
+}
+
+export function isRootCompoundChildBlock( blockName: string ): boolean {
+\tconst childSpec = getChildSpec( blockName );
+\treturn childSpec?.placement === 'root';
+}
+
+export { ROOT_BLOCK_NAME };
 `;

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-onboarding.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-onboarding.ts
@@ -231,7 +231,7 @@ export function getCompoundExtensionWorkflowSection(
 		return null;
 	}
 
-	return `## Compound Extension Workflow
+return `## Compound Extension Workflow
 
 \`\`\`bash
 ${ formatRunScript(
@@ -239,9 +239,21 @@ ${ formatRunScript(
 		"add-child",
 		'--slug faq-item --title "FAQ Item"'
 	) }
+
+${ formatRunScript(
+		packageManager,
+		"add-child",
+		'--slug section --title "Section" --container --inserter visible'
+	) }
+
+${ formatRunScript(
+		packageManager,
+		"add-child",
+		'--slug clause --title "Clause" --ancestor section'
+	) }
 \`\`\`
 
-This scaffolds a new hidden child block type, updates \`scripts/block-config.ts\` and \`src/blocks/*/children.ts\`, and leaves the default seeded child template unchanged.`;
+This scaffolds additional compound child block types, updates \`scripts/block-config.ts\` and \`src/blocks/*/children.ts\`, and now supports root-level hidden children, visible container children, and nested ancestor chains for richer document-style block hierarchies.`;
 }
 
 function formatPhpRestExtensionPointsSection({

--- a/packages/wp-typia-project-tools/templates/_shared/compound/core/scripts/add-compound-child.ts.mustache
+++ b/packages/wp-typia-project-tools/templates/_shared/compound/core/scripts/add-compound-child.ts.mustache
@@ -4,7 +4,7 @@ import path from 'node:path';
 
 const PROJECT_ROOT = process.cwd();
 
-const ALLOWED_CHILD_MARKER = '// add-child: insert new allowed child block names here';
+const CHILD_SPEC_MARKER = '// add-child: insert new child specs here';
 const BLOCK_CONFIG_MARKER = '// add-child: insert new block config entries here';
 const CHILD_PLACEHOLDER = 'Add supporting details for this internal item.';
 const BLOCK_SLUG_PATTERN = /^[a-z][a-z0-9-]*$/;
@@ -16,8 +16,10 @@ type StarterManifestDocument = {
 };
 
 type CompoundParentConfig = {
+	blockJsonPath: string;
 	blockName: string;
 	namespace: string;
+	blocksRoot: string;
 	slug: string;
 	styleImport: string;
 	textDomain: string;
@@ -25,12 +27,27 @@ type CompoundParentConfig = {
 	typeName: string;
 };
 
+type ExistingCompoundChild = {
+	blockJsonPath: string;
+	blockName: string;
+	folderSlug: string;
+	key: string;
+};
+
+type ParsedArgs = {
+	ancestorValues: string[];
+	container: boolean;
+	inserter?: 'hidden' | 'visible';
+	slug?: string;
+	title?: string;
+};
+
 function parseArgs() {
 	const args = process.argv.slice( 2 );
-	const parsed: {
-		slug?: string;
-		title?: string;
-	} = {};
+	const parsed: ParsedArgs = {
+		ancestorValues: [],
+		container: false,
+	};
 
 	for ( let index = 0; index < args.length; index += 1 ) {
 		const arg = args[ index ];
@@ -50,6 +67,31 @@ function parseArgs() {
 				throw new Error( '--title requires a value.' );
 			}
 			parsed.title = value;
+			index += 1;
+			continue;
+		}
+
+		if ( arg === '--ancestor' ) {
+			const value = args[ index + 1 ];
+			if ( ! value || value.startsWith( '--' ) ) {
+				throw new Error( '--ancestor requires a value.' );
+			}
+			parsed.ancestorValues.push( value );
+			index += 1;
+			continue;
+		}
+
+		if ( arg === '--container' ) {
+			parsed.container = true;
+			continue;
+		}
+
+		if ( arg === '--inserter' ) {
+			const value = args[ index + 1 ];
+			if ( value !== 'hidden' && value !== 'visible' ) {
+				throw new Error( "--inserter must be either 'hidden' or 'visible'." );
+			}
+			parsed.inserter = value;
 			index += 1;
 			continue;
 		}
@@ -177,8 +219,10 @@ function resolveCompoundParentConfig(): CompoundParentConfig {
 			: parentSlug;
 
 	return {
+		blockJsonPath,
 		blockName,
 		namespace,
+		blocksRoot,
 		slug: parentSlug,
 		styleImport: `../${ parentSlug }/style.scss`,
 		textDomain,
@@ -188,8 +232,10 @@ function resolveCompoundParentConfig(): CompoundParentConfig {
 }
 
 const {
+	blockJsonPath: PARENT_BLOCK_JSON_PATH,
 	blockName: PARENT_BLOCK_NAME,
 	namespace: PARENT_BLOCK_NAMESPACE,
+	blocksRoot: BLOCKS_ROOT,
 	slug: PARENT_BLOCK_SLUG,
 	styleImport: PARENT_STYLE_IMPORT,
 	textDomain: TEXT_DOMAIN,
@@ -300,50 +346,186 @@ function insertBeforeMarker( filePath: string, marker: string, insertionLines: s
 	);
 }
 
+function readBlockJsonDocument(
+	filePath: string
+): Record< string, unknown > {
+	return readJsonFile( filePath );
+}
+
+function writeBlockJsonDocument(
+	filePath: string,
+	document: Record< string, unknown >
+) {
+	fs.writeFileSync(
+		filePath,
+		`${ JSON.stringify( document, null, '\t' ) }\n`,
+		'utf8'
+	);
+}
+
+function deriveChildKey( folderSlug: string ): string {
+	if ( folderSlug.startsWith( `${ PARENT_BLOCK_SLUG }-` ) ) {
+		return folderSlug.slice( PARENT_BLOCK_SLUG.length + 1 );
+	}
+
+	return resolveValidatedBlockSlug( folderSlug );
+}
+
+function listExistingCompoundChildren(): ExistingCompoundChild[] {
+	if ( ! fs.existsSync( BLOCKS_ROOT ) ) {
+		return [];
+	}
+
+	return fs
+		.readdirSync( BLOCKS_ROOT, { withFileTypes: true } )
+		.filter( ( entry ) => entry.isDirectory() )
+		.map( ( entry ) => entry.name )
+		.filter( ( folderSlug ) => folderSlug !== PARENT_BLOCK_SLUG )
+		.filter( ( folderSlug ) => folderSlug.startsWith( `${ PARENT_BLOCK_SLUG }-` ) )
+		.map( ( folderSlug ) => {
+			const blockJsonPath = path.join( BLOCKS_ROOT, folderSlug, 'block.json' );
+			if ( ! fs.existsSync( blockJsonPath ) ) {
+				return null;
+			}
+
+			const blockJson = readBlockJsonDocument( blockJsonPath );
+			const blockName =
+				typeof blockJson.name === 'string' ? blockJson.name.trim() : '';
+			if ( blockName.length === 0 ) {
+				return null;
+			}
+
+			return {
+				blockJsonPath,
+				blockName,
+				folderSlug,
+				key: deriveChildKey( folderSlug ),
+			} satisfies ExistingCompoundChild;
+		} )
+		.filter( ( child ): child is ExistingCompoundChild => child !== null );
+}
+
+function resolveExistingCompoundChild(
+	value: string,
+	existingChildren: ExistingCompoundChild[]
+): ExistingCompoundChild {
+	const trimmedValue = value.trim();
+	if ( trimmedValue.length === 0 ) {
+		throw new Error( 'Ancestor references must not be empty.' );
+	}
+
+	const normalizedCandidate = resolveValidatedBlockSlug(
+		trimmedValue.includes( '/' )
+			? trimmedValue.slice( trimmedValue.lastIndexOf( '/' ) + 1 )
+			: trimmedValue
+	);
+	const resolved = existingChildren.find(
+		( child ) =>
+			child.blockName === trimmedValue ||
+			child.folderSlug === trimmedValue ||
+			child.key === normalizedCandidate ||
+			child.folderSlug === `${ PARENT_BLOCK_SLUG }-${ normalizedCandidate }`
+	);
+
+	if ( ! resolved ) {
+		throw new Error(
+			`Unable to resolve compound child ancestor "${ value }". Use an existing child key, folder slug, or block name.`
+		);
+	}
+
+	return resolved;
+}
+
+function ensureUniqueAncestorChain(
+	ancestors: ExistingCompoundChild[]
+): ExistingCompoundChild[] {
+	const seenKeys = new Set< string >();
+
+	return ancestors.filter( ( ancestor ) => {
+		if ( seenKeys.has( ancestor.key ) ) {
+			return false;
+		}
+
+		seenKeys.add( ancestor.key );
+		return true;
+	} );
+}
+
+function updateAllowedBlocks(
+	filePath: string,
+	blockName: string
+) {
+	const blockJson = readBlockJsonDocument( filePath );
+	const existingAllowedBlocks = Array.isArray( blockJson.allowedBlocks )
+		? blockJson.allowedBlocks.filter(
+			( value ): value is string => typeof value === 'string'
+		)
+		: [];
+
+	if ( existingAllowedBlocks.includes( blockName ) ) {
+		return;
+	}
+
+	blockJson.allowedBlocks = [ ...existingAllowedBlocks, blockName ];
+	writeBlockJsonDocument( filePath, blockJson );
+}
+
 function renderBlockJson(
 	childBlockName: string,
 	childFolderSlug: string,
-	childTitle: string
+	childTitle: string,
+	options: {
+		allowedBlocks?: string[];
+		ancestorBlockNames: string[];
+		container: boolean;
+		supportsInserter: boolean;
+	}
 ): string {
 	const childCssClassName = buildBlockCssClassName( PARENT_BLOCK_NAMESPACE, childFolderSlug );
-
-	return `${ JSON.stringify(
-		{
-			$schema: 'https://schemas.wp.org/trunk/block.json',
-			apiVersion: 3,
-			name: childBlockName,
-			version: '{{blockMetadataVersion}}',
-			title: childTitle,
-			category: '{{compoundChildCategory}}',
-			icon: '{{compoundChildIcon}}',
-			description: `Internal item block used by ${ PARENT_BLOCK_TITLE }.`,
-			parent: [ PARENT_BLOCK_NAME ],
-			example: {},
-			supports: {
-				html: false,
-				inserter: false,
-				reusable: false,
-			},
-			attributes: {
-				title: {
-					type: 'string',
-					source: 'html',
-					selector: `.${ childCssClassName }__title`,
-					default: childTitle,
-				},
-				body: {
-					type: 'string',
-					source: 'html',
-					selector: `.${ childCssClassName }__body`,
-					default: CHILD_PLACEHOLDER,
-				},
-			},
-			textdomain: TEXT_DOMAIN,
-			editorScript: 'file:./index.js',
+	const document: Record< string, unknown > = {
+		$schema: 'https://schemas.wp.org/trunk/block.json',
+		apiVersion: 3,
+		name: childBlockName,
+		version: '{{blockMetadataVersion}}',
+		title: childTitle,
+		category: '{{compoundChildCategory}}',
+		icon: '{{compoundChildIcon}}',
+		description: `Internal item block used by ${ PARENT_BLOCK_TITLE }.`,
+		example: {},
+		supports: {
+			html: false,
+			inserter: options.supportsInserter,
+			reusable: false,
 		},
-		null,
-		'\t'
-	) }\n`;
+		attributes: {
+			title: {
+				type: 'string',
+				source: 'html',
+				selector: `.${ childCssClassName }__title`,
+				default: childTitle,
+			},
+			body: {
+				type: 'string',
+				source: 'html',
+				selector: `.${ childCssClassName }__body`,
+				default: CHILD_PLACEHOLDER,
+			},
+		},
+		textdomain: TEXT_DOMAIN,
+		editorScript: 'file:./index.js',
+	};
+
+	if ( options.ancestorBlockNames.length > 0 ) {
+		document.ancestor = options.ancestorBlockNames;
+	} else {
+		document.parent = [ PARENT_BLOCK_NAME ];
+	}
+
+	if ( options.container || ( options.allowedBlocks && options.allowedBlocks.length > 0 ) ) {
+		document.allowedBlocks = options.allowedBlocks ?? [];
+	}
+
+	return `${ JSON.stringify( document, null, '\t' ) }\n`;
 }
 
 function renderTypesFile(
@@ -491,10 +673,16 @@ function renderEditFile(
 	const childCssClassName = buildBlockCssClassName( PARENT_BLOCK_NAMESPACE, childFolderSlug );
 
 	return `import type { BlockEditProps } from '@wp-typia/block-types/blocks/registration';
-import { RichText, useBlockProps } from '@wordpress/block-editor';
+import { InnerBlocks, RichText, useBlockProps } from '@wordpress/block-editor';
 import { Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
+import metadata from './block-metadata';
+import {
+\tgetChildAllowedBlocks,
+\tgetChildTemplate,
+\thasNestedChildBlocks,
+} from '../${ PARENT_BLOCK_SLUG }/children';
 import { useTypiaValidation } from './hooks';
 import type { ${ childTypeName } } from './types';
 import {
@@ -513,6 +701,9 @@ export default function Edit( {
 \t\tattributes,
 \t\tvalidate${ childInterfaceName }
 \t);
+\tconst nestedAllowedBlocks = getChildAllowedBlocks( metadata.name );
+\tconst nestedTemplate = getChildTemplate( metadata.name );
+\tconst showsNestedChildren = hasNestedChildBlocks( metadata.name );
 
 \treturn (
 \t\t<div { ...useBlockProps( { className: '${ childCssClassName }' } ) }>
@@ -539,6 +730,16 @@ export default function Edit( {
 \t\t\t\t\t</ul>
 \t\t\t\t</Notice>
 \t\t\t) }
+\t\t\t{ showsNestedChildren && (
+\t\t\t\t<div className="${ childCssClassName }__children">
+\t\t\t\t\t<InnerBlocks
+\t\t\t\t\t\tallowedBlocks={ nestedAllowedBlocks }
+\t\t\t\t\t\trenderAppender={ InnerBlocks.ButtonBlockAppender }
+\t\t\t\t\t\ttemplate={ nestedTemplate }
+\t\t\t\t\t\ttemplateLock={ false }
+\t\t\t\t\t/>
+\t\t\t\t</div>
+\t\t\t) }
 \t\t</div>
 \t);
 }
@@ -548,8 +749,10 @@ export default function Edit( {
 function renderSaveFile( childFolderSlug: string, childTypeName: string ): string {
 	const childCssClassName = buildBlockCssClassName( PARENT_BLOCK_NAMESPACE, childFolderSlug );
 
-	return `import { RichText, useBlockProps } from '@wordpress/block-editor';
+	return `import { InnerBlocks, RichText, useBlockProps } from '@wordpress/block-editor';
 
+import metadata from './block-metadata';
+import { hasNestedChildBlocks } from '../${ PARENT_BLOCK_SLUG }/children';
 import type { ${ childTypeName } } from './types';
 
 export default function Save( {
@@ -557,6 +760,8 @@ export default function Save( {
 }: {
 \tattributes: ${ childTypeName };
 } ) {
+\tconst showsNestedChildren = hasNestedChildBlocks( metadata.name );
+
 \treturn (
 \t\t<div { ...useBlockProps.save( { className: '${ childCssClassName }' } ) }>
 \t\t\t<RichText.Content
@@ -569,13 +774,18 @@ export default function Save( {
 \t\t\t\tclassName="${ childCssClassName }__body"
 \t\t\t\tvalue={ attributes.body }
 \t\t\t/>
+\t\t\t{ showsNestedChildren && (
+\t\t\t\t<div className="${ childCssClassName }__children">
+\t\t\t\t\t<InnerBlocks.Content />
+\t\t\t\t</div>
+\t\t\t) }
 \t\t</div>
 \t);
 }
 `;
 }
 
-function renderIndexFile( childTypeName: string, childFolderSlug: string ): string {
+function renderIndexFile( childTypeName: string ): string {
 return `import {
 \tregisterScaffoldBlockType,
 \ttype BlockConfiguration,
@@ -604,14 +814,67 @@ registerScaffoldBlockType( registration.name, registration.settings );
 `;
 }
 
+function renderChildSpecLines(
+	options: {
+		ancestorKeys: string[];
+		blockName: string;
+		container: boolean;
+		folderSlug: string;
+		key: string;
+		placement: 'nested' | 'root';
+		seedTemplate: boolean;
+		supportsInserter: boolean;
+		title: string;
+	}
+): string[] {
+	const templateLines =
+		options.seedTemplate
+			? [
+				'\ttemplateInstances: [',
+				'\t\t{',
+				`\t\t\tbody: ${ JSON.stringify( CHILD_PLACEHOLDER ) },`,
+				`\t\t\ttitle: ${ JSON.stringify( options.title ) },`,
+				'\t\t},',
+				'\t],',
+			]
+			: [ '\ttemplateInstances: [],' ];
+
+	return [
+		'{',
+		`\tancestorKeys: [ ${ options.ancestorKeys.map( ( value ) => JSON.stringify( value ) ).join( ', ' ) } ],`,
+		`\tblockName: ${ JSON.stringify( options.blockName ) },`,
+		`\tbodyPlaceholder: ${ JSON.stringify( CHILD_PLACEHOLDER ) },`,
+		`\tcontainer: ${ options.container ? 'true' : 'false' },`,
+		`\tfolderSlug: ${ JSON.stringify( options.folderSlug ) },`,
+		`\tkey: ${ JSON.stringify( options.key ) },`,
+		`\tplacement: ${ JSON.stringify( options.placement ) },`,
+		`\tsupportsInserter: ${ options.supportsInserter ? 'true' : 'false' },`,
+		...templateLines,
+		`\ttitle: ${ JSON.stringify( options.title ) },`,
+		'},',
+	];
+}
+
 function main() {
-	const { slug, title } = parseArgs();
+	const {
+		ancestorValues,
+		container,
+		inserter,
+		slug,
+		title,
+	} = parseArgs();
 	const normalizedSlug = slug ? resolveValidatedBlockSlug( slug ) : '';
 
 	if ( normalizedSlug.length === 0 ) {
 		throw new Error( 'Use a child slug with lowercase letters, numbers, and hyphens only.' );
 	}
 
+	const existingChildren = listExistingCompoundChildren();
+	const ancestorChain = ensureUniqueAncestorChain(
+		ancestorValues.map( ( value ) =>
+			resolveExistingCompoundChild( value, existingChildren )
+		)
+	);
 	const childTitle = title?.trim().length ? title.trim() : toTitleCase( normalizedSlug );
 	const childFolderSlug = `${ PARENT_BLOCK_SLUG }-${ normalizedSlug }`;
 	const childBlockName = `${ PARENT_BLOCK_NAME }-${ normalizedSlug }`;
@@ -628,6 +891,10 @@ function main() {
 	);
 	const blockConfigFile = path.join( PROJECT_ROOT, 'scripts', 'block-config.ts' );
 
+	if ( ancestorChain.some( ( ancestor ) => ancestor.key === normalizedSlug ) ) {
+		throw new Error( 'A child block cannot list itself as an ancestor.' );
+	}
+
 	if ( fs.existsSync( childDir ) ) {
 		throw new Error( `Child block already exists: ${ childFolderSlug }` );
 	}
@@ -638,11 +905,26 @@ function main() {
 		);
 	}
 
+	const supportsInserter =
+		inserter === 'visible'
+			? true
+			: inserter === 'hidden'
+				? false
+				: container || ancestorChain.length > 0;
+	const placement = ancestorChain.length > 0 ? 'nested' : 'root';
+	const seedTemplate = supportsInserter || container || ancestorChain.length > 0;
+	const directAllowedBlocks: string[] = [];
+
 	fs.mkdirSync( childDir, { recursive: true } );
 
 	fs.writeFileSync(
 		path.join( childDir, 'block.json' ),
-		renderBlockJson( childBlockName, childFolderSlug, childTitle ),
+		renderBlockJson( childBlockName, childFolderSlug, childTitle, {
+			allowedBlocks: directAllowedBlocks,
+			ancestorBlockNames: ancestorChain.map( ( ancestor ) => ancestor.blockName ),
+			container,
+			supportsInserter,
+		} ),
 		'utf8'
 	);
 	fs.writeFileSync(
@@ -688,14 +970,24 @@ function main() {
 	);
 	fs.writeFileSync(
 		path.join( childDir, 'index.tsx' ),
-		renderIndexFile( childTypeName, childFolderSlug ),
+		renderIndexFile( childTypeName ),
 		'utf8'
 	);
 
 	insertBeforeMarker(
 		childrenFile,
-		ALLOWED_CHILD_MARKER,
-		[ `'${ childBlockName }',` ]
+		CHILD_SPEC_MARKER,
+		renderChildSpecLines( {
+			ancestorKeys: ancestorChain.map( ( ancestor ) => ancestor.key ),
+			blockName: childBlockName,
+			container,
+			folderSlug: childFolderSlug,
+			key: normalizedSlug,
+			placement,
+			seedTemplate,
+			supportsInserter,
+			title: childTitle,
+		} )
 	);
 	insertBeforeMarker(
 		blockConfigFile,
@@ -708,6 +1000,13 @@ function main() {
 			'},',
 		]
 	);
+
+	if ( placement === 'root' ) {
+		updateAllowedBlocks( PARENT_BLOCK_JSON_PATH, childBlockName );
+	} else {
+		const directAncestor = ancestorChain[ ancestorChain.length - 1 ];
+		updateAllowedBlocks( directAncestor.blockJsonPath, childBlockName );
+	}
 
 	console.log( `✅ Added compound child block ${ childBlockName }` );
 	console.log(

--- a/packages/wp-typia-project-tools/templates/_shared/compound/core/scripts/add-compound-child.ts.mustache
+++ b/packages/wp-typia-project-tools/templates/_shared/compound/core/scripts/add-compound-child.ts.mustache
@@ -474,6 +474,60 @@ function validateAncestorChain(
 	}
 }
 
+function findCompoundChildSpecSource(
+	childrenRegistrySource: string,
+	childKey: string
+): string | null {
+	const childSpecPattern = /\{[\s\S]*?key:\s*["'][^"']+["'][\s\S]*?\n\s*\},/g;
+
+	for ( const match of childrenRegistrySource.matchAll( childSpecPattern ) ) {
+		const candidate = match[ 0 ];
+		if (
+			candidate.includes( `key: "${ childKey }"` ) ||
+			candidate.includes( `key: '${ childKey }'` )
+		) {
+			return candidate;
+		}
+	}
+
+	return null;
+}
+
+function validateAncestorInstantiability(
+	childrenFile: string,
+	ancestorChain: ExistingCompoundChild[]
+) {
+	if ( ancestorChain.length === 0 ) {
+		return;
+	}
+
+	const childrenRegistrySource = fs.readFileSync( childrenFile, 'utf8' );
+
+	for ( const ancestor of ancestorChain ) {
+		const childSpecSource = findCompoundChildSpecSource(
+			childrenRegistrySource,
+			ancestor.key
+		);
+		if ( ! childSpecSource ) {
+			continue;
+		}
+
+		const supportsInserterMatch = childSpecSource.match(
+			/supportsInserter:\s*(true|false)/
+		);
+		const supportsInserter = supportsInserterMatch?.[ 1 ] === 'true';
+		const hasTemplateInstances = ! /templateInstances:\s*\[\s*\]/.test( childSpecSource );
+
+		if ( supportsInserter || hasTemplateInstances ) {
+			continue;
+		}
+
+		throw new Error(
+			`Cannot nest descendants under ${ ancestor.blockName } because it is hidden and has no seeded template instances. Re-add or promote that child with a visible inserter or a seeded template first.`
+		);
+	}
+}
+
 function updateAllowedBlocks(
 	filePath: string,
 	blockName: string
@@ -928,6 +982,8 @@ function main() {
 			'This command expects a compound scaffold with src/blocks/<parent>/children.ts and scripts/block-config.ts.'
 		);
 	}
+
+	validateAncestorInstantiability( childrenFile, ancestorChain );
 
 	const supportsInserter =
 		inserter === 'visible'

--- a/packages/wp-typia-project-tools/templates/_shared/compound/core/scripts/add-compound-child.ts.mustache
+++ b/packages/wp-typia-project-tools/templates/_shared/compound/core/scripts/add-compound-child.ts.mustache
@@ -451,6 +451,29 @@ function ensureUniqueAncestorChain(
 	} );
 }
 
+function validateAncestorChain(
+	ancestorChain: ExistingCompoundChild[]
+) {
+	for ( let index = 0; index < ancestorChain.length - 1; index += 1 ) {
+		const currentAncestor = ancestorChain[ index ];
+		const nextAncestor = ancestorChain[ index + 1 ];
+		const blockJson = readBlockJsonDocument( currentAncestor.blockJsonPath );
+		const allowedBlocks = Array.isArray( blockJson.allowedBlocks )
+			? blockJson.allowedBlocks.filter(
+				( value ): value is string => typeof value === 'string'
+			)
+			: [];
+
+		if ( allowedBlocks.includes( nextAncestor.blockName ) ) {
+			continue;
+		}
+
+		throw new Error(
+			`Invalid ancestor chain: ${ currentAncestor.blockName } does not currently allow ${ nextAncestor.blockName } as a direct child.`
+		);
+	}
+}
+
 function updateAllowedBlocks(
 	filePath: string,
 	blockName: string
@@ -875,6 +898,7 @@ function main() {
 			resolveExistingCompoundChild( value, existingChildren )
 		)
 	);
+	validateAncestorChain( ancestorChain );
 	const childTitle = title?.trim().length ? title.trim() : toTitleCase( normalizedSlug );
 	const childFolderSlug = `${ PARENT_BLOCK_SLUG }-${ normalizedSlug }`;
 	const childBlockName = `${ PARENT_BLOCK_NAME }-${ normalizedSlug }`;

--- a/packages/wp-typia-project-tools/tests/built-in-block-artifacts.test.ts
+++ b/packages/wp-typia-project-tools/tests/built-in-block-artifacts.test.ts
@@ -608,17 +608,17 @@ const EXPECTED_CODE_ARTIFACT_HASH_SUMMARIES: Record<
   },
   compound: {
     'src/blocks/demo-compound-item/block-metadata.ts': '50956333a97a824a',
-    'src/blocks/demo-compound-item/edit.tsx': '9a4c290e05e8e8ad',
+    'src/blocks/demo-compound-item/edit.tsx': 'f3beaa7687e573e0',
     'src/blocks/demo-compound-item/hooks.ts': '485092aef1c4e019',
     'src/blocks/demo-compound-item/index.tsx': '5b5805db42c0b1f6',
     'src/blocks/demo-compound-item/manifest-defaults-document.ts':
       '16818959f3d5a7d6',
     'src/blocks/demo-compound-item/manifest-document.ts':
       'b8fffee2c728488e',
-    'src/blocks/demo-compound-item/save.tsx': 'ee03c7f3e16d3a3e',
+    'src/blocks/demo-compound-item/save.tsx': 'e2a9d7c5df3e615f',
     'src/blocks/demo-compound-item/validators.ts': '7123c8ea0e650172',
     'src/blocks/demo-compound/block-metadata.ts': '50956333a97a824a',
-    'src/blocks/demo-compound/children.ts': '26513801ef796584',
+    'src/blocks/demo-compound/children.ts': '0d245ef27cf66a90',
     'src/blocks/demo-compound/edit.tsx': 'efa27cbb540a19cb',
     'src/blocks/demo-compound/hooks.ts': '485092aef1c4e019',
     'src/blocks/demo-compound/index.tsx': 'c9d9139901e6e4b9',

--- a/packages/wp-typia-project-tools/tests/scaffold-compound.test.ts
+++ b/packages/wp-typia-project-tools/tests/scaffold-compound.test.ts
@@ -238,6 +238,9 @@ describe('@wp-typia/project-tools scaffold compound', () => {
       expect(parentBlockJson.version).toBe('0.1.0');
       expect(parentBlockJson.category).toBe('widgets');
       expect(parentBlockJson.icon).toBe('screenoptions');
+      expect(parentBlockJson.allowedBlocks).toEqual([
+        'create-block/demo-compound-item',
+      ]);
       expect(parentManifest.sourceType).toBe('DemoCompoundAttributes');
       expect(parentManifest.attributes.heading.typia.defaultValue).toBe(
         'Demo Compound',
@@ -304,12 +307,15 @@ describe('@wp-typia/project-tools scaffold compound', () => {
       );
       expect(generatedValidatorToolkit).not.toContain('typia.createValidate');
       expect(parentChildren).toContain('DEFAULT_CHILD_BLOCK_NAME');
+      expect(parentChildren).toContain('COMPOUND_CHILD_SPECS');
+      expect(parentChildren).toContain('getChildAllowedBlocks');
+      expect(parentChildren).toContain('hasNestedChildBlocks');
       expect(parentChildren).toContain(
         '@wp-typia/block-types/blocks/registration',
       );
       expect(parentChildren).toContain('BlockTemplate');
       expect(parentChildren).toContain(
-        'add-child: insert new allowed child block names here',
+        'add-child: insert new child specs here',
       );
       expect(parentStyle).toContain('.wp-block-create-block-demo-compound');
       expect(parentStyle).toContain(
@@ -325,6 +331,8 @@ describe('@wp-typia/project-tools scaffold compound', () => {
       expect(childEdit).toContain('}: EditProps )');
       expect(childEdit).toContain('useTypiaValidation');
       expect(childEdit).not.toMatch(/setAttributes\s*\(\s*\{/);
+      expect(childEdit).toContain('hasNestedChildBlocks( metadata.name )');
+      expect(childEdit).toContain("from '../demo-compound/children'");
       expect(childEdit).toContain(
         'wp-block-create-block-demo-compound-item__title',
       );
@@ -385,9 +393,12 @@ describe('@wp-typia/project-tools scaffold compound', () => {
       expect(addChildScript).toContain(
         "import currentManifest from './manifest-defaults-document';",
       );
-      expect(addChildScript).toContain('ALLOWED_CHILD_MARKER');
+      expect(addChildScript).toContain('CHILD_SPEC_MARKER');
       expect(addChildScript).toContain('BLOCK_CONFIG_MARKER');
       expect(addChildScript).toContain('buildBlockCssClassName');
+      expect(addChildScript).toContain('--ancestor');
+      expect(addChildScript).toContain('--container');
+      expect(addChildScript).toContain('--inserter');
       expect(generatedWebpackConfig).toContain('createTypiaWebpackConfig');
       expect(readme).toContain('npm run sync');
       expect(readme).toContain('npm run sync-types');
@@ -937,7 +948,7 @@ describe('@wp-typia/project-tools scaffold compound', () => {
         'manifest as ManifestDefaultsDocument',
       );
       expect(generatedValidatorToolkit).not.toContain('typia.createValidate');
-      expect(generatedAddChild).toContain('ALLOWED_CHILD_MARKER');
+      expect(generatedAddChild).toContain('CHILD_SPEC_MARKER');
       expect(generatedAddChild).toContain('buildScaffoldBlockRegistration');
       expect(generatedAddChild).toContain(
         'registerScaffoldBlockType( registration.name, registration.settings );',
@@ -1156,8 +1167,8 @@ describe('@wp-typia/project-tools scaffold compound', () => {
         fs
           .readFileSync(childrenRegistryPath, 'utf8')
           .replace(
-            /\t\/\/ add-child: insert new allowed child block names here/u,
-            '  // add-child: insert new allowed child block names here',
+            /\t\/\/ add-child: insert new child specs here/u,
+            '  // add-child: insert new child specs here',
           ),
         'utf8',
       );
@@ -1217,8 +1228,10 @@ describe('@wp-typia/project-tools scaffold compound', () => {
       expect(blockConfig).toContain('demo-compound-add-child-faq-item');
       expect(blockConfig).toContain('DemoCompoundAddChildFaqItemAttributes');
       expect(childrenRegistry).toContain(
-        "'create-block/demo-compound-add-child-faq-item'",
+        'create-block/demo-compound-add-child-faq-item',
       );
+      expect(childrenRegistry).toContain("placement: 'root'");
+      expect(childrenRegistry).toContain('templateInstances: []');
       expect(newChildHooks).toContain('createUseTypiaValidationHook');
       expect(newChildValidators).toContain('createTemplateValidatorToolkit');
       expect(newChildValidators).not.toContain(
@@ -1261,6 +1274,7 @@ describe('@wp-typia/project-tools scaffold compound', () => {
           ) ?? []
         ).length,
       ).toBe(1);
+      expect(childrenRegistry).toContain('add-child: insert new child specs here');
 
       runGeneratedScript(targetDir, 'scripts/sync-types-to-block-json.ts');
 
@@ -1275,6 +1289,108 @@ describe('@wp-typia/project-tools scaffold compound', () => {
       );
       expect(fs.existsSync(path.join(newChildDir, 'typia-validator.php'))).toBe(
         true,
+      );
+    },
+    { timeout: 30_000 },
+  );
+
+  test(
+    'compound add-child scaffolds visible container children and nested ancestor children',
+    async () => {
+      const targetDir = path.join(tempRoot, 'demo-compound-nested');
+
+      await scaffoldProject({
+        projectDir: targetDir,
+        templateId: 'compound',
+        packageManager: 'npm',
+        noInstall: true,
+        answers: {
+          author: 'Test Runner',
+          description: 'Demo compound nested workflow',
+          namespace: 'create-block',
+          slug: 'demo-compound-nested',
+          title: 'Demo Compound Nested',
+        },
+      });
+
+      runGeneratedScript(targetDir, 'scripts/add-compound-child.ts', [
+        '--slug',
+        'section',
+        '--title',
+        'Section',
+        '--container',
+        '--inserter',
+        'visible',
+      ]);
+
+      runGeneratedScript(targetDir, 'scripts/add-compound-child.ts', [
+        '--slug',
+        'clause',
+        '--title',
+        'Clause',
+        '--ancestor',
+        'section',
+      ]);
+
+      const parentBlockJson = JSON.parse(
+        fs.readFileSync(
+          path.join(targetDir, 'src', 'blocks', 'demo-compound-nested', 'block.json'),
+          'utf8',
+        ),
+      );
+      const sectionDir = path.join(
+        targetDir,
+        'src',
+        'blocks',
+        'demo-compound-nested-section',
+      );
+      const clauseDir = path.join(
+        targetDir,
+        'src',
+        'blocks',
+        'demo-compound-nested-clause',
+      );
+      const sectionBlockJson = JSON.parse(
+        fs.readFileSync(path.join(sectionDir, 'block.json'), 'utf8'),
+      );
+      const clauseBlockJson = JSON.parse(
+        fs.readFileSync(path.join(clauseDir, 'block.json'), 'utf8'),
+      );
+      const sectionEdit = fs.readFileSync(path.join(sectionDir, 'edit.tsx'), 'utf8');
+      const sectionSave = fs.readFileSync(path.join(sectionDir, 'save.tsx'), 'utf8');
+      const childrenRegistry = fs.readFileSync(
+        path.join(
+          targetDir,
+          'src',
+          'blocks',
+          'demo-compound-nested',
+          'children.ts',
+        ),
+        'utf8',
+      );
+
+      expect(parentBlockJson.allowedBlocks).toEqual([
+        'create-block/demo-compound-nested-item',
+        'create-block/demo-compound-nested-section',
+      ]);
+      expect(sectionBlockJson.parent).toEqual(['create-block/demo-compound-nested']);
+      expect(sectionBlockJson.allowedBlocks).toEqual([
+        'create-block/demo-compound-nested-clause',
+      ]);
+      expect(sectionBlockJson.supports.inserter).toBe(true);
+      expect(clauseBlockJson.ancestor).toEqual([
+        'create-block/demo-compound-nested-section',
+      ]);
+      expect(clauseBlockJson.supports.inserter).toBe(true);
+      expect(sectionEdit).toContain('InnerBlocks');
+      expect(sectionEdit).toContain('hasNestedChildBlocks( metadata.name )');
+      expect(sectionSave).toContain('InnerBlocks.Content');
+      expect(childrenRegistry).toContain('key: "section"');
+      expect(childrenRegistry).toContain('key: "clause"');
+      expect(childrenRegistry).toContain('ancestorKeys: [ "section" ]');
+      expect(childrenRegistry).toContain('placement: "nested"');
+      expect(childrenRegistry).toContain(
+        'create-block/demo-compound-nested-clause',
       );
     },
     { timeout: 30_000 },
@@ -1347,9 +1463,9 @@ describe('@wp-typia/project-tools scaffold compound', () => {
     expect(childBlockJson.name).toBe('renamed-space/renamed-parent-faq-item');
     expect(childBlockJson.parent).toEqual(['renamed-space/renamed-parent']);
     expect(childBlockJson.textdomain).toBe('renamed-parent');
-    expect(childrenRegistry).toContain(
-      "'renamed-space/renamed-parent-faq-item'",
-    );
+      expect(childrenRegistry).toContain(
+        'renamed-space/renamed-parent-faq-item',
+      );
     expect(childEdit).toContain("'renamed-parent'");
   });
 

--- a/packages/wp-typia-project-tools/tests/scaffold-compound.test.ts
+++ b/packages/wp-typia-project-tools/tests/scaffold-compound.test.ts
@@ -1227,11 +1227,9 @@ describe('@wp-typia/project-tools scaffold compound', () => {
       expect(newChildBlockJson.icon).toBe('excerpt-view');
       expect(blockConfig).toContain('demo-compound-add-child-faq-item');
       expect(blockConfig).toContain('DemoCompoundAddChildFaqItemAttributes');
-      expect(childrenRegistry).toContain(
-        'create-block/demo-compound-add-child-faq-item',
+      expect(childrenRegistry).toMatch(
+        /blockName:\s*["']create-block\/demo-compound-add-child-faq-item["'][\s\S]*?placement:\s*["']root["'][\s\S]*?templateInstances:\s*\[\]/u,
       );
-      expect(childrenRegistry).toContain("placement: 'root'");
-      expect(childrenRegistry).toContain('templateInstances: []');
       expect(newChildHooks).toContain('createUseTypiaValidationHook');
       expect(newChildValidators).toContain('createTemplateValidatorToolkit');
       expect(newChildValidators).not.toContain(

--- a/packages/wp-typia-project-tools/tests/scaffold-compound.test.ts
+++ b/packages/wp-typia-project-tools/tests/scaffold-compound.test.ts
@@ -1394,6 +1394,48 @@ describe('@wp-typia/project-tools scaffold compound', () => {
     { timeout: 30_000 },
   );
 
+  test(
+    'compound add-child rejects nesting under hidden unseeded ancestor children',
+    async () => {
+      const targetDir = path.join(tempRoot, 'demo-compound-unreachable-nested');
+
+      await scaffoldProject({
+        projectDir: targetDir,
+        templateId: 'compound',
+        packageManager: 'npm',
+        noInstall: true,
+        answers: {
+          author: 'Test Runner',
+          description: 'Demo compound unreachable nested workflow',
+          namespace: 'create-block',
+          slug: 'demo-compound-unreachable-nested',
+          title: 'Demo Compound Unreachable Nested',
+        },
+      });
+
+      runGeneratedScript(targetDir, 'scripts/add-compound-child.ts', [
+        '--slug',
+        'faq-item',
+        '--title',
+        'FAQ Item',
+      ]);
+
+      expect(() =>
+        runGeneratedScript(targetDir, 'scripts/add-compound-child.ts', [
+          '--slug',
+          'follow-up',
+          '--title',
+          'Follow Up',
+          '--ancestor',
+          'faq-item',
+        ]),
+      ).toThrow(
+        'Cannot nest descendants under create-block/demo-compound-unreachable-nested-faq-item because it is hidden and has no seeded template instances.',
+      );
+    },
+    { timeout: 30_000 },
+  );
+
   test('compound add-child reads live parent metadata from disk', async () => {
     const targetDir = path.join(tempRoot, 'demo-compound-live-parent');
 


### PR DESCRIPTION
## Context

`compound` scaffolds were still optimized around one parent block plus one hidden child block. That was a good baseline, but it made richer document-style hierarchies awkward because multi-child growth and nested ancestor relationships were still manual follow-up work.

## What Changed

- switched generated `src/blocks/<parent>/children.ts` to a spec-driven child registry that derives root allowed blocks, seeded default templates, nested child templates, and ancestor metadata from one source of truth
- taught generated child editors/saves to render nested `InnerBlocks` when a child spec is a container or gains descendant specs later
- upgraded `scripts/add-compound-child.ts` to support:
  - `--container` for container child scaffolds
  - repeated `--ancestor <child>` for nested ancestor chains
  - `--inserter hidden|visible` for explicit inserter behavior
- kept the legacy hidden-child extension flow stable: plain `npm run add-child -- --slug faq-item --title "FAQ Item"` still adds a root hidden child without changing the seeded default template
- updated generated metadata so compound parents carry root `allowedBlocks`, and nested/container children get `parent`, `ancestor`, `allowedBlocks`, and `supports.inserter` wired automatically
- documented the richer add-child workflow in generated onboarding plus public docs

## Verification

- `bun run --filter @wp-typia/project-tools build`
- `bun test packages/wp-typia-project-tools/tests/built-in-block-artifacts.test.ts`
- `bun test packages/wp-typia-project-tools/tests/scaffold-compound.test.ts`
- `bun test packages/wp-typia-project-tools/tests/cli-entry.test.ts`
- `bun test packages/wp-typia-project-tools/tests/workspace-add.test.ts -t "canonical CLI can add a compound persistence block to an official workspace template"`
- `bun run typecheck`
- `bun run docs:build:site`
- `bun run changesets:validate`

## Closes

Closes #440


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for multi-child and nested compound block scaffolding via the `add-child` workflow.
  * Enabled visible container children and nested ancestor chains in compound templates.
  * Introduced new CLI flags (`--ancestor`, `--container`, `--inserter`) for enhanced control over child block creation.
  
* **Documentation**
  * Updated guides with additional workflow examples and clarifications on nested hierarchy capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->