### PR TITLE
Add persistent block identity lifecycle helpers

### DIFF
--- a/.sampo/changesets/persistent-block-identity-helpers.md
+++ b/.sampo/changesets/persistent-block-identity-helpers.md
@@ -1,0 +1,7 @@
+---
+npm/@wp-typia/block-runtime: minor
+---
+
+Add duplicate-safe persistent block identity helpers so structured document
+blocks can preserve stable logical ids across normal edits while repairing
+missing or duplicated ids inside the same document tree.

--- a/apps/docs/src/content/docs/reference/api.md
+++ b/apps/docs/src/content/docs/reference/api.md
@@ -468,6 +468,11 @@ Generated projects can also import shared runtime helpers from `@wp-typia/block-
 Use `@wp-typia/block-runtime/metadata-core` for metadata sync and
 `@wp-typia/block-runtime/*` for generated-project runtime helpers.
 
+`runtime/identifiers` now also includes duplicate-safe persistent-id lifecycle
+helpers for structured document blocks. Use
+`collectPersistentBlockIdentityRepairs(...)` when you already have a plain block
+tree and need deterministic repair patches without React.
+
 `runtime/blocks` is the shared generated-project surface for scaffold-owned
 block registration helpers and webpack artifact/config adapters.
 
@@ -520,6 +525,7 @@ When you want a higher-level inspector layer, use
 import currentManifest from './manifest-document';
 import {
   InspectorFromManifest,
+  usePersistentBlockIdentity,
   useEditorFields,
   useTypedAttributeUpdater,
 } from '@wp-typia/block-runtime/inspector';
@@ -542,11 +548,27 @@ const { updateField } = useTypedAttributeUpdater(
 />;
 ```
 
+When the same block family also needs a stable logical id that survives save,
+reopen, and duplicate repair, the inspector facade now exposes
+`usePersistentBlockIdentity(...)`:
+
+```tsx
+const persistentId = usePersistentBlockIdentity({
+  attributeName: 'sectionId',
+  attributes,
+  blocks,
+  clientId,
+  prefix: 'sec',
+  setAttributes,
+});
+```
+
 `runtime/inspector` keeps `runtime/editor` as the descriptor/model layer and
 adds:
 
 - `useEditorFields()` for memoized field lookup, defaults, and select options
 - `useTypedAttributeUpdater()` for top-level and dotted-path updates from one hook
+- `usePersistentBlockIdentity()` for duplicate-safe block ids in one document tree
 - `FieldControl` for one manifest-backed WordPress control
 - `InspectorFromManifest` for ordered manifest-driven `PanelBody` rendering
 

--- a/packages/wp-typia-block-runtime/README.md
+++ b/packages/wp-typia-block-runtime/README.md
@@ -22,8 +22,10 @@ Typical usage:
 import { createEditorModel } from '@wp-typia/block-runtime/editor';
 import {
   InspectorFromManifest,
+  usePersistentBlockIdentity,
   useEditorFields,
 } from '@wp-typia/block-runtime/inspector';
+import { collectPersistentBlockIdentityRepairs } from '@wp-typia/block-runtime/identifiers';
 import { createNestedAttributeUpdater } from '@wp-typia/block-runtime/validation';
 import { runSyncBlockMetadata } from '@wp-typia/block-runtime/metadata-core';
 ```
@@ -47,3 +49,13 @@ and `json-utils` are also published and documented, but they are secondary to
 the main generated-project runtime roots. The canonical hosted reference now
 splits these into Core API, Advanced Helpers, and Internal APIs sections under
 `https://imjlk.github.io/wp-typia/`.
+
+For structured document blocks that need stable logical ids separate from the
+editor `clientId`, use:
+
+- `collectPersistentBlockIdentityRepairs(...)` from
+  `@wp-typia/block-runtime/identifiers` when you already have a plain block
+  tree and want deterministic duplicate-safe repairs without React.
+- `usePersistentBlockIdentity(...)` from `@wp-typia/block-runtime/inspector`
+  when you are inside a block edit component and want the same repair logic
+  wired to `setAttributes(...)`.

--- a/packages/wp-typia-block-runtime/src/identifiers.ts
+++ b/packages/wp-typia-block-runtime/src/identifiers.ts
@@ -5,6 +5,44 @@ type CryptoLike = Partial<
 const UUID_HEX_RADIX = 16;
 const SCOPED_SUFFIX_LENGTH = 9;
 
+export type PersistentBlockIdentityRepairReason = 'missing' | 'duplicate';
+
+export interface PersistentBlockIdentityNode {
+	attributes?: Record< string, unknown > | null;
+	clientId: string;
+	innerBlocks?: readonly PersistentBlockIdentityNode[];
+}
+
+export interface PersistentBlockIdentityRepair {
+	clientId: string;
+	nextValue: string;
+	previousValue: string | null;
+	reason: PersistentBlockIdentityRepairReason;
+}
+
+export interface EnsurePersistentBlockIdentityOptions {
+	duplicateDetection?: boolean;
+	existingIds?: Iterable< string >;
+	generateId?: ( prefix: string ) => string;
+	prefix: string;
+	seenIds?: Iterable< string >;
+	value: unknown;
+}
+
+export interface EnsurePersistentBlockIdentityResult {
+	changed: boolean;
+	previousValue: string | null;
+	reason: PersistentBlockIdentityRepairReason | null;
+	value: string;
+}
+
+export interface CollectPersistentBlockIdentityRepairsOptions {
+	attributeName: string;
+	duplicateDetection?: boolean;
+	generateId?: ( prefix: string ) => string;
+	prefix: string;
+}
+
 /**
  * Generate a UUID v4-style id for block attributes.
  *
@@ -47,6 +85,97 @@ export function generatePublicWriteRequestId(): string {
 	return generateUuidV4();
 }
 
+/**
+ * Resolve one persistent block id against the ids already used in the current
+ * document tree.
+ *
+ * Missing ids always get generated. Duplicate repair only happens when
+ * `duplicateDetection` is enabled and the current value is already present in
+ * `seenIds`.
+ *
+ * @param options Current id plus scope metadata used to preserve valid values and generate safe replacements.
+ * @returns The preserved or regenerated persistent id and whether it changed.
+ * @category Utilities
+ */
+export function ensurePersistentBlockIdentity(
+	options: EnsurePersistentBlockIdentityOptions
+): EnsurePersistentBlockIdentityResult {
+	const currentValue = toPersistentBlockIdentityValue( options.value );
+	if (
+		currentValue &&
+		( options.duplicateDetection === false ||
+			! createPersistentIdentitySet( options.seenIds ).has( currentValue ) )
+	) {
+		return {
+			changed: false,
+			previousValue: currentValue,
+			reason: null,
+			value: currentValue,
+		};
+	}
+
+	const reservedIds = createPersistentIdentitySet( options.existingIds );
+	for ( const seenId of createPersistentIdentitySet( options.seenIds ) ) {
+		reservedIds.add( seenId );
+	}
+
+	const nextValue = generateUniquePersistentBlockIdentity(
+		options.prefix,
+		reservedIds,
+		options.generateId
+	);
+
+	return {
+		changed: true,
+		previousValue: currentValue,
+		reason: currentValue ? 'duplicate' : 'missing',
+		value: nextValue,
+	};
+}
+
+/**
+ * Collect the persistent-id repairs required to make one document tree safe for
+ * duplicate-aware structured block workflows.
+ *
+ * Existing non-empty ids are preserved when they are unique. Missing ids are
+ * generated, and only the later duplicates in one depth-first traversal are
+ * repaired when duplicate detection is enabled.
+ *
+ * @param blocks Current document tree rooted at the relevant editor scope.
+ * @param options Attribute key plus prefix/generator settings.
+ * @returns One repair patch per block that should regenerate or seed its persistent id.
+ * @category Utilities
+ */
+export function collectPersistentBlockIdentityRepairs(
+	blocks: readonly PersistentBlockIdentityNode[],
+	options: CollectPersistentBlockIdentityRepairsOptions
+): PersistentBlockIdentityRepair[] {
+	const duplicateCounts = new Map< string, number >();
+	const reservedIds = new Set< string >();
+	collectPersistentIdentityCounts(
+		blocks,
+		options.attributeName,
+		duplicateCounts,
+		reservedIds
+	);
+
+	const preservedDuplicates = new Set< string >();
+	const repairs: PersistentBlockIdentityRepair[] = [];
+
+	for ( const block of blocks ) {
+		collectPersistentIdentityRepairsForNode(
+			block,
+			options,
+			duplicateCounts,
+			preservedDuplicates,
+			reservedIds,
+			repairs
+		);
+	}
+
+	return repairs;
+}
+
 function generateUuidV4(): string {
 	const cryptoObject = getCryptoObject();
 
@@ -76,6 +205,131 @@ function generateUuidV4(): string {
 
 function generatePrefixedScopedId( prefix: string ): string {
 	return `${ prefix }-${ generateScopedSuffix() }`;
+}
+
+function collectPersistentIdentityCounts(
+	blocks: readonly PersistentBlockIdentityNode[],
+	attributeName: string,
+	duplicateCounts: Map< string, number >,
+	reservedIds: Set< string >
+): void {
+	for ( const block of blocks ) {
+		const currentValue = toPersistentBlockIdentityValue(
+			block.attributes?.[ attributeName ]
+		);
+		if ( currentValue ) {
+			duplicateCounts.set(
+				currentValue,
+				( duplicateCounts.get( currentValue ) ?? 0 ) + 1
+			);
+			reservedIds.add( currentValue );
+		}
+
+		if ( block.innerBlocks?.length ) {
+			collectPersistentIdentityCounts(
+				block.innerBlocks,
+				attributeName,
+				duplicateCounts,
+				reservedIds
+			);
+		}
+	}
+}
+
+function collectPersistentIdentityRepairsForNode(
+	block: PersistentBlockIdentityNode,
+	options: CollectPersistentBlockIdentityRepairsOptions,
+	duplicateCounts: Map< string, number >,
+	preservedDuplicates: Set< string >,
+	reservedIds: Set< string >,
+	repairs: PersistentBlockIdentityRepair[]
+): void {
+	const currentValue = toPersistentBlockIdentityValue(
+		block.attributes?.[ options.attributeName ]
+	);
+
+	if ( ! currentValue ) {
+		repairs.push( {
+			clientId: block.clientId,
+			nextValue: generateUniquePersistentBlockIdentity(
+				options.prefix,
+				reservedIds,
+				options.generateId
+			),
+			previousValue: null,
+			reason: 'missing',
+		} );
+	} else if (
+		options.duplicateDetection !== false &&
+		( duplicateCounts.get( currentValue ) ?? 0 ) > 1
+	) {
+		if ( ! preservedDuplicates.has( currentValue ) ) {
+			preservedDuplicates.add( currentValue );
+		} else {
+			repairs.push( {
+				clientId: block.clientId,
+				nextValue: generateUniquePersistentBlockIdentity(
+					options.prefix,
+					reservedIds,
+					options.generateId
+				),
+				previousValue: currentValue,
+				reason: 'duplicate',
+			} );
+		}
+	}
+
+	if ( block.innerBlocks?.length ) {
+		for ( const innerBlock of block.innerBlocks ) {
+			collectPersistentIdentityRepairsForNode(
+				innerBlock,
+				options,
+				duplicateCounts,
+				preservedDuplicates,
+				reservedIds,
+				repairs
+			);
+		}
+	}
+}
+
+function createPersistentIdentitySet(
+	values: Iterable< string > | undefined
+): Set< string > {
+	const ids = new Set< string >();
+
+	if ( ! values ) {
+		return ids;
+	}
+
+	for ( const value of values ) {
+		const persistentValue = toPersistentBlockIdentityValue( value );
+		if ( persistentValue ) {
+			ids.add( persistentValue );
+		}
+	}
+
+	return ids;
+}
+
+function generateUniquePersistentBlockIdentity(
+	prefix: string,
+	reservedIds: Set< string >,
+	generateId: ( ( prefix: string ) => string ) | undefined
+): string {
+	const generateScopedId = generateId ?? generateScopedClientId;
+	let nextValue = generateScopedId( prefix );
+
+	while ( reservedIds.has( nextValue ) ) {
+		nextValue = generateScopedId( prefix );
+	}
+
+	reservedIds.add( nextValue );
+	return nextValue;
+}
+
+function toPersistentBlockIdentityValue( value: unknown ): string | null {
+	return typeof value === 'string' && value.trim().length > 0 ? value : null;
 }
 
 function generateScopedSuffix(): string {

--- a/packages/wp-typia-block-runtime/src/identifiers.ts
+++ b/packages/wp-typia-block-runtime/src/identifiers.ts
@@ -4,6 +4,7 @@ type CryptoLike = Partial<
 
 const UUID_HEX_RADIX = 16;
 const SCOPED_SUFFIX_LENGTH = 9;
+const MAX_PERSISTENT_BLOCK_ID_ATTEMPTS = 32;
 
 export type PersistentBlockIdentityRepairReason = 'missing' | 'duplicate';
 
@@ -318,18 +319,33 @@ function generateUniquePersistentBlockIdentity(
 	generateId: ( ( prefix: string ) => string ) | undefined
 ): string {
 	const generateScopedId = generateId ?? generateScopedClientId;
-	let nextValue = generateScopedId( prefix );
 
-	while ( reservedIds.has( nextValue ) ) {
-		nextValue = generateScopedId( prefix );
+	for (
+		let attempt = 1;
+		attempt <= MAX_PERSISTENT_BLOCK_ID_ATTEMPTS;
+		attempt++
+	) {
+		const nextValue = toPersistentBlockIdentityValue(
+			generateScopedId( prefix )
+		);
+		if ( nextValue && ! reservedIds.has( nextValue ) ) {
+			reservedIds.add( nextValue );
+			return nextValue;
+		}
 	}
 
-	reservedIds.add( nextValue );
-	return nextValue;
+	throw new Error(
+		`Unable to generate a unique persistent block identity for prefix "${ prefix }" after ${ MAX_PERSISTENT_BLOCK_ID_ATTEMPTS } attempts.`
+	);
 }
 
 function toPersistentBlockIdentityValue( value: unknown ): string | null {
-	return typeof value === 'string' && value.trim().length > 0 ? value : null;
+	if ( typeof value !== 'string' ) {
+		return null;
+	}
+
+	const trimmedValue = value.trim();
+	return trimmedValue.length > 0 ? trimmedValue : null;
 }
 
 function generateScopedSuffix(): string {

--- a/packages/wp-typia-block-runtime/src/identifiers.ts
+++ b/packages/wp-typia-block-runtime/src/identifiers.ts
@@ -101,11 +101,12 @@ export function generatePublicWriteRequestId(): string {
 export function ensurePersistentBlockIdentity(
 	options: EnsurePersistentBlockIdentityOptions
 ): EnsurePersistentBlockIdentityResult {
+	const seenIds = createPersistentIdentitySet( options.seenIds );
 	const currentValue = toPersistentBlockIdentityValue( options.value );
 	if (
 		currentValue &&
 		( options.duplicateDetection === false ||
-			! createPersistentIdentitySet( options.seenIds ).has( currentValue ) )
+			! seenIds.has( currentValue ) )
 	) {
 		return {
 			changed: false,
@@ -116,7 +117,7 @@ export function ensurePersistentBlockIdentity(
 	}
 
 	const reservedIds = createPersistentIdentitySet( options.existingIds );
-	for ( const seenId of createPersistentIdentitySet( options.seenIds ) ) {
+	for ( const seenId of seenIds ) {
 		reservedIds.add( seenId );
 	}
 

--- a/packages/wp-typia-block-runtime/src/inspector-runtime-model.tsx
+++ b/packages/wp-typia-block-runtime/src/inspector-runtime-model.tsx
@@ -25,6 +25,8 @@ import {
 import type {
 	EditorFieldDescriptor,
 	InspectorSelectOption,
+	PersistentBlockIdentityNode,
+	PersistentBlockIdentityRepair,
 	UsePersistentBlockIdentityOptions,
 	UsePersistentBlockIdentityResult,
 	StableEditorModelOptions,
@@ -33,6 +35,10 @@ import type {
 } from "./inspector-runtime-types.js";
 
 type UnknownRecord = Record<string, unknown>;
+const persistentBlockIdentityRepairCache = new WeakMap<
+	readonly PersistentBlockIdentityNode[],
+	Map<string, Map<string, PersistentBlockIdentityRepair>>
+>();
 
 function getPathSegments(path: string): string[] {
 	return path.split(".").filter(Boolean);
@@ -92,7 +98,12 @@ function createValidationResult<T extends object>(value: T): ValidationResult<T>
 function getPersistentBlockIdentityValue(
 	value: unknown,
 ): string | null {
-	return typeof value === "string" && value.trim().length > 0 ? value : null;
+	if (typeof value !== "string") {
+		return null;
+	}
+
+	const trimmedValue = value.trim();
+	return trimmedValue.length > 0 ? trimmedValue : null;
 }
 
 function createPersistentIdAttributePatch<T extends object>(
@@ -102,6 +113,37 @@ function createPersistentIdAttributePatch<T extends object>(
 	return {
 		[attributeName]: value,
 	} as Partial<T>;
+}
+
+function getPersistentBlockIdentityRepairMap(
+	blocks: readonly PersistentBlockIdentityNode[],
+	options: {
+		attributeName: string;
+		duplicateDetection?: boolean;
+		prefix: string;
+	},
+): Map<string, PersistentBlockIdentityRepair> {
+	const duplicateMode = options.duplicateDetection === false ? "off" : "on";
+	const cacheKey = `${options.attributeName}:${options.prefix}:${duplicateMode}`;
+	let repairMapsByKey = persistentBlockIdentityRepairCache.get(blocks);
+	if (!repairMapsByKey) {
+		repairMapsByKey = new Map();
+		persistentBlockIdentityRepairCache.set(blocks, repairMapsByKey);
+	}
+
+	const cachedRepairMap = repairMapsByKey.get(cacheKey);
+	if (cachedRepairMap) {
+		return cachedRepairMap;
+	}
+
+	const nextRepairMap = new Map(
+		collectPersistentBlockIdentityRepairs(blocks, options).map((repair) => [
+			repair.clientId,
+			repair,
+		]),
+	);
+	repairMapsByKey.set(cacheKey, nextRepairMap);
+	return nextRepairMap;
 }
 
 export function getFieldValue(
@@ -264,8 +306,12 @@ export function useTypedAttributeUpdater<T extends object>(
  * Keep one block attribute populated with a stable document-level id that
  * survives normal edits and repairs duplicates inside the current block tree.
  *
+ * `autoRepair` defaults to enabled when omitted. Callers should pass a stable
+ * or memoized `blocks` reference so equivalent renders can reuse cached repair
+ * analysis instead of re-walking the full document tree.
+ *
  * @param options Current block identity inputs including the attribute key, editor tree snapshot, and `setAttributes` callback.
- * @returns The current/pending persistent id plus a helper that can force the attribute repair immediately.
+ * @returns The current/pending persistent id plus a helper that can force the attribute repair immediately. `nextPersistentId` can stay `null` when no repair is pending yet, while `ensurePersistentId()` always returns a non-null string.
  * @category React
  */
 export function usePersistentBlockIdentity<T extends object>(
@@ -283,11 +329,11 @@ export function usePersistentBlockIdentity<T extends object>(
 	} = options;
 	const pendingRepair = useMemo(
 		() =>
-			collectPersistentBlockIdentityRepairs(blocks, {
+			getPersistentBlockIdentityRepairMap(blocks, {
 				attributeName,
 				duplicateDetection,
 				prefix,
-			}).find((repair) => repair.clientId === clientId) ?? null,
+			}).get(clientId) ?? null,
 		[
 			attributeName,
 			blocks,
@@ -331,7 +377,9 @@ export function usePersistentBlockIdentity<T extends object>(
 			return;
 		}
 
-		const repairKey = `${clientId}:${pendingRepair.nextValue}`;
+		const repairKey = `${clientId}:${pendingRepair.reason}:${
+			currentPersistentId ?? ""
+		}`;
 		if (lastAppliedRepairRef.current === repairKey) {
 			return;
 		}
@@ -347,6 +395,7 @@ export function usePersistentBlockIdentity<T extends object>(
 		attributeName,
 		autoRepair,
 		clientId,
+		currentPersistentId,
 		pendingRepair,
 		setAttributes,
 	]);

--- a/packages/wp-typia-block-runtime/src/inspector-runtime-model.tsx
+++ b/packages/wp-typia-block-runtime/src/inspector-runtime-model.tsx
@@ -1,6 +1,8 @@
 import {
 	useCallback,
+	useEffect,
 	useMemo,
+	useRef,
 } from "react";
 
 import {
@@ -9,6 +11,10 @@ import {
 	type EditorModelOptions,
 	type ManifestDocument,
 } from "./editor.js";
+import {
+	collectPersistentBlockIdentityRepairs,
+	generateScopedClientId,
+} from "./identifiers.js";
 import { isPlainObject as isRecord } from "./object-utils.js";
 import {
 	type ValidationResult,
@@ -19,6 +25,8 @@ import {
 import type {
 	EditorFieldDescriptor,
 	InspectorSelectOption,
+	UsePersistentBlockIdentityOptions,
+	UsePersistentBlockIdentityResult,
 	StableEditorModelOptions,
 	TypedAttributeUpdater,
 	UseEditorFieldsResult,
@@ -79,6 +87,21 @@ function createValidationResult<T extends object>(value: T): ValidationResult<T>
 		errors: [],
 		isValid: true,
 	};
+}
+
+function getPersistentBlockIdentityValue(
+	value: unknown,
+): string | null {
+	return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function createPersistentIdAttributePatch<T extends object>(
+	attributeName: string,
+	value: string,
+): Partial<T> {
+	return {
+		[attributeName]: value,
+	} as Partial<T>;
 }
 
 export function getFieldValue(
@@ -234,5 +257,105 @@ export function useTypedAttributeUpdater<T extends object>(
 		updateAttribute,
 		updateField,
 		updatePath,
+	};
+}
+
+/**
+ * Keep one block attribute populated with a stable document-level id that
+ * survives normal edits and repairs duplicates inside the current block tree.
+ *
+ * @param options Current block identity inputs including the attribute key, editor tree snapshot, and `setAttributes` callback.
+ * @returns The current/pending persistent id plus a helper that can force the attribute repair immediately.
+ * @category React
+ */
+export function usePersistentBlockIdentity<T extends object>(
+	options: UsePersistentBlockIdentityOptions<T>,
+): UsePersistentBlockIdentityResult {
+	const {
+		attributeName,
+		attributes,
+		autoRepair,
+		blocks,
+		clientId,
+		duplicateDetection,
+		prefix,
+		setAttributes,
+	} = options;
+	const pendingRepair = useMemo(
+		() =>
+			collectPersistentBlockIdentityRepairs(blocks, {
+				attributeName,
+				duplicateDetection,
+				prefix,
+			}).find((repair) => repair.clientId === clientId) ?? null,
+		[
+			attributeName,
+			blocks,
+			clientId,
+			duplicateDetection,
+			prefix,
+		],
+	);
+	const currentPersistentId = getPersistentBlockIdentityValue(
+		(attributes as Record<string, unknown>)[attributeName],
+	);
+	const lastAppliedRepairRef = useRef<string | null>(null);
+
+	const ensurePersistentId = useCallback(() => {
+		const nextValue =
+			pendingRepair?.nextValue ??
+			currentPersistentId ??
+			generateScopedClientId(prefix);
+
+		if (nextValue !== currentPersistentId) {
+			setAttributes(
+				createPersistentIdAttributePatch<T>(
+					attributeName,
+					nextValue,
+				),
+			);
+		}
+
+		return nextValue;
+	}, [
+		attributeName,
+		currentPersistentId,
+		pendingRepair,
+		prefix,
+		setAttributes,
+	]);
+
+	useEffect(() => {
+		if (autoRepair === false || !pendingRepair) {
+			lastAppliedRepairRef.current = null;
+			return;
+		}
+
+		const repairKey = `${clientId}:${pendingRepair.nextValue}`;
+		if (lastAppliedRepairRef.current === repairKey) {
+			return;
+		}
+
+		lastAppliedRepairRef.current = repairKey;
+		setAttributes(
+			createPersistentIdAttributePatch<T>(
+				attributeName,
+				pendingRepair.nextValue,
+			),
+		);
+	}, [
+		attributeName,
+		autoRepair,
+		clientId,
+		pendingRepair,
+		setAttributes,
+	]);
+
+	return {
+		currentPersistentId,
+		ensurePersistentId,
+		nextPersistentId: pendingRepair?.nextValue ?? currentPersistentId,
+		repairReason: pendingRepair?.reason ?? null,
+		shouldRepairPersistentId: pendingRepair !== null,
 	};
 }

--- a/packages/wp-typia-block-runtime/src/inspector-runtime-types.ts
+++ b/packages/wp-typia-block-runtime/src/inspector-runtime-types.ts
@@ -158,13 +158,22 @@ export interface TypedAttributeUpdater<T extends object> {
 	updatePath: (path: string, value: unknown) => boolean;
 }
 
+export type AttributeNameFor<T extends object> =
+	[Extract<keyof T, string>] extends [never]
+		? string
+		: Extract<keyof T, string>;
+
 /**
  * Describe the options accepted by `usePersistentBlockIdentity()`.
+ *
+ * `autoRepair` defaults to enabled when omitted. Pass a stable or memoized
+ * `blocks` reference so equivalent renders can reuse the same duplicate-repair
+ * analysis instead of recomputing it.
  *
  * @category React
  */
 export interface UsePersistentBlockIdentityOptions<T extends object> {
-	attributeName: string;
+	attributeName: AttributeNameFor<T>;
 	attributes: T;
 	autoRepair?: boolean;
 	blocks: readonly PersistentBlockIdentityNode[];
@@ -177,6 +186,10 @@ export interface UsePersistentBlockIdentityOptions<T extends object> {
 /**
  * Describe the duplicate-safe id lifecycle helpers returned from
  * `usePersistentBlockIdentity()`.
+ *
+ * `nextPersistentId` mirrors the current pending repair target and can be
+ * `null` when no repair is pending yet. Use `ensurePersistentId()` when you
+ * need a guaranteed non-null id for immediate writes or orchestration.
  *
  * @category React
  */

--- a/packages/wp-typia-block-runtime/src/inspector-runtime-types.ts
+++ b/packages/wp-typia-block-runtime/src/inspector-runtime-types.ts
@@ -6,6 +6,10 @@ import type {
 import type {
 	EditorFieldDescriptor,
 } from "./editor.js";
+import type {
+	PersistentBlockIdentityNode,
+	PersistentBlockIdentityRepairReason,
+} from "./identifiers.js";
 
 /**
  * Describe one string-valued option for an inspector select control.
@@ -155,6 +159,36 @@ export interface TypedAttributeUpdater<T extends object> {
 }
 
 /**
+ * Describe the options accepted by `usePersistentBlockIdentity()`.
+ *
+ * @category React
+ */
+export interface UsePersistentBlockIdentityOptions<T extends object> {
+	attributeName: string;
+	attributes: T;
+	autoRepair?: boolean;
+	blocks: readonly PersistentBlockIdentityNode[];
+	clientId: string;
+	duplicateDetection?: boolean;
+	prefix: string;
+	setAttributes: (attrs: Partial<T>) => void;
+}
+
+/**
+ * Describe the duplicate-safe id lifecycle helpers returned from
+ * `usePersistentBlockIdentity()`.
+ *
+ * @category React
+ */
+export interface UsePersistentBlockIdentityResult {
+	currentPersistentId: string | null;
+	ensurePersistentId: () => string;
+	nextPersistentId: string | null;
+	repairReason: PersistentBlockIdentityRepairReason | null;
+	shouldRepairPersistentId: boolean;
+}
+
+/**
  * Describe the resolved render context passed to custom field-control renderers.
  *
  * @category React
@@ -237,3 +271,8 @@ export type {
 	EditorFieldOption,
 	EditorModelOptions,
 } from "./editor.js";
+export type {
+	PersistentBlockIdentityNode,
+	PersistentBlockIdentityRepair,
+	PersistentBlockIdentityRepairReason,
+} from "./identifiers.js";

--- a/packages/wp-typia-block-runtime/src/inspector-runtime.tsx
+++ b/packages/wp-typia-block-runtime/src/inspector-runtime.tsx
@@ -19,6 +19,9 @@ export type {
 	InspectorFieldOverride,
 	InspectorFromManifestProps,
 	InspectorSelectOption,
+	PersistentBlockIdentityNode,
+	PersistentBlockIdentityRepair,
+	PersistentBlockIdentityRepairReason,
 	PanelBodyLikeProps,
 	RangeControlLikeProps,
 	SelectControlLikeProps,
@@ -26,9 +29,12 @@ export type {
 	TextareaControlLikeProps,
 	ToggleControlLikeProps,
 	TypedAttributeUpdater,
+	UsePersistentBlockIdentityOptions,
+	UsePersistentBlockIdentityResult,
 	UseEditorFieldsResult,
 } from "./inspector-runtime-types.js";
 export {
+	usePersistentBlockIdentity,
 	useEditorFields,
 	useTypedAttributeUpdater,
 } from "./inspector-runtime-model.js";

--- a/packages/wp-typia-block-runtime/tests/block-runtime.test.ts
+++ b/packages/wp-typia-block-runtime/tests/block-runtime.test.ts
@@ -73,9 +73,16 @@ describe("@wp-typia/block-runtime", () => {
 		expect(typeof editorModule.defineManifestDocument).toBe("function");
 		expect(typeof editorModule.assertManifestDocument).toBe("function");
 		expect(typeof editorModule.parseManifestDocument).toBe("function");
+		expect(typeof identifiersModule.collectPersistentBlockIdentityRepairs).toBe(
+			"function",
+		);
+		expect(typeof identifiersModule.ensurePersistentBlockIdentity).toBe(
+			"function",
+		);
 		expect(typeof identifiersModule.generateBlockId).toBe("function");
 		expect(typeof identifiersModule.generatePublicWriteRequestId).toBe("function");
 		expect(typeof inspectorModule.useEditorFields).toBe("function");
+		expect(typeof inspectorModule.usePersistentBlockIdentity).toBe("function");
 		expect(typeof inspectorModule.parseManifestDocument).toBe("function");
 		expect(typeof validationModule.toValidationResult).toBe("function");
 		expect(typeof blocksModule.assertTypiaWebpackCompatibility).toBe("function");

--- a/packages/wp-typia-block-runtime/tests/identifiers.test.ts
+++ b/packages/wp-typia-block-runtime/tests/identifiers.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 
 import {
+	collectPersistentBlockIdentityRepairs,
+	ensurePersistentBlockIdentity,
 	generateBlockId,
 	generatePublicWriteRequestId,
 	generateResourceKey,
@@ -82,6 +84,106 @@ describe( '@wp-typia/block-runtime/identifiers', () => {
 
 		expect( generateScopedClientId( 'demo' ) ).toMatch( /^demo-[a-z0-9]{9}$/ );
 		expect( generateResourceKey( 'demo' ) ).toMatch( /^demo-[a-z0-9]{9}$/ );
+	} );
+
+	test( 'ensurePersistentBlockIdentity preserves unique ids and regenerates missing or duplicate values', () => {
+		expect(
+			ensurePersistentBlockIdentity( {
+				existingIds: [ 'sec-existing' ],
+				prefix: 'sec',
+				seenIds: [ 'sec-existing' ],
+				value: 'sec-current',
+			} )
+		).toEqual( {
+			changed: false,
+			previousValue: 'sec-current',
+			reason: null,
+			value: 'sec-current',
+		} );
+
+		expect(
+			ensurePersistentBlockIdentity( {
+				existingIds: [ 'sec-existing' ],
+				generateId: () => 'sec-generated',
+				prefix: 'sec',
+				seenIds: [ 'sec-existing' ],
+				value: undefined,
+			} )
+		).toEqual( {
+			changed: true,
+			previousValue: null,
+			reason: 'missing',
+			value: 'sec-generated',
+		} );
+
+		expect(
+			ensurePersistentBlockIdentity( {
+				existingIds: [ 'sec-existing' ],
+				generateId: () => 'sec-duplicate-fix',
+				prefix: 'sec',
+				seenIds: [ 'sec-existing' ],
+				value: 'sec-existing',
+			} )
+		).toEqual( {
+			changed: true,
+			previousValue: 'sec-existing',
+			reason: 'duplicate',
+			value: 'sec-duplicate-fix',
+		} );
+	} );
+
+	test( 'collectPersistentBlockIdentityRepairs only patches missing ids and later duplicates in one tree', () => {
+		const repairs = collectPersistentBlockIdentityRepairs(
+			[
+				{
+					attributes: {
+						sectionId: 'sec-keep',
+					},
+					clientId: 'parent',
+					innerBlocks: [
+						{
+							attributes: {},
+							clientId: 'child-missing',
+						},
+						{
+							attributes: {
+								sectionId: 'sec-keep',
+							},
+							clientId: 'child-duplicate',
+						},
+						{
+							attributes: {
+								sectionId: 'custom-stable',
+							},
+							clientId: 'child-custom',
+						},
+					],
+				},
+			],
+			{
+				attributeName: 'sectionId',
+				generateId: ( ( values ) => {
+					let index = 0;
+					return () => values[ index++ ] ?? `sec-fallback-${ index }`;
+				} )( [ 'sec-generated', 'sec-regenerated' ] ),
+				prefix: 'sec',
+			}
+		);
+
+		expect( repairs ).toEqual( [
+			{
+				clientId: 'child-missing',
+				nextValue: 'sec-generated',
+				previousValue: null,
+				reason: 'missing',
+			},
+			{
+				clientId: 'child-duplicate',
+				nextValue: 'sec-regenerated',
+				previousValue: 'sec-keep',
+				reason: 'duplicate',
+			},
+		] );
 	} );
 } );
 

--- a/packages/wp-typia-block-runtime/tests/identifiers.test.ts
+++ b/packages/wp-typia-block-runtime/tests/identifiers.test.ts
@@ -185,6 +185,30 @@ describe( '@wp-typia/block-runtime/identifiers', () => {
 			},
 		] );
 	} );
+
+	test( 'ensurePersistentBlockIdentity handles one-shot seenId iterables safely', () => {
+		function* createSeenIds() {
+			yield 'sec-existing';
+		}
+
+		expect(
+			ensurePersistentBlockIdentity( {
+				existingIds: [ 'sec-existing' ],
+				generateId: ( ( values ) => {
+					let index = 0;
+					return () => values[ index++ ] ?? `sec-fallback-${ index }`;
+				} )( [ 'sec-existing', 'sec-fixed' ] ),
+				prefix: 'sec',
+				seenIds: createSeenIds(),
+				value: 'sec-existing',
+			} )
+		).toEqual( {
+			changed: true,
+			previousValue: 'sec-existing',
+			reason: 'duplicate',
+			value: 'sec-fixed',
+		} );
+	} );
 } );
 
 function mockCrypto(

--- a/tests/unit/inspector-runtime.test.tsx
+++ b/tests/unit/inspector-runtime.test.tsx
@@ -8,11 +8,13 @@ import {
 	FieldControl,
 	InspectorFromManifest,
 	useEditorFields,
+	usePersistentBlockIdentity,
 	useTypedAttributeUpdater,
 	type EditorFieldDescriptor,
 	type InspectorComponentMap,
 	type ManifestAttribute,
 	type ManifestDocument,
+	type PersistentBlockIdentityNode,
 	type ValidationResult,
 } from "../../packages/wp-typia-block-runtime/src/inspector";
 
@@ -152,10 +154,16 @@ describe("runtime inspector helpers", () => {
 		);
 		expect(inspectorRuntimeSource).not.toContain("function getPathSegments(");
 		expect(inspectorRuntimeSource).not.toContain("export function useEditorFields(");
+		expect(inspectorRuntimeSource).not.toContain(
+			"export function usePersistentBlockIdentity(",
+		);
 		expect(inspectorRuntimeSource).not.toContain("export function FieldControl(");
 		expect(inspectorModelSource).toContain("export function useEditorFields(");
 		expect(inspectorModelSource).toContain(
 			"export function useTypedAttributeUpdater<",
+		);
+		expect(inspectorModelSource).toContain(
+			"export function usePersistentBlockIdentity<",
 		);
 		expect(inspectorControlsSource).toContain(
 			"export function FieldControl(",
@@ -347,6 +355,124 @@ describe("runtime inspector helpers", () => {
 
 		expect(updater.updateField("content", "")).toBe(false);
 		expect(patches).toHaveLength(2);
+	});
+
+	test("usePersistentBlockIdentity reports pending repairs for missing and duplicate ids", () => {
+		const blocks: PersistentBlockIdentityNode[] = [
+			{
+				attributes: {
+					sectionId: "sec-keep",
+				},
+				clientId: "parent",
+				innerBlocks: [
+					{
+						attributes: {},
+						clientId: "child-missing",
+					},
+					{
+						attributes: {
+							sectionId: "sec-keep",
+						},
+						clientId: "child-duplicate",
+					},
+				],
+			},
+		];
+		const patches: Array<Record<string, unknown>> = [];
+
+		const missingIdentity = renderHook(() =>
+			usePersistentBlockIdentity({
+				attributeName: "sectionId",
+				attributes: {},
+				autoRepair: false,
+				blocks,
+				clientId: "child-missing",
+				prefix: "sec",
+				setAttributes: (patch) => {
+					patches.push(patch);
+				},
+			}),
+		);
+		const duplicateIdentity = renderHook(() =>
+			usePersistentBlockIdentity({
+				attributeName: "sectionId",
+				attributes: {
+					sectionId: "sec-keep",
+				},
+				autoRepair: false,
+				blocks,
+				clientId: "child-duplicate",
+				prefix: "sec",
+				setAttributes: (patch) => {
+					patches.push(patch);
+				},
+			}),
+		);
+
+		expect(missingIdentity.currentPersistentId).toBeNull();
+		expect(missingIdentity.nextPersistentId).toMatch(/^sec-[a-z0-9]{9}$/);
+		expect(missingIdentity.repairReason).toBe("missing");
+		expect(missingIdentity.shouldRepairPersistentId).toBe(true);
+
+		expect(duplicateIdentity.currentPersistentId).toBe("sec-keep");
+		expect(duplicateIdentity.nextPersistentId).toMatch(/^sec-[a-z0-9]{9}$/);
+		expect(duplicateIdentity.nextPersistentId).not.toBe("sec-keep");
+		expect(duplicateIdentity.repairReason).toBe("duplicate");
+		expect(duplicateIdentity.shouldRepairPersistentId).toBe(true);
+
+		const expectedMissingId = missingIdentity.nextPersistentId;
+		const expectedDuplicateId = duplicateIdentity.nextPersistentId;
+		const ensuredMissingId = missingIdentity.ensurePersistentId();
+		const ensuredDuplicateId = duplicateIdentity.ensurePersistentId();
+
+		expect(expectedMissingId).not.toBeNull();
+		expect(expectedDuplicateId).not.toBeNull();
+		if (expectedMissingId === null || expectedDuplicateId === null) {
+			throw new Error("identity helper should precompute repair ids");
+		}
+		expect(ensuredMissingId).toBe(expectedMissingId);
+		expect(ensuredDuplicateId).toBe(expectedDuplicateId);
+		expect(patches).toEqual([
+			{
+				sectionId: ensuredMissingId,
+			},
+			{
+				sectionId: ensuredDuplicateId,
+			},
+		]);
+	});
+
+	test("usePersistentBlockIdentity preserves stable ids during normal edits", () => {
+		const patches: Array<Record<string, unknown>> = [];
+		const identity = renderHook(() =>
+			usePersistentBlockIdentity({
+				attributeName: "sectionId",
+				attributes: {
+					sectionId: "custom-stable",
+				},
+				autoRepair: false,
+				blocks: [
+					{
+						attributes: {
+							sectionId: "custom-stable",
+						},
+						clientId: "solo",
+					},
+				],
+				clientId: "solo",
+				prefix: "sec",
+				setAttributes: (patch) => {
+					patches.push(patch);
+				},
+			}),
+		);
+
+		expect(identity.currentPersistentId).toBe("custom-stable");
+		expect(identity.nextPersistentId).toBe("custom-stable");
+		expect(identity.repairReason).toBeNull();
+		expect(identity.shouldRepairPersistentId).toBe(false);
+		expect(identity.ensurePersistentId()).toBe("custom-stable");
+		expect(patches).toEqual([]);
 	});
 
 	test("FieldControl maps supported field kinds and skips unsupported fields by default", () => {


### PR DESCRIPTION
## Context

Structured document blocks sometimes need stable logical ids that survive save/reopen, remain stable across ordinary edits, and regenerate safely when a block is duplicated inside the same document tree. Today that lifecycle still had to be hand-rolled by block authors.

## What Changed

- added duplicate-safe persistent id helpers to `@wp-typia/block-runtime/identifiers`
  - `ensurePersistentBlockIdentity(...)`
  - `collectPersistentBlockIdentityRepairs(...)`
- added `usePersistentBlockIdentity(...)` to `@wp-typia/block-runtime/inspector`
  - preserves existing ids during normal edits
  - repairs missing ids
  - repairs only later duplicates within one depth-first document traversal
  - keeps the React hook on the inspector facade while leaving the pure helper on the non-React identifiers facade
- documented when to use the pure helper vs the React hook in the block-runtime README and hosted API reference
- added regression coverage for the new identifiers helpers, inspector hook behavior, and published export surface

## Verification

- `bun test packages/wp-typia-block-runtime/tests/identifiers.test.ts packages/wp-typia-block-runtime/tests/block-runtime.test.ts tests/unit/inspector-runtime.test.tsx`
- `bun run --filter @wp-typia/block-runtime build`
- `bun run typecheck`
- `bun run docs:build:site`
- `bun run changesets:validate`

Closes #438


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent block identity helpers with duplicate detection to maintain stable logical IDs across block edits, saves, reopens, and duplications
  * New React hook and utility functions for deterministic, duplicate-safe block identity repairs

* **Documentation**
  * Updated API reference and README with persistent block identity feature overview, usage examples, and implementation guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->