### PR TITLE
Fix Bunli runtime chunk collisions in generated-project smoke

### DIFF
--- a/.sampo/changesets/bunli-runtime-smoke-collision.md
+++ b/.sampo/changesets/bunli-runtime-smoke-collision.md
@@ -1,0 +1,6 @@
+---
+npm/wp-typia: patch
+---
+
+Avoid split-chunk output collisions when rebuilding the linked Bunli runtime
+from generated example projects such as `my-typia-block`.

--- a/packages/wp-typia/scripts/build-bunli-runtime.ts
+++ b/packages/wp-typia/scripts/build-bunli-runtime.ts
@@ -299,7 +299,11 @@ async function buildFullBunliRuntime() {
     outdir,
     root: buildRoot,
     sourcemap: buildConfig.sourcemap ? 'external' : 'none',
-    splitting: true,
+    // Keep the published full Bunli runtime as one stable entry bundle.
+    // Linked example/workspace installs can resolve Bun dependencies through
+    // different absolute store paths, which makes code-split chunk filenames
+    // collide even when the main cli entry remains stable.
+    splitting: false,
     target: 'bun',
   });
 

--- a/packages/wp-typia/scripts/build-bunli-runtime.ts
+++ b/packages/wp-typia/scripts/build-bunli-runtime.ts
@@ -293,17 +293,16 @@ async function buildFullBunliRuntime() {
     format: 'esm',
     naming: {
       asset: '[dir]/[name]-[hash].[ext]',
-      chunk: '[name]-[hash].[ext]',
+      // Preserve directory context for split chunks so linked generated-project
+      // rebuilds do not collapse distinct Bun dependency graphs onto the same
+      // output path when absolute store roots differ across environments.
+      chunk: '[dir]/[name]-[hash].[ext]',
       entry: '[name].[ext]',
     },
     outdir,
     root: buildRoot,
     sourcemap: buildConfig.sourcemap ? 'external' : 'none',
-    // Keep the published full Bunli runtime as one stable entry bundle.
-    // Linked example/workspace installs can resolve Bun dependencies through
-    // different absolute store paths, which makes code-split chunk filenames
-    // collide even when the main cli entry remains stable.
-    splitting: false,
+    splitting: true,
     target: 'bun',
   });
 

--- a/packages/wp-typia/tests/bunli-prep.test.ts
+++ b/packages/wp-typia/tests/bunli-prep.test.ts
@@ -67,6 +67,10 @@ describe('wp-typia Bunli preparation', () => {
       path.join(packageRoot, 'scripts', 'build-bunli-runtime.ts'),
       'utf8',
     );
+    const fullRuntimeSection = runtimeBuildScript.slice(
+      runtimeBuildScript.indexOf('async function buildFullBunliRuntime()'),
+      runtimeBuildScript.indexOf('async function buildGeneratedMetadataRuntime()'),
+    );
 
     expect(runtimeBuildScript).toContain(
       'const requireFromWpTypia = createRequire(',
@@ -107,12 +111,12 @@ describe('wp-typia Bunli preparation', () => {
     expect(runtimeBuildScript).toContain(
       'const buildRoot = path.parse(packageRoot).root;',
     );
-    expect(runtimeBuildScript).toContain("naming: {");
-    expect(runtimeBuildScript).toContain("asset: '[dir]/[name]-[hash].[ext]'");
-    expect(runtimeBuildScript).toContain("chunk: '[name]-[hash].[ext]'");
-    expect(runtimeBuildScript).toContain("entry: '[name].[ext]'");
-    expect(runtimeBuildScript).toContain('root: buildRoot');
-    expect(runtimeBuildScript).toContain('splitting: false');
+    expect(fullRuntimeSection).toContain("naming: {");
+    expect(fullRuntimeSection).toContain("asset: '[dir]/[name]-[hash].[ext]'");
+    expect(fullRuntimeSection).toContain("chunk: '[dir]/[name]-[hash].[ext]'");
+    expect(fullRuntimeSection).toContain("entry: '[name].[ext]'");
+    expect(fullRuntimeSection).toContain('root: buildRoot');
+    expect(fullRuntimeSection).toContain('splitting: true');
   });
 
   test('future Bunli command tree preserves the reserved top-level taxonomy', async () => {

--- a/packages/wp-typia/tests/bunli-prep.test.ts
+++ b/packages/wp-typia/tests/bunli-prep.test.ts
@@ -112,7 +112,7 @@ describe('wp-typia Bunli preparation', () => {
     expect(runtimeBuildScript).toContain("chunk: '[name]-[hash].[ext]'");
     expect(runtimeBuildScript).toContain("entry: '[name].[ext]'");
     expect(runtimeBuildScript).toContain('root: buildRoot');
-    expect(runtimeBuildScript).toContain('splitting: true');
+    expect(runtimeBuildScript).toContain('splitting: false');
   });
 
   test('future Bunli command tree preserves the reserved top-level taxonomy', async () => {


### PR DESCRIPTION
## Context

`main` after PR #474 left `CI/CD Pipeline` failing in `Generated Project Smoke (smoke-reference-my-typia-block-bun)`. The linked `my-typia-block` example rebuilds the Bunli runtime while running `wp-typia migrate snapshot`, and the split full-runtime build was still producing chunk output path collisions.

## What Changed

- switched the full Bunli runtime build in `packages/wp-typia/scripts/build-bunli-runtime.ts` to a single stable entry bundle instead of split chunks
- kept the filesystem-root asset handling from the earlier Linux path fix while avoiding the new linked-store chunk collision
- updated the Bunli prep regression test to lock the new runtime build policy
- added a `wp-typia` patch changeset for the published CLI runtime behavior change

## Verification

- `bun test packages/wp-typia/tests/bunli-prep.test.ts`
- `bun run --filter wp-typia build`
- `node scripts/run-generated-project-smoke.mjs --runtime bun --example-project my-typia-block --package-manager bun --project-name smoke-reference-my-typia-block-bun-post-474`
- `bun run changesets:validate`

Closes #475


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed split-chunk output collisions during Bunli runtime rebuilds, ensuring the runtime generates as a single stable bundle instead of separate chunk files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->