### PR TITLE
Fix linked Bunli rebuild mode for reference generated-project smoke

### DIFF
--- a/.sampo/changesets/linked-bunli-runtime-mode.md
+++ b/.sampo/changesets/linked-bunli-runtime-mode.md
@@ -1,0 +1,7 @@
+---
+npm/wp-typia: patch
+---
+
+Keep the repo-owned Bunli runtime split for canonical CLI startup paths while
+using a single-file rebuild mode for linked installed-package copies inside
+generated project smoke runs.

--- a/packages/wp-typia/scripts/build-bunli-runtime.ts
+++ b/packages/wp-typia/scripts/build-bunli-runtime.ts
@@ -22,6 +22,9 @@ const generatedMetadataEntrypoint = path.resolve(
 );
 const nodeRuntimeEntrypoint = path.resolve(packageRoot, 'src', 'node-cli.ts');
 const buildRoot = path.parse(packageRoot).root;
+const isLinkedInstalledWpTypiaRuntime = packageRoot.includes(
+  `${path.sep}node_modules${path.sep}.bun${path.sep}`,
+);
 const outdir = path.resolve(packageRoot, buildConfig.outdir);
 const generatedMetadataOutdir = path.join(outdir, '.bunli');
 const requireFromWpTypia = createRequire(
@@ -293,16 +296,17 @@ async function buildFullBunliRuntime() {
     format: 'esm',
     naming: {
       asset: '[dir]/[name]-[hash].[ext]',
-      // Preserve directory context for split chunks so linked generated-project
-      // rebuilds do not collapse distinct Bun dependency graphs onto the same
-      // output path when absolute store roots differ across environments.
-      chunk: '[dir]/[name]-[hash].[ext]',
+      chunk: '[name]-[hash].[ext]',
       entry: '[name].[ext]',
     },
     outdir,
     root: buildRoot,
     sourcemap: buildConfig.sourcemap ? 'external' : 'none',
-    splitting: true,
+    // Keep the repo-owned runtime split so canonical help/completion flows
+    // avoid eagerly resolving heavy external runtime packages, but collapse
+    // linked installed-package rebuilds into a single file to avoid Bun asset
+    // path collisions inside `.bun` store copies used by generated smoke.
+    splitting: !isLinkedInstalledWpTypiaRuntime,
     target: 'bun',
   });
 

--- a/packages/wp-typia/tests/bunli-prep.test.ts
+++ b/packages/wp-typia/tests/bunli-prep.test.ts
@@ -111,12 +111,20 @@ describe('wp-typia Bunli preparation', () => {
     expect(runtimeBuildScript).toContain(
       'const buildRoot = path.parse(packageRoot).root;',
     );
+    expect(runtimeBuildScript).toContain(
+      'const isLinkedInstalledWpTypiaRuntime = packageRoot.includes(',
+    );
+    expect(runtimeBuildScript).toContain(
+      "`${path.sep}node_modules${path.sep}.bun${path.sep}`",
+    );
     expect(fullRuntimeSection).toContain("naming: {");
     expect(fullRuntimeSection).toContain("asset: '[dir]/[name]-[hash].[ext]'");
-    expect(fullRuntimeSection).toContain("chunk: '[dir]/[name]-[hash].[ext]'");
+    expect(fullRuntimeSection).toContain("chunk: '[name]-[hash].[ext]'");
     expect(fullRuntimeSection).toContain("entry: '[name].[ext]'");
     expect(fullRuntimeSection).toContain('root: buildRoot');
-    expect(fullRuntimeSection).toContain('splitting: true');
+    expect(fullRuntimeSection).toContain(
+      'splitting: !isLinkedInstalledWpTypiaRuntime',
+    );
   });
 
   test('future Bunli command tree preserves the reserved top-level taxonomy', async () => {


### PR DESCRIPTION
## Context
- `main` still fails after #476, but only in `smoke-reference-my-typia-block-bun`.
- Repo-owned CLI startup paths still need split Bunli output so canonical help/completions do not require built block-runtime artifacts.

## What Changed
- detect linked installed-package Bunli rebuilds inside `.bun` store copies
- keep repo-owned full runtime builds split, but collapse linked installed-package rebuilds into a single file
- tighten the Bunli prep boundary test around the full-runtime build section and the linked-install detection contract
- add a patch changeset for the follow-up smoke fix

## Verification
- `bun test ./packages/wp-typia/tests/bunli-prep.test.ts`
- `bun run --filter wp-typia build`
- `rm -rf packages/wp-typia-block-runtime/dist && node packages/wp-typia/bin/wp-typia.js --help`
- `rm -rf packages/wp-typia-block-runtime/dist && node packages/wp-typia/bin/wp-typia.js skills list`
- `node scripts/run-generated-project-smoke.mjs --runtime bun --example-project my-typia-block --package-manager bun --project-name smoke-reference-my-typia-block-bun-post-477`
- `bun run changesets:validate`

Closes #477

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized runtime build behavior for different installation scenarios, improving CLI startup performance and ensuring consistent build output across repository and linked package configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->