### PR TITLE
Fix Bun reference example smoke api-client linking

### DIFF
--- a/scripts/lib/generated-project-smoke-core.mjs
+++ b/scripts/lib/generated-project-smoke-core.mjs
@@ -206,6 +206,35 @@ export function rewriteWorkspaceDependencies(projectDir, packageManager) {
 		packageJson.dependencies["wp-typia"] = localCliDependency;
 	}
 
+	const linkedRuntimePackages = [
+		"@wp-typia/block-runtime",
+		"@wp-typia/rest",
+		"wp-typia",
+	];
+	const hasApiClientDependency =
+		packageJson.devDependencies?.["@wp-typia/api-client"] ||
+		packageJson.dependencies?.["@wp-typia/api-client"];
+	const shouldSeedApiClientInDevDependencies = linkedRuntimePackages.some(
+		(packageName) => packageJson.devDependencies?.[packageName],
+	);
+	const shouldSeedApiClientInDependencies = linkedRuntimePackages.some(
+		(packageName) => packageJson.dependencies?.[packageName],
+	);
+
+	if (!hasApiClientDependency) {
+		if (shouldSeedApiClientInDevDependencies) {
+			packageJson.devDependencies = {
+				...(packageJson.devDependencies ?? {}),
+				"@wp-typia/api-client": localApiClientDependency,
+			};
+		} else if (shouldSeedApiClientInDependencies) {
+			packageJson.dependencies = {
+				...(packageJson.dependencies ?? {}),
+				"@wp-typia/api-client": localApiClientDependency,
+			};
+		}
+	}
+
 	packageJson.overrides = {
 		...(packageJson.overrides ?? {}),
 		"@wp-typia/block-runtime": localBlockRuntimeDependency,

--- a/tests/unit/generated-project-smoke-reference-lane.test.ts
+++ b/tests/unit/generated-project-smoke-reference-lane.test.ts
@@ -3,8 +3,6 @@ import fs from "node:fs";
 import os from "node:os";
 import { join } from "node:path";
 
-import { rewriteWorkspaceDependencies } from "../../scripts/lib/generated-project-smoke-core.mjs";
-
 const repoRoot = join(import.meta.dir, "..", "..");
 const tempDirs: string[] = [];
 
@@ -85,7 +83,7 @@ test("CI generated smoke matrix includes the checked-in example lanes", () => {
 	expect(ciWorkflow).toContain('--example-project "${{ matrix.example_project }}"');
 });
 
-test("workspace dependency rewrite seeds api-client for linked Bun reference examples", () => {
+test("workspace dependency rewrite seeds api-client for linked Bun reference examples", async () => {
 	const projectDir = fs.mkdtempSync(
 		join(os.tmpdir(), "wp-typia-generated-smoke-reference-"),
 	);
@@ -110,6 +108,15 @@ test("workspace dependency rewrite seeds api-client for linked Bun reference exa
 		)}\n`,
 		"utf8",
 	);
+
+	const { rewriteWorkspaceDependencies } = (await import(
+		new URL("../../scripts/lib/generated-project-smoke-core.mjs", import.meta.url).href
+	)) as {
+		rewriteWorkspaceDependencies: (
+			projectDir: string,
+			packageManager: "bun" | "npm" | "pnpm" | "yarn",
+		) => void;
+	};
 
 	rewriteWorkspaceDependencies(projectDir, "bun");
 

--- a/tests/unit/generated-project-smoke-reference-lane.test.ts
+++ b/tests/unit/generated-project-smoke-reference-lane.test.ts
@@ -1,23 +1,34 @@
-import { expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { afterEach, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
 import { join } from "node:path";
 
+import { rewriteWorkspaceDependencies } from "../../scripts/lib/generated-project-smoke-core.mjs";
+
 const repoRoot = join(import.meta.dir, "..", "..");
+const tempDirs: string[] = [];
+
+afterEach(() => {
+	for (const tempDir of tempDirs) {
+		fs.rmSync(tempDir, { force: true, recursive: true });
+	}
+	tempDirs.length = 0;
+});
 
 test("generated project smoke script supports a reference example lane", () => {
-	const smokeScript = readFileSync(
+	const smokeScript = fs.readFileSync(
 		join(repoRoot, "scripts", "run-generated-project-smoke.mjs"),
 		"utf8",
 	);
-	const exampleHelper = readFileSync(
+	const exampleHelper = fs.readFileSync(
 		join(repoRoot, "scripts", "lib", "generated-project-smoke-example.mjs"),
 		"utf8",
 	);
-	const assertionHelper = readFileSync(
+	const assertionHelper = fs.readFileSync(
 		join(repoRoot, "scripts", "lib", "generated-project-smoke-assertions.mjs"),
 		"utf8",
 	);
-	const coreHelper = readFileSync(
+	const coreHelper = fs.readFileSync(
 		join(repoRoot, "scripts", "lib", "generated-project-smoke-core.mjs"),
 		"utf8",
 	);
@@ -55,7 +66,7 @@ test("generated project smoke script supports a reference example lane", () => {
 });
 
 test("CI generated smoke matrix includes the checked-in example lanes", () => {
-	const ciWorkflow = readFileSync(
+	const ciWorkflow = fs.readFileSync(
 		join(repoRoot, ".github", "workflows", "ci.yml"),
 		"utf8",
 	);
@@ -72,4 +83,49 @@ test("CI generated smoke matrix includes the checked-in example lanes", () => {
 	expect(ciWorkflow).toContain('if [ -n "${{ matrix.template || \'\' }}" ]; then');
 	expect(ciWorkflow).toContain('args+=(--template "${{ matrix.template }}")');
 	expect(ciWorkflow).toContain('--example-project "${{ matrix.example_project }}"');
+});
+
+test("workspace dependency rewrite seeds api-client for linked Bun reference examples", () => {
+	const projectDir = fs.mkdtempSync(
+		join(os.tmpdir(), "wp-typia-generated-smoke-reference-"),
+	);
+	tempDirs.push(projectDir);
+
+	const packageJsonPath = join(projectDir, "package.json");
+	fs.writeFileSync(
+		packageJsonPath,
+		`${JSON.stringify(
+			{
+				name: "my-typia-block",
+				private: true,
+				devDependencies: {
+					"@wp-typia/block-runtime": "workspace:*",
+					"@wp-typia/block-types": "workspace:*",
+					"@wp-typia/rest": "workspace:*",
+					"wp-typia": "workspace:*",
+				},
+			},
+			null,
+			2,
+		)}\n`,
+		"utf8",
+	);
+
+	rewriteWorkspaceDependencies(projectDir, "bun");
+
+	const rewrittenPackageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+
+	expect(rewrittenPackageJson.packageManager).toBe("bun@1.3.11");
+	expect(rewrittenPackageJson.devDependencies["@wp-typia/api-client"]).toContain(
+		"packages/wp-typia-api-client",
+	);
+	expect(rewrittenPackageJson.devDependencies["@wp-typia/block-runtime"]).toContain(
+		"packages/wp-typia-block-runtime",
+	);
+	expect(rewrittenPackageJson.devDependencies["@wp-typia/rest"]).toContain(
+		"packages/wp-typia-rest",
+	);
+	expect(rewrittenPackageJson.devDependencies["wp-typia"]).toContain(
+		"packages/wp-typia",
+	);
 });


### PR DESCRIPTION
## Context
- `main` is failing in `Generated Project Smoke (smoke-reference-my-typia-block-bun)` after PR #467 merged
- the copied `examples/my-typia-block` lane links local runtime packages, but Bun still fails during `migration:snapshot` because `@wp-typia/block-runtime` cannot resolve `@wp-typia/api-client`

## What Changed
- seed a direct local `@wp-typia/api-client` dependency during smoke dependency rewrites whenever linked local runtime packages are present and the copied project does not already declare it
- keep the existing local overrides/resolutions behavior intact
- add a focused regression test that exercises the rewrite on a copied reference-example style package manifest

## Verification
- `bun test tests/unit/generated-project-smoke-reference-lane.test.ts`
- `node scripts/run-generated-project-smoke.mjs --runtime bun --example-project my-typia-block --package-manager bun --project-name smoke-reference-my-typia-block-bun-fix`
- `bun run changesets:validate`

Closes #479

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced workspace dependency resolution to automatically include required API client packages when other linked packages are detected in generated projects.

* **Tests**
  * Improved test infrastructure and expanded test coverage for dependency management functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->