### PR TITLE
test: fix project-tools coverage follow-up

### DIFF
--- a/packages/wp-typia-project-tools/package.json
+++ b/packages/wp-typia-project-tools/package.json
@@ -86,7 +86,7 @@
     "test:migration-planning": "bun run build && bun test tests/migration-init.test.ts tests/migration-config.test.ts tests/migration-plan-wizard.test.ts",
     "test:migration-execution": "bun run build && bun test tests/migration-scaffold-diff.test.ts tests/migration-doctor.test.ts tests/migration-fixtures-fuzz.test.ts",
     "test:project-tools": "bun run test:scaffold-core && bun run test:workspace && bun run test:compound && bun run test:migration-planning && bun run test:migration-execution",
-    "test:coverage": "bun run build && bun test tests/*.test.ts --coverage --coverage-reporter=lcov --coverage-dir=coverage",
+    "test:coverage": "bun run build && bun run --filter wp-typia build && bun test tests/*.test.ts --coverage --coverage-reporter=lcov --coverage-dir=coverage",
     "clean": "rm -rf dist",
     "prepublishOnly": "bun run build"
   },

--- a/packages/wp-typia-project-tools/tests/cli-templates.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-templates.test.ts
@@ -9,7 +9,7 @@ import {
 describe("@wp-typia/project-tools template discovery formatting", () => {
 	test("list output surfaces flag hints for persistence and query-loop templates", () => {
 		expect(formatTemplateFeatures(getTemplateById("persistence"))).toContain(
-			"Supports: --data-storage • --persistence-policy • external layers",
+			"Supports: --alternate-render-targets • --data-storage • --persistence-policy • external layers",
 		);
 		expect(formatTemplateFeatures(getTemplateById("query-loop"))).toContain(
 			"Supports: --query-post-type • external layers",


### PR DESCRIPTION
## Context

`main` started failing the `Project Tools Coverage` lane after the alternate render target work landed. Reproducing the lane locally surfaced two related gaps: the template-discovery assertion still expected the old persistence feature hint string, and clean coverage runs were not explicitly rebuilding the canonical `wp-typia` CLI runtime before tests that spawn `packages/wp-typia/bin/wp-typia.js`.

## What Changed

- update the persistence template discovery expectation to include `--alternate-render-targets`
- make `@wp-typia/project-tools` coverage runs build `wp-typia` before executing the test suite, so canonical CLI-spawning tests stay reproducible on clean checkouts

## Verification

- `bun test packages/wp-typia-project-tools/tests/cli-templates.test.ts`
- `bun run --filter @wp-typia/project-tools test:coverage`
- `bun run changesets:validate`

Closes #490


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build script orchestration for coverage test execution.

* **Tests**
  * Updated CLI template test expectations for the persistence feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->