### PR TITLE
docs: define retrofit init direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,22 @@ wp-typia add hooked-block counter-card --anchor core/post-content --position aft
 - Need a branded Query Loop inserter variation? Start with `query-loop`.
 - Need schema evolution for a long-lived block? Enable `--with-migration-ui`.
 
+## Retrofitting Existing Projects
+
+Today there is still no general-purpose `wp-typia init` command for arbitrary
+existing plugins or block repos.
+
+The currently supported retrofit path is narrower:
+
+- `wp-typia migrate init` bootstraps **migration support only**
+- it expects an existing project that already matches supported first-party
+  `wp-typia` block layouts
+- it does not try to convert an arbitrary project into a full scaffolded
+  `wp-typia` workspace
+
+The broader project-level adoption path is tracked in
+[Retrofit and Init Direction](RETROFIT_INIT_DIRECTION.md).
+
 ## Remote templates
 
 `wp-typia` can scaffold from:
@@ -201,6 +217,7 @@ npx wp-typia create my-block --template @scope/create-block-template --variant h
 - [External Template-Layer Composition RFC](https://imjlk.github.io/wp-typia/architecture/external-template-layer-composition/)
 - [API Guide](https://imjlk.github.io/wp-typia/reference/api/)
 - [Migration Guide](https://imjlk.github.io/wp-typia/guides/migrations/)
+- [Retrofit and Init Direction](RETROFIT_INIT_DIRECTION.md)
 - [Error and Export Contract Guide](https://imjlk.github.io/wp-typia/reference/error-export-contracts/)
 - [Formatting Toolchain Policy](https://imjlk.github.io/wp-typia/maintainers/formatting-toolchain-policy/)
 - [Maintenance Automation Policy](https://imjlk.github.io/wp-typia/maintainers/maintenance-automation-policy/)

--- a/RETROFIT_INIT_DIRECTION.md
+++ b/RETROFIT_INIT_DIRECTION.md
@@ -1,0 +1,89 @@
+# Retrofit and Init Direction
+
+`wp-typia` still needs a broader project-level retrofit path for existing
+WordPress plugins and block repos.
+
+This note is the stable place to accumulate that direction before a full
+`wp-typia init` workflow exists.
+
+## Current State
+
+Today the supported entrypoints are intentionally split:
+
+- `wp-typia create` scaffolds a new project or workspace from a known template.
+- `wp-typia add ...` extends an official `wp-typia` workspace after it already
+  exists.
+- `wp-typia migrate init` retrofits **migration support only** into projects that
+  already match supported first-party `wp-typia` block layouts.
+
+That means there is still no general-purpose command that takes an arbitrary
+existing WordPress project and adopts the minimum `wp-typia` infrastructure in a
+single supported flow.
+
+## Direction
+
+Any future `wp-typia init` or equivalent retrofit workflow should stay narrower
+than `create`.
+
+The intended shape is:
+
+1. Detect whether the target already looks like a supported single-block,
+   multi-block, or plugin/workspace project.
+2. Show a preview of the minimum dependencies, scripts, generated files, and
+   config changes that `wp-typia` would add.
+3. Apply only the requested adoption layer, instead of silently converting the
+   project into a full scaffolded template.
+4. Leave higher-level systems such as migration UI, workspace inventory, and
+   richer persistence flows as explicit follow-up opt-ins when possible.
+
+## Minimum Adoption Scope
+
+The first production-ready retrofit lane should focus on the smallest useful
+package of changes:
+
+- add the canonical `wp-typia` and supporting package dependencies
+- add the minimum sync scripts and package metadata needed for typed artifacts
+- add missing generated helper files only where they are required by that sync
+  surface
+- keep existing block/plugin source files in place whenever possible
+- provide explicit guidance for the next optional step, such as migration setup
+  or workspace expansion
+
+## Non-Goals
+
+The retrofit flow should **not** try to do these by default:
+
+- rewrite arbitrary project structures into the official scaffold layout
+- move files across directories without an explicit opt-in
+- infer product-specific persistence, REST, or editor-plugin architecture
+- auto-enable migration UI for projects that have not explicitly chosen schema
+  lineage tracking
+- replace `create` as the preferred entrypoint for greenfield projects
+
+## Guardrails
+
+To keep retrofit predictable, the workflow should prefer:
+
+- read-only preview or dry-run output before writes
+- explicit messages when the project falls outside supported shapes
+- narrow, composable adoption steps instead of one-shot project rewrites
+- preserving the user's package manager, repo layout, and existing source of
+  truth unless the user asks for a deeper conversion
+
+## Relationship To Existing Commands
+
+- `wp-typia create` remains the recommended path for new projects.
+- `wp-typia migrate init` remains the migration-only retrofit command for
+  supported `wp-typia`-style layouts.
+- a future `wp-typia init` should cover broader typed-artifact adoption, not
+  merely alias `migrate init`.
+
+## Open Questions
+
+- Which existing project layouts should be considered first-class for retrofit?
+- Should the first retrofit workflow target single-block projects before plugin
+  workspaces?
+- How much generated source should be seeded up front versus deferred until the
+  first `sync` run?
+- Should migration setup remain a separate explicit step even after a broader
+  retrofit command exists?

--- a/packages/wp-typia-project-tools/src/runtime/migration-command-surface.ts
+++ b/packages/wp-typia-project-tools/src/runtime/migration-command-surface.ts
@@ -62,6 +62,8 @@ export function formatMigrationHelpText(): string {
 
 Notes:
   \`migrate init\` auto-detects supported single-block and \`src/blocks/*\` multi-block layouts.
+  \`migrate init\` only retrofits migration support into projects that already match those layouts.
+  A broader project-level \`wp-typia init\` path remains future work.
   Migration versions use strict schema labels like \`v1\`, \`v2\`, and \`v3\`.
   \`migrate wizard\` is TTY-only and helps you choose one legacy migration version to preview.
   \`migrate plan\` and \`migrate wizard\` are read-only previews; they do not scaffold rules or fixtures.

--- a/packages/wp-typia-project-tools/tests/migration-init.test.ts
+++ b/packages/wp-typia-project-tools/tests/migration-init.test.ts
@@ -2,6 +2,7 @@ import { afterAll, describe, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { cleanupMigrationTempRoot, createBrokenOnlyMultiBlockProject, createCurrentProjectFiles, createCurrentSingleBlockScaffoldProject, createLegacyConfiguredCurrentPreferredSameNameMixedSingleBlockProject, createLegacyConfiguredMixedSingleBlockProject, createLegacyConfiguredSameNameMixedSingleBlockProject, createMalformedFallbackSingleBlockProject, createMalformedPreferredSingleBlockProject, createMigrationTempRoot, createMixedSingleBlockProject, createRetrofitMultiBlockProject, createRetrofitMultiBlockProjectWithBrokenCandidate, createSameNameMixedSingleBlockProject, createSingleBlockProjectWithBrokenMultiBlockCandidate, entryPath, runCli, writeJson } from "./helpers/migration-test-harness.js";
+import { formatMigrationHelpText } from "../src/runtime/migration-command-surface.js";
 import { loadMigrationProject } from "../src/runtime/migration-project.js";
 
 describe("wp-typia migrate init", () => {
@@ -300,8 +301,8 @@ test("migrate init fails with actionable guidance when no supported retrofit lay
 });
 
 test("migrate help text explains retrofit auto-detection, read-only planning, and --all workspace scope", () => {
-	expect(runCli("node", [entryPath, "migrate"])).toMatch(
-		/`migrate init` auto-detects supported single-block and `src\/blocks\/\*` multi-block layouts[\s\S]*Migration versions use strict schema labels like `v1`, `v2`, and `v3`[\s\S]*`migrate wizard` is TTY-only[\s\S]*`migrate plan` and `migrate wizard` are read-only previews[\s\S]*--all runs across every configured legacy migration version and every configured block target\.[\s\S]*Existing fixture files are preserved and reported as skipped unless you pass `--force`\.[\s\S]*Use `migrate fixtures --force` as the explicit refresh path/,
+	expect(formatMigrationHelpText()).toMatch(
+		/`migrate init` auto-detects supported single-block and `src\/blocks\/\*` multi-block layouts[\s\S]*`migrate init` only retrofits migration support into projects that already match those layouts\.[\s\S]*A broader project-level `wp-typia init` path remains future work\.[\s\S]*Migration versions use strict schema labels like `v1`, `v2`, and `v3`[\s\S]*`migrate wizard` is TTY-only[\s\S]*`migrate plan` and `migrate wizard` are read-only previews[\s\S]*--all runs across every configured legacy migration version and every configured block target\.[\s\S]*Existing fixture files are preserved and reported as skipped unless you pass `--force`\.[\s\S]*Use `migrate fixtures --force` as the explicit refresh path/,
 	);
 });
 });


### PR DESCRIPTION
## Context

`wp-typia` already has `create`, `add`, and a migration-only `migrate init` flow, but the repo still lacked a stable place to describe the broader future retrofit/init direction for existing projects.

## What Changed

- add a dedicated `RETROFIT_INIT_DIRECTION.md` note that records the current state, minimum future adoption scope, non-goals, and open questions for a broader `wp-typia init`
- link that direction from the root README and add a short “Retrofitting Existing Projects” section so the current limitation is visible from the main entrypoint docs
- clarify `migrate` help text so `migrate init` is explicitly described as a migration-only retrofit path, not a general project adoption command
- update the migration help regression test to lock that wording to the source-owned formatter

## Verification

- `bun test packages/wp-typia-project-tools/tests/migration-init.test.ts packages/wp-typia/tests/cli-package.test.ts`
- `bun run docs:build:site`
- `bun run changesets:validate`

Closes #449
