### PR TITLE
Tighten create/add/sync preflight and dry-run ergonomics

### DIFF
--- a/.sampo/changesets/issue-483-dry-run-preflight.md
+++ b/.sampo/changesets/issue-483-dry-run-preflight.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Improve create/add/sync CLI ergonomics for preview-first and no-install workflows. `wp-typia create --dry-run` now defaults non-interactive answers without requiring an extra `--yes`, `wp-typia sync` fails early with install guidance when local dependencies like `tsx` are missing, and `wp-typia add ... --dry-run` can preview planned workspace file updates without mutating the real workspace.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-shared.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-shared.ts
@@ -520,16 +520,17 @@ export function assertEditorPluginDoesNotExist(projectDir: string, editorPluginS
  */
 export function formatAddHelpText(): string {
 	return `Usage:
-  wp-typia add block <name> --template <${ADD_BLOCK_TEMPLATE_IDS.join("|")}> [--external-layer-source <./path|github:owner/repo/path[#ref]|npm-package>] [--external-layer-id <layer-id>] [--alternate-render-targets <email,mjml,plain-text>] [--data-storage <post-meta|custom-table>] [--persistence-policy <authenticated|public>]
-  wp-typia add variation <name> --block <block-slug>
-  wp-typia add pattern <name>
-  wp-typia add binding-source <name>
-  wp-typia add rest-resource <name> [--namespace <vendor/v1>] [--methods <list,read,create,update,delete>]
-  wp-typia add hooked-block <block-slug> --anchor <anchor-block-name> --position <${HOOKED_BLOCK_POSITION_IDS.join("|")}>
-  wp-typia add editor-plugin <name> [--slot <${EDITOR_PLUGIN_SLOT_IDS.join("|")}>]
+  wp-typia add block <name> --template <${ADD_BLOCK_TEMPLATE_IDS.join("|")}> [--external-layer-source <./path|github:owner/repo/path[#ref]|npm-package>] [--external-layer-id <layer-id>] [--alternate-render-targets <email,mjml,plain-text>] [--data-storage <post-meta|custom-table>] [--persistence-policy <authenticated|public>] [--dry-run]
+  wp-typia add variation <name> --block <block-slug> [--dry-run]
+  wp-typia add pattern <name> [--dry-run]
+  wp-typia add binding-source <name> [--dry-run]
+  wp-typia add rest-resource <name> [--namespace <vendor/v1>] [--methods <list,read,create,update,delete>] [--dry-run]
+  wp-typia add hooked-block <block-slug> --anchor <anchor-block-name> --position <${HOOKED_BLOCK_POSITION_IDS.join("|")}> [--dry-run]
+  wp-typia add editor-plugin <name> [--slot <${EDITOR_PLUGIN_SLOT_IDS.join("|")}>] [--dry-run]
 
 Notes:
   \`wp-typia add\` runs only inside official ${WORKSPACE_TEMPLATE_PACKAGE} workspaces.
+  Pass \`--dry-run\` to preview the workspace files that would change without writing them.
   \`add variation\` targets an existing block slug from \`scripts/block-config.ts\`.
   \`add pattern\` scaffolds a namespaced PHP pattern shell under \`src/patterns/\`.
   \`add binding-source\` scaffolds shared PHP and editor registration under \`src/bindings/\`.

--- a/packages/wp-typia-project-tools/tests/cli-entry.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-entry.test.ts
@@ -654,7 +654,6 @@ test("node entry supports dry-run create previews without writing files", () => 
     "basic",
     "--package-manager",
     "npm",
-    "--yes",
     "--dry-run",
   ]);
 
@@ -663,6 +662,33 @@ test("node entry supports dry-run create previews without writing files", () => 
   expect(output).toContain("Planned files");
   expect(output).toContain("write package.json");
   expect(fs.existsSync(targetDir)).toBe(false);
+});
+
+test("node entry fails early for sync when scaffold dependencies are missing", () => {
+  const targetDir = path.join(tempRoot, "demo-node-sync-no-install");
+
+  runCli("node", [
+    entryPath,
+    "create",
+    targetDir,
+    "--template",
+    "basic",
+    "--package-manager",
+    "npm",
+    "--yes",
+    "--no-install",
+  ]);
+
+  const errorMessage = getCommandErrorMessage(() =>
+    runCli("node", [entryPath, "sync"], {
+      cwd: targetDir,
+      stdio: "pipe",
+    })
+  );
+
+  expect(errorMessage).toContain("npm install");
+  expect(errorMessage).toContain("wp-typia sync");
+  expect(errorMessage).toContain("tsx");
 });
 
 test("node entry supports external layer flags for built-in create scaffolds", () => {

--- a/packages/wp-typia-project-tools/tests/workspace-add.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-add.test.ts
@@ -592,6 +592,87 @@ test("canonical CLI can add hooked-block metadata to an official workspace block
   ).toBe("pass");
 }, 20_000);
 
+test("canonical CLI can dry-run an add block scaffold without mutating the workspace", async () => {
+  const targetDir = path.join(tempRoot, "demo-workspace-add-block-dry-run");
+
+  await scaffoldOfficialWorkspace(targetDir, {
+    description: "Demo workspace add block dry run",
+    slug: "demo-workspace-add-block-dry-run",
+    title: "Demo Workspace Add Block Dry Run",
+  });
+
+  linkWorkspaceNodeModules(targetDir);
+  const output = runCli(
+    "node",
+    [
+      entryPath,
+      "add",
+      "block",
+      "counter-card",
+      "--template",
+      "basic",
+      "--dry-run",
+    ],
+    { cwd: targetDir }
+  );
+
+  expect(output).toContain("Dry run");
+  expect(output).toContain("Blocks: counter-card");
+  expect(output).toContain("write src/blocks/counter-card/index.tsx");
+  expect(
+    fs.existsSync(path.join(targetDir, "src", "blocks", "counter-card"))
+  ).toBe(false);
+});
+
+test("canonical CLI can dry-run hooked-block metadata updates without rewriting block.json", async () => {
+  const targetDir = path.join(tempRoot, "demo-workspace-add-hooked-block-dry-run");
+
+  await scaffoldOfficialWorkspace(targetDir, {
+    description: "Demo workspace add hooked block dry run",
+    slug: "demo-workspace-add-hooked-block-dry-run",
+    title: "Demo Workspace Add Hooked Block Dry Run",
+  });
+
+  linkWorkspaceNodeModules(targetDir);
+  runCli(
+    "node",
+    [entryPath, "add", "block", "counter-card", "--template", "basic"],
+    {
+      cwd: targetDir,
+    }
+  );
+  const originalBlockJsonSource = fs.readFileSync(
+    path.join(targetDir, "src", "blocks", "counter-card", "block.json"),
+    "utf8"
+  );
+
+  const output = runCli(
+    "node",
+    [
+      entryPath,
+      "add",
+      "hooked-block",
+      "counter-card",
+      "--anchor",
+      "core/post-content",
+      "--position",
+      "after",
+      "--dry-run",
+    ],
+    { cwd: targetDir }
+  );
+
+  expect(output).toContain("Dry run");
+  expect(output).toContain("Block: counter-card");
+  expect(output).toContain("update src/blocks/counter-card/block.json");
+  expect(
+    fs.readFileSync(
+      path.join(targetDir, "src", "blocks", "counter-card", "block.json"),
+      "utf8"
+    )
+  ).toBe(originalBlockJsonSource);
+});
+
 test("duplicate add block failures preserve existing workspace blocks", async () => {
   const targetDir = path.join(tempRoot, "demo-workspace-add-duplicate");
 

--- a/packages/wp-typia/src/commands/add.ts
+++ b/packages/wp-typia/src/commands/add.ts
@@ -22,6 +22,11 @@ function loadAddFlow() {
 }
 
 const addOptions = {
+	"dry-run": {
+		argumentKind: "flag" as const,
+		description: "Preview workspace file updates without writing them.",
+		schema: z.boolean().default(false),
+	},
 	"alternate-render-targets": {
 		description:
 			"Comma-separated alternate render targets for dynamic block scaffolds (email,mjml,plain-text).",

--- a/packages/wp-typia/src/commands/add.ts
+++ b/packages/wp-typia/src/commands/add.ts
@@ -22,11 +22,6 @@ function loadAddFlow() {
 }
 
 const addOptions = {
-	"dry-run": {
-		argumentKind: "flag" as const,
-		description: "Preview workspace file updates without writing them.",
-		schema: z.boolean().default(false),
-	},
 	"alternate-render-targets": {
 		description:
 			"Comma-separated alternate render targets for dynamic block scaffolds (email,mjml,plain-text).",
@@ -43,6 +38,11 @@ const addOptions = {
 	"data-storage": {
 		description: "Persistence storage mode for persistence-capable templates.",
 		schema: z.string().optional(),
+	},
+	"dry-run": {
+		argumentKind: "flag" as const,
+		description: "Preview workspace file updates without writing them.",
+		schema: z.boolean().default(false),
 	},
 	"external-layer-id": {
 		description: "Explicit layer id when an external layer package exposes multiple selectable layers.",

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -341,6 +341,7 @@ function renderAddHelp() {
 		"Usage: wp-typia add <kind> <name>",
 		"",
 		"Supported non-interactive flags:",
+		"--dry-run",
 		"--template",
 		"--alternate-render-targets",
 		"--data-storage",

--- a/packages/wp-typia/src/runtime-bridge-add-dry-run.ts
+++ b/packages/wp-typia/src/runtime-bridge-add-dry-run.ts
@@ -1,9 +1,9 @@
-import { promises as fsp } from "node:fs";
 import fs from "node:fs";
+import { promises as fsp } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-type WorkspaceFileOperation = `update ${string}` | `write ${string}`;
+type WorkspaceFileOperation = `delete ${string}` | `update ${string}` | `write ${string}`;
 
 const SKIPPED_COPY_ROOT_ENTRIES = new Set([".git", "node_modules"]);
 const SKIPPED_COMPARE_ROOT_ENTRIES = new Set([
@@ -40,12 +40,21 @@ function ensureWorkspaceInstallMarkers(sourceDir: string, targetDir: string): vo
 			continue;
 		}
 
-		fs.symlinkSync(sourceMarker, path.join(targetDir, marker));
+		const targetMarker = path.join(targetDir, marker);
+		try {
+			fs.symlinkSync(sourceMarker, targetMarker);
+		} catch {
+			try {
+				fs.linkSync(sourceMarker, targetMarker);
+			} catch {
+				fs.copyFileSync(sourceMarker, targetMarker);
+			}
+		}
 	}
 }
 
-async function listWorkspaceFiles(rootDir: string): Promise<Map<string, string>> {
-	const files = new Map<string, string>();
+async function listWorkspaceFiles(rootDir: string): Promise<Map<string, Buffer>> {
+	const files = new Map<string, Buffer>();
 
 	async function visit(currentDir: string): Promise<void> {
 		const entries = await fsp.readdir(currentDir, { withFileTypes: true });
@@ -68,13 +77,23 @@ async function listWorkspaceFiles(rootDir: string): Promise<Map<string, string>>
 
 			files.set(
 				relativePath.replace(path.sep === "\\" ? /\\/gu : /\//gu, "/"),
-				await fsp.readFile(absolutePath, "utf8"),
+				await fsp.readFile(absolutePath),
 			);
 		}
 	}
 
 	await visit(rootDir);
 	return files;
+}
+
+function compareStrings(left: string, right: string): number {
+	if (left < right) {
+		return -1;
+	}
+	if (left > right) {
+		return 1;
+	}
+	return 0;
 }
 
 async function collectWorkspaceFileOperations(
@@ -94,12 +113,18 @@ async function collectWorkspaceFileOperations(
 			continue;
 		}
 
-		if (originalSource !== simulatedSource) {
+		if (!originalSource.equals(simulatedSource)) {
 			operations.push(`update ${relativePath}`);
 		}
 	}
 
-	return operations.sort((left, right) => left.localeCompare(right));
+	for (const relativePath of sourceFiles.keys()) {
+		if (!simulatedFiles.has(relativePath)) {
+			operations.push(`delete ${relativePath}`);
+		}
+	}
+
+	return operations.sort(compareStrings);
 }
 
 /**

--- a/packages/wp-typia/src/runtime-bridge-add-dry-run.ts
+++ b/packages/wp-typia/src/runtime-bridge-add-dry-run.ts
@@ -1,0 +1,147 @@
+import { promises as fsp } from "node:fs";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+type WorkspaceFileOperation = `update ${string}` | `write ${string}`;
+
+const SKIPPED_COPY_ROOT_ENTRIES = new Set([".git", "node_modules"]);
+const SKIPPED_COMPARE_ROOT_ENTRIES = new Set([
+	".git",
+	".pnp.cjs",
+	".pnp.loader.mjs",
+	"node_modules",
+]);
+
+async function copyWorkspaceProject(sourceDir: string, targetDir: string): Promise<void> {
+	await fsp.cp(sourceDir, targetDir, {
+		filter: (sourcePath) => {
+			const relativePath = path.relative(sourceDir, sourcePath);
+			if (relativePath === "") {
+				return true;
+			}
+
+			const [rootEntry] = relativePath.split(path.sep);
+			return !SKIPPED_COPY_ROOT_ENTRIES.has(rootEntry ?? "");
+		},
+		recursive: true,
+	});
+}
+
+function ensureWorkspaceInstallMarkers(sourceDir: string, targetDir: string): void {
+	const sourceNodeModules = path.join(sourceDir, "node_modules");
+	if (fs.existsSync(sourceNodeModules)) {
+		fs.symlinkSync(sourceNodeModules, path.join(targetDir, "node_modules"), "junction");
+	}
+
+	for (const marker of [".pnp.cjs", ".pnp.loader.mjs"] as const) {
+		const sourceMarker = path.join(sourceDir, marker);
+		if (!fs.existsSync(sourceMarker)) {
+			continue;
+		}
+
+		fs.symlinkSync(sourceMarker, path.join(targetDir, marker));
+	}
+}
+
+async function listWorkspaceFiles(rootDir: string): Promise<Map<string, string>> {
+	const files = new Map<string, string>();
+
+	async function visit(currentDir: string): Promise<void> {
+		const entries = await fsp.readdir(currentDir, { withFileTypes: true });
+		for (const entry of entries) {
+			const absolutePath = path.join(currentDir, entry.name);
+			const relativePath = path.relative(rootDir, absolutePath);
+			const [rootEntry] = relativePath.split(path.sep);
+			if (SKIPPED_COMPARE_ROOT_ENTRIES.has(rootEntry ?? "")) {
+				continue;
+			}
+
+			if (entry.isDirectory()) {
+				await visit(absolutePath);
+				continue;
+			}
+
+			if (!entry.isFile()) {
+				continue;
+			}
+
+			files.set(
+				relativePath.replace(path.sep === "\\" ? /\\/gu : /\//gu, "/"),
+				await fsp.readFile(absolutePath, "utf8"),
+			);
+		}
+	}
+
+	await visit(rootDir);
+	return files;
+}
+
+async function collectWorkspaceFileOperations(
+	sourceDir: string,
+	simulatedDir: string,
+): Promise<WorkspaceFileOperation[]> {
+	const [sourceFiles, simulatedFiles] = await Promise.all([
+		listWorkspaceFiles(sourceDir),
+		listWorkspaceFiles(simulatedDir),
+	]);
+	const operations: WorkspaceFileOperation[] = [];
+
+	for (const [relativePath, simulatedSource] of simulatedFiles) {
+		const originalSource = sourceFiles.get(relativePath);
+		if (originalSource === undefined) {
+			operations.push(`write ${relativePath}`);
+			continue;
+		}
+
+		if (originalSource !== simulatedSource) {
+			operations.push(`update ${relativePath}`);
+		}
+	}
+
+	return operations.sort((left, right) => left.localeCompare(right));
+}
+
+/**
+ * Runs a mutating workspace add command against a temporary clone and reports
+ * the file operations that would be applied to the real workspace.
+ *
+ * @param options Workspace add dry-run options.
+ * @returns The simulated command result plus normalized file operations.
+ */
+export async function simulateWorkspaceAddDryRun<T>({
+	cwd,
+	execute,
+}: {
+	cwd: string;
+	execute: (simulatedCwd: string) => Promise<T>;
+}): Promise<{
+	fileOperations: WorkspaceFileOperation[];
+	result: T;
+}> {
+	const { resolveWorkspaceProject } = await import("@wp-typia/project-tools/workspace-project");
+	const workspace = resolveWorkspaceProject(cwd);
+	const relativeCwd = path.relative(workspace.projectDir, path.resolve(cwd));
+	const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "wp-typia-add-plan-"));
+	const simulatedProjectDir = path.join(tempRoot, "workspace");
+
+	try {
+		await copyWorkspaceProject(workspace.projectDir, simulatedProjectDir);
+		ensureWorkspaceInstallMarkers(workspace.projectDir, simulatedProjectDir);
+
+		const simulatedCwd =
+			relativeCwd.length > 0 ? path.join(simulatedProjectDir, relativeCwd) : simulatedProjectDir;
+		const result = await execute(simulatedCwd);
+		const fileOperations = await collectWorkspaceFileOperations(
+			workspace.projectDir,
+			simulatedProjectDir,
+		);
+
+		return {
+			fileOperations,
+			result,
+		};
+	} finally {
+		await fsp.rm(tempRoot, { force: true, recursive: true });
+	}
+}

--- a/packages/wp-typia/src/runtime-bridge-output.ts
+++ b/packages/wp-typia/src/runtime-bridge-output.ts
@@ -272,6 +272,30 @@ export function buildAddCompletionPayload(options: {
 }
 
 /**
+ * Builds the completion payload shown after a dry-run add flow succeeds.
+ *
+ * @param options Existing add completion metadata plus the planned file updates.
+ * @returns A structured alternate-buffer completion payload.
+ */
+export function buildAddDryRunPayload(options: {
+	completion: AlternateBufferCompletionPayload;
+	fileOperations: string[];
+}): AlternateBufferCompletionPayload {
+	const normalizedTitle = options.completion.title.replace(/^✅\s*Added\s*/u, "");
+
+	return {
+		optionalLines: options.fileOperations,
+		optionalNote:
+			"No workspace files were changed because --dry-run was enabled. Re-run without --dry-run to apply this add command.",
+		optionalTitle: `Planned workspace updates (${options.fileOperations.length}):`,
+		preambleLines: options.completion.preambleLines,
+		summaryLines: options.completion.summaryLines,
+		title: `🧪 Dry run for ${normalizedTitle || "workspace add command"}`,
+		warningLines: options.completion.warningLines,
+	};
+}
+
+/**
  * Prints a block of text lines using a shared line printer.
  *
  * @param lines Lines to print in order.

--- a/packages/wp-typia/src/runtime-bridge-sync.ts
+++ b/packages/wp-typia/src/runtime-bridge-sync.ts
@@ -17,6 +17,7 @@ type SyncProjectContext = {
 };
 
 const SYNC_INSTALL_MARKERS = ["node_modules", ".pnp.cjs", ".pnp.loader.mjs"] as const;
+const LOCAL_SYNC_TOOL_PATTERN = /(^|[\s;&|()])(?:tsx|wp-scripts)(?=($|[\s;&|()]))/u;
 
 function formatRunScript(
 	packageManagerId: PackageManagerId,
@@ -122,19 +123,48 @@ function resolveSyncProjectContext(cwd: string): SyncProjectContext {
 	};
 }
 
-function hasInstalledProjectDependencies(projectDir: string): boolean {
-	return SYNC_INSTALL_MARKERS.some((marker) =>
-		fs.existsSync(path.join(projectDir, marker)),
+function findInstalledDependencyMarkerDir(projectDir: string): string | null {
+	let currentDir = path.resolve(projectDir);
+
+	while (true) {
+		if (
+			SYNC_INSTALL_MARKERS.some((marker) =>
+				fs.existsSync(path.join(currentDir, marker)),
+			)
+		) {
+			return currentDir;
+		}
+
+		const parentDir = path.dirname(currentDir);
+		if (parentDir === currentDir) {
+			return null;
+		}
+		currentDir = parentDir;
+	}
+}
+
+function scriptsLikelyNeedInstalledDependencies(project: SyncProjectContext): boolean {
+	const candidateScripts = project.scripts.sync
+		? [project.scripts.sync]
+		: [project.scripts["sync-types"], project.scripts["sync-rest"]];
+
+	return candidateScripts.some(
+		(script): script is string =>
+			typeof script === "string" && LOCAL_SYNC_TOOL_PATTERN.test(script),
 	);
 }
 
 function assertSyncDependenciesInstalled(project: SyncProjectContext): void {
-	if (hasInstalledProjectDependencies(project.cwd)) {
+	if (!scriptsLikelyNeedInstalledDependencies(project)) {
+		return;
+	}
+	const markerDir = findInstalledDependencyMarkerDir(project.cwd);
+	if (markerDir) {
 		return;
 	}
 
 	throw new Error(
-		`Project dependencies have not been installed yet. Run \`${formatInstallCommand(project.packageManager)}\` from ${project.cwd} before \`wp-typia sync\`. The generated sync scripts rely on local tools such as \`tsx\`.`,
+		`Project dependencies have not been installed yet. Run \`${formatInstallCommand(project.packageManager)}\` from the project root before \`wp-typia sync\`. The generated sync scripts rely on local tools such as \`tsx\`.`,
 	);
 }
 

--- a/packages/wp-typia/src/runtime-bridge-sync.ts
+++ b/packages/wp-typia/src/runtime-bridge-sync.ts
@@ -16,6 +16,8 @@ type SyncProjectContext = {
 	scripts: Partial<Record<"sync" | "sync-rest" | "sync-types", string>>;
 };
 
+const SYNC_INSTALL_MARKERS = ["node_modules", ".pnp.cjs", ".pnp.loader.mjs"] as const;
+
 function formatRunScript(
 	packageManagerId: PackageManagerId,
 	scriptName: string,
@@ -32,6 +34,19 @@ function formatRunScript(
 		return args ? `pnpm run ${scriptName} ${args}` : `pnpm run ${scriptName}`;
 	}
 	return args ? `yarn run ${scriptName} ${args}` : `yarn run ${scriptName}`;
+}
+
+function formatInstallCommand(packageManagerId: PackageManagerId): string {
+	switch (packageManagerId) {
+		case "bun":
+			return "bun install";
+		case "pnpm":
+			return "pnpm install";
+		case "yarn":
+			return "yarn install";
+		default:
+			return "npm install";
+	}
 }
 
 function getSyncRootError(cwd: string): Error {
@@ -107,6 +122,22 @@ function resolveSyncProjectContext(cwd: string): SyncProjectContext {
 	};
 }
 
+function hasInstalledProjectDependencies(projectDir: string): boolean {
+	return SYNC_INSTALL_MARKERS.some((marker) =>
+		fs.existsSync(path.join(projectDir, marker)),
+	);
+}
+
+function assertSyncDependenciesInstalled(project: SyncProjectContext): void {
+	if (hasInstalledProjectDependencies(project.cwd)) {
+		return;
+	}
+
+	throw new Error(
+		`Project dependencies have not been installed yet. Run \`${formatInstallCommand(project.packageManager)}\` from ${project.cwd} before \`wp-typia sync\`. The generated sync scripts rely on local tools such as \`tsx\`.`,
+	);
+}
+
 function getPackageManagerRunInvocation(
 	packageManager: PackageManagerId,
 	scriptName: string,
@@ -170,6 +201,7 @@ export async function executeSyncCommand({
 	cwd,
 }: SyncExecutionInput): Promise<void> {
 	const project = resolveSyncProjectContext(cwd);
+	assertSyncDependenciesInstalled(project);
 	const extraArgs = check ? ["--check"] : [];
 
 	if (project.scripts.sync) {

--- a/packages/wp-typia/src/runtime-bridge.ts
+++ b/packages/wp-typia/src/runtime-bridge.ts
@@ -1,7 +1,9 @@
 import type { ReadlinePrompt } from "@wp-typia/project-tools/cli-prompt";
+import { simulateWorkspaceAddDryRun } from "./runtime-bridge-add-dry-run";
 import type { AlternateBufferCompletionPayload } from "./ui/alternate-buffer-lifecycle";
 import {
 	buildAddCompletionPayload,
+	buildAddDryRunPayload,
 	buildCreateCompletionPayload,
 	buildCreateDryRunPayload,
 	buildMigrationCompletionPayload,
@@ -157,6 +159,24 @@ const BOOLEAN_PROMPT_OPTIONS = [
 	{ label: "No", value: "no", hint: "Keep the default disabled state" },
 ] as const;
 
+function emitCompletion(
+	payload: AlternateBufferCompletionPayload,
+	options: {
+		emitOutput: boolean;
+		printLine: PrintLine;
+		warnLine?: PrintLine;
+	},
+): AlternateBufferCompletionPayload {
+	if (options.emitOutput) {
+		printCompletionPayload(payload, {
+			printLine: options.printLine,
+			warnLine: options.warnLine,
+		});
+	}
+
+	return payload;
+}
+
 export async function executeCreateCommand({
 	projectDir,
 	cwd,
@@ -182,6 +202,7 @@ export async function executeCreateCommand({
 	const activePrompt = shouldPrompt ? (prompt ?? createReadlinePrompt()) : undefined;
 	const shouldPromptForExternalLayerSelection =
 		Boolean(activePrompt) && activePrompt !== prompt;
+	const effectiveYes = Boolean(flags.yes) || (Boolean(flags["dry-run"]) && !Boolean(activePrompt));
 
 	try {
 		const flow = await runScaffoldFlow({
@@ -261,7 +282,7 @@ export async function executeCreateCommand({
 			withMigrationUi: flags["with-migration-ui"] as boolean | undefined,
 			withTestPreset: flags["with-test-preset"] as boolean | undefined,
 			withWpEnv: flags["with-wp-env"] as boolean | undefined,
-			yes: Boolean(flags.yes),
+			yes: effectiveYes,
 		});
 
 		const payload = flow.dryRun && flow.plan
@@ -272,13 +293,7 @@ export async function executeCreateCommand({
 					result: flow.result,
 				})
 			: buildCreateCompletionPayload(flow);
-		if (emitOutput) {
-			printCompletionPayload(payload, {
-				printLine,
-				warnLine,
-			});
-		}
-		return payload;
+		return emitCompletion(payload, { emitOutput, printLine, warnLine });
 	} catch (error) {
 		if (!shouldWrapCliCommandError({ emitOutput })) {
 			throw error;
@@ -310,6 +325,7 @@ export async function executeAddCommand({
 
 	const addRuntime = await loadCliAddRuntime();
 	let activePrompt: ReadlinePrompt | undefined;
+	const dryRun = Boolean(flags["dry-run"]);
 
 	try {
 		if (kind === "variation") {
@@ -324,12 +340,25 @@ export async function executeAddCommand({
 				throw new Error("`wp-typia add variation` requires --block <block-slug>.");
 			}
 
-			const result = await addRuntime.runAddVariationCommand({
-				blockName: blockSlug,
-				cwd,
-				variationName: name,
-			});
-			const payload = buildAddCompletionPayload({
+			const simulated = dryRun
+				? await simulateWorkspaceAddDryRun({
+						cwd,
+						execute: (simulatedCwd) =>
+							addRuntime.runAddVariationCommand({
+								blockName: blockSlug,
+								cwd: simulatedCwd,
+								variationName: name,
+							}),
+					})
+				: null;
+			const result =
+				simulated?.result ??
+				(await addRuntime.runAddVariationCommand({
+					blockName: blockSlug,
+					cwd,
+					variationName: name,
+				}));
+			const completion = buildAddCompletionPayload({
 				kind: "variation",
 				projectDir: result.projectDir,
 				values: {
@@ -337,10 +366,17 @@ export async function executeAddCommand({
 					variationSlug: result.variationSlug,
 				},
 			});
-			if (emitOutput) {
-				printCompletionPayload(payload, { printLine });
+			if (!dryRun) {
+				return emitCompletion(completion, { emitOutput, printLine });
 			}
-			return payload;
+
+			return emitCompletion(
+				buildAddDryRunPayload({
+					completion,
+					fileOperations: simulated!.fileOperations,
+				}),
+				{ emitOutput, printLine },
+			);
 		}
 
 		if (kind === "pattern") {
@@ -350,21 +386,40 @@ export async function executeAddCommand({
 				);
 			}
 
-			const result = await addRuntime.runAddPatternCommand({
-				cwd,
-				patternName: name,
-			});
-			const payload = buildAddCompletionPayload({
+			const simulated = dryRun
+				? await simulateWorkspaceAddDryRun({
+						cwd,
+						execute: (simulatedCwd) =>
+							addRuntime.runAddPatternCommand({
+								cwd: simulatedCwd,
+								patternName: name,
+							}),
+					})
+				: null;
+			const result =
+				simulated?.result ??
+				(await addRuntime.runAddPatternCommand({
+					cwd,
+					patternName: name,
+				}));
+			const completion = buildAddCompletionPayload({
 				kind: "pattern",
 				projectDir: result.projectDir,
 				values: {
 					patternSlug: result.patternSlug,
 				},
 			});
-			if (emitOutput) {
-				printCompletionPayload(payload, { printLine });
+			if (!dryRun) {
+				return emitCompletion(completion, { emitOutput, printLine });
 			}
-			return payload;
+
+			return emitCompletion(
+				buildAddDryRunPayload({
+					completion,
+					fileOperations: simulated!.fileOperations,
+				}),
+				{ emitOutput, printLine },
+			);
 		}
 
 		if (kind === "binding-source") {
@@ -374,21 +429,40 @@ export async function executeAddCommand({
 				);
 			}
 
-			const result = await addRuntime.runAddBindingSourceCommand({
-				bindingSourceName: name,
-				cwd,
-			});
-			const payload = buildAddCompletionPayload({
+			const simulated = dryRun
+				? await simulateWorkspaceAddDryRun({
+						cwd,
+						execute: (simulatedCwd) =>
+							addRuntime.runAddBindingSourceCommand({
+								bindingSourceName: name,
+								cwd: simulatedCwd,
+							}),
+					})
+				: null;
+			const result =
+				simulated?.result ??
+				(await addRuntime.runAddBindingSourceCommand({
+					bindingSourceName: name,
+					cwd,
+				}));
+			const completion = buildAddCompletionPayload({
 				kind: "binding-source",
 				projectDir: result.projectDir,
 				values: {
 					bindingSourceSlug: result.bindingSourceSlug,
 				},
 			});
-			if (emitOutput) {
-				printCompletionPayload(payload, { printLine });
+			if (!dryRun) {
+				return emitCompletion(completion, { emitOutput, printLine });
 			}
-			return payload;
+
+			return emitCompletion(
+				buildAddDryRunPayload({
+					completion,
+					fileOperations: simulated!.fileOperations,
+				}),
+				{ emitOutput, printLine },
+			);
 		}
 
 		if (kind === "rest-resource") {
@@ -398,13 +472,29 @@ export async function executeAddCommand({
 				);
 			}
 
-			const result = await addRuntime.runAddRestResourceCommand({
-				cwd,
-				methods: readOptionalStringFlag(flags, "methods"),
-				namespace: readOptionalStringFlag(flags, "namespace"),
-				restResourceName: name,
-			});
-			const payload = buildAddCompletionPayload({
+			const methods = readOptionalStringFlag(flags, "methods");
+			const namespace = readOptionalStringFlag(flags, "namespace");
+			const simulated = dryRun
+				? await simulateWorkspaceAddDryRun({
+						cwd,
+						execute: (simulatedCwd) =>
+							addRuntime.runAddRestResourceCommand({
+								cwd: simulatedCwd,
+								methods,
+								namespace,
+								restResourceName: name,
+							}),
+					})
+				: null;
+			const result =
+				simulated?.result ??
+				(await addRuntime.runAddRestResourceCommand({
+					cwd,
+					methods,
+					namespace,
+					restResourceName: name,
+				}));
+			const completion = buildAddCompletionPayload({
 				kind: "rest-resource",
 				projectDir: result.projectDir,
 				values: {
@@ -413,10 +503,17 @@ export async function executeAddCommand({
 					restResourceSlug: result.restResourceSlug,
 				},
 			});
-			if (emitOutput) {
-				printCompletionPayload(payload, { printLine });
+			if (!dryRun) {
+				return emitCompletion(completion, { emitOutput, printLine });
 			}
-			return payload;
+
+			return emitCompletion(
+				buildAddDryRunPayload({
+					completion,
+					fileOperations: simulated!.fileOperations,
+				}),
+				{ emitOutput, printLine },
+			);
 		}
 
 		if (kind === "editor-plugin") {
@@ -426,12 +523,26 @@ export async function executeAddCommand({
 				);
 			}
 
-			const result = await addRuntime.runAddEditorPluginCommand({
-				cwd,
-				editorPluginName: name,
-				slot: readOptionalStringFlag(flags, "slot"),
-			});
-			const payload = buildAddCompletionPayload({
+			const slot = readOptionalStringFlag(flags, "slot");
+			const simulated = dryRun
+				? await simulateWorkspaceAddDryRun({
+						cwd,
+						execute: (simulatedCwd) =>
+							addRuntime.runAddEditorPluginCommand({
+								cwd: simulatedCwd,
+								editorPluginName: name,
+								slot,
+							}),
+					})
+				: null;
+			const result =
+				simulated?.result ??
+				(await addRuntime.runAddEditorPluginCommand({
+					cwd,
+					editorPluginName: name,
+					slot,
+				}));
+			const completion = buildAddCompletionPayload({
 				kind: "editor-plugin",
 				projectDir: result.projectDir,
 				values: {
@@ -439,10 +550,17 @@ export async function executeAddCommand({
 					slot: result.slot,
 				},
 			});
-			if (emitOutput) {
-				printCompletionPayload(payload, { printLine });
+			if (!dryRun) {
+				return emitCompletion(completion, { emitOutput, printLine });
 			}
-			return payload;
+
+			return emitCompletion(
+				buildAddDryRunPayload({
+					completion,
+					fileOperations: simulated!.fileOperations,
+				}),
+				{ emitOutput, printLine },
+			);
 		}
 
 		if (kind === "hooked-block") {
@@ -464,13 +582,27 @@ export async function executeAddCommand({
 				);
 			}
 
-			const result = await addRuntime.runAddHookedBlockCommand({
-				anchorBlockName,
-				blockName: name,
-				cwd,
-				position,
-			});
-			const payload = buildAddCompletionPayload({
+			const simulated = dryRun
+				? await simulateWorkspaceAddDryRun({
+						cwd,
+						execute: (simulatedCwd) =>
+							addRuntime.runAddHookedBlockCommand({
+								anchorBlockName,
+								blockName: name,
+								cwd: simulatedCwd,
+								position,
+							}),
+					})
+				: null;
+			const result =
+				simulated?.result ??
+				(await addRuntime.runAddHookedBlockCommand({
+					anchorBlockName,
+					blockName: name,
+					cwd,
+					position,
+				}));
+			const completion = buildAddCompletionPayload({
 				kind: "hooked-block",
 				projectDir: result.projectDir,
 				values: {
@@ -479,10 +611,17 @@ export async function executeAddCommand({
 					position: result.position,
 				},
 			});
-			if (emitOutput) {
-				printCompletionPayload(payload, { printLine });
+			if (!dryRun) {
+				return emitCompletion(completion, { emitOutput, printLine });
 			}
-			return payload;
+
+			return emitCompletion(
+				buildAddDryRunPayload({
+					completion,
+					fileOperations: simulated!.fileOperations,
+				}),
+				{ emitOutput, printLine },
+			);
 		}
 
 		if (kind !== "block") {
@@ -517,33 +656,64 @@ export async function executeAddCommand({
 			: undefined;
 		const selectPrompt = activePrompt;
 
-		const result = await addRuntime.runAddBlockCommand({
-			alternateRenderTargets: readOptionalStringFlag(
-				flags,
-				"alternate-render-targets",
-			),
-			blockName: name,
-			cwd,
-			dataStorageMode: readOptionalStringFlag(flags, "data-storage"),
-			externalLayerId,
-			externalLayerSource,
-			persistencePolicy: readOptionalStringFlag(flags, "persistence-policy"),
-			selectExternalLayerId: selectPrompt
-				? (options) =>
-						selectPrompt.select(
-							"Select an external layer",
-							toExternalLayerPromptOptions(options),
-							1,
-						)
-				: undefined,
-			templateId: readOptionalStringFlag(flags, "template") as
-				| "basic"
-				| "interactivity"
-				| "persistence"
-				| "compound",
-		});
+		const alternateRenderTargets = readOptionalStringFlag(
+			flags,
+			"alternate-render-targets",
+		);
+		const dataStorageMode = readOptionalStringFlag(flags, "data-storage");
+		const persistencePolicy = readOptionalStringFlag(flags, "persistence-policy");
+		const resolvedTemplateId = readOptionalStringFlag(flags, "template") as
+			| "basic"
+			| "interactivity"
+			| "persistence"
+			| "compound";
 
-		const payload = buildAddCompletionPayload({
+		const simulated = dryRun
+			? await simulateWorkspaceAddDryRun({
+					cwd,
+					execute: (simulatedCwd) =>
+						addRuntime.runAddBlockCommand({
+							alternateRenderTargets,
+							blockName: name,
+							cwd: simulatedCwd,
+							dataStorageMode,
+							externalLayerId,
+							externalLayerSource,
+							persistencePolicy,
+							selectExternalLayerId: selectPrompt
+								? (options) =>
+										selectPrompt.select(
+											"Select an external layer",
+											toExternalLayerPromptOptions(options),
+											1,
+										)
+								: undefined,
+							templateId: resolvedTemplateId,
+						}),
+				})
+			: null;
+		const result =
+			simulated?.result ??
+			(await addRuntime.runAddBlockCommand({
+				alternateRenderTargets,
+				blockName: name,
+				cwd,
+				dataStorageMode,
+				externalLayerId,
+				externalLayerSource,
+				persistencePolicy,
+				selectExternalLayerId: selectPrompt
+					? (options) =>
+							selectPrompt.select(
+								"Select an external layer",
+								toExternalLayerPromptOptions(options),
+								1,
+							)
+					: undefined,
+				templateId: resolvedTemplateId,
+			}));
+
+		const completion = buildAddCompletionPayload({
 			kind: "block",
 			projectDir: result.projectDir,
 			values: {
@@ -552,10 +722,17 @@ export async function executeAddCommand({
 			},
 			warnings: result.warnings,
 		});
-		if (emitOutput) {
-			printCompletionPayload(payload, { printLine, warnLine });
+		if (!dryRun) {
+			return emitCompletion(completion, { emitOutput, printLine, warnLine });
 		}
-		return payload;
+
+		return emitCompletion(
+			buildAddDryRunPayload({
+				completion,
+				fileOperations: simulated!.fileOperations,
+			}),
+			{ emitOutput, printLine, warnLine },
+		);
 	} catch (error) {
 		if (!shouldWrapCliCommandError({ emitOutput })) {
 			throw error;

--- a/packages/wp-typia/tests/create-command.test.ts
+++ b/packages/wp-typia/tests/create-command.test.ts
@@ -111,4 +111,25 @@ test("keeps ambiguous external layers fail-fast when a synthetic prompt is suppl
 		expect(payload.optionalLines?.some((line) => line === "write package.json")).toBe(true);
 		expect(fs.existsSync(targetDir)).toBe(false);
 	});
+
+	test("dry-run create defaults non-interactive answers without requiring --yes", async () => {
+		const targetDir = path.join(tempRoot, "demo-dry-run-preview-no-yes");
+
+		const payload = await executeCreateCommand({
+			cwd: tempRoot,
+			emitOutput: false,
+			flags: {
+				"dry-run": true,
+				"package-manager": "npm",
+				template: "basic",
+			},
+			interactive: false,
+			projectDir: "demo-dry-run-preview-no-yes",
+		});
+
+		expect(payload.title).toContain("Dry run");
+		expect(payload.summaryLines).toContain(`Project directory: ${targetDir}`);
+		expect(payload.optionalLines?.some((line) => line === "write package.json")).toBe(true);
+		expect(fs.existsSync(targetDir)).toBe(false);
+	});
 });

--- a/packages/wp-typia/tests/runtime-bridge-sync.test.ts
+++ b/packages/wp-typia/tests/runtime-bridge-sync.test.ts
@@ -1,0 +1,39 @@
+import { afterAll, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { executeSyncCommand } from "../src/runtime-bridge-sync";
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "wp-typia-sync-bridge-"));
+
+afterAll(() => {
+	fs.rmSync(tempRoot, { force: true, recursive: true });
+});
+
+test("sync fails early with install guidance when local dependencies are missing", async () => {
+	const projectDir = path.join(tempRoot, "demo-sync-no-install");
+	fs.mkdirSync(projectDir, { recursive: true });
+	fs.writeFileSync(
+		path.join(projectDir, "package.json"),
+		JSON.stringify(
+			{
+				name: "demo-sync-no-install",
+				packageManager: "npm@10.9.0",
+				scripts: {
+					sync: "tsx scripts/sync-project.ts",
+				},
+			},
+			null,
+			2,
+		),
+		"utf8",
+	);
+
+	const error = await executeSyncCommand({ cwd: projectDir }).catch((thrown) => thrown);
+
+	expect(error).toBeInstanceOf(Error);
+	expect((error as Error).message).toContain("npm install");
+	expect((error as Error).message).toContain("wp-typia sync");
+	expect((error as Error).message).toContain("tsx");
+});


### PR DESCRIPTION
## Context

Issue #483 tracks the remaining workflow-level rough edges around preview-first and no-install CLI flows.

The main regressions here were:
- `wp-typia sync` still collapsing into a generic subprocess failure when dependencies had not been installed yet
- non-interactive `wp-typia create --dry-run` still requiring an extra `--yes` even though the user had already chosen a non-mutating preview path
- `wp-typia add` still lacking a dry-run story for real workspace mutations

## What Changed

- added an early dependency preflight to `wp-typia sync` so generated projects now fail with direct install guidance before the sync script shells out into a missing `tsx` binary
- treated non-interactive `create --dry-run` as an explicit default-accepting preview intent, so it now resolves scaffold answers without an extra `--yes` requirement
- introduced a shared workspace add dry-run simulator that runs the selected add workflow against a temporary clone and reports planned `write` / `update` operations without mutating the real workspace
- wired `--dry-run` into canonical `wp-typia add` help/option metadata and applied it across block, variation, pattern, binding-source, rest-resource, editor-plugin, and hooked-block flows
- added regression coverage for sync preflight messaging, node-entry dry-run create behavior, and workspace add dry-run flows for both new-file and existing-file updates

## Verification

- `bun test packages/wp-typia/tests/create-command.test.ts packages/wp-typia/tests/runtime-bridge-sync.test.ts`
- `bun run --filter wp-typia build`
- `bun test packages/wp-typia-project-tools/tests/cli-entry.test.ts packages/wp-typia-project-tools/tests/workspace-add.test.ts`
- `bun run typecheck`
- `bun run --filter @wp-typia/project-tools build`
- `bun run changesets:validate`

Closes #483


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--dry-run` flag to preview workspace file changes without modifying your project in `add`, `create`, and `sync` commands
  * Improved error messages with clear guidance when required dependencies are missing

* **Tests**
  * Added comprehensive test coverage for dry-run functionality and dependency validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->