### PR TITLE
Clarify template capability boundaries and ignored flag guidance

### DIFF
--- a/.sampo/changesets/issue-484-template-capability-boundaries.md
+++ b/.sampo/changesets/issue-484-template-capability-boundaries.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Clarify template capability boundaries across create/add/help/onboarding flows. Query Loop discovery now explains that it is a create-time `core/query` variation scaffold rather than an `add block` family, explicit but inapplicable flags like `--with-migration-ui` and `--query-post-type` now surface visible warnings, and workspace guidance more consistently points users at the short `--template workspace` alias.

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Empty workspace flow:
 ```bash
 npx wp-typia create my-plugin --template workspace --package-manager bun --yes --no-install
 cd my-plugin
+bun install
 wp-typia add block counter-card --template basic
 wp-typia add block faq-stack --template compound --persistence-policy public --data-storage custom-table
 wp-typia add binding-source hero-data

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ The `compound` template creates a parent/child block structure with hidden imple
 
 ### 5. Query Loop variations get a first-class scaffold
 
-The `query-loop` template scaffolds an editor-facing `core/query` variation plugin instead of a standalone block, so you can ship a branded inserter entry with stable namespace identity, default query settings, allowed inspector controls, and inline starter `innerBlocks` without rebuilding the full Query Loop setup flow by hand. It also includes connected `src/patterns/*.php` presets so richer editorial layouts can live in pattern files while `src/index.ts` stays focused on variation identity and query defaults, a dedicated `src/query-extension.ts` seam for custom query params and optional editor-side hook registration, and `inc/query-runtime.php` hooks that keep frontend query mapping and editor preview requests aligned for the same variation.
+The `query-loop` template scaffolds an editor-facing `core/query` variation plugin instead of a standalone block, so you can ship a branded inserter entry with stable namespace identity, default query settings, allowed inspector controls, and inline starter `innerBlocks` without rebuilding the full Query Loop setup flow by hand. Because it owns a variation rather than a standalone custom block, it intentionally does not generate `src/types.ts`, `block.json`, or Typia manifests. It also includes connected `src/patterns/*.php` presets so richer editorial layouts can live in pattern files while `src/index.ts` stays focused on variation identity and query defaults, a dedicated `src/query-extension.ts` seam for custom query params and optional editor-side hook registration, and `inc/query-runtime.php` hooks that keep frontend query mapping and editor preview requests aligned for the same variation.
 
 ## Example flows
 
@@ -138,7 +138,7 @@ npx wp-typia create my-block --template basic --with-migration-ui --package-mana
 Empty workspace flow:
 
 ```bash
-npx wp-typia create my-plugin --template @wp-typia/create-workspace-template --package-manager bun --yes --no-install
+npx wp-typia create my-plugin --template workspace --package-manager bun --yes --no-install
 cd my-plugin
 wp-typia add block counter-card --template basic
 wp-typia add block faq-stack --template compound --persistence-policy public --data-storage custom-table
@@ -154,6 +154,7 @@ wp-typia add hooked-block counter-card --anchor core/post-content --position aft
 - Need data, REST, or persistence policies? Start with `persistence`.
 - Need a parent/child block system? Start with `compound`.
 - Need a branded Query Loop inserter variation? Start with `query-loop`.
+- Need an empty workspace that will grow through `wp-typia add ...` workflows? Start with `--template workspace`.
 - Need schema evolution for a long-lived block? Enable `--with-migration-ui`.
 
 ## Retrofitting Existing Projects

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-block.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-block.ts
@@ -531,6 +531,11 @@ export async function runAddBlockCommand({
 	templateId: AddBlockTemplateId;
 	warnings: string[];
 }> {
+	if (templateId === "query-loop") {
+		throw new Error(
+			"`wp-typia add block --template query-loop` is not supported. Query Loop is a create-time `core/query` variation scaffold, so use `wp-typia create <project-dir> --template query-loop` instead.",
+		);
+	}
 	if (!isAddBlockTemplateId(templateId)) {
 		throw new Error(
 			`Unknown add-block template "${templateId}". Expected one of: ${ADD_BLOCK_TEMPLATE_IDS.join(", ")}`,

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-shared.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-shared.ts
@@ -529,8 +529,9 @@ export function formatAddHelpText(): string {
   wp-typia add editor-plugin <name> [--slot <${EDITOR_PLUGIN_SLOT_IDS.join("|")}>] [--dry-run]
 
 Notes:
-  \`wp-typia add\` runs only inside official ${WORKSPACE_TEMPLATE_PACKAGE} workspaces.
+  \`wp-typia add\` runs only inside official ${WORKSPACE_TEMPLATE_PACKAGE} workspaces scaffolded via \`wp-typia create <project-dir> --template workspace\`.
   Pass \`--dry-run\` to preview the workspace files that would change without writing them.
+  \`query-loop\` is a create-time scaffold family. Use \`wp-typia create <project-dir> --template query-loop\` instead of \`wp-typia add block\`.
   \`add variation\` targets an existing block slug from \`scripts/block-config.ts\`.
   \`add pattern\` scaffolds a namespaced PHP pattern shell under \`src/patterns/\`.
   \`add binding-source\` scaffolds shared PHP and editor registration under \`src/bindings/\`.

--- a/packages/wp-typia-project-tools/src/runtime/cli-help.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-help.ts
@@ -39,6 +39,7 @@ Notes:
   \`wp-typia create\` is the canonical scaffold command.
   \`wp-typia <project-dir>\` remains a backward-compatible alias to \`create\` when \`<project-dir>\` is the only positional argument.
   Use \`--template workspace\` as shorthand for \`@wp-typia/create-workspace-template\`, the official empty workspace scaffold behind \`wp-typia add ...\`.
+  \`query-loop\` is create-only. Use \`wp-typia create <project-dir> --template query-loop\`; \`wp-typia add block\` accepts only basic, interactivity, persistence, and compound families.
   \`add variation\` uses an existing workspace block from \`scripts/block-config.ts\`.
   \`add pattern\` scaffolds a namespaced PHP pattern shell under \`src/patterns/\`.
   \`add binding-source\` scaffolds shared PHP and editor registration under \`src/bindings/\`.

--- a/packages/wp-typia-project-tools/src/runtime/cli-scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-scaffold.ts
@@ -286,6 +286,39 @@ function templateSupportsPersistenceFlags(templateId: string): boolean {
 	return templateId === "persistence" || templateId === "compound";
 }
 
+function createTemplateLabel(templateId: string): string {
+	return templateId === OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE
+		? "`--template workspace`"
+		: `"${templateId}"`;
+}
+
+function collectTemplateCapabilityWarnings(options: {
+	queryPostType?: string;
+	templateId: string;
+	withMigrationUi?: boolean;
+}): string[] {
+	const warnings: string[] = [];
+	const trimmedQueryPostType = options.queryPostType?.trim();
+
+	if (trimmedQueryPostType && options.templateId !== "query-loop") {
+		warnings.push(
+			`\`--query-post-type\` only applies to \`wp-typia create --template query-loop\`, which scaffolds a create-time \`core/query\` variation instead of a standalone block. ${createTemplateLabel(options.templateId)} will ignore "${trimmedQueryPostType}".`,
+		);
+	}
+
+	if (
+		options.withMigrationUi === true &&
+		!isBuiltInTemplateId(options.templateId) &&
+		options.templateId !== OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE
+	) {
+		warnings.push(
+			`\`--with-migration-ui\` was ignored for ${createTemplateLabel(options.templateId)}. Migration UI currently scaffolds built-in templates and the official \`--template workspace\` flow; external templates still need to opt into that surface explicitly.`,
+		);
+	}
+
+	return warnings;
+}
+
 function templateSupportsAlternateRenderTargets(options: {
 	alternateRenderTargets?: string;
 	dataStorageMode?: string;
@@ -750,6 +783,11 @@ export async function runScaffoldFlow({
 				...resolvedResult.result,
 				warnings: [
 					...resolvedResult.result.warnings,
+					...collectTemplateCapabilityWarnings({
+						queryPostType,
+						templateId: resolvedTemplateId,
+						withMigrationUi,
+					}),
 					...collectProjectDirectoryWarnings(projectDir),
 				],
 			},

--- a/packages/wp-typia-project-tools/src/runtime/cli-scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-scaffold.ts
@@ -300,7 +300,12 @@ function collectTemplateCapabilityWarnings(options: {
 	const warnings: string[] = [];
 	const trimmedQueryPostType = options.queryPostType?.trim();
 
-	if (trimmedQueryPostType && options.templateId !== "query-loop") {
+	if (
+		trimmedQueryPostType &&
+		options.templateId !== "query-loop" &&
+		(isBuiltInTemplateId(options.templateId) ||
+			options.templateId === OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE)
+	) {
 		warnings.push(
 			`\`--query-post-type\` only applies to \`wp-typia create --template query-loop\`, which scaffolds a create-time \`core/query\` variation instead of a standalone block. ${createTemplateLabel(options.templateId)} will ignore "${trimmedQueryPostType}".`,
 		);

--- a/packages/wp-typia-project-tools/src/runtime/cli-templates.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-templates.ts
@@ -106,7 +106,7 @@ function getTemplateCapabilityHints(template: TemplateDefinition): string[] {
 function getTemplateSpecialNotes(template: TemplateDefinition): string[] {
 	if (template.id === "query-loop") {
 		return [
-			"Create-time variation scaffold only; use `wp-typia create --template query-loop` instead of `wp-typia add block`.",
+			"Create-time variation scaffold only; use `wp-typia create <project-dir> --template query-loop` instead of `wp-typia add block`.",
 			"Owns a `core/query` variation, so it does not generate `src/types.ts`, `block.json`, or Typia manifests.",
 		];
 	}

--- a/packages/wp-typia-project-tools/src/runtime/cli-templates.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-templates.ts
@@ -31,6 +31,10 @@ export function formatTemplateFeatures(template: TemplateDefinition): string {
 	if (capabilityHints.length > 0) {
 		lines.push(`  Supports: ${capabilityHints.join(" • ")}`);
 	}
+	const specialNotes = getTemplateSpecialNotes(template);
+	if (specialNotes.length > 0) {
+		lines.push(`  Notes: ${specialNotes.join(" • ")}`);
+	}
 	if (template.id === OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE) {
 		lines.push(
 			`  Alias: ${WORKSPACE_TEMPLATE_ALIAS} (\`--template ${WORKSPACE_TEMPLATE_ALIAS}\`)`,
@@ -64,6 +68,13 @@ export function formatTemplateDetails(template: TemplateDefinition): string {
 			detailLines.push(`  - ${capabilityHint}`);
 		}
 	}
+	const specialNotes = getTemplateSpecialNotes(template);
+	if (specialNotes.length > 0) {
+		detailLines.push("Notes:");
+		for (const specialNote of specialNotes) {
+			detailLines.push(`  - ${specialNote}`);
+		}
+	}
 	detailLines.push("Logical layers:");
 	for (const logicalLayer of getTemplateLogicalLayerSummaries(template)) {
 		detailLines.push(`  - ${logicalLayer}`);
@@ -87,6 +98,17 @@ function getTemplateCapabilityHints(template: TemplateDefinition): string[] {
 	}
 	if (isBuiltInTemplateId(template.id)) {
 		return ["external layers"];
+	}
+
+	return [];
+}
+
+function getTemplateSpecialNotes(template: TemplateDefinition): string[] {
+	if (template.id === "query-loop") {
+		return [
+			"Create-time variation scaffold only; use `wp-typia create --template query-loop` instead of `wp-typia add block`.",
+			"Owns a `core/query` variation, so it does not generate `src/types.ts`, `block.json`, or Typia manifests.",
+		];
 	}
 
 	return [];

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-onboarding.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-onboarding.ts
@@ -91,7 +91,7 @@ export function getQuickStartWorkflowNote(
 	options: SyncOnboardingOptions = {},
 ): string {
 	if (templateId === "query-loop") {
-		return `${formatRunScript(packageManager, "dev")} runs the editor build/watch loop that registers your Query Loop variation in the block editor. This scaffold is editor-facing by design: update \`src/index.ts\` when you want to change the variation namespace, default query, allowed controls, or the minimal inline starter layout, update \`src/patterns/*.php\` when you want richer connected layout presets in the inserter, use \`src/query-extension.ts\` when the variation needs custom query params or optional editor-side hooks, and mirror frontend/editor preview query mapping in \`inc/query-runtime.php\`.`;
+		return `${formatRunScript(packageManager, "dev")} runs the editor build/watch loop that registers your Query Loop variation in the block editor. This scaffold is editor-facing by design and intentionally skips \`src/types.ts\`, \`block.json\`, and Typia manifest generation because the source of truth lives in the variation registration flow instead of a standalone block contract. Update \`src/index.ts\` when you want to change the variation namespace, default query, allowed controls, or the minimal inline starter layout, update \`src/patterns/*.php\` when you want richer connected layout presets in the inserter, use \`src/query-extension.ts\` when the variation needs custom query params or optional editor-side hooks, and mirror frontend/editor preview query mapping in \`inc/query-runtime.php\`.`;
 	}
 
 	const developmentScript = getPrimaryDevelopmentScript(templateId);
@@ -122,7 +122,7 @@ export function getOptionalOnboardingNote(
 	options: SyncOnboardingOptions = {},
 ): string {
 	if (templateId === "query-loop") {
-		return `This scaffold does not generate a \`sync\` script, \`block.json\`, or Typia manifests. Edit \`src/index.ts\` to change the variation contract, edit \`src/patterns/*.php\` when you want richer connected layouts beyond the inline fallback, edit \`src/query-extension.ts\` when you need variation-specific query params or custom editor hooks, and edit \`inc/query-runtime.php\` when those params need frontend or editor preview parity. Then rerun ${formatRunScript(packageManager, "build")}, ${formatRunScript(packageManager, "dev")}, or ${formatRunScript(packageManager, "typecheck")} as needed.`;
+		return `This scaffold does not generate \`src/types.ts\`, a \`sync\` script, \`block.json\`, or Typia manifests because it owns a \`core/query\` variation rather than a standalone block. Edit \`src/index.ts\` to change the variation contract, edit \`src/patterns/*.php\` when you want richer connected layouts beyond the inline fallback, edit \`src/query-extension.ts\` when you need variation-specific query params or custom editor hooks, and edit \`inc/query-runtime.php\` when those params need frontend or editor preview parity. Then rerun ${formatRunScript(packageManager, "build")}, ${formatRunScript(packageManager, "dev")}, or ${formatRunScript(packageManager, "typecheck")} as needed.`;
 	}
 
 	const optionalSyncScripts = getOptionalSyncScriptNames(templateId, options);
@@ -199,7 +199,7 @@ export function getTemplateSourceOfTruthNote(
 	{ compoundPersistenceEnabled = false }: SyncOnboardingOptions = {},
 ): string {
 	if (templateId === "query-loop") {
-		return "`src/index.ts` remains the source of truth for the Query Loop variation name, default query attributes, `allowedControls`, and the minimal inline starter `innerBlocks`. Use `src/patterns/*.php` for richer connected layout presets that stay tied to the same variation namespace, use `src/query-extension.ts` for custom query seed values or optional editor-only hook registration, and use `inc/query-runtime.php` to keep frontend and editor preview query mapping aligned for those custom keys. The generated plugin bootstrap should stay focused on script registration, pattern loading, and explicit runtime glue for the variation.";
+		return "`src/index.ts` remains the source of truth for the Query Loop variation name, default query attributes, `allowedControls`, and the minimal inline starter `innerBlocks`. This scaffold intentionally does not generate `src/types.ts`, `block.json`, or Typia manifests because those artifacts belong to standalone block families, not `core/query` variation ownership. Use `src/patterns/*.php` for richer connected layout presets that stay tied to the same variation namespace, use `src/query-extension.ts` for custom query seed values or optional editor-only hook registration, and use `inc/query-runtime.php` to keep frontend and editor preview query mapping aligned for those custom keys. The generated plugin bootstrap should stay focused on script registration, pattern loading, and explicit runtime glue for the variation.";
 	}
 
 	if (templateId === "compound") {

--- a/packages/wp-typia-project-tools/src/runtime/workspace-project.ts
+++ b/packages/wp-typia-project-tools/src/runtime/workspace-project.ts
@@ -202,6 +202,6 @@ export function resolveWorkspaceProject(startDir: string): WorkspaceProject {
 	}
 
 	throw new Error(
-		`This command must run inside a ${WORKSPACE_TEMPLATE_PACKAGE} project. Create one with \`wp-typia create my-plugin --template ${WORKSPACE_TEMPLATE_PACKAGE}\` first.`,
+		`This command must run inside an official wp-typia workspace. Create one with \`wp-typia create my-plugin --template workspace\` first (the short alias for \`${WORKSPACE_TEMPLATE_PACKAGE}\`).`,
 	);
 }

--- a/packages/wp-typia-project-tools/tests/cli-entry.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-entry.test.ts
@@ -431,6 +431,22 @@ test("runScaffoldFlow carries query-loop post type overrides into the generated 
   );
 });
 
+test("runScaffoldFlow warns when query-loop-only flags are passed to other templates", async () => {
+  const flow = await runScaffoldFlow({
+    cwd: tempRoot,
+    noInstall: true,
+    packageManager: "npm",
+    projectInput: "demo-basic-ignored-query-post-type",
+    queryPostType: "book",
+    templateId: "basic",
+    yes: true,
+  });
+
+  expect(flow.result.warnings).toContain(
+    '`--query-post-type` only applies to `wp-typia create --template query-loop`, which scaffolds a create-time `core/query` variation instead of a standalone block. "basic" will ignore "book".'
+  );
+});
+
 test("runScaffoldFlow dry-run previews scaffold output without writing the target directory", async () => {
   const projectInput = "demo-dry-run-plan";
   const targetDir = path.join(tempRoot, projectInput);
@@ -552,6 +568,7 @@ test("formatHelpText keeps migration UI flags out of external template usage", (
   expect(helpText).toContain("--external-layer-source");
   expect(helpText).toContain("--external-layer-id");
   expect(helpText).toContain("@wp-typia/create-workspace-template");
+  expect(helpText).toContain("`query-loop` is create-only.");
   expect(helpText).toContain("wp-typia add editor-plugin <name>");
   expect(helpText).toContain(
     "wp-typia add editor-plugin <name> [--slot <PluginSidebar>]"
@@ -608,6 +625,9 @@ test("runScaffoldFlow does not prompt for migration UI on external templates", a
 
   expect(promptedForMigrationUi).toBe(false);
   expect(flow.result.variables.needsMigration).toBe("{{needsMigration}}");
+  expect(flow.result.warnings).toContain(
+    `\`--with-migration-ui\` was ignored for "${createBlockSubsetFixturePath}". Migration UI currently scaffolds built-in templates and the official \`--template workspace\` flow; external templates still need to opt into that surface explicitly.`
+  );
 });
 
 test("node entry exposes templates and doctor commands", () => {

--- a/packages/wp-typia-project-tools/tests/cli-templates.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-templates.test.ts
@@ -15,7 +15,7 @@ describe("@wp-typia/project-tools template discovery formatting", () => {
 			"Supports: --query-post-type • external layers",
 		);
 		expect(formatTemplateFeatures(getTemplateById("query-loop"))).toContain(
-			"Notes: Create-time variation scaffold only; use `wp-typia create --template query-loop` instead of `wp-typia add block`. • Owns a `core/query` variation, so it does not generate `src/types.ts`, `block.json`, or Typia manifests.",
+			"Notes: Create-time variation scaffold only; use `wp-typia create <project-dir> --template query-loop` instead of `wp-typia add block`. • Owns a `core/query` variation, so it does not generate `src/types.ts`, `block.json`, or Typia manifests.",
 		);
 	});
 
@@ -40,7 +40,7 @@ describe("@wp-typia/project-tools template discovery formatting", () => {
 		expect(basicDetails).not.toContain("/templates/basic");
 		expect(queryLoopDetails).toContain("Notes:");
 		expect(queryLoopDetails).toContain(
-			"Create-time variation scaffold only; use `wp-typia create --template query-loop` instead of `wp-typia add block`.",
+			"Create-time variation scaffold only; use `wp-typia create <project-dir> --template query-loop` instead of `wp-typia add block`.",
 		);
 		expect(queryLoopDetails).toContain(
 			"Owns a `core/query` variation, so it does not generate `src/types.ts`, `block.json`, or Typia manifests.",

--- a/packages/wp-typia-project-tools/tests/cli-templates.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-templates.test.ts
@@ -14,6 +14,9 @@ describe("@wp-typia/project-tools template discovery formatting", () => {
 		expect(formatTemplateFeatures(getTemplateById("query-loop"))).toContain(
 			"Supports: --query-post-type • external layers",
 		);
+		expect(formatTemplateFeatures(getTemplateById("query-loop"))).toContain(
+			"Notes: Create-time variation scaffold only; use `wp-typia create --template query-loop` instead of `wp-typia add block`. • Owns a `core/query` variation, so it does not generate `src/types.ts`, `block.json`, or Typia manifests.",
+		);
 	});
 
 	test("workspace template discovery surfaces the workspace alias", () => {
@@ -24,6 +27,7 @@ describe("@wp-typia/project-tools template discovery formatting", () => {
 
 	test("inspect output prefers logical layer summaries over raw overlay paths", () => {
 		const basicDetails = formatTemplateDetails(getTemplateById("basic"));
+		const queryLoopDetails = formatTemplateDetails(getTemplateById("query-loop"));
 		const workspaceDetails = formatTemplateDetails(
 			getTemplateById("@wp-typia/create-workspace-template"),
 		);
@@ -34,6 +38,13 @@ describe("@wp-typia/project-tools template discovery formatting", () => {
 		expect(basicDetails).toContain("shared/base -> basic overlay");
 		expect(basicDetails).not.toContain("Overlay path:");
 		expect(basicDetails).not.toContain("/templates/basic");
+		expect(queryLoopDetails).toContain("Notes:");
+		expect(queryLoopDetails).toContain(
+			"Create-time variation scaffold only; use `wp-typia create --template query-loop` instead of `wp-typia add block`.",
+		);
+		expect(queryLoopDetails).toContain(
+			"Owns a `core/query` variation, so it does not generate `src/types.ts`, `block.json`, or Typia manifests.",
+		);
 
 		expect(workspaceDetails).toContain("Official package: @wp-typia/create-workspace-template");
 		expect(workspaceDetails).toContain("Alias: workspace (`--template workspace`)");

--- a/packages/wp-typia-project-tools/tests/workspace-add.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-add.test.ts
@@ -361,6 +361,27 @@ test("canonical CLI rejects add-block external layers that emit workspace-level 
   ).toBe(false);
 }, 20_000);
 
+test("runAddBlockCommand explains that query-loop is a create-time scaffold family", async () => {
+  const targetDir = path.join(
+    tempRoot,
+    "demo-workspace-add-query-loop-unsupported",
+  );
+
+  await scaffoldOfficialWorkspace(targetDir);
+
+  linkWorkspaceNodeModules(targetDir);
+
+  await expect(
+    runAddBlockCommand({
+      blockName: "query-listing",
+      cwd: targetDir,
+      templateId: "query-loop",
+    })
+  ).rejects.toThrow(
+    "`wp-typia add block --template query-loop` is not supported. Query Loop is a create-time `core/query` variation scaffold, so use `wp-typia create <project-dir> --template query-loop` instead."
+  );
+});
+
 test("canonical CLI can add a variation to an official workspace template", async () => {
   const targetDir = path.join(tempRoot, "demo-workspace-add-variation");
 


### PR DESCRIPTION
## Context

Issue #484 called out a few template-capability boundaries that were still too implicit, especially around Query Loop behavior, quietly ignored flags, and workspace alias discoverability.

## What Changed

- clarified that `query-loop` is a create-time `core/query` variation scaffold rather than an `add block` family
- added visible warnings when users explicitly pass template-specific flags that do not apply, including `--query-post-type` on non-Query-Loop templates and `--with-migration-ui` on external templates that do not opt into that surface
- expanded template discovery, help text, onboarding notes, and README guidance so Query Loop's no-`src/types.ts` / no-`block.json` model is easier to understand
- pointed workspace guidance more consistently at the short `--template workspace` alias

## Verification

- `bun run --filter wp-typia build`
- `bun run --filter @wp-typia/project-tools build`
- `bun run typecheck`
- `bun test packages/wp-typia-project-tools/tests/cli-entry.test.ts packages/wp-typia-project-tools/tests/cli-templates.test.ts packages/wp-typia-project-tools/tests/workspace-add.test.ts`
- `bun run changesets:validate`

Closes #484


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the `query-loop` template scaffolds a variation rather than a standalone block and is only available at project creation time.
  * Updated guidance to use the `--template workspace` alias for creating empty workspaces.

* **New Features**
  * Added informational warnings when using incompatible flags with templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->