### PR TITLE
Fix query-loop README coverage expectation

### DIFF
--- a/packages/wp-typia-project-tools/tests/scaffold-query-loop.test.ts
+++ b/packages/wp-typia-project-tools/tests/scaffold-query-loop.test.ts
@@ -131,7 +131,7 @@ describe("@wp-typia/project-tools scaffold query-loop", () => {
 			expect(listPatternSource).toContain('"wpTypiaVariation":"demo-space/demo-query-loop"');
 			expect(readme).toContain("## Variation Workflow");
 			expect(readme).toContain(
-				"This scaffold does not generate a `sync` script, `block.json`, or Typia manifests.",
+				"This scaffold does not generate `src/types.ts`, a `sync` script, `block.json`, or Typia manifests because it owns a `core/query` variation rather than a standalone block.",
 			);
 			expect(readme).toContain(
 				"`src/index.ts` remains the source of truth for the Query Loop variation name",


### PR DESCRIPTION
## Context

The `#494` template-capability wording update changed the generated Query Loop README text, but one project-tools coverage assertion still expected the older wording. That caused the `main` `Project Tools Coverage` lane to fail after merge.

## What Changed

- updated the Query Loop scaffold README assertion in `scaffold-query-loop.test.ts` to match the new generated wording

## Verification

- `bun test packages/wp-typia-project-tools/tests/scaffold-query-loop.test.ts`
- `bun run test:coverage:project-tools`
- `bun run changesets:validate`

Closes #495
