### PR TITLE
Unify CLI validation diagnostics and shared create/add contracts

### DIFF
--- a/.sampo/changesets/issue-485-cli-diagnostic-validation.md
+++ b/.sampo/changesets/issue-485-cli-diagnostic-validation.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Unify high-frequency create/add validation paths around shared helpers so built-in `--variant` errors, `externalLayerId` composition rules, and local `--external-layer-source` path failures surface the same messages across CLI entry points. Query Loop post-type validation now mentions the original offending input, and `wp-typia add block` explains when a provided name normalizes to an empty slug instead of falling back to a generic required-field error.

--- a/packages/wp-typia-project-tools/src/runtime/block-generator-service-core.ts
+++ b/packages/wp-typia-project-tools/src/runtime/block-generator-service-core.ts
@@ -38,6 +38,10 @@ import {
 	type ValidateBlockResult,
 } from "./block-generator-service-spec.js";
 import type { ScaffoldProjectResult } from "./scaffold.js";
+import {
+	assertBuiltInTemplateVariantAllowed,
+	assertExternalLayerCompositionOptions,
+} from "./cli-validation.js";
 
 const renderedArtifactCache = new WeakMap<
 	RenderBlockResult,
@@ -207,17 +211,14 @@ export class BlockGeneratorService {
 	}
 
 	async validate({ plan }: ValidateBlockInput): Promise<ValidateBlockResult> {
-		if (plan.target.externalLayerId && !plan.target.externalLayerSource) {
-			throw new Error(
-				"externalLayerId requires externalLayerSource when composing built-in template layers.",
-			);
-		}
-
-		if (plan.target.variant) {
-			throw new Error(
-				`--variant is only supported for official external template configs. Received variant "${plan.target.variant}" for built-in template "${plan.spec.template.family}".`,
-			);
-		}
+		assertExternalLayerCompositionOptions({
+			externalLayerId: plan.target.externalLayerId,
+			externalLayerSource: plan.target.externalLayerSource,
+		});
+		assertBuiltInTemplateVariantAllowed({
+			templateId: plan.spec.template.family,
+			variant: plan.target.variant,
+		});
 
 		return plan;
 	}

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-block.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-block.ts
@@ -71,6 +71,7 @@ import {
 } from "./external-layer-selection.js";
 import { parseAlternateRenderTargets } from "./alternate-render-targets.js";
 import {
+	assertExternalLayerCompositionOptions,
 	normalizeOptionalCliString,
 	resolveLocalCliPathOption,
 } from "./cli-validation.js";
@@ -538,6 +539,10 @@ export async function runAddBlockCommand({
 		cwd,
 		label: "--external-layer-source",
 		value: externalLayerSource,
+	});
+	assertExternalLayerCompositionOptions({
+		externalLayerId: normalizedExternalLayerId,
+		externalLayerSource: normalizedExternalLayerSource,
 	});
 	const resolvedExternalLayerSelection =
 		await resolveOptionalInteractiveExternalLayerId({

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-block.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-block.ts
@@ -35,7 +35,6 @@ import {
 	type AddBlockTemplateId,
 	buildWorkspacePhpPrefix,
 	isAddBlockTemplateId,
-	normalizeBlockSlug,
 	patchFile,
 	readOptionalFile,
 	type RunAddBlockCommandOptions,
@@ -43,6 +42,9 @@ import {
 	type WorkspaceMutationSnapshot,
 	snapshotWorkspaceFiles,
 } from "./cli-add-shared.js";
+import {
+	resolveNonEmptyNormalizedBlockSlug,
+} from "./scaffold-identifiers.js";
 import {
 	buildConfigEntries,
 	buildMigrationBlocks,
@@ -68,6 +70,10 @@ import {
 	resolveOptionalInteractiveExternalLayerId,
 } from "./external-layer-selection.js";
 import { parseAlternateRenderTargets } from "./alternate-render-targets.js";
+import {
+	normalizeOptionalCliString,
+	resolveLocalCliPathOption,
+} from "./cli-validation.js";
 
 const COLLECTION_IMPORT_LINE = "import '../../collection';";
 // This is a lightweight preflight heuristic for the common install layouts:
@@ -141,30 +147,6 @@ async function renderWorkspacePersistenceServerModule(
 	const targetDir = path.join(projectDir, "src", "blocks", variables.slugKebabCase);
 	const templateDir = buildServerTemplateRoot(variables.persistencePolicy);
 	await copyInterpolatedDirectory(templateDir, targetDir, variables);
-}
-
-function normalizeExternalLayerOption(value?: string): string | undefined {
-	if (typeof value !== "string") {
-		return undefined;
-	}
-
-	const trimmed = value.trim();
-	return trimmed.length > 0 ? trimmed : undefined;
-}
-
-function resolveExternalLayerSourceFromCaller(
-	source: string | undefined,
-	callerCwd: string,
-): string | undefined {
-	if (
-		typeof source !== "string" ||
-		source.length === 0 ||
-		!(path.isAbsolute(source) || source.startsWith("./") || source.startsWith("../"))
-	) {
-		return source;
-	}
-
-	return path.resolve(callerCwd, source);
 }
 
 function hasInstalledWorkspaceDependencies(projectDir: string): boolean {
@@ -551,11 +533,12 @@ export async function runAddBlockCommand({
 
 	const workspace = resolveWorkspaceProject(cwd);
 	assertWorkspaceDependenciesInstalled(workspace);
-	const normalizedExternalLayerId = normalizeExternalLayerOption(externalLayerId);
-	const normalizedExternalLayerSource = resolveExternalLayerSourceFromCaller(
-		normalizeExternalLayerOption(externalLayerSource),
+	const normalizedExternalLayerId = normalizeOptionalCliString(externalLayerId);
+	const normalizedExternalLayerSource = resolveLocalCliPathOption({
 		cwd,
-	);
+		label: "--external-layer-source",
+		value: externalLayerSource,
+	});
 	const resolvedExternalLayerSelection =
 		await resolveOptionalInteractiveExternalLayerId({
 		callerCwd: cwd,
@@ -566,10 +549,11 @@ export async function runAddBlockCommand({
 	let tempRoot = "";
 
 	try {
-		const normalizedSlug = normalizeBlockSlug(blockName);
-		if (!normalizedSlug) {
-			throw new Error("Block name is required. Use `wp-typia add block <name> --template <family>`.");
-		}
+		const normalizedSlug = resolveNonEmptyNormalizedBlockSlug({
+			input: blockName,
+			label: "Block name",
+			usage: "wp-typia add block <name> --template <family>",
+		});
 
 		const defaults = getDefaultAnswers(normalizedSlug, resolvedTemplateId);
 		tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "wp-typia-add-block-"));

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-shared.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-shared.ts
@@ -9,7 +9,6 @@ import {
 	type HookedBlockPositionId,
 } from "./hooked-blocks.js";
 import {
-	toKebabCase,
 	toSnakeCase,
 } from "./string-case.js";
 import {
@@ -19,6 +18,9 @@ import {
 	WORKSPACE_TEMPLATE_PACKAGE,
 	type WorkspaceProject,
 } from "./workspace-project.js";
+export {
+	normalizeBlockSlug,
+} from "./scaffold-identifiers.js";
 
 /**
  * Supported top-level `wp-typia add` kinds exposed by the canonical CLI.
@@ -142,10 +144,6 @@ export interface WorkspaceMutationSnapshot {
 	snapshotDirs: string[];
 	/** Files or directories created by the mutation that should be removed on rollback. */
 	targetPaths: string[];
-}
-
-export function normalizeBlockSlug(input: string): string {
-	return toKebabCase(input);
 }
 
 export function assertValidGeneratedSlug(label: string, slug: string, usage: string): string {

--- a/packages/wp-typia-project-tools/src/runtime/cli-scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-scaffold.ts
@@ -39,6 +39,11 @@ import {
 	type ExternalLayerSelectionOption,
 } from "./external-layer-selection.js";
 import type { TemplateDefinition } from "./template-registry.js";
+import {
+	assertBuiltInTemplateVariantAllowed,
+	resolveLocalCliPathOption,
+	normalizeOptionalCliString,
+} from "./cli-validation.js";
 
 interface GetNextStepsOptions {
 	noInstall: boolean;
@@ -390,10 +395,11 @@ function validateCreateFlagContract(options: {
 	}
 	parseAlternateRenderTargets(alternateRenderTargets);
 
-	if (variant && isBuiltInTemplateId(templateId)) {
-		throw new Error(
-			`--variant is only supported for official external template configs. Received variant "${variant}" for built-in template "${templateId}".`,
-		);
+	if (isBuiltInTemplateId(templateId)) {
+		assertBuiltInTemplateVariantAllowed({
+			templateId,
+			variant,
+		});
 	}
 }
 
@@ -589,14 +595,12 @@ export async function runScaffoldFlow({
 	withWpEnv,
 }: RunScaffoldFlowOptions) {
 	const normalizedExternalLayerId =
-		typeof externalLayerId === "string" && externalLayerId.trim().length > 0
-			? externalLayerId.trim()
-			: undefined;
-	const normalizedExternalLayerSource =
-		typeof externalLayerSource === "string" &&
-		externalLayerSource.trim().length > 0
-			? externalLayerSource.trim()
-			: undefined;
+		normalizeOptionalCliString(externalLayerId);
+	const normalizedExternalLayerSource = resolveLocalCliPathOption({
+		cwd,
+		label: "--external-layer-source",
+		value: externalLayerSource,
+	});
 
 	validateCreateProjectInput(projectInput);
 

--- a/packages/wp-typia-project-tools/src/runtime/cli-validation.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-validation.ts
@@ -1,6 +1,13 @@
 import fs from "node:fs";
 import path from "node:path";
 
+/**
+ * Normalize one optional CLI string flag by trimming whitespace and collapsing
+ * empty strings to `undefined`.
+ *
+ * @param value Raw CLI value before normalization.
+ * @returns The trimmed string when present, otherwise `undefined`.
+ */
 export function normalizeOptionalCliString(value?: string): string | undefined {
 	if (typeof value !== "string") {
 		return undefined;
@@ -11,9 +18,31 @@ export function normalizeOptionalCliString(value?: string): string | undefined {
 }
 
 function looksLikeLocalCliPath(value: string): boolean {
-	return path.isAbsolute(value) || value.startsWith("./") || value.startsWith("../");
+	return (
+		path.isAbsolute(value) ||
+		value.startsWith("./") ||
+		value.startsWith("../") ||
+		value.startsWith(".\\") ||
+		value.startsWith("..\\")
+	);
 }
 
+/**
+ * Resolve one CLI path flag relative to the caller when it is expressed as a
+ * local filesystem path.
+ *
+ * Non-local values such as npm package specs or `github:` locators pass
+ * through unchanged. Local relative and absolute paths are resolved against the
+ * provided `cwd` and must exist on disk.
+ *
+ * @param options Path resolution inputs for one CLI flag.
+ * @param options.cwd Caller working directory used for relative path
+ * resolution.
+ * @param options.label Human-readable option label used in thrown errors.
+ * @param options.value Raw CLI value before trimming and path resolution.
+ * @returns The normalized string, or `undefined` when the option was omitted.
+ * @throws When a local-looking path resolves to a missing filesystem entry.
+ */
 export function resolveLocalCliPathOption(options: {
 	cwd: string;
 	label: string;
@@ -34,6 +63,14 @@ export function resolveLocalCliPathOption(options: {
 	return resolvedPath;
 }
 
+/**
+ * Validate the built-in template composition rule for external layers.
+ *
+ * @param options External layer CLI options after normalization.
+ * @param options.externalLayerId Optional selected layer id.
+ * @param options.externalLayerSource Optional layer source locator or path.
+ * @throws When `externalLayerId` is provided without `externalLayerSource`.
+ */
 export function assertExternalLayerCompositionOptions(options: {
 	externalLayerId?: string;
 	externalLayerSource?: string;
@@ -45,6 +82,15 @@ export function assertExternalLayerCompositionOptions(options: {
 	}
 }
 
+/**
+ * Build the shared error message used when a built-in template receives a
+ * `--variant` override.
+ *
+ * @param options Built-in template context.
+ * @param options.templateId Built-in template id that rejected the variant.
+ * @param options.variant User-supplied variant override.
+ * @returns The canonical user-facing error message.
+ */
 export function createBuiltInVariantErrorMessage(options: {
 	templateId: string;
 	variant: string;
@@ -52,6 +98,14 @@ export function createBuiltInVariantErrorMessage(options: {
 	return `--variant is only supported for official external template configs. Received variant "${options.variant}" for built-in template "${options.templateId}".`;
 }
 
+/**
+ * Reject unsupported `--variant` usage for built-in templates.
+ *
+ * @param options Built-in template validation context.
+ * @param options.templateId Built-in template id being scaffolded.
+ * @param options.variant Optional variant override from CLI flags.
+ * @throws When a built-in template receives any explicit `--variant` value.
+ */
 export function assertBuiltInTemplateVariantAllowed(options: {
 	templateId: string;
 	variant?: string;

--- a/packages/wp-typia-project-tools/src/runtime/cli-validation.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-validation.ts
@@ -1,0 +1,69 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export function normalizeOptionalCliString(value?: string): string | undefined {
+	if (typeof value !== "string") {
+		return undefined;
+	}
+
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function looksLikeLocalCliPath(value: string): boolean {
+	return path.isAbsolute(value) || value.startsWith("./") || value.startsWith("../");
+}
+
+export function resolveLocalCliPathOption(options: {
+	cwd: string;
+	label: string;
+	value?: string;
+}): string | undefined {
+	const normalizedValue = normalizeOptionalCliString(options.value);
+	if (!normalizedValue || !looksLikeLocalCliPath(normalizedValue)) {
+		return normalizedValue;
+	}
+
+	const resolvedPath = path.resolve(options.cwd, normalizedValue);
+	if (!fs.existsSync(resolvedPath)) {
+		throw new Error(
+			`\`${options.label}\` path does not exist: ${resolvedPath}. Check the path relative to ${options.cwd}.`,
+		);
+	}
+
+	return resolvedPath;
+}
+
+export function assertExternalLayerCompositionOptions(options: {
+	externalLayerId?: string;
+	externalLayerSource?: string;
+}): void {
+	if (options.externalLayerId && !options.externalLayerSource) {
+		throw new Error(
+			"externalLayerId requires externalLayerSource when composing built-in template layers.",
+		);
+	}
+}
+
+export function createBuiltInVariantErrorMessage(options: {
+	templateId: string;
+	variant: string;
+}): string {
+	return `--variant is only supported for official external template configs. Received variant "${options.variant}" for built-in template "${options.templateId}".`;
+}
+
+export function assertBuiltInTemplateVariantAllowed(options: {
+	templateId: string;
+	variant?: string;
+}): void {
+	if (!options.variant) {
+		return;
+	}
+
+	throw new Error(
+		createBuiltInVariantErrorMessage({
+			templateId: options.templateId,
+			variant: options.variant,
+		}),
+	);
+}

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-answer-resolution.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-answer-resolution.ts
@@ -38,6 +38,8 @@ const TEMPLATE_SELECTION_HINT = `--template <${[
   WORKSPACE_TEMPLATE_ALIAS,
 ].join('|')}|./path|github:owner/repo/path[#ref]|npm-package>`;
 const TEMPLATE_SUGGESTION_IDS = [...TEMPLATE_IDS, WORKSPACE_TEMPLATE_ALIAS] as const;
+const QUERY_POST_TYPE_RULE =
+  'Use lowercase, 1-20 chars, and only a-z, 0-9, "_" or "-".';
 
 /**
  * Detect the current author name from local Git config.
@@ -85,13 +87,16 @@ export function getDefaultAnswers(
 }
 
 function validateQueryPostType(value: string): true | string {
-  const normalizedValue = value.trim().toLowerCase();
+  const rawValue = value.trim();
+  const normalizedValue = rawValue.toLowerCase();
   if (normalizedValue.length === 0) {
     return 'Query post type is required.';
   }
 
   if (!/^[a-z0-9_-]{1,20}$/u.test(normalizedValue)) {
-    return 'Query post type must be lowercase, 1-20 chars, and only a-z, 0-9, "_" or "-".';
+    return rawValue === normalizedValue
+      ? `Query post type "${rawValue}" is invalid. ${QUERY_POST_TYPE_RULE}`
+      : `Query post type "${rawValue}" normalizes to "${normalizedValue}", which is invalid. ${QUERY_POST_TYPE_RULE}`;
   }
 
   return true;
@@ -102,12 +107,12 @@ function normalizeQueryPostType(value: string | undefined): string | undefined {
     return undefined;
   }
 
-  const normalizedValue = value.trim().toLowerCase();
-  if (validateQueryPostType(normalizedValue) !== true) {
-    throw new Error('Query post type must be lowercase, 1-20 chars, and only a-z, 0-9, "_" or "-".');
+  const validationResult = validateQueryPostType(value);
+  if (validationResult !== true) {
+    throw new Error(validationResult);
   }
 
-  return normalizedValue;
+  return value.trim().toLowerCase();
 }
 
 function normalizeTemplateSelection(templateId: string): string {

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-identifiers.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-identifiers.ts
@@ -58,6 +58,25 @@ export function normalizeBlockSlug(input: string): string {
 	return toKebabCase(input);
 }
 
+export function resolveNonEmptyNormalizedBlockSlug(options: {
+	input: string;
+	label: string;
+	usage: string;
+}): string {
+	const normalizedSlug = normalizeBlockSlug(options.input);
+	if (normalizedSlug.length > 0) {
+		return normalizedSlug;
+	}
+
+	if (options.input.trim().length === 0) {
+		throw new Error(`${options.label} is required. Use \`${options.usage}\`.`);
+	}
+
+	throw new Error(
+		`${options.label} "${options.input.trim()}" normalizes to an empty slug. Use letters or numbers so wp-typia can generate a block slug.`,
+	);
+}
+
 export function resolveValidatedBlockSlug(value: string): string {
 	return assertValidIdentifier("Block slug", normalizeBlockSlug(value), validateBlockSlug);
 }

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-identifiers.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-identifiers.ts
@@ -58,6 +58,18 @@ export function normalizeBlockSlug(input: string): string {
 	return toKebabCase(input);
 }
 
+/**
+ * Normalize one human-entered block slug and reject values that collapse to an
+ * empty generated slug.
+ *
+ * @param options Normalization context for one block-like name.
+ * @param options.input Raw user input before kebab-case normalization.
+ * @param options.label Human-readable field label used in thrown errors.
+ * @param options.usage Example CLI usage shown when the input is blank.
+ * @returns A non-empty normalized slug.
+ * @throws When the input is blank after trimming.
+ * @throws When normalization removes every character from the original input.
+ */
 export function resolveNonEmptyNormalizedBlockSlug(options: {
 	input: string;
 	label: string;

--- a/packages/wp-typia-project-tools/src/runtime/scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold.ts
@@ -41,6 +41,9 @@ import {
 import {
 } from "./scaffold-answer-resolution.js";
 import { getTemplateVariables } from "./scaffold-template-variables.js";
+import {
+	assertExternalLayerCompositionOptions,
+} from "./cli-validation.js";
 
 const WORKSPACE_TEMPLATE_ALIAS = "workspace";
 
@@ -285,11 +288,10 @@ export async function scaffoldProject({
 	const resolvedPackageManager = getPackageManager(packageManager).id;
 	const isBuiltInTemplate = isBuiltInTemplateId(resolvedTemplateId);
 
-	if (externalLayerId && !externalLayerSource) {
-		throw new Error(
-			"externalLayerId requires externalLayerSource when composing built-in template layers.",
-		);
-	}
+	assertExternalLayerCompositionOptions({
+		externalLayerId,
+		externalLayerSource,
+	});
 
 	if (isBuiltInTemplate) {
 		const blockGeneratorService = new BlockGeneratorService();

--- a/packages/wp-typia-project-tools/src/runtime/template-source.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source.ts
@@ -23,6 +23,9 @@ import {
   isOfficialWorkspaceTemplateSeed,
   resolveTemplateSeed,
 } from './template-source-seeds.js'
+import {
+  assertBuiltInTemplateVariantAllowed,
+} from './cli-validation.js'
 
 export type {
   GitHubTemplateLocator,
@@ -46,11 +49,10 @@ export async function resolveTemplateSource(
   variant?: string,
 ): Promise<ResolvedTemplateSource> {
   if (isBuiltInTemplateId(templateId)) {
-    if (variant) {
-      throw new Error(
-        `--variant is only supported for official external template configs. Received variant "${variant}" for built-in template "${templateId}".`,
-      )
-    }
+    assertBuiltInTemplateVariantAllowed({
+      templateId,
+      variant,
+    })
     return resolveBuiltInTemplateSource(templateId, {
       persistenceEnabled: variables.compoundPersistenceEnabled === 'true',
       persistencePolicy:

--- a/packages/wp-typia-project-tools/tests/block-generator-service.test.ts
+++ b/packages/wp-typia-project-tools/tests/block-generator-service.test.ts
@@ -103,6 +103,22 @@ describe("BlockGeneratorService", () => {
 		);
 	});
 
+	test("validate rejects external layer ids without a layer source through the shared contract", async () => {
+		const service = new BlockGeneratorService();
+		const plan = await service.plan({
+			answers: buildAnswers("basic"),
+			externalLayerId: "acme/observability",
+			noInstall: true,
+			packageManager: "npm",
+			projectDir: path.join(tempRoot, "external-layer-id-only"),
+			templateId: "basic",
+		});
+
+		await expect(service.validate({ plan })).rejects.toThrow(
+			"externalLayerId requires externalLayerSource when composing built-in template layers.",
+		);
+	});
+
 	test("render exposes explicit stage intent for compound persistence scaffolds", async () => {
 		const service = new BlockGeneratorService();
 		const plan = await service.plan({

--- a/packages/wp-typia-project-tools/tests/cli-entry.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-entry.test.ts
@@ -447,6 +447,22 @@ test("runScaffoldFlow warns when query-loop-only flags are passed to other templ
   );
 });
 
+test("runScaffoldFlow explains invalid query post type input with the original value", async () => {
+  await expect(
+    runScaffoldFlow({
+      cwd: tempRoot,
+      noInstall: true,
+      packageManager: "npm",
+      projectInput: "demo-invalid-query-post-type",
+      queryPostType: "Books!",
+      templateId: "query-loop",
+      yes: true,
+    })
+  ).rejects.toThrow(
+    'Query post type "Books!" normalizes to "books!", which is invalid. Use lowercase, 1-20 chars, and only a-z, 0-9, "_" or "-".'
+  );
+});
+
 test("runScaffoldFlow dry-run previews scaffold output without writing the target directory", async () => {
   const projectInput = "demo-dry-run-plan";
   const targetDir = path.join(tempRoot, projectInput);
@@ -526,6 +542,24 @@ test("runScaffoldFlow rejects external layer ids without a layer source", async 
     })
   ).rejects.toThrow(
     "externalLayerId requires externalLayerSource when composing built-in template layers."
+  );
+});
+
+test("runScaffoldFlow rejects missing local external layer paths before template resolution", async () => {
+  const missingLayerPath = "./missing-template-layer";
+
+  await expect(
+    runScaffoldFlow({
+      cwd: tempRoot,
+      externalLayerSource: missingLayerPath,
+      noInstall: true,
+      packageManager: "npm",
+      projectInput: "demo-missing-local-external-layer",
+      templateId: "basic",
+      yes: true,
+    })
+  ).rejects.toThrow(
+    `\`--external-layer-source\` path does not exist: ${path.resolve(tempRoot, missingLayerPath)}.`
   );
 });
 

--- a/packages/wp-typia-project-tools/tests/workspace-add.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-add.test.ts
@@ -313,6 +313,38 @@ test("canonical CLI resolves add-block local external layer paths from the calle
   ).toContain("counter-card-telemetry");
 }, 20_000);
 
+test("runAddBlockCommand explains when a block name normalizes to an empty slug", async () => {
+  const targetDir = path.join(tempRoot, "demo-workspace-add-invalid-block-name");
+
+  await scaffoldProject({
+    projectDir: targetDir,
+    templateId: workspaceTemplatePackageManifest.name,
+    packageManager: "npm",
+    noInstall: true,
+    answers: {
+      author: "Test Runner",
+      description: "Demo workspace add invalid block name",
+      namespace: "demo-space",
+      phpPrefix: "demo_space",
+      slug: "demo-workspace-add-invalid-block-name",
+      textDomain: "demo-space",
+      title: "Demo Workspace Add Invalid Block Name",
+    },
+  });
+
+  linkWorkspaceNodeModules(targetDir);
+
+  await expect(
+    runAddBlockCommand({
+      blockName: "!!!",
+      cwd: targetDir,
+      templateId: "basic",
+    })
+  ).rejects.toThrow(
+    'Block name "!!!" normalizes to an empty slug. Use letters or numbers so wp-typia can generate a block slug.'
+  );
+}, 20_000);
+
 test("canonical CLI rejects add-block external layers that emit workspace-level files", async () => {
   const targetDir = path.join(tempRoot, "demo-workspace-add-basic-layered-root-output");
 


### PR DESCRIPTION
## Context

Issue #485 tracks a consistency pass across CLI diagnostics and duplicated validation paths. The current create/add flows still had repeated built-in variant checks, repeated `externalLayerId` composition checks, add-block slug normalization falling back to a generic required error, and local `--external-layer-source` path failures surfacing too deep in template resolution.

## What Changed

- added a shared `cli-validation` helper for built-in `--variant` rejection, `externalLayerId` composition rules, trimmed CLI string normalization, and local path preflight for `--external-layer-source`
- reused those helpers across `runScaffoldFlow`, `scaffoldProject`, `BlockGeneratorService.validate`, `template-source`, and `runAddBlockCommand` so equivalent flows now fail with the same messages
- improved query-loop post-type validation so invalid input mentions the original value and any lossy normalization, and improved add-block empty-slug failures so the offending name is called out directly
- added regression coverage for the shared contract paths in scaffold CLI, generator service, and workspace add flows
- added a changeset for `@wp-typia/project-tools` and `wp-typia`

## Verification

- `bun run --filter @wp-typia/project-tools build`
- `bun run --filter wp-typia build`
- `bun run typecheck`
- `bun test packages/wp-typia-project-tools/tests/cli-entry.test.ts packages/wp-typia-project-tools/tests/block-generator-service.test.ts packages/wp-typia-project-tools/tests/workspace-add.test.ts`
- `bun run changesets:validate`

Closes #485

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unified diagnostic messages across CLI commands for consistent error reporting
  * Enhanced validation error messages to include original input values for Query Loop post types
  * Improved block name validation with specific feedback when normalized slugs become empty
  * Aligned error messages for `--variant`, external layer composition, and `--external-layer-source` validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->