### PR TITLE
Align Node fallback help, runtime docs, and shared CLI option metadata

### DIFF
--- a/.sampo/changesets/issue-486-node-fallback-alignment.md
+++ b/.sampo/changesets/issue-486-node-fallback-alignment.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Align Bunli command metadata with the Node fallback help and parser surfaces so `wp-typia --help`, command-specific fallback help, and end-user runtime guidance stay consistent as CLI flags evolve.

--- a/packages/wp-typia-project-tools/tests/cli-entry.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-entry.test.ts
@@ -768,21 +768,18 @@ test("node entry supports external layer flags for built-in create scaffolds", (
   );
 });
 
-test("node entry exposes Bunli-owned help and rejects the removed migrations alias", () => {
+test("node entry exposes fallback help and rejects the removed migrations alias", () => {
   const helpOutput = runCli("node", [entryPath, "--help"]);
   const errorMessage = getCommandErrorMessage(() =>
     runCli("node", [entryPath, "migrations", "init"], { stdio: "pipe" })
   );
 
+  expect(helpOutput).toContain("Runtime: Node fallback");
   expect(helpOutput).toContain("Scaffold a new wp-typia project.");
+  expect(helpOutput).toContain("Run migration workflows.");
   expect(helpOutput).toContain(
-    "Run migration workflows for migration-capable wp-typia projects."
+    "Inspect or sync schema-driven MCP metadata."
   );
-  expect(helpOutput).toContain(
-    "Inspect or sync schema-driven MCP metadata for wp-typia."
-  );
-  expect(helpOutput).toContain("Manage agent skill files");
-  expect(helpOutput).toContain("Generate shell completion scripts");
   expect(errorMessage).toContain(
     "`wp-typia migrations` was removed in favor of `wp-typia migrate`."
   );
@@ -803,21 +800,18 @@ test("bun entry exposes templates and doctor commands", () => {
   expect(doctorOutput).toContain('"label": "Template basic"');
 });
 
-test("bun entry exposes Bunli-owned help and rejects the removed migrations alias", () => {
+test("bun entry exposes fallback help and rejects the removed migrations alias", () => {
   const helpOutput = runCli("bun", [entryPath, "--help"]);
   const errorMessage = getCommandErrorMessage(() =>
     runCli("bun", [entryPath, "migrations", "init"], { stdio: "pipe" })
   );
 
+  expect(helpOutput).toContain("Runtime: Node fallback");
   expect(helpOutput).toContain("Scaffold a new wp-typia project.");
+  expect(helpOutput).toContain("Run migration workflows.");
   expect(helpOutput).toContain(
-    "Run migration workflows for migration-capable wp-typia projects."
+    "Inspect or sync schema-driven MCP metadata."
   );
-  expect(helpOutput).toContain(
-    "Inspect or sync schema-driven MCP metadata for wp-typia."
-  );
-  expect(helpOutput).toContain("Manage agent skill files");
-  expect(helpOutput).toContain("Generate shell completion scripts");
   expect(errorMessage).toContain(
     "`wp-typia migrations` was removed in favor of `wp-typia migrate`."
   );

--- a/packages/wp-typia/README.md
+++ b/packages/wp-typia/README.md
@@ -21,7 +21,7 @@ Compatibility notes:
 
 - `@wp-typia/project-tools` is the canonical programmatic project orchestration package
 - the published CLI now ships built `dist-bunli` runtimes, and the canonical Node bin uses a Node-safe fallback runtime for non-TUI `create`/`add`/`migrate`, `doctor`, `sync`, `--version`, `--help`, and template inspection without requiring a locally installed Bun binary
-- if `wp-typia --help` says `Runtime: Node fallback`, you are on that Bun-free path: human-readable help/output, common non-interactive project workflows, and lighter prompt behavior where interactive fallback is still supported
+- if `wp-typia --help` says `Runtime: Node fallback`, you are on that Bun-free path. You get human-readable help/output, common non-interactive project workflows, and lighter prompt behavior where interactive fallback is still supported
 - when that Node fallback prompts interactively, it intentionally stays lighter than the Bun/OpenTUI flow: numbered lists, option label/value matching, inline validation retries, and redraw commands for the current choices: `?` for the short reprint shortcut, `help` for the explicit redraw command, and `list` for users who expect option listing semantics
 - Bunli-specific command surfaces such as `skills`, `completions`, and `mcp` still run through the built `dist-bunli/cli.js` artifact and require Bun; if you need the full Bunli/OpenTUI runtime story, prefer `bunx wp-typia` or install Bun locally
 - any future `curl`-style installer should reuse the same published `dist-bunli` runtime instead of reintroducing a Bun bootstrap path

--- a/packages/wp-typia/README.md
+++ b/packages/wp-typia/README.md
@@ -21,6 +21,7 @@ Compatibility notes:
 
 - `@wp-typia/project-tools` is the canonical programmatic project orchestration package
 - the published CLI now ships built `dist-bunli` runtimes, and the canonical Node bin uses a Node-safe fallback runtime for non-TUI `create`/`add`/`migrate`, `doctor`, `sync`, `--version`, `--help`, and template inspection without requiring a locally installed Bun binary
+- if `wp-typia --help` says `Runtime: Node fallback`, you are on that Bun-free path: human-readable help/output, common non-interactive project workflows, and lighter prompt behavior where interactive fallback is still supported
 - when that Node fallback prompts interactively, it intentionally stays lighter than the Bun/OpenTUI flow: numbered lists, option label/value matching, inline validation retries, and redraw commands for the current choices: `?` for the short reprint shortcut, `help` for the explicit redraw command, and `list` for users who expect option listing semantics
 - Bunli-specific command surfaces such as `skills`, `completions`, and `mcp` still run through the built `dist-bunli/cli.js` artifact and require Bun; if you need the full Bunli/OpenTUI runtime story, prefer `bunx wp-typia` or install Bun locally
 - any future `curl`-style installer should reuse the same published `dist-bunli` runtime instead of reintroducing a Bun bootstrap path

--- a/packages/wp-typia/bin/wp-typia.js
+++ b/packages/wp-typia/bin/wp-typia.js
@@ -11,6 +11,7 @@ const nodeCliEntrypoint = path.join(packageRoot, "dist-bunli", "node-cli.js");
 const bunBinary = process.env.BUN_BIN || "bun";
 const fullRuntimeCommands = new Set(["complete", "completions", "mcp", "skills"]);
 const longValueOptions = new Set([
+	"--alternate-render-targets",
 	"--anchor",
 	"--block",
 	"--config",
@@ -22,6 +23,7 @@ const longValueOptions = new Set([
 	"--from-migration-version",
 	"--id",
 	"--iterations",
+	"--methods",
 	"--migration-version",
 	"--namespace",
 	"--output-dir",
@@ -29,7 +31,9 @@ const longValueOptions = new Set([
 	"--persistence-policy",
 	"--php-prefix",
 	"--position",
+	"--query-post-type",
 	"--seed",
+	"--slot",
 	"--template",
 	"--text-domain",
 	"--to-migration-version",

--- a/packages/wp-typia/bin/wp-typia.js
+++ b/packages/wp-typia/bin/wp-typia.js
@@ -103,12 +103,12 @@ function ensureBuiltRuntime() {
 
 const argv = process.argv.slice(2);
 const command = firstPositional(argv);
-const helpInvocation = argv.includes("--help") || command === "help";
 const shouldUseFullRuntime = command ? fullRuntimeCommands.has(command) : false;
 const hasBuiltRuntime = ensureBuiltRuntime();
 const hasWorkingBun = isWorkingBunBinary();
 
-if (hasWorkingBun && hasBuiltRuntime && (helpInvocation || shouldUseFullRuntime)) {
+// Keep common help on the human-readable Node fallback even when Bun is present.
+if (hasWorkingBun && hasBuiltRuntime && shouldUseFullRuntime) {
 	const result = spawnSync(bunBinary, [cliEntrypoint, ...argv], {
 		cwd: process.cwd(),
 		env: process.env,

--- a/packages/wp-typia/src/command-contract.ts
+++ b/packages/wp-typia/src/command-contract.ts
@@ -1,4 +1,12 @@
 import path from 'node:path'
+import {
+  ADD_OPTION_METADATA,
+  collectOptionNamesByType,
+  CREATE_OPTION_METADATA,
+  GLOBAL_OPTION_METADATA,
+  MIGRATE_OPTION_METADATA,
+  TEMPLATES_OPTION_METADATA,
+} from './command-option-metadata'
 
 export const WP_TYPIA_CANONICAL_CREATE_USAGE = 'wp-typia create <project-dir>';
 export const WP_TYPIA_POSITIONAL_ALIAS_USAGE = 'wp-typia <project-dir>';
@@ -34,52 +42,26 @@ export const WP_TYPIA_TOP_LEVEL_COMMAND_NAMES = [
 ] as const;
 
 const STRING_OPTION_NAMES_BY_COMMAND = {
-  add: new Set([
-    'alternate-render-targets',
-    'anchor',
-    'block',
-    'data-storage',
-    'external-layer-id',
-    'external-layer-source',
-    'methods',
-    'namespace',
-    'persistence-policy',
-    'position',
-    'slot',
-    'template',
-  ]),
-  create: new Set([
-    'alternate-render-targets',
-    'data-storage',
-    'external-layer-id',
-    'external-layer-source',
-    'namespace',
-    'package-manager',
-    'persistence-policy',
-    'php-prefix',
-    'query-post-type',
-    'template',
-    'text-domain',
-    'variant',
-  ]),
-  migrate: new Set([
-    'current-migration-version',
-    'from-migration-version',
-    'iterations',
-    'migration-version',
-    'seed',
-    'to-migration-version',
-  ]),
+  add: new Set(collectOptionNamesByType(ADD_OPTION_METADATA, 'string')),
+  create: new Set(collectOptionNamesByType(CREATE_OPTION_METADATA, 'string')),
+  migrate: new Set(collectOptionNamesByType(MIGRATE_OPTION_METADATA, 'string')),
+  templates: new Set(collectOptionNamesByType(TEMPLATES_OPTION_METADATA, 'string')),
 } as const;
 
-const GLOBAL_STRING_OPTION_NAMES = new Set([
-  'config',
-  'format',
-  'id',
-  'output-dir',
-]);
+const GLOBAL_STRING_OPTION_NAMES = new Set(
+  collectOptionNamesByType(GLOBAL_OPTION_METADATA, 'string'),
+);
 
-const SHORT_OPTION_NAMES_WITH_VALUES = new Set(['c', 'p', 't']);
+const SHORT_OPTION_NAMES_WITH_VALUES = new Set<string>(
+  Object.values({
+    ...GLOBAL_OPTION_METADATA,
+    ...CREATE_OPTION_METADATA,
+  })
+    .filter((option) => option.type === 'string')
+    .flatMap((option) =>
+      'short' in option && typeof option.short === 'string' ? [option.short] : [],
+    ),
+);
 
 function isLongOptionValueConsumer(optionName: string): boolean {
   if (GLOBAL_STRING_OPTION_NAMES.has(optionName)) {

--- a/packages/wp-typia/src/command-contract.ts
+++ b/packages/wp-typia/src/command-contract.ts
@@ -54,8 +54,11 @@ const GLOBAL_STRING_OPTION_NAMES = new Set(
 
 const SHORT_OPTION_NAMES_WITH_VALUES = new Set<string>(
   Object.values({
+    ...ADD_OPTION_METADATA,
     ...GLOBAL_OPTION_METADATA,
     ...CREATE_OPTION_METADATA,
+    ...MIGRATE_OPTION_METADATA,
+    ...TEMPLATES_OPTION_METADATA,
   })
     .filter((option) => option.type === 'string')
     .flatMap((option) =>

--- a/packages/wp-typia/src/command-option-metadata.ts
+++ b/packages/wp-typia/src/command-option-metadata.ts
@@ -1,0 +1,274 @@
+import { z } from "zod";
+
+export type CommandOptionMetadata = {
+	argumentKind?: "flag";
+	description: string;
+	short?: string;
+	type: "boolean" | "string";
+};
+
+type CommandOptionMetadataMap = Record<string, CommandOptionMetadata>;
+
+/**
+ * Shared `wp-typia create` option metadata used by both the Bunli command
+ * definitions and the Node fallback parser/help surface.
+ */
+export const CREATE_OPTION_METADATA = {
+	"alternate-render-targets": {
+		description:
+			"Comma-separated alternate render targets for dynamic block scaffolds (email,mjml,plain-text).",
+		type: "string",
+	},
+	"data-storage": {
+		description: "Persistence storage mode for persistence-capable templates.",
+		type: "string",
+	},
+	"dry-run": {
+		argumentKind: "flag",
+		description: "Preview scaffold output without writing files to the target directory.",
+		type: "boolean",
+	},
+	"external-layer-id": {
+		description: "Explicit layer id when an external layer package exposes multiple selectable layers.",
+		type: "string",
+	},
+	"external-layer-source": {
+		description: "Local path, GitHub locator, or npm package that exposes wp-typia.layers.json for built-in templates.",
+		type: "string",
+	},
+	namespace: {
+		description: "Override the default block namespace.",
+		type: "string",
+	},
+	"no-install": {
+		argumentKind: "flag",
+		description: "Skip dependency installation after scaffold.",
+		type: "boolean",
+	},
+	"package-manager": {
+		description: "Package manager to use for install and scripts.",
+		short: "p",
+		type: "string",
+	},
+	"persistence-policy": {
+		description: "Authenticated or public write policy for persistence-capable templates.",
+		type: "string",
+	},
+	"php-prefix": {
+		description: "Custom PHP symbol prefix.",
+		type: "string",
+	},
+	"query-post-type": {
+		description: "Default post type assigned to Query Loop variation scaffolds.",
+		type: "string",
+	},
+	template: {
+		description: "Template id or external template package.",
+		short: "t",
+		type: "string",
+	},
+	"text-domain": {
+		description: "Custom text domain for the generated project.",
+		type: "string",
+	},
+	variant: {
+		description: "Optional template variant identifier.",
+		type: "string",
+	},
+	"with-migration-ui": {
+		argumentKind: "flag",
+		description: "Enable migration UI support when the template supports it.",
+		type: "boolean",
+	},
+	"with-test-preset": {
+		argumentKind: "flag",
+		description: "Include the Playwright smoke-test preset.",
+		type: "boolean",
+	},
+	"with-wp-env": {
+		argumentKind: "flag",
+		description: "Include a local wp-env preset.",
+		type: "boolean",
+	},
+	yes: {
+		argumentKind: "flag",
+		description: "Accept defaults without prompt fallbacks.",
+		short: "y",
+		type: "boolean",
+	},
+} as const satisfies CommandOptionMetadataMap;
+
+/**
+ * Shared `wp-typia add` option metadata used by both runtime entry paths.
+ */
+export const ADD_OPTION_METADATA = {
+	"alternate-render-targets": {
+		description:
+			"Comma-separated alternate render targets for dynamic block scaffolds (email,mjml,plain-text).",
+		type: "string",
+	},
+	anchor: {
+		description: "Anchor block name for hooked-block workflows.",
+		type: "string",
+	},
+	block: {
+		description: "Target block slug for variation workflows.",
+		type: "string",
+	},
+	"data-storage": {
+		description: "Persistence storage mode for persistence-capable templates.",
+		type: "string",
+	},
+	"dry-run": {
+		argumentKind: "flag",
+		description: "Preview workspace file updates without writing them.",
+		type: "boolean",
+	},
+	"external-layer-id": {
+		description: "Explicit layer id when an external layer package exposes multiple selectable layers.",
+		type: "string",
+	},
+	"external-layer-source": {
+		description: "Local path, GitHub locator, or npm package that exposes wp-typia.layers.json for built-in block templates.",
+		type: "string",
+	},
+	methods: {
+		description: "Comma-separated REST resource methods for rest-resource workflows.",
+		type: "string",
+	},
+	namespace: {
+		description: "REST namespace for rest-resource workflows.",
+		type: "string",
+	},
+	"persistence-policy": {
+		description: "Persistence write policy for persistence-capable templates.",
+		type: "string",
+	},
+	position: {
+		description: "Hook position for hooked-block workflows.",
+		type: "string",
+	},
+	slot: {
+		description: "Document editor shell slot for editor-plugin workflows.",
+		type: "string",
+	},
+	template: {
+		description: "Built-in block family for the new block.",
+		type: "string",
+	},
+} as const satisfies CommandOptionMetadataMap;
+
+/**
+ * Shared `wp-typia migrate` option metadata used by both runtime entry paths.
+ */
+export const MIGRATE_OPTION_METADATA = {
+	all: {
+		argumentKind: "flag",
+		description: "Run across every configured migration version and block target.",
+		type: "boolean",
+	},
+	"current-migration-version": {
+		description: "Current migration version label for `migrate init`.",
+		type: "string",
+	},
+	force: {
+		argumentKind: "flag",
+		description: "Force overwrite behavior where supported.",
+		type: "boolean",
+	},
+	"from-migration-version": {
+		description: "Source migration version label.",
+		type: "string",
+	},
+	iterations: {
+		description: "Iteration count for `migrate fuzz`.",
+		type: "string",
+	},
+	"migration-version": {
+		description: "Version label to capture with `migrate snapshot`.",
+		type: "string",
+	},
+	seed: {
+		description: "Deterministic fuzz seed.",
+		type: "string",
+	},
+	"to-migration-version": {
+		description: "Target migration version label.",
+		type: "string",
+	},
+} as const satisfies CommandOptionMetadataMap;
+
+/**
+ * Shared `wp-typia templates` option metadata.
+ */
+export const TEMPLATES_OPTION_METADATA = {
+	id: {
+		description: "Template id for `templates inspect`.",
+		type: "string",
+	},
+} as const satisfies CommandOptionMetadataMap;
+
+/**
+ * Global option metadata used by Node fallback parsing before command dispatch.
+ */
+export const GLOBAL_OPTION_METADATA = {
+	config: {
+		description: "Config override file path.",
+		short: "c",
+		type: "string",
+	},
+	format: {
+		description: "Output format for supported commands.",
+		type: "string",
+	},
+	id: {
+		description: "Template id for top-level `templates inspect` convenience.",
+		type: "string",
+	},
+	"output-dir": {
+		description: "Output directory for generated MCP metadata.",
+		type: "string",
+	},
+} as const satisfies CommandOptionMetadataMap;
+
+export function buildCommandOptions<TOptions extends CommandOptionMetadataMap>(
+	metadata: TOptions,
+): Record<string, {
+	argumentKind?: "flag";
+	description: string;
+	schema: z.ZodDefault<z.ZodBoolean> | z.ZodOptional<z.ZodString>;
+	short?: string;
+}> {
+	return Object.fromEntries(
+		Object.entries(metadata).map(([name, option]) => [
+			name,
+			{
+				...(option.argumentKind ? { argumentKind: option.argumentKind } : {}),
+				description: option.description,
+				schema:
+					option.type === "boolean"
+						? z.boolean().default(false)
+						: z.string().optional(),
+				...(option.short ? { short: option.short } : {}),
+			},
+		]),
+	);
+}
+
+export function collectOptionNamesByType(
+	metadata: CommandOptionMetadataMap,
+	type: CommandOptionMetadata["type"],
+): string[] {
+	return Object.entries(metadata)
+		.filter(([, option]) => option.type === type)
+		.map(([name]) => name);
+}
+
+export function formatNodeFallbackOptionHelp(
+	metadata: CommandOptionMetadataMap,
+): string[] {
+	return Object.entries(metadata).map(([name, option]) => {
+		const short = option.short ? `, -${option.short}` : "";
+		return `- --${name}${short}: ${option.description}`;
+	});
+}

--- a/packages/wp-typia/src/commands/add.ts
+++ b/packages/wp-typia/src/commands/add.ts
@@ -1,8 +1,11 @@
 import { createElement } from "react";
 
 import { defineCommand } from "@bunli/core";
-import { z } from "zod";
 
+import {
+	ADD_OPTION_METADATA,
+	buildCommandOptions,
+} from "../command-option-metadata";
 import { getAddBlockDefaults } from "../config";
 import { resolveBundledModuleHref } from "../render-loader";
 import { executeAddCommand } from "../runtime-bridge";
@@ -21,62 +24,7 @@ function loadAddFlow() {
 	).then((module) => ({ default: module.AddFlow }));
 }
 
-const addOptions = {
-	"alternate-render-targets": {
-		description:
-			"Comma-separated alternate render targets for dynamic block scaffolds (email,mjml,plain-text).",
-		schema: z.string().optional(),
-	},
-	anchor: {
-		description: "Anchor block name for hooked-block workflows.",
-		schema: z.string().optional(),
-	},
-	block: {
-		description: "Target block slug for variation workflows.",
-		schema: z.string().optional(),
-	},
-	"data-storage": {
-		description: "Persistence storage mode for persistence-capable templates.",
-		schema: z.string().optional(),
-	},
-	"dry-run": {
-		argumentKind: "flag" as const,
-		description: "Preview workspace file updates without writing them.",
-		schema: z.boolean().default(false),
-	},
-	"external-layer-id": {
-		description: "Explicit layer id when an external layer package exposes multiple selectable layers.",
-		schema: z.string().optional(),
-	},
-	"external-layer-source": {
-		description: "Local path, GitHub locator, or npm package that exposes wp-typia.layers.json for built-in block templates.",
-		schema: z.string().optional(),
-	},
-	methods: {
-		description: "Comma-separated REST resource methods for rest-resource workflows.",
-		schema: z.string().optional(),
-	},
-	namespace: {
-		description: "REST namespace for rest-resource workflows.",
-		schema: z.string().optional(),
-	},
-	"persistence-policy": {
-		description: "Persistence write policy for persistence-capable templates.",
-		schema: z.string().optional(),
-	},
-	position: {
-		description: "Hook position for hooked-block workflows.",
-		schema: z.string().optional(),
-	},
-	slot: {
-		description: "Document editor shell slot for editor-plugin workflows.",
-		schema: z.string().optional(),
-	},
-	template: {
-		description: "Built-in block family for the new block.",
-		schema: z.string().optional(),
-	},
-};
+const addOptions = buildCommandOptions(ADD_OPTION_METADATA);
 
 export const addCommand = defineCommand({
 	defaultFormat: "toon",

--- a/packages/wp-typia/src/commands/create.ts
+++ b/packages/wp-typia/src/commands/create.ts
@@ -1,8 +1,11 @@
 import { createElement } from "react";
 
 import { defineCommand } from "@bunli/core";
-import { z } from "zod";
 
+import {
+	buildCommandOptions,
+	CREATE_OPTION_METADATA,
+} from "../command-option-metadata";
 import { getCreateDefaults } from "../config";
 import { resolveBundledModuleHref } from "../render-loader";
 import { executeCreateCommand } from "../runtime-bridge";
@@ -21,90 +24,7 @@ function loadCreateFlow() {
 	).then((module) => ({ default: module.CreateFlow }));
 }
 
-const createOptions = {
-	"alternate-render-targets": {
-		description:
-			"Comma-separated alternate render targets for dynamic block scaffolds (email,mjml,plain-text).",
-		schema: z.string().optional(),
-	},
-	"data-storage": {
-		description: "Persistence storage mode for persistence-capable templates.",
-		schema: z.string().optional(),
-	},
-	"dry-run": {
-		argumentKind: "flag" as const,
-		description: "Preview scaffold output without writing files to the target directory.",
-		schema: z.boolean().default(false),
-	},
-	"external-layer-id": {
-		description: "Explicit layer id when an external layer package exposes multiple selectable layers.",
-		schema: z.string().optional(),
-	},
-	"external-layer-source": {
-		description: "Local path, GitHub locator, or npm package that exposes wp-typia.layers.json for built-in templates.",
-		schema: z.string().optional(),
-	},
-	namespace: {
-		description: "Override the default block namespace.",
-		schema: z.string().optional(),
-	},
-	"no-install": {
-		argumentKind: "flag" as const,
-		description: "Skip dependency installation after scaffold.",
-		schema: z.boolean().default(false),
-	},
-	"package-manager": {
-		description: "Package manager to use for install and scripts.",
-		schema: z.string().optional(),
-		short: "p",
-	},
-	"persistence-policy": {
-		description: "Authenticated or public write policy for persistence-capable templates.",
-		schema: z.string().optional(),
-	},
-	"php-prefix": {
-		description: "Custom PHP symbol prefix.",
-		schema: z.string().optional(),
-	},
-	"query-post-type": {
-		description: "Default post type assigned to Query Loop variation scaffolds.",
-		schema: z.string().optional(),
-	},
-	template: {
-		description: "Template id or external template package.",
-		schema: z.string().optional(),
-		short: "t",
-	},
-	"text-domain": {
-		description: "Custom text domain for the generated project.",
-		schema: z.string().optional(),
-	},
-	variant: {
-		description: "Optional template variant identifier.",
-		schema: z.string().optional(),
-	},
-	"with-migration-ui": {
-		argumentKind: "flag" as const,
-		description: "Enable migration UI support when the template supports it.",
-		schema: z.boolean().default(false),
-	},
-	"with-test-preset": {
-		argumentKind: "flag" as const,
-		description: "Include the Playwright smoke-test preset.",
-		schema: z.boolean().default(false),
-	},
-	"with-wp-env": {
-		argumentKind: "flag" as const,
-		description: "Include a local wp-env preset.",
-		schema: z.boolean().default(false),
-	},
-	yes: {
-		argumentKind: "flag" as const,
-		description: "Accept defaults without prompt fallbacks.",
-		schema: z.boolean().default(false),
-		short: "y",
-	},
-};
+const createOptions = buildCommandOptions(CREATE_OPTION_METADATA);
 
 export const createCommand = defineCommand({
 	defaultFormat: "toon",

--- a/packages/wp-typia/src/commands/migrate.ts
+++ b/packages/wp-typia/src/commands/migrate.ts
@@ -1,8 +1,11 @@
 import { createElement } from "react";
 
 import { defineCommand } from "@bunli/core";
-import { z } from "zod";
 
+import {
+	buildCommandOptions,
+	MIGRATE_OPTION_METADATA,
+} from "../command-option-metadata";
 import { resolveBundledModuleHref } from "../render-loader";
 import { executeMigrateCommand } from "../runtime-bridge";
 import type { WpTypiaRenderArgs } from "./render-types";
@@ -20,42 +23,7 @@ function loadMigrateFlow() {
 	).then((module) => ({ default: module.MigrateFlow }));
 }
 
-const migrateOptions = {
-	all: {
-		argumentKind: "flag" as const,
-		description: "Run across every configured migration version and block target.",
-		schema: z.boolean().default(false),
-	},
-	"current-migration-version": {
-		description: "Current migration version label for `migrate init`.",
-		schema: z.string().optional(),
-	},
-	force: {
-		argumentKind: "flag" as const,
-		description: "Force overwrite behavior where supported.",
-		schema: z.boolean().default(false),
-	},
-	"from-migration-version": {
-		description: "Source migration version label.",
-		schema: z.string().optional(),
-	},
-	iterations: {
-		description: "Iteration count for `migrate fuzz`.",
-		schema: z.string().optional(),
-	},
-	"migration-version": {
-		description: "Version label to capture with `migrate snapshot`.",
-		schema: z.string().optional(),
-	},
-	seed: {
-		description: "Deterministic fuzz seed.",
-		schema: z.string().optional(),
-	},
-	"to-migration-version": {
-		description: "Target migration version label.",
-		schema: z.string().optional(),
-	},
-};
+const migrateOptions = buildCommandOptions(MIGRATE_OPTION_METADATA);
 
 export const migrateCommand = defineCommand({
 	defaultFormat: "toon",

--- a/packages/wp-typia/src/commands/templates.ts
+++ b/packages/wp-typia/src/commands/templates.ts
@@ -1,6 +1,9 @@
 import { defineCommand } from "@bunli/core";
-import { z } from "zod";
 
+import {
+	buildCommandOptions,
+	TEMPLATES_OPTION_METADATA,
+} from "../command-option-metadata";
 import { executeTemplatesCommand, listTemplatesForRuntime } from "../runtime-bridge";
 
 export const templatesCommand = defineCommand({
@@ -39,12 +42,7 @@ export const templatesCommand = defineCommand({
 		});
 	},
 	name: "templates",
-	options: {
-		id: {
-			description: "Template id for `templates inspect`.",
-			schema: z.string().optional(),
-		},
-	},
+	options: buildCommandOptions(TEMPLATES_OPTION_METADATA),
 });
 
 export default templatesCommand;

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -68,6 +68,26 @@ const BOOLEAN_FLAG_NAMES = new Set([
 	"version",
 ]);
 
+const SHORT_FLAG_MAP = new Map<
+	string,
+	{
+		name: string;
+		type: "boolean" | "string";
+	}
+>(
+	Object.entries({
+		...GLOBAL_OPTION_METADATA,
+		...CREATE_OPTION_METADATA,
+		...ADD_OPTION_METADATA,
+		...MIGRATE_OPTION_METADATA,
+		...TEMPLATES_OPTION_METADATA,
+	}).flatMap(([name, option]) =>
+		"short" in option && typeof option.short === "string"
+			? [[option.short, { name, type: option.type }] as const]
+			: [],
+	),
+);
+
 const NODE_FALLBACK_RUNTIME_SUMMARY_LINES = [
 	"Runtime: Node fallback",
 	"Human-readable fallback for common non-interactive create/add/migrate flows, doctor, sync, templates, --help, and --version when Bun is unavailable.",
@@ -193,23 +213,20 @@ function parseArgv(argv: string[]): ParsedArgv {
 			break;
 		}
 
-		if (arg === "-y") {
-			flags.yes = true;
-			continue;
-		}
-
-		if (arg === "-t" || arg === "-p" || arg === "-c") {
+		if (arg.length === 2 && arg.startsWith("-")) {
+			const shortFlag = SHORT_FLAG_MAP.get(arg.slice(1));
+			if (!shortFlag) {
+				throw new Error(`Unknown option \`${arg}\`.`);
+			}
+			if (shortFlag.type === "boolean") {
+				flags[shortFlag.name] = true;
+				continue;
+			}
 			const next = argv[index + 1];
 			if (!next || next.startsWith("-")) {
 				throw new Error(`\`${arg}\` requires a value.`);
 			}
-			if (arg === "-t") {
-				flags.template = next;
-			} else if (arg === "-p") {
-				flags["package-manager"] = next;
-			} else {
-				flags.config = next;
-			}
+			flags[shortFlag.name] = next;
 			index += 1;
 			continue;
 		}

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -4,6 +4,15 @@ import {
 	formatCliDiagnosticError,
 } from "@wp-typia/project-tools/cli-diagnostics";
 import {
+	ADD_OPTION_METADATA,
+	collectOptionNamesByType,
+	CREATE_OPTION_METADATA,
+	formatNodeFallbackOptionHelp,
+	GLOBAL_OPTION_METADATA,
+	MIGRATE_OPTION_METADATA,
+	TEMPLATES_OPTION_METADATA,
+} from "./command-option-metadata";
+import {
 	getTemplateById,
 	listTemplates,
 } from "@wp-typia/project-tools/cli-templates";
@@ -26,6 +35,7 @@ import {
 import {
 	WP_TYPIA_CANONICAL_CREATE_USAGE,
 	WP_TYPIA_CANONICAL_MIGRATE_USAGE,
+	WP_TYPIA_FUTURE_COMMAND_TREE,
 	WP_TYPIA_POSITIONAL_ALIAS_USAGE,
 	WP_TYPIA_TOP_LEVEL_COMMAND_NAMES,
 	normalizeWpTypiaArgv,
@@ -42,46 +52,27 @@ type ParsedArgv = {
 };
 
 const STRING_FLAG_NAMES = new Set([
-	"alternate-render-targets",
-	"anchor",
-	"block",
-	"current-migration-version",
-	"data-storage",
-	"external-layer-id",
-	"external-layer-source",
-	"format",
-	"id",
-	"iterations",
-	"methods",
-	"migration-version",
-	"namespace",
-	"package-manager",
-	"persistence-policy",
-	"php-prefix",
-	"position",
-	"query-post-type",
-	"seed",
-	"slot",
-	"template",
-	"text-domain",
-	"to-migration-version",
-	"from-migration-version",
-	"variant",
+	...collectOptionNamesByType(GLOBAL_OPTION_METADATA, "string"),
+	...collectOptionNamesByType(CREATE_OPTION_METADATA, "string"),
+	...collectOptionNamesByType(ADD_OPTION_METADATA, "string"),
+	...collectOptionNamesByType(MIGRATE_OPTION_METADATA, "string"),
+	...collectOptionNamesByType(TEMPLATES_OPTION_METADATA, "string"),
 ]);
 
 const BOOLEAN_FLAG_NAMES = new Set([
-	"all",
+	...collectOptionNamesByType(CREATE_OPTION_METADATA, "boolean"),
+	...collectOptionNamesByType(ADD_OPTION_METADATA, "boolean"),
+	...collectOptionNamesByType(MIGRATE_OPTION_METADATA, "boolean"),
 	"check",
-	"dry-run",
-	"force",
 	"help",
-	"no-install",
 	"version",
-	"with-migration-ui",
-	"with-test-preset",
-	"with-wp-env",
-	"yes",
 ]);
+
+const NODE_FALLBACK_RUNTIME_SUMMARY_LINES = [
+	"Runtime: Node fallback",
+	"Human-readable fallback for common non-interactive create/add/migrate flows, doctor, sync, templates, --help, and --version when Bun is unavailable.",
+	"Install Bun 1.3.11+ or use `bunx wp-typia ...` for the full Bunli/OpenTUI runtime and Bun-only command surfaces such as `skills`, `completions`, and `mcp`.",
+];
 
 function printLine(line = "") {
 	console.log(line);
@@ -272,26 +263,17 @@ function renderGeneralHelp() {
 		"",
 		"Canonical CLI package for wp-typia scaffolding and project workflows.",
 		"",
-		"Supported without a local Bun binary:",
-		"- `wp-typia --version`",
-		"- `wp-typia --help`",
-		`- ${WP_TYPIA_CANONICAL_CREATE_USAGE} (non-interactive)`,
-		"- `wp-typia add <kind> ...` (non-interactive)",
-		`- ${WP_TYPIA_CANONICAL_MIGRATE_USAGE} (non-interactive)`,
-		"- `wp-typia doctor`",
-		"- `wp-typia sync`",
-		"- `wp-typia templates list`",
-		"- `wp-typia templates inspect --id <template-id>`",
+		...NODE_FALLBACK_RUNTIME_SUMMARY_LINES,
 		"",
 		"Commands:",
-		...WP_TYPIA_TOP_LEVEL_COMMAND_NAMES.map((command) => `- ${command}`),
+		...WP_TYPIA_FUTURE_COMMAND_TREE.map(
+			(command) => `- ${command.name}: ${command.description}`,
+		),
 		"",
 		"Canonical usage:",
 		`- ${WP_TYPIA_CANONICAL_CREATE_USAGE}`,
 		`- ${WP_TYPIA_CANONICAL_MIGRATE_USAGE}`,
 		`- ${WP_TYPIA_POSITIONAL_ALIAS_USAGE}`,
-		"",
-		"Install Bun 1.3.11+ or use `bunx wp-typia ...` for the full Bunli-powered interactive runtime.",
 	]);
 }
 
@@ -299,14 +281,10 @@ function renderTemplatesHelp() {
 	printBlock([
 		"wp-typia templates <list|inspect>",
 		"",
-		"Node fallback support:",
-		`- ${WP_TYPIA_CANONICAL_CREATE_USAGE} (non-interactive)`,
-		"- `wp-typia add <kind> ...` (non-interactive)",
-		`- ${WP_TYPIA_CANONICAL_MIGRATE_USAGE} (non-interactive)`,
-		"- `wp-typia doctor`",
-		"- `wp-typia sync`",
-		"- `wp-typia templates list`",
-		"- `wp-typia templates inspect --id <template-id>`",
+		...NODE_FALLBACK_RUNTIME_SUMMARY_LINES,
+		"",
+		"Supported flags:",
+		...formatNodeFallbackOptionHelp(TEMPLATES_OPTION_METADATA),
 	]);
 }
 
@@ -314,25 +292,10 @@ function renderCreateHelp() {
 	printBlock([
 		`Usage: ${WP_TYPIA_CANONICAL_CREATE_USAGE}`,
 		"",
-		"Supported non-interactive flags:",
-		"--template",
-		"--variant",
-		"--namespace",
-		"--php-prefix",
-		"--text-domain",
-		"--package-manager",
-		"--alternate-render-targets",
-		"--data-storage",
-		"--persistence-policy",
-		"--query-post-type",
-		"--external-layer-source",
-		"--external-layer-id",
-		"--with-migration-ui",
-		"--with-test-preset",
-		"--with-wp-env",
-		"--no-install",
-		"--dry-run",
-		"--yes",
+		...NODE_FALLBACK_RUNTIME_SUMMARY_LINES,
+		"",
+		"Supported flags:",
+		...formatNodeFallbackOptionHelp(CREATE_OPTION_METADATA),
 	]);
 }
 
@@ -340,20 +303,21 @@ function renderAddHelp() {
 	printBlock([
 		"Usage: wp-typia add <kind> <name>",
 		"",
-		"Supported non-interactive flags:",
-		"--dry-run",
-		"--template",
-		"--alternate-render-targets",
-		"--data-storage",
-		"--persistence-policy",
-		"--external-layer-source",
-		"--external-layer-id",
-		"--block",
-		"--methods",
-		"--namespace",
-		"--anchor",
-		"--position",
-		"--slot",
+		...NODE_FALLBACK_RUNTIME_SUMMARY_LINES,
+		"",
+		"Supported flags:",
+		...formatNodeFallbackOptionHelp(ADD_OPTION_METADATA),
+	]);
+}
+
+function renderMigrateHelp() {
+	printBlock([
+		`Usage: ${WP_TYPIA_CANONICAL_MIGRATE_USAGE}`,
+		"",
+		...NODE_FALLBACK_RUNTIME_SUMMARY_LINES,
+		"",
+		"Supported flags:",
+		...formatNodeFallbackOptionHelp(MIGRATE_OPTION_METADATA),
 	]);
 }
 
@@ -478,6 +442,10 @@ export async function runNodeCli(argv = process.argv.slice(2)): Promise<void> {
 		}
 		if (command === "add") {
 			renderAddHelp();
+			return;
+		}
+		if (command === "migrate") {
+			renderMigrateHelp();
 			return;
 		}
 		renderGeneralHelp();

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -25,6 +25,26 @@ const doctorCommandSource = fs.readFileSync(
 	path.join(packageRoot, "src", "commands", "doctor.ts"),
 	"utf8",
 );
+const createCommandSource = fs.readFileSync(
+	path.join(packageRoot, "src", "commands", "create.ts"),
+	"utf8",
+);
+const addCommandSource = fs.readFileSync(
+	path.join(packageRoot, "src", "commands", "add.ts"),
+	"utf8",
+);
+const migrateCommandSource = fs.readFileSync(
+	path.join(packageRoot, "src", "commands", "migrate.ts"),
+	"utf8",
+);
+const templatesCommandSource = fs.readFileSync(
+	path.join(packageRoot, "src", "commands", "templates.ts"),
+	"utf8",
+);
+const nodeCliSource = fs.readFileSync(
+	path.join(packageRoot, "src", "node-cli.ts"),
+	"utf8",
+);
 const addFlowSource = fs.readFileSync(
 	path.join(packageRoot, "src", "ui", "add-flow.tsx"),
 	"utf8",
@@ -193,12 +213,20 @@ describe("wp-typia package", () => {
 		for (const commandName of WP_TYPIA_TOP_LEVEL_COMMAND_NAMES) {
 			expect(helpOutput).toContain(commandName);
 		}
+		expect(helpOutput).toContain("Runtime: Node fallback");
+		expect(helpOutput).toContain("create: Scaffold a new wp-typia project.");
 		expect(createHelpOutput).toContain("--external-layer-source");
 		expect(createHelpOutput).toContain("--external-layer-id");
 		expect(createHelpOutput).toContain("--alternate-render-targets");
+		expect(createHelpOutput).toContain(
+			"Default post type assigned to Query Loop variation scaffolds.",
+		);
 		expect(addHelpOutput).toContain("--external-layer-source");
 		expect(addHelpOutput).toContain("--external-layer-id");
 		expect(addHelpOutput).toContain("--alternate-render-targets");
+		expect(addHelpOutput).toContain(
+			"Document editor shell slot for editor-plugin workflows.",
+		);
 	});
 
 	test("renders a human-readable version line through the canonical bin", () => {
@@ -245,7 +273,7 @@ describe("wp-typia package", () => {
 		expect(helpResult.status).toBe(0);
 		expect(helpResult.stderr).toBe("");
 		expect(helpResult.stdout).toContain("Canonical CLI package for wp-typia scaffolding");
-		expect(helpResult.stdout).toContain("Supported without a local Bun binary:");
+		expect(helpResult.stdout).toContain("Runtime: Node fallback");
 		expect(createHelpResult.status).toBe(0);
 		expect(createHelpResult.stderr).toBe("");
 		expect(createHelpResult.stdout).toContain("--external-layer-source");
@@ -279,6 +307,16 @@ describe("wp-typia package", () => {
 		expect(result.stderr).not.toContain("requires Bun");
 		expect(fs.existsSync(path.join(targetDir, "package.json"))).toBe(true);
 		expect(fs.existsSync(path.join(targetDir, "src", "block.json"))).toBe(true);
+	});
+
+	test("derives Bunli and Node fallback option metadata from the same source", () => {
+		expect(createCommandSource).toContain("buildCommandOptions(CREATE_OPTION_METADATA)");
+		expect(addCommandSource).toContain("buildCommandOptions(ADD_OPTION_METADATA)");
+		expect(migrateCommandSource).toContain("buildCommandOptions(MIGRATE_OPTION_METADATA)");
+		expect(templatesCommandSource).toContain("buildCommandOptions(TEMPLATES_OPTION_METADATA)");
+		expect(nodeCliSource).toContain('from "./command-option-metadata"');
+		expect(nodeCliSource).toContain("formatNodeFallbackOptionHelp(CREATE_OPTION_METADATA)");
+		expect(nodeCliSource).toContain("formatNodeFallbackOptionHelp(ADD_OPTION_METADATA)");
 	});
 
 	test("packs a built dist-bunli runtime for the published CLI entrypoint", () => {

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -218,15 +218,11 @@ describe("wp-typia package", () => {
 		expect(createHelpOutput).toContain("--external-layer-source");
 		expect(createHelpOutput).toContain("--external-layer-id");
 		expect(createHelpOutput).toContain("--alternate-render-targets");
-		expect(createHelpOutput).toContain(
-			"Default post type assigned to Query Loop variation scaffolds.",
-		);
+		expect(createHelpOutput).toContain("Query Loop");
 		expect(addHelpOutput).toContain("--external-layer-source");
 		expect(addHelpOutput).toContain("--external-layer-id");
 		expect(addHelpOutput).toContain("--alternate-render-targets");
-		expect(addHelpOutput).toContain(
-			"Document editor shell slot for editor-plugin workflows.",
-		);
+		expect(addHelpOutput).toContain("editor-plugin");
 	});
 
 	test("renders a human-readable version line through the canonical bin", () => {
@@ -317,6 +313,8 @@ describe("wp-typia package", () => {
 		expect(nodeCliSource).toContain('from "./command-option-metadata"');
 		expect(nodeCliSource).toContain("formatNodeFallbackOptionHelp(CREATE_OPTION_METADATA)");
 		expect(nodeCliSource).toContain("formatNodeFallbackOptionHelp(ADD_OPTION_METADATA)");
+		expect(nodeCliSource).toContain("formatNodeFallbackOptionHelp(MIGRATE_OPTION_METADATA)");
+		expect(nodeCliSource).toContain("formatNodeFallbackOptionHelp(TEMPLATES_OPTION_METADATA)");
 	});
 
 	test("packs a built dist-bunli runtime for the published CLI entrypoint", () => {


### PR DESCRIPTION
## Context

The Node fallback path still had a few places where Bunli and the Bun-free runtime could drift: help output still routed through the machine-oriented Bunli surface when Bun was available, option metadata lived in separate definitions, and runtime identity was still under-documented at the point users feel it.

## What Changed

- added a shared `command-option-metadata.ts` module so Bunli command definitions, `command-contract.ts`, and the Node fallback parser/help surface all derive string/boolean flags from the same source
- updated the canonical Node bin so common `--help` invocations stay on the human-readable Node fallback, while Bun-only command families like `skills`, `completions`, and `mcp` still route to the full Bunli runtime
- expanded Node fallback help/documentation coverage with runtime identity lines, command-specific option descriptions, README guidance, and boundary tests that lock the shared metadata path in place

## Verification

- `bun run --filter wp-typia build`
- `bun test packages/wp-typia/tests/cli-package.test.ts`
- `bun run typecheck`
- `bun run changesets:validate`

Closes #486


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved help invocation incorrectly triggering Bun execution on Node fallback systems.

* **Documentation**
  * Help text now clearly displays "Runtime: Node fallback" status.
  * Improved consistency of command-specific help output across all CLI surfaces.
  * Updated documentation with Node fallback runtime details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->