### PR TITLE
Polish scaffold onboarding output and verification guidance

### DIFF
--- a/.sampo/changesets/issue-487-onboarding-guidance.md
+++ b/.sampo/changesets/issue-487-onboarding-guidance.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Polish scaffold onboarding so create-time output and generated READMEs make `wp-typia doctor` easier to discover, keep sync notes shorter, and favor the default workspace quick-start path over more specialized first-run examples.

--- a/packages/wp-typia-project-tools/src/runtime/package-versions.ts
+++ b/packages/wp-typia-project-tools/src/runtime/package-versions.ts
@@ -15,11 +15,13 @@ interface PackageVersions {
 	blockTypesPackageVersion: string;
 	projectToolsPackageVersion: string;
 	restPackageVersion: string;
+	wpTypiaPackageExactVersion: string;
 	wpTypiaPackageVersion: string;
 }
 
 const require = createRequire(import.meta.url);
 const DEFAULT_VERSION_RANGE = "^0.0.0";
+const DEFAULT_EXACT_VERSION = "0.0.0";
 
 let cachedPackageVersions: PackageVersions | null = null;
 
@@ -39,6 +41,17 @@ function normalizeVersionRange(value: string | undefined): string {
 	}
 
 	return /^[~^<>=]/.test(trimmed) ? trimmed : `^${trimmed}`;
+}
+
+function normalizeExactVersion(value: string | undefined): string {
+	const trimmed = value?.trim();
+	if (!trimmed) {
+		return DEFAULT_EXACT_VERSION;
+	}
+	if (trimmed.startsWith("workspace:")) {
+		return DEFAULT_EXACT_VERSION;
+	}
+	return trimmed.replace(/^[~^<>=]+/, "");
 }
 
 function readPackageManifest(packageJsonPath: string): PackageManifest | null {
@@ -104,6 +117,7 @@ export function getPackageVersions(): PackageVersions {
 			createManifest.dependencies?.["@wp-typia/rest"] ??
 				resolveInstalledPackageManifest("@wp-typia/rest")?.version,
 		),
+		wpTypiaPackageExactVersion: normalizeExactVersion(wpTypiaManifest.version),
 		wpTypiaPackageVersion: normalizeVersionRange(wpTypiaManifest.version),
 	};
 

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-documents.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-documents.ts
@@ -11,9 +11,11 @@ import {
 } from './scaffold-onboarding.js';
 import type { PackageManagerId } from './package-managers.js';
 import {
+  formatPackageExecCommand,
   formatInstallCommand,
   formatRunScript,
 } from './package-managers.js';
+import { getPackageVersions } from './package-versions.js';
 import type { ScaffoldTemplateVariables } from './scaffold.js';
 
 /**
@@ -120,6 +122,11 @@ ${getQuickStartWorkflowNote(packageManager, templateId, {
 \`\`\`bash
 ${formatRunScript(packageManager, 'build')}
 ${formatRunScript(packageManager, 'typecheck')}
+${formatPackageExecCommand(
+    packageManager,
+    `wp-typia@${getPackageVersions().wpTypiaPackageExactVersion}`,
+    'doctor',
+  )}
 \`\`\`
 
 ${advancedSyncSection}

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-onboarding.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-onboarding.ts
@@ -1,5 +1,9 @@
-import { formatRunScript } from "./package-managers.js";
+import {
+	formatPackageExecCommand,
+	formatRunScript,
+} from "./package-managers.js";
 import type { PackageManagerId } from "./package-managers.js";
+import { getPackageVersions } from "./package-versions.js";
 import { getPrimaryDevelopmentScript } from "./local-dev-presets.js";
 import {
 	OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE,
@@ -28,6 +32,14 @@ const INITIAL_COMMIT_COMMANDS = [
 	"git add .",
 	'git commit -m "Initial scaffold"',
 ] as const;
+
+function getDoctorVerificationCommand(packageManager: PackageManagerId): string {
+	return formatPackageExecCommand(
+		packageManager,
+		`wp-typia@${getPackageVersions().wpTypiaPackageExactVersion}`,
+		"doctor",
+	);
+}
 
 function templateHasPersistenceSync(
 	templateId: string,
@@ -90,8 +102,10 @@ export function getQuickStartWorkflowNote(
 	templateId = "basic",
 	options: SyncOnboardingOptions = {},
 ): string {
+	const doctorCommand = getDoctorVerificationCommand(packageManager);
+
 	if (templateId === "query-loop") {
-		return `${formatRunScript(packageManager, "dev")} runs the editor build/watch loop that registers your Query Loop variation in the block editor. This scaffold is editor-facing by design and intentionally skips \`src/types.ts\`, \`block.json\`, and Typia manifest generation because the source of truth lives in the variation registration flow instead of a standalone block contract. Update \`src/index.ts\` when you want to change the variation namespace, default query, allowed controls, or the minimal inline starter layout, update \`src/patterns/*.php\` when you want richer connected layout presets in the inserter, use \`src/query-extension.ts\` when the variation needs custom query params or optional editor-side hooks, and mirror frontend/editor preview query mapping in \`inc/query-runtime.php\`.`;
+		return `${formatRunScript(packageManager, "dev")} runs the editor build/watch loop that registers your Query Loop variation in the block editor. This scaffold intentionally skips \`src/types.ts\`, \`block.json\`, and Typia manifests because the source of truth lives in the variation registration flow. Update \`src/index.ts\` for variation defaults, \`src/patterns/*.php\` for richer connected layouts, \`src/query-extension.ts\` for custom query params, and \`inc/query-runtime.php\` for frontend/editor preview parity. Use ${doctorCommand} when you want a quick environment and workspace sanity check.`;
 	}
 
 	const developmentScript = getPrimaryDevelopmentScript(templateId);
@@ -99,18 +113,18 @@ export function getQuickStartWorkflowNote(
 	const startCommand = formatRunScript(packageManager, "start");
 
 	if (developmentScript === "start") {
-		return `${startCommand} is the primary local entry point for this template. If the template also exposes a dedicated watch mode or alternate editor workflow, follow that template-specific documentation alongside the generated project scripts.`;
+		return `${startCommand} is the primary local entry point for this template. Use ${doctorCommand} when you want a quick environment and workspace sanity check before build or commit.`;
 	}
 
 	if (developmentScript !== "dev") {
-		return `${devCommand} is the primary local entry point for this template. Use ${startCommand} when you want the scaffold's one-shot startup flow instead of the watch-oriented workflow.`;
+		return `${devCommand} is the primary local entry point for this template. Use ${startCommand} for the one-shot startup flow, and ${doctorCommand} when you want a quick verification pass before build or commit.`;
 	}
 
 	if (templateHasPersistenceSync(templateId, options)) {
-		return `${devCommand} keeps the editor, type-derived artifacts, and REST-derived artifacts moving together during local development. Use ${startCommand} when you want a one-shot sync plus editor startup without the long-running watch loop.`;
+		return `${devCommand} keeps the editor, type-derived artifacts, and REST-derived artifacts moving together during local development. Use ${startCommand} for a one-shot sync plus editor startup, and ${doctorCommand} when you want an explicit verification pass before build or commit.`;
 	}
 
-	return `${devCommand} keeps the editor and type-derived artifacts moving together during local development. Use ${startCommand} when you want a one-shot sync plus editor startup without the long-running watch loop.`;
+	return `${devCommand} keeps the editor and type-derived artifacts moving together during local development. Use ${startCommand} for a one-shot sync plus editor startup, and ${doctorCommand} when you want an explicit verification pass before build or commit.`;
 }
 
 /**
@@ -121,8 +135,10 @@ export function getOptionalOnboardingNote(
 	templateId = "basic",
 	options: SyncOnboardingOptions = {},
 ): string {
+	const doctorCommand = getDoctorVerificationCommand(packageManager);
+
 	if (templateId === "query-loop") {
-		return `This scaffold does not generate \`src/types.ts\`, a \`sync\` script, \`block.json\`, or Typia manifests because it owns a \`core/query\` variation rather than a standalone block. Edit \`src/index.ts\` to change the variation contract, edit \`src/patterns/*.php\` when you want richer connected layouts beyond the inline fallback, edit \`src/query-extension.ts\` when you need variation-specific query params or custom editor hooks, and edit \`inc/query-runtime.php\` when those params need frontend or editor preview parity. Then rerun ${formatRunScript(packageManager, "build")}, ${formatRunScript(packageManager, "dev")}, or ${formatRunScript(packageManager, "typecheck")} as needed.`;
+		return `This scaffold owns a \`core/query\` variation, so it does not generate a \`sync\` script, \`src/types.ts\`, \`block.json\`, or Typia manifests. Edit \`src/index.ts\`, \`src/patterns/*.php\`, \`src/query-extension.ts\`, and \`inc/query-runtime.php\` as needed, then rerun ${formatRunScript(packageManager, "build")}, ${formatRunScript(packageManager, "typecheck")}, or ${doctorCommand}.`;
 	}
 
 	const optionalSyncScripts = getOptionalSyncScriptNames(templateId, options);
@@ -154,7 +170,7 @@ export function getOptionalOnboardingNote(
 		"--strict --report json",
 	);
 	const advancedPersistenceNote = templateHasPersistenceSync(templateId, options)
-		? ` ${syncRestCommand} remains available for advanced REST-only refreshes, but it now fails fast when type-derived artifacts are stale; run \`${syncCommand}\` or \`${syncTypesCommand}\` first.`
+		? ` ${syncRestCommand} remains available for REST-only refreshes after ${syncTypesCommand}.`
 		: "";
 	const isCustomTemplate =
 		!isBuiltInTemplateId(templateId) &&
@@ -167,14 +183,14 @@ export function getOptionalOnboardingNote(
 			: null;
 
 	if (fallbackCustomTemplateNote) {
-		return fallbackCustomTemplateNote;
+		return `${fallbackCustomTemplateNote} Use ${doctorCommand} when you want a quick environment and workspace sanity check.`;
 	}
 
 	if (isCustomTemplate && syncSteps.length === 0) {
-		return "No optional sync command was detected for this custom template. Follow the template's own artifact-refresh guidance before build, typecheck, or your first commit.";
+		return `No optional sync command was detected for this custom template. Use ${doctorCommand} for a quick environment and workspace sanity check, then follow the template's own artifact-refresh guidance before build, typecheck, or your first commit.`;
 	}
 
-	return `You usually do not need to run ${syncCommand} during a normal ${formatRunScript(packageManager, developmentScript)} session. Run ${syncCommand} manually when you want a reviewable artifact refresh before ${formatRunScript(packageManager, "build")}, ${typecheckCommand}, or your first commit. ${syncTypesCommand} stays warn-only by default; use \`${failOnLossySyncCommand}\` to fail only on lossy WordPress projections, or \`${strictSyncCommand}\` for the stricter CI-oriented report.${advancedPersistenceNote} They do not create migration history. If this directory is new, create your first Git commit after that refresh.`;
+	return `You usually do not need to run ${syncCommand} during a normal ${formatRunScript(packageManager, developmentScript)} session. Run ${syncCommand} before ${formatRunScript(packageManager, "build")}, ${typecheckCommand}, or ${doctorCommand} when you want a reviewable refresh. ${syncTypesCommand} stays warn-only by default; use \`${failOnLossySyncCommand}\` or \`${strictSyncCommand}\` for stricter CI checks.${advancedPersistenceNote} Generated syncs do not create migration history, so refresh before your first commit if this directory is new.`;
 }
 
 /**

--- a/packages/wp-typia-project-tools/tests/cli-entry.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-entry.test.ts
@@ -269,11 +269,13 @@ test("optional onboarding derives sync steps from available custom-template scri
     "npm run sync-rest",
   ]);
   expect(onboarding.note).toContain(
-    "Run npm run sync-types then npm run sync-rest manually before build, typecheck, or commit."
+    "Run npm run sync-types then npm run sync-rest manually before build, typecheck"
   );
   expect(onboarding.note).toContain(
     "npm run sync-types -- --check verifies the current type-derived artifacts without rewriting them."
   );
+  expect(onboarding.note).toContain("npx --yes wp-typia@");
+  expect(onboarding.note).toContain("doctor");
   expect(onboarding.note).not.toContain("npm run sync -- --check");
 });
 
@@ -288,6 +290,8 @@ test("optional onboarding avoids synthesized sync commands for custom templates 
   expect(onboarding.note).toContain(
     "No optional sync command was detected for this custom template."
   );
+  expect(onboarding.note).toContain("npx --yes wp-typia@");
+  expect(onboarding.note).toContain("doctor");
   expect(onboarding.note).not.toContain("npm run sync");
   expect(onboarding.note).not.toContain("npm run sync-types");
 });
@@ -682,7 +686,7 @@ test("node entry exposes templates and doctor commands", () => {
 test("node entry supports the explicit create command", () => {
   const targetDir = path.join(tempRoot, "demo-node-create-command");
 
-  runCli("node", [
+  const output = runCli("node", [
     entryPath,
     "create",
     targetDir,
@@ -696,6 +700,9 @@ test("node entry supports the explicit create command", () => {
 
   expect(fs.existsSync(path.join(targetDir, "package.json"))).toBe(true);
   expect(fs.existsSync(path.join(targetDir, "src", "block.json"))).toBe(true);
+  expect(output).toContain("Verify and sync (optional):");
+  expect(output).toContain("npx --yes wp-typia@");
+  expect(output).toContain("doctor");
 });
 
 test("node entry supports dry-run create previews without writing files", () => {

--- a/packages/wp-typia-project-tools/tests/scaffold-basic.test.ts
+++ b/packages/wp-typia-project-tools/tests/scaffold-basic.test.ts
@@ -296,6 +296,9 @@ describe('@wp-typia/project-tools scaffold core', () => {
       expect(readme).toContain('npm run start');
       expect(readme).toContain('## Quick Start');
       expect(readme).toContain('## Build and Verify');
+      expect(readme).toContain(
+        `npx --yes wp-typia@${wpTypiaPackageManifest.version} doctor`,
+      );
       expect(readme).toContain('## Advanced Sync');
       expect(readme).toContain('## Before First Commit');
       expect(readme).toContain('npm run sync');

--- a/packages/wp-typia-project-tools/tests/scaffold-compound.test.ts
+++ b/packages/wp-typia-project-tools/tests/scaffold-compound.test.ts
@@ -11,6 +11,7 @@ import {
   restPackageVersion,
   runGeneratedScript,
   typecheckGeneratedProject,
+  wpTypiaPackageManifest,
 } from './helpers/scaffold-test-harness.js';
 import { scaffoldProject } from '../src/runtime/index.js';
 import { applyMigrationUiCapability } from '../src/runtime/migration-ui-capability.js';
@@ -405,6 +406,9 @@ describe('@wp-typia/project-tools scaffold compound', () => {
       expect(readme).not.toContain('npm run sync-rest');
       expect(readme).toContain('npm run dev');
       expect(readme).toContain('## Quick Start');
+      expect(readme).toContain(
+        `npx --yes wp-typia@${wpTypiaPackageManifest.version} doctor`,
+      );
       expect(readme).toContain('## Advanced Sync');
       expect(readme).toContain('## Before First Commit');
       expect(readme).toContain('src/blocks/*/types.ts');
@@ -987,6 +991,9 @@ describe('@wp-typia/project-tools scaffold compound', () => {
       expect(readme).toContain('npm run sync');
       expect(readme).toContain('npm run sync-rest');
       expect(readme).toContain('## Quick Start');
+      expect(readme).toContain(
+        `npx --yes wp-typia@${wpTypiaPackageManifest.version} doctor`,
+      );
       expect(readme).toContain('## Advanced Sync');
       expect(readme).toContain('## Before First Commit');
       expect(readme).toContain('src/blocks/*/api-types.ts');

--- a/packages/wp-typia-project-tools/tests/scaffold-persistence.test.ts
+++ b/packages/wp-typia-project-tools/tests/scaffold-persistence.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, describe, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { apiClientPackageVersion, cleanupScaffoldTempRoot, createScaffoldTempRoot, getCommandErrorMessage, replaceGeneratedTransportBaseUrls, restPackageVersion, runGeneratedJsonScript, runGeneratedJsonScriptAsync, runGeneratedScript, startLocalCounterStubServer, typecheckGeneratedProject } from "./helpers/scaffold-test-harness.js";
+import { apiClientPackageVersion, cleanupScaffoldTempRoot, createScaffoldTempRoot, getCommandErrorMessage, replaceGeneratedTransportBaseUrls, restPackageVersion, runGeneratedJsonScript, runGeneratedJsonScriptAsync, runGeneratedScript, startLocalCounterStubServer, typecheckGeneratedProject, wpTypiaPackageManifest } from "./helpers/scaffold-test-harness.js";
 import { scaffoldProject } from "../src/runtime/index.js";
 
 describe("@wp-typia/project-tools scaffold persistence", () => {
@@ -720,6 +720,9 @@ test(
   expect(readme).toContain("## Quick Start");
   expect(readme).toContain("## Advanced Sync");
   expect(readme).toContain("## Before First Commit");
+  expect(readme).toContain(
+    `npx --yes wp-typia@${wpTypiaPackageManifest.version} doctor`
+  );
   expect(readme).toContain("## PHP REST Extension Points");
   expect(readme).toContain("Edit `demo-persistence-authenticated.php`");
   expect(readme).toContain(

--- a/packages/wp-typia/README.md
+++ b/packages/wp-typia/README.md
@@ -2,12 +2,15 @@
 
 Canonical CLI package for `wp-typia`.
 
-Use this package for new installs:
+Use this package for new projects:
 
 - `npx wp-typia create my-block`
-- `npx wp-typia create my-books --template query-loop --query-post-type book`
 - `bunx wp-typia create my-block`
-- `npx wp-typia create my-plugin --template @wp-typia/create-workspace-template`
+- `npx wp-typia create my-plugin --template workspace`
+- `npx wp-typia create my-books --template query-loop --query-post-type book`
+
+Extend an existing workspace with:
+
 - `wp-typia add block counter-card --template basic`
 - `wp-typia add binding-source hero-data`
 - `wp-typia add rest-resource snapshots --namespace my-plugin/v1 --methods list,read,create`

--- a/packages/wp-typia/src/runtime-bridge-output.ts
+++ b/packages/wp-typia/src/runtime-bridge-output.ts
@@ -1,3 +1,5 @@
+import packageJson from "../package.json";
+import { formatPackageExecCommand } from "@wp-typia/project-tools/package-managers";
 import type { AlternateBufferCompletionPayload } from "./ui/alternate-buffer-lifecycle";
 
 type PrintLine = (line: string) => void;
@@ -89,6 +91,7 @@ export function buildCreateCompletionPayload(flow: {
 		note: string;
 		steps: string[];
 	};
+	packageManager: string;
 	projectDir: string;
 	result: {
 		selectedVariant?: string | null;
@@ -98,14 +101,20 @@ export function buildCreateCompletionPayload(flow: {
 		warnings: string[];
 	};
 }): AlternateBufferCompletionPayload {
+	const verificationSteps = [
+		formatPackageExecCommand(
+			flow.packageManager as "bun" | "npm" | "pnpm" | "yarn",
+			`wp-typia@${packageJson.version}`,
+			"doctor",
+		),
+		...flow.optionalOnboarding.steps,
+	];
+
 	return {
 		nextSteps: flow.nextSteps,
-		optionalLines:
-			flow.optionalOnboarding.steps.length > 0 ? flow.optionalOnboarding.steps : undefined,
-		optionalNote:
-			flow.optionalOnboarding.steps.length > 0 ? flow.optionalOnboarding.note : undefined,
-		optionalTitle:
-			flow.optionalOnboarding.steps.length > 0 ? "Advanced sync (optional):" : undefined,
+		optionalLines: verificationSteps,
+		optionalNote: flow.optionalOnboarding.note,
+		optionalTitle: "Verify and sync (optional):",
 		preambleLines: flow.result.selectedVariant
 			? [`Template variant: ${flow.result.selectedVariant}`]
 			: undefined,

--- a/packages/wp-typia/tests/completion-output.test.ts
+++ b/packages/wp-typia/tests/completion-output.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import packageJson from "../package.json";
 
 import {
 	buildCreateCompletionPayload,
@@ -16,6 +17,7 @@ describe("alternate-buffer completion output helpers", () => {
 				note: "Run npm run sync before your first commit if you edited types.",
 				steps: ["npm run sync"],
 			},
+			packageManager: "npm",
 			projectDir: "/tmp/demo-block",
 			result: {
 				selectedVariant: "hero",
@@ -30,8 +32,11 @@ describe("alternate-buffer completion output helpers", () => {
 		expect(payload.preambleLines).toEqual(["Template variant: hero"]);
 		expect(payload.warningLines).toEqual(["This template enables optional migration UI."]);
 		expect(payload.nextSteps).toEqual(["cd demo-block", "npm install", "npm run dev"]);
-		expect(payload.optionalTitle).toBe("Advanced sync (optional):");
-		expect(payload.optionalLines).toEqual(["npm run sync"]);
+		expect(payload.optionalTitle).toBe("Verify and sync (optional):");
+		expect(payload.optionalLines).toEqual([
+			`npx --yes wp-typia@${packageJson.version} doctor`,
+			"npm run sync",
+		]);
 		expect(payload.optionalNote).toContain("npm run sync");
 	});
 
@@ -42,9 +47,12 @@ describe("alternate-buffer completion output helpers", () => {
 		printCompletionPayload(
 			{
 				nextSteps: ["cd demo-block", "npm install"],
-				optionalLines: ["npm run sync"],
+				optionalLines: [
+					`npx --yes wp-typia@${packageJson.version} doctor`,
+					"npm run sync",
+				],
 				optionalNote: "Review the generated metadata before first commit.",
-				optionalTitle: "Advanced sync (optional):",
+				optionalTitle: "Verify and sync (optional):",
 				preambleLines: ["Template variant: hero"],
 				summaryLines: ["Project directory: /tmp/demo-block"],
 				title: "✅ Created Demo Block in /tmp/demo-block",
@@ -64,7 +72,8 @@ describe("alternate-buffer completion output helpers", () => {
 			"Next steps:",
 			"  cd demo-block",
 			"  npm install",
-			"\nAdvanced sync (optional):",
+			"\nVerify and sync (optional):",
+			`  npx --yes wp-typia@${packageJson.version} doctor`,
 			"  npm run sync",
 			"Note: Review the generated metadata before first commit.",
 		]);

--- a/tests/unit/package-versions.test.ts
+++ b/tests/unit/package-versions.test.ts
@@ -27,6 +27,7 @@ async function importPackageVersionsModule(options: {
 		blockTypesPackageVersion: string;
 		projectToolsPackageVersion: string;
 		restPackageVersion: string;
+		wpTypiaPackageExactVersion: string;
 		wpTypiaPackageVersion: string;
 	};
 }> {
@@ -89,6 +90,7 @@ describe("package version helpers", () => {
 			blockTypesPackageVersion: "^2.3.4",
 			projectToolsPackageVersion: "^4.5.6",
 			restPackageVersion: "^3.4.5",
+			wpTypiaPackageExactVersion: "0.0.0",
 			wpTypiaPackageVersion: "^0.0.0",
 		});
 	});
@@ -119,6 +121,7 @@ describe("package version helpers", () => {
 			blockTypesPackageVersion: "^2.3.4",
 			projectToolsPackageVersion: "^4.5.6",
 			restPackageVersion: "^3.4.5",
+			wpTypiaPackageExactVersion: "0.0.0",
 			wpTypiaPackageVersion: "^0.0.0",
 		});
 	});
@@ -153,6 +156,7 @@ describe("package version helpers", () => {
 			blockTypesPackageVersion: "^0.3.0",
 			projectToolsPackageVersion: "^0.8.0",
 			restPackageVersion: "~0.4.0",
+			wpTypiaPackageExactVersion: "0.8.0",
 			wpTypiaPackageVersion: "^0.8.0",
 		});
 	});
@@ -179,6 +183,7 @@ describe("package version helpers", () => {
 		});
 
 		expect(module.getPackageVersions().wpTypiaPackageVersion).toBe("^0.12.0");
+		expect(module.getPackageVersions().wpTypiaPackageExactVersion).toBe("0.12.0");
 		expect(module.getPackageVersions().projectToolsPackageVersion).toBe("^1.0.0");
 	});
 
@@ -205,6 +210,7 @@ describe("package version helpers", () => {
 			blockTypesPackageVersion: "^0.2.0",
 			projectToolsPackageVersion: "^0.11.0",
 			restPackageVersion: "^0.3.1",
+			wpTypiaPackageExactVersion: "0.0.0",
 			wpTypiaPackageVersion: "^0.0.0",
 		});
 	});
@@ -227,6 +233,7 @@ describe("package version helpers", () => {
 			blockTypesPackageVersion: "^0.0.0",
 			projectToolsPackageVersion: "^0.0.0",
 			restPackageVersion: "^0.0.0",
+			wpTypiaPackageExactVersion: "0.0.0",
 			wpTypiaPackageVersion: "^0.0.0",
 		});
 		expect(secondResult).toBe(firstResult);


### PR DESCRIPTION
## Context

The v0.18 review showed that first-run guidance is much better than before, but `doctor` is still easy to miss, some completion paths still bury the most important follow-up commands, and the package README still over-indexes on more specialized examples instead of the default first-run path.

## What Changed

- promoted `wp-typia doctor` into scaffold verification guidance by surfacing it in create completion payloads and generated README `Build and Verify` sections
- shortened onboarding copy in `scaffold-onboarding.ts` so sync guidance stays readable while still covering stricter sync modes and custom-template edge cases
- updated onboarding-related tests to lock the new verification/sync wording in place and split the package README examples into clearer “new project” vs “extend an existing workspace” groups, including the short `--template workspace` path

## Verification

- `bun run --filter @wp-typia/project-tools build`
- `bun run --filter wp-typia build`
- `bun test packages/wp-typia/tests/completion-output.test.ts packages/wp-typia-project-tools/tests/cli-entry.test.ts packages/wp-typia-project-tools/tests/scaffold-basic.test.ts packages/wp-typia-project-tools/tests/scaffold-persistence.test.ts packages/wp-typia-project-tools/tests/scaffold-compound.test.ts`
- `bun run typecheck`
- `bun run changesets:validate`

Closes #487


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated automated verification into project scaffolding onboarding guidance for improved setup validation and faster error detection.

* **Documentation**
  * Updated README with clearer examples and simplified workspace template references for new projects.
  * Streamlined scaffolding onboarding guidance with improved workspace synchronization instructions, shorter verification workflows, and enhanced quick-start paths across all generated project types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->