### PR TITLE
Trim the published wp-typia CLI footprint

### DIFF
--- a/.sampo/changesets/issue-488-package-footprint-audit.md
+++ b/.sampo/changesets/issue-488-package-footprint-audit.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Trim the published `wp-typia` CLI tarball so Bunli/OpenTUI runtime assets stay under `dist-bunli/.bunli/` and repo-only build inputs like `bunli.config.ts` no longer ship to npm.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,8 +203,8 @@ If you want to move `typescript` out of `dependencies` for `@wp-typia/block-runt
 
 Published package size is intentional, but it still needs regular review.
 
-- `wp-typia` should only ship the canonical `bin/wp-typia.js` launcher plus the built `dist-bunli/` runtime. Repo-only inputs such as `bunli.config.ts` should stay out of the published file list.
-- Bunli/OpenTUI runtime assets should resolve from `dist-bunli/.bunli/` in the packed CLI tarball. Avoid publishing repo-specific absolute-path asset trees under `dist-bunli/Users/...`.
+- `wp-typia` should publish only the runtime assets needed by the CLI (for example `bin/wp-typia.js` and `dist-bunli/`) plus standard npm metadata such as `package.json`, `README.md`, and `LICENSE`. Repo-only inputs such as `bunli.config.ts` should stay out of the published file list.
+- Bunli/OpenTUI runtime assets should resolve from `dist-bunli/.bunli/` in the packed CLI tarball. Avoid publishing repo-specific absolute-path asset trees under `dist-bunli/<home-root>/...`.
 - `@wp-typia/project-tools` still ships `templates/` and keeps `typescript` in `dependencies` intentionally, because published scaffolding and workspace inventory paths rely on those runtime inputs today.
 
 When you change package metadata or build output layout, verify the packed surface directly with `npm pack --dry-run --json ./packages/<name>` before opening the PR.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -199,6 +199,16 @@ This is enforced by `bun run typescript-runtime:validate` in local CI and GitHub
 
 If you want to move `typescript` out of `dependencies` for `@wp-typia/block-runtime` or `@wp-typia/project-tools`, first remove the runtime compiler-API usage itself. A dependency-only manifest edit without that refactor is not safe.
 
+## Published package footprint
+
+Published package size is intentional, but it still needs regular review.
+
+- `wp-typia` should only ship the canonical `bin/wp-typia.js` launcher plus the built `dist-bunli/` runtime. Repo-only inputs such as `bunli.config.ts` should stay out of the published file list.
+- Bunli/OpenTUI runtime assets should resolve from `dist-bunli/.bunli/` in the packed CLI tarball. Avoid publishing repo-specific absolute-path asset trees under `dist-bunli/Users/...`.
+- `@wp-typia/project-tools` still ships `templates/` and keeps `typescript` in `dependencies` intentionally, because published scaffolding and workspace inventory paths rely on those runtime inputs today.
+
+When you change package metadata or build output layout, verify the packed surface directly with `npm pack --dry-run --json ./packages/<name>` before opening the PR.
+
 ## Pull requests
 
 - Keep changes scoped and intentional.

--- a/packages/wp-typia/package.json
+++ b/packages/wp-typia/package.json
@@ -9,7 +9,6 @@
   },
   "files": [
     "bin/",
-    "bunli.config.ts",
     "dist-bunli/",
     "README.md",
     "package.json"

--- a/packages/wp-typia/scripts/build-bunli-runtime.ts
+++ b/packages/wp-typia/scripts/build-bunli-runtime.ts
@@ -21,7 +21,6 @@ const generatedMetadataEntrypoint = path.resolve(
   'commands.gen.ts',
 );
 const nodeRuntimeEntrypoint = path.resolve(packageRoot, 'src', 'node-cli.ts');
-const buildRoot = path.parse(packageRoot).root;
 const isLinkedInstalledWpTypiaRuntime = packageRoot.includes(
   `${path.sep}node_modules${path.sep}.bun${path.sep}`,
 );
@@ -295,12 +294,12 @@ async function buildFullBunliRuntime() {
     external: WP_TYPIA_EXTERNALS,
     format: 'esm',
     naming: {
-      asset: '[dir]/[name]-[hash].[ext]',
+      asset: '.bunli/[name]-[hash].[ext]',
       chunk: '[name]-[hash].[ext]',
       entry: '[name].[ext]',
     },
     outdir,
-    root: buildRoot,
+    root: packageRoot,
     sourcemap: buildConfig.sourcemap ? 'external' : 'none',
     // Keep the repo-owned runtime split so canonical help/completion flows
     // avoid eagerly resolving heavy external runtime packages, but collapse

--- a/packages/wp-typia/tests/bunli-prep.test.ts
+++ b/packages/wp-typia/tests/bunli-prep.test.ts
@@ -23,7 +23,7 @@ describe('wp-typia Bunli preparation', () => {
   test('checks in the Bunli prep tree while promoting a built CLI runtime', () => {
     expect(packageManifest.bin['wp-typia']).toBe('bin/wp-typia.js');
     expect(packageManifest.files).toContain('dist-bunli/');
-    expect(packageManifest.files).toContain('bunli.config.ts');
+    expect(packageManifest.files).not.toContain('bunli.config.ts');
     expect(packageManifest.scripts['bunli:build']).toBe('bun run build');
     expect(packageManifest.scripts['bunli:dev']).toBe('bun src/cli.ts');
     expect(packageManifest.scripts['bunli:test']).toBe(
@@ -109,19 +109,16 @@ describe('wp-typia Bunli preparation', () => {
       'wp-typia runtime alias artifacts still missing after rebuild',
     );
     expect(runtimeBuildScript).toContain(
-      'const buildRoot = path.parse(packageRoot).root;',
-    );
-    expect(runtimeBuildScript).toContain(
       'const isLinkedInstalledWpTypiaRuntime = packageRoot.includes(',
     );
     expect(runtimeBuildScript).toContain(
       "`${path.sep}node_modules${path.sep}.bun${path.sep}`",
     );
     expect(fullRuntimeSection).toContain("naming: {");
-    expect(fullRuntimeSection).toContain("asset: '[dir]/[name]-[hash].[ext]'");
+    expect(fullRuntimeSection).toContain("asset: '.bunli/[name]-[hash].[ext]'");
     expect(fullRuntimeSection).toContain("chunk: '[name]-[hash].[ext]'");
     expect(fullRuntimeSection).toContain("entry: '[name].[ext]'");
-    expect(fullRuntimeSection).toContain('root: buildRoot');
+    expect(fullRuntimeSection).toContain('root: packageRoot');
     expect(fullRuntimeSection).toContain(
       'splitting: !isLinkedInstalledWpTypiaRuntime',
     );

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -332,8 +332,17 @@ describe("wp-typia package", () => {
 		expect(tarball?.files.some((entry) => entry.path === "dist-bunli/.bunli/commands.gen.js")).toBe(
 			true,
 		);
+		expect(
+			tarball?.files.some((entry) =>
+				entry.path.startsWith("dist-bunli/.bunli/tree-sitter-"),
+			),
+		).toBe(true);
 		expect(tarball?.files.some((entry) => entry.path === "dist-bunli/node-cli.js")).toBe(true);
 		expect(tarball?.files.some((entry) => entry.path === "bin/wp-typia.js")).toBe(true);
+		expect(tarball?.files.some((entry) => entry.path === "bunli.config.ts")).toBe(false);
+		expect(
+			tarball?.files.some((entry) => entry.path.startsWith("dist-bunli/Users/")),
+		).toBe(false);
 		expect(tarball?.files.some((entry) => entry.path === ".bunli/commands.gen.ts")).toBe(false);
 		expect(tarball?.files.some((entry) => entry.path === "src/cli.ts")).toBe(false);
 

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -318,6 +318,7 @@ describe("wp-typia package", () => {
 	});
 
 	test("packs a built dist-bunli runtime for the published CLI entrypoint", () => {
+		const rootSegment = path.basename(os.homedir());
 		const packResult = runCapturedCommand("npm", ["pack", "--json", "--pack-destination", packageRoot], {
 			cwd: packageRoot,
 		});
@@ -341,7 +342,9 @@ describe("wp-typia package", () => {
 		expect(tarball?.files.some((entry) => entry.path === "bin/wp-typia.js")).toBe(true);
 		expect(tarball?.files.some((entry) => entry.path === "bunli.config.ts")).toBe(false);
 		expect(
-			tarball?.files.some((entry) => entry.path.startsWith("dist-bunli/Users/")),
+			tarball?.files.some((entry) =>
+				entry.path.startsWith(`dist-bunli/${rootSegment}/`),
+			),
 		).toBe(false);
 		expect(tarball?.files.some((entry) => entry.path === ".bunli/commands.gen.ts")).toBe(false);
 		expect(tarball?.files.some((entry) => entry.path === "src/cli.ts")).toBe(false);


### PR DESCRIPTION
## Context
Issue #488 called for a deliberate audit of the published CLI footprint and runtime dependency tradeoffs. The immediate safe wins were in the `wp-typia` tarball itself: repo-only build inputs were still being published, and Bunli/OpenTUI assets were leaking into repo-specific absolute-path directories inside `dist-bunli/`.

## What Changed
- removed `bunli.config.ts` from the published `wp-typia` file list while keeping it in-repo for local build orchestration
- normalized Bunli/OpenTUI asset output so the packed CLI tarball keeps those assets under `dist-bunli/.bunli/` instead of publishing `dist-bunli/Users/...` absolute-path trees
- tightened the `wp-typia` pack contract tests to assert the slimmer tarball surface directly
- documented the current published-footprint and intentional TypeScript runtime tradeoffs in `CONTRIBUTING.md`

## Verification
- `bun run --filter wp-typia build`
- `bun test packages/wp-typia/tests/bunli-prep.test.ts packages/wp-typia/tests/cli-package.test.ts`
- `npm pack --dry-run --json ./packages/wp-typia`
- `node packages/wp-typia/bin/wp-typia.js --version`
- `node packages/wp-typia/bin/wp-typia.js --help`
- `bun run typecheck`
- `bun run docs:build:site`
- `node scripts/run-generated-project-smoke.mjs --runtime bun --example-project my-typia-block --package-manager bun --project-name smoke-reference-my-typia-block-bun-footprint`
- `bun run changesets:validate`

Closes #488


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified published package distribution to exclude build configuration files
  * Updated runtime asset organization to use centralized directory structure
  * Added package footprint documentation specifying included files for published artifacts
  * Updated build configuration and tests to reflect new packaging structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->