### PR TITLE
Prefer metadata-owned static constraints in compound scaffolds

### DIFF
--- a/.sampo/changesets/issue-499-metadata-owned-nested-constraints.md
+++ b/.sampo/changesets/issue-499-metadata-owned-nested-constraints.md
@@ -1,0 +1,8 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Clarify compound nested block ownership so static child constraints stay metadata-owned.
+
+Generated compound parent and nested child editors now rely on `block.json` for static `allowedBlocks`, `parent`, and `ancestor` relationships, while `children.ts` stays focused on editor-only preset behavior such as `template`, `defaultBlock`, `orientation`, `templateLock`, and `directInsert`.

--- a/packages/wp-typia-project-tools/src/runtime/built-in-block-code-templates/compound-child.ts
+++ b/packages/wp-typia-project-tools/src/runtime/built-in-block-code-templates/compound-child.ts
@@ -63,7 +63,6 @@ export default function Edit( {
 \t\t\t{ showsNestedChildren && (
 \t\t\t\t<div className="{{compoundChildCssClassName}}__children">
 \t\t\t\t\t<TypedInnerBlocks
-\t\t\t\t\t\tallowedBlocks={ nestedInnerBlocksConfig?.allowedBlocks }
 \t\t\t\t\t\tdefaultBlock={ nestedInnerBlocksConfig?.defaultBlock }
 \t\t\t\t\t\tdirectInsert={ nestedInnerBlocksConfig?.directInsert }
 \t\t\t\t\t\torientation={ nestedInnerBlocksConfig?.orientation }

--- a/packages/wp-typia-project-tools/src/runtime/built-in-block-code-templates/compound-parent.ts
+++ b/packages/wp-typia-project-tools/src/runtime/built-in-block-code-templates/compound-parent.ts
@@ -283,10 +283,6 @@ export const COMPOUND_CHILD_SPECS: CompoundChildSpec[] = [
 \t// add-child: insert new child specs here
 ];
 
-function getChildSpecByKey( key: string ): CompoundChildSpec | undefined {
-\treturn COMPOUND_CHILD_SPECS.find( ( spec ) => spec.key === key );
-}
-
 function buildTemplateEntriesForSpec( spec: CompoundChildSpec ): BlockTemplate {
 \tconst nestedTemplate = buildNestedTemplateForKey( spec.key );
 
@@ -335,20 +331,6 @@ export function getRootInnerBlocksConfig(): CompoundInnerBlocksConfig {
 
 export function getChildSpec( blockName: string ): CompoundChildSpec | undefined {
 \treturn COMPOUND_CHILD_SPECS.find( ( spec ) => spec.blockName === blockName );
-}
-
-export function getChildAncestorBlockNames(
-\tblockName: string
-): string[] | undefined {
-\tconst childSpec = getChildSpec( blockName );
-\tif ( ! childSpec || childSpec.ancestorKeys.length === 0 ) {
-\t\treturn undefined;
-\t}
-
-\treturn childSpec.ancestorKeys.flatMap( ( key ) => {
-\t\tconst ancestorSpec = getChildSpecByKey( key );
-\t\treturn ancestorSpec ? [ ancestorSpec.blockName ] : [];
-\t} );
 }
 
 export function getChildTemplate(

--- a/packages/wp-typia-project-tools/src/runtime/built-in-block-code-templates/compound-parent.ts
+++ b/packages/wp-typia-project-tools/src/runtime/built-in-block-code-templates/compound-parent.ts
@@ -89,7 +89,6 @@ export default function Edit( {
 				) }
 				<div className="{{cssClassName}}__items">
 					<TypedInnerBlocks
-						allowedBlocks={ rootInnerBlocksConfig.allowedBlocks }
 						defaultBlock={ rootInnerBlocksConfig.defaultBlock }
 						directInsert={ rootInnerBlocksConfig.directInsert }
 						orientation={ rootInnerBlocksConfig.orientation }
@@ -237,7 +236,6 @@ export interface CompoundChildSpec {
 }
 
 export interface CompoundInnerBlocksConfig {
-\tallowedBlocks?: string[];
 \tdefaultBlock?: [ string, Record< string, unknown > ];
 \tdirectInsert: boolean;
 \torientation?: 'horizontal' | 'vertical';
@@ -251,7 +249,7 @@ export const ROOT_INNER_BLOCKS_PRESET_DESCRIPTION =
 
 const BASE_INNER_BLOCKS_CONFIG: Omit<
 \tCompoundInnerBlocksConfig,
-\t'allowedBlocks' | 'defaultBlock' | 'template'
+\t'defaultBlock' | 'template'
 > = {
 \tdirectInsert: {{compoundInnerBlocksDirectInsert}},
 \torientation: {{compoundInnerBlocksOrientationExpression}},
@@ -307,61 +305,36 @@ function buildNestedTemplateForKey( key: string ): BlockTemplate {
 \t).flatMap( ( spec ) => buildTemplateEntriesForSpec( spec ) );
 }
 
-export const ALLOWED_CHILD_BLOCKS = COMPOUND_CHILD_SPECS.filter(
-\t( spec ) => spec.placement === 'root'
-).map( ( spec ) => spec.blockName );
-
 export const DEFAULT_CHILD_TEMPLATE: BlockTemplate =
 \tCOMPOUND_CHILD_SPECS.filter( ( spec ) => spec.placement === 'root' ).flatMap(
 \t\t( spec ) => buildTemplateEntriesForSpec( spec )
 \t);
 
 function buildDefaultBlockEntry(
-\tallowedBlocks?: string[]
+\ttemplate?: BlockTemplate
 ): [ string, Record< string, unknown > ] | undefined {
 \tif (
 \t\t! BASE_INNER_BLOCKS_CONFIG.directInsert ||
-\t\t! Array.isArray( allowedBlocks ) ||
-\t\tallowedBlocks.length === 0
+\t\t! Array.isArray( template ) ||
+\t\ttemplate.length === 0 ||
+\t\ttypeof template[ 0 ]?.[ 0 ] !== 'string'
 \t) {
 \t\treturn undefined;
 \t}
 
-\treturn [ allowedBlocks[ 0 ], {} ];
+\treturn [ template[ 0 ][ 0 ], {} ];
 }
 
 export function getRootInnerBlocksConfig(): CompoundInnerBlocksConfig {
 \treturn {
 \t\t...BASE_INNER_BLOCKS_CONFIG,
-\t\tallowedBlocks: ALLOWED_CHILD_BLOCKS,
-\t\tdefaultBlock: buildDefaultBlockEntry( ALLOWED_CHILD_BLOCKS ),
+\t\tdefaultBlock: buildDefaultBlockEntry( DEFAULT_CHILD_TEMPLATE ),
 \t\ttemplate: DEFAULT_CHILD_TEMPLATE,
 \t};
 }
 
 export function getChildSpec( blockName: string ): CompoundChildSpec | undefined {
 \treturn COMPOUND_CHILD_SPECS.find( ( spec ) => spec.blockName === blockName );
-}
-
-export function getChildAllowedBlocks(
-\tblockName: string
-): string[] | undefined {
-\tconst childSpec = getChildSpec( blockName );
-\tif ( ! childSpec ) {
-\t\treturn undefined;
-\t}
-
-\tconst directDescendants = COMPOUND_CHILD_SPECS.filter(
-\t\t( spec ) =>
-\t\t\tspec.placement === 'nested' &&
-\t\t\tspec.ancestorKeys[ spec.ancestorKeys.length - 1 ] === childSpec.key
-\t).map( ( spec ) => spec.blockName );
-
-\tif ( directDescendants.length > 0 ) {
-\t\treturn directDescendants;
-\t}
-
-\treturn childSpec.container ? [] : undefined;
 }
 
 export function getChildAncestorBlockNames(
@@ -402,17 +375,15 @@ export function getChildInnerBlocksConfig(
 \t\treturn undefined;
 \t}
 
-\tconst allowedBlocks = getChildAllowedBlocks( blockName );
 \tconst template = getChildTemplate( blockName );
 
-\tif ( ! childSpec.container && ! allowedBlocks && ! template ) {
+\tif ( ! childSpec.container && ! template ) {
 \t\treturn undefined;
 \t}
 
 \treturn {
 \t\t...BASE_INNER_BLOCKS_CONFIG,
-\t\tallowedBlocks,
-\t\tdefaultBlock: buildDefaultBlockEntry( allowedBlocks ),
+\t\tdefaultBlock: buildDefaultBlockEntry( template ),
 \t\ttemplate,
 \t};
 }

--- a/packages/wp-typia-project-tools/src/runtime/built-in-block-code-templates/compound-persistence.ts
+++ b/packages/wp-typia-project-tools/src/runtime/built-in-block-code-templates/compound-persistence.ts
@@ -119,7 +119,6 @@ export default function Edit( {
 \t\t\t\t</p>
 \t\t\t\t<div className="{{cssClassName}}__items">
 \t\t\t\t\t<TypedInnerBlocks
-\t\t\t\t\t\tallowedBlocks={ rootInnerBlocksConfig.allowedBlocks }
 \t\t\t\t\t\tdefaultBlock={ rootInnerBlocksConfig.defaultBlock }
 \t\t\t\t\t\tdirectInsert={ rootInnerBlocksConfig.directInsert }
 \t\t\t\t\t\torientation={ rootInnerBlocksConfig.orientation }

--- a/packages/wp-typia-project-tools/templates/_shared/compound/core/scripts/add-compound-child.ts.mustache
+++ b/packages/wp-typia-project-tools/templates/_shared/compound/core/scripts/add-compound-child.ts.mustache
@@ -816,7 +816,6 @@ export default function Edit( {
 \t\t\t{ showsNestedChildren && (
 \t\t\t\t<div className="${ childCssClassName }__children">
 \t\t\t\t\t<TypedInnerBlocks
-\t\t\t\t\t\tallowedBlocks={ nestedInnerBlocksConfig?.allowedBlocks }
 \t\t\t\t\t\tdefaultBlock={ nestedInnerBlocksConfig?.defaultBlock }
 \t\t\t\t\t\tdirectInsert={ nestedInnerBlocksConfig?.directInsert }
 \t\t\t\t\t\torientation={ nestedInnerBlocksConfig?.orientation }

--- a/packages/wp-typia-project-tools/tests/built-in-block-artifacts.test.ts
+++ b/packages/wp-typia-project-tools/tests/built-in-block-artifacts.test.ts
@@ -608,7 +608,7 @@ const EXPECTED_CODE_ARTIFACT_HASH_SUMMARIES: Record<
   },
   compound: {
     'src/blocks/demo-compound-item/block-metadata.ts': '50956333a97a824a',
-    'src/blocks/demo-compound-item/edit.tsx': 'dd0d1a19c2d34ec0',
+    'src/blocks/demo-compound-item/edit.tsx': 'b66725c7b00db080',
     'src/blocks/demo-compound-item/hooks.ts': '485092aef1c4e019',
     'src/blocks/demo-compound-item/index.tsx': '5b5805db42c0b1f6',
     'src/blocks/demo-compound-item/manifest-defaults-document.ts':
@@ -618,8 +618,8 @@ const EXPECTED_CODE_ARTIFACT_HASH_SUMMARIES: Record<
     'src/blocks/demo-compound-item/save.tsx': 'e2a9d7c5df3e615f',
     'src/blocks/demo-compound-item/validators.ts': '7123c8ea0e650172',
     'src/blocks/demo-compound/block-metadata.ts': '50956333a97a824a',
-    'src/blocks/demo-compound/children.ts': '4142dcf3e16f4a86',
-    'src/blocks/demo-compound/edit.tsx': 'f3dfbaeefa94f36d',
+    'src/blocks/demo-compound/children.ts': '3b026ddaecc8b9c8',
+    'src/blocks/demo-compound/edit.tsx': '28fe042914bf6070',
     'src/blocks/demo-compound/hooks.ts': '485092aef1c4e019',
     'src/blocks/demo-compound/index.tsx': 'c9d9139901e6e4b9',
     'src/blocks/demo-compound/interactivity.ts': 'eddaf331fa622b91',

--- a/packages/wp-typia-project-tools/tests/scaffold-compound.test.ts
+++ b/packages/wp-typia-project-tools/tests/scaffold-compound.test.ts
@@ -310,10 +310,11 @@ describe('@wp-typia/project-tools scaffold compound', () => {
       expect(parentChildren).toContain('DEFAULT_CHILD_BLOCK_NAME');
       expect(parentChildren).toContain('COMPOUND_CHILD_SPECS');
       expect(parentChildren).toContain('ROOT_INNER_BLOCKS_PRESET_ID');
-      expect(parentChildren).toContain('getChildAllowedBlocks');
       expect(parentChildren).toContain('getChildInnerBlocksConfig');
       expect(parentChildren).toContain('getRootInnerBlocksConfig');
       expect(parentChildren).toContain('hasNestedChildBlocks');
+      expect(parentChildren).not.toContain('ALLOWED_CHILD_BLOCKS');
+      expect(parentChildren).not.toContain('getChildAllowedBlocks');
       expect(parentChildren).toContain(
         '@wp-typia/block-types/blocks/registration',
       );
@@ -337,6 +338,7 @@ describe('@wp-typia/project-tools scaffold compound', () => {
       expect(childEdit).not.toMatch(/setAttributes\s*\(\s*\{/);
       expect(childEdit).toContain('getChildInnerBlocksConfig');
       expect(childEdit).toContain('hasNestedChildBlocks( metadata.name )');
+      expect(childEdit).not.toContain('allowedBlocks={');
       expect(childEdit).toContain("from '../demo-compound/children'");
       expect(childEdit).toContain(
         'wp-block-create-block-demo-compound-item__title',
@@ -1396,6 +1398,7 @@ describe('@wp-typia/project-tools scaffold compound', () => {
       expect(clauseBlockJson.supports.inserter).toBe(true);
       expect(sectionEdit).toContain('InnerBlocks');
       expect(sectionEdit).toContain('hasNestedChildBlocks( metadata.name )');
+      expect(sectionEdit).not.toContain('allowedBlocks={');
       expect(sectionSave).toContain('InnerBlocks.Content');
       expect(childrenRegistry).toContain('key: "section"');
       expect(childrenRegistry).toContain('key: "clause"');


### PR DESCRIPTION
## Context

Compound scaffolds were expressing some static nested child constraints in two places at once: generated block metadata and generated InnerBlocks runtime helpers. That made it less obvious which layer owned the relationship and created room for drift as nested child graphs evolve.

## What Changed

- stopped passing static `allowedBlocks` constraints through generated compound parent and child `InnerBlocks` props
- removed duplicate runtime `allowedBlocks` derivation from generated `children.ts`, while keeping metadata-owned `allowedBlocks`, `parent`, and `ancestor` relationships intact
- kept runtime helpers focused on editor-only preset behavior such as `template`, `defaultBlock`, `orientation`, `templateLock`, and `directInsert`
- updated compound scaffold regression coverage to assert that static child constraints stay metadata-owned instead of being duplicated in generated editor code
- added a changeset for `@wp-typia/project-tools` and `wp-typia`

## Verification

- `bun run --filter @wp-typia/project-tools build`
- `bun test packages/wp-typia-project-tools/tests/scaffold-compound.test.ts`
- `bun run changesets:validate`

Closes #499

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that static nested block relationships (`allowedBlocks`, `parent`, `ancestor`) are now managed through `block.json`, while `children.ts` handles editor-specific behavior (templates, defaults, locking).

* **Refactor**
  * Removed runtime constraint logic for nested blocks from generated code to streamline block configuration and consolidate relationship definitions into `block.json`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->