### PR TITLE
Validate and preview compound child graphs before nested writes

### DIFF
--- a/.sampo/changesets/issue-500-compound-child-graph-preview.md
+++ b/.sampo/changesets/issue-500-compound-child-graph-preview.md
@@ -1,0 +1,8 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Validate compound child graphs before generated nested child scaffolds write files.
+
+Generated compound child add-flow scripts can now preview the resulting nested hierarchy with `--dry-run`, emit planned writes before mutating files, and fail early when existing or requested ancestor graphs are structurally invalid.

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-onboarding.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-onboarding.ts
@@ -267,9 +267,15 @@ ${ formatRunScript(
 		"add-child",
 		'--slug clause --title "Clause" --ancestor section'
 	) }
+
+${ formatRunScript(
+		packageManager,
+		"add-child",
+		'--slug clause --title "Clause" --ancestor section --dry-run'
+	) }
 \`\`\`
 
-This scaffolds additional compound child block types, updates \`scripts/block-config.ts\` and \`src/blocks/*/children.ts\`, and now supports root-level hidden children, visible container children, and nested ancestor chains for richer document-style block hierarchies.`;
+This scaffolds additional compound child block types, updates \`scripts/block-config.ts\` and \`src/blocks/*/children.ts\`, and now supports root-level hidden children, visible container children, and nested ancestor chains for richer document-style block hierarchies. Pass \`--dry-run\` when you want a validated child-graph preview and planned write list before the script mutates files.`;
 }
 
 function formatPhpRestExtensionPointsSection({

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-onboarding.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-onboarding.ts
@@ -265,13 +265,13 @@ ${ formatRunScript(
 ${ formatRunScript(
 		packageManager,
 		"add-child",
-		'--slug clause --title "Clause" --ancestor section'
+		'--slug clause --title "Clause" --ancestor section --dry-run'
 	) }
 
 ${ formatRunScript(
 		packageManager,
 		"add-child",
-		'--slug clause --title "Clause" --ancestor section --dry-run'
+		'--slug clause --title "Clause" --ancestor section'
 	) }
 \`\`\`
 

--- a/packages/wp-typia-project-tools/templates/_shared/compound/core/scripts/add-compound-child.ts.mustache
+++ b/packages/wp-typia-project-tools/templates/_shared/compound/core/scripts/add-compound-child.ts.mustache
@@ -548,7 +548,7 @@ function validateExistingCompoundChildGraph(
 						expectedAncestorBlockName
 				);
 
-			if ( ancestorChild.ancestorBlockNames.length > 0 && ! ancestorRouteMatches ) {
+			if ( ! ancestorRouteMatches ) {
 				throw new Error(
 					`Existing compound child graph is invalid: ${ ancestorChild.blockName } is not on the declared ancestor route for ${ child.blockName }.`
 				);

--- a/packages/wp-typia-project-tools/templates/_shared/compound/core/scripts/add-compound-child.ts.mustache
+++ b/packages/wp-typia-project-tools/templates/_shared/compound/core/scripts/add-compound-child.ts.mustache
@@ -120,6 +120,10 @@ function parseArgs() {
 			index += 1;
 			continue;
 		}
+
+		if ( arg.startsWith( '--' ) ) {
+			throw new Error( `Unknown option: ${ arg }.` );
+		}
 	}
 
 	return parsed;
@@ -480,7 +484,11 @@ function buildCompoundChildGraphMap(
 }
 
 function resolveDirectParentBlockName( child: ExistingCompoundChild ): string {
-	return child.ancestorBlockNames[ child.ancestorBlockNames.length - 1 ] ?? PARENT_BLOCK_NAME;
+	return (
+		child.ancestorBlockNames[ child.ancestorBlockNames.length - 1 ] ??
+		child.parentBlockNames[ 0 ] ??
+		PARENT_BLOCK_NAME
+	);
 }
 
 function validateExistingCompoundChildGraph(
@@ -528,6 +536,21 @@ function validateExistingCompoundChildGraph(
 			if ( ! ancestorChild.container ) {
 				throw new Error(
 					`Existing compound child graph is invalid: ${ ancestorChild.blockName } is not declared as a container child but has nested descendants.`
+				);
+			}
+
+			const expectedAncestorRoute = child.ancestorBlockNames.slice( 0, index );
+			const ancestorRouteMatches =
+				ancestorChild.ancestorBlockNames.length === expectedAncestorRoute.length &&
+				expectedAncestorRoute.every(
+					( expectedAncestorBlockName, expectedIndex ) =>
+						ancestorChild.ancestorBlockNames[ expectedIndex ] ===
+						expectedAncestorBlockName
+				);
+
+			if ( ancestorChild.ancestorBlockNames.length > 0 && ! ancestorRouteMatches ) {
+				throw new Error(
+					`Existing compound child graph is invalid: ${ ancestorChild.blockName } is not on the declared ancestor route for ${ child.blockName }.`
 				);
 			}
 

--- a/packages/wp-typia-project-tools/templates/_shared/compound/core/scripts/add-compound-child.ts.mustache
+++ b/packages/wp-typia-project-tools/templates/_shared/compound/core/scripts/add-compound-child.ts.mustache
@@ -28,18 +28,37 @@ type CompoundParentConfig = {
 };
 
 type ExistingCompoundChild = {
+	ancestorBlockNames: string[];
 	blockJsonPath: string;
 	blockName: string;
+	container: boolean;
+	directAllowedBlocks: string[];
 	folderSlug: string;
 	key: string;
+	parentBlockNames: string[];
+	placement: 'nested' | 'root';
+	supportsInserter: boolean;
+	title: string;
 };
 
 type ParsedArgs = {
 	ancestorValues: string[];
 	container: boolean;
+	dryRun: boolean;
 	inserter?: 'hidden' | 'visible';
 	slug?: string;
 	title?: string;
+};
+
+type CompoundChildGraphNode = {
+	blockName: string;
+	container: boolean;
+	directParentBlockName: string;
+	isProspective: boolean;
+	key: string;
+	placement: 'nested' | 'root';
+	supportsInserter: boolean;
+	title: string;
 };
 
 function parseArgs() {
@@ -47,6 +66,7 @@ function parseArgs() {
 	const parsed: ParsedArgs = {
 		ancestorValues: [],
 		container: false,
+		dryRun: false,
 	};
 
 	for ( let index = 0; index < args.length; index += 1 ) {
@@ -83,6 +103,11 @@ function parseArgs() {
 
 		if ( arg === '--container' ) {
 			parsed.container = true;
+			continue;
+		}
+
+		if ( arg === '--dry-run' ) {
+			parsed.dryRun = true;
 			continue;
 		}
 
@@ -395,14 +420,128 @@ function listExistingCompoundChildren(): ExistingCompoundChild[] {
 				return null;
 			}
 
+			const ancestorBlockNames = Array.isArray( blockJson.ancestor )
+				? blockJson.ancestor.filter(
+					( value ): value is string => typeof value === 'string'
+				)
+				: [];
+			const parentBlockNames = Array.isArray( blockJson.parent )
+				? blockJson.parent.filter(
+					( value ): value is string => typeof value === 'string'
+				)
+				: [];
+			const directAllowedBlocks = Array.isArray( blockJson.allowedBlocks )
+				? blockJson.allowedBlocks.filter(
+					( value ): value is string => typeof value === 'string'
+				)
+				: [];
+			const supports =
+				typeof blockJson.supports === 'object' &&
+				blockJson.supports &&
+				! Array.isArray( blockJson.supports )
+					? blockJson.supports
+					: null;
+			const supportsInserter =
+				supports && typeof supports.inserter === 'boolean'
+					? supports.inserter
+					: true;
+			const title =
+				typeof blockJson.title === 'string' &&
+				blockJson.title.trim().length > 0
+					? blockJson.title.trim()
+					: toTitleCase( deriveChildKey( folderSlug ) );
+
 			return {
+				ancestorBlockNames,
 				blockJsonPath,
 				blockName,
+				container: Object.prototype.hasOwnProperty.call(
+					blockJson,
+					'allowedBlocks'
+				),
+				directAllowedBlocks,
 				folderSlug,
 				key: deriveChildKey( folderSlug ),
+				parentBlockNames,
+				placement: ancestorBlockNames.length > 0 ? 'nested' : 'root',
+				supportsInserter,
+				title,
 			} satisfies ExistingCompoundChild;
 		} )
 		.filter( ( child ): child is ExistingCompoundChild => child !== null );
+}
+
+function buildCompoundChildGraphMap(
+	existingChildren: ExistingCompoundChild[]
+): Map< string, ExistingCompoundChild > {
+	return new Map(
+		existingChildren.map( ( child ) => [ child.blockName, child ] )
+	);
+}
+
+function resolveDirectParentBlockName( child: ExistingCompoundChild ): string {
+	return child.ancestorBlockNames[ child.ancestorBlockNames.length - 1 ] ?? PARENT_BLOCK_NAME;
+}
+
+function validateExistingCompoundChildGraph(
+	existingChildren: ExistingCompoundChild[]
+) {
+	const seenKeys = new Set< string >();
+	const seenBlockNames = new Set< string >();
+	const childByBlockName = buildCompoundChildGraphMap( existingChildren );
+
+	for ( const child of existingChildren ) {
+		if ( seenKeys.has( child.key ) ) {
+			throw new Error(
+				`Existing compound child graph is invalid: child key "${ child.key }" is declared more than once.`
+			);
+		}
+
+		if ( seenBlockNames.has( child.blockName ) ) {
+			throw new Error(
+				`Existing compound child graph is invalid: ${ child.blockName } is declared more than once.`
+			);
+		}
+
+		seenKeys.add( child.key );
+		seenBlockNames.add( child.blockName );
+
+		if ( child.ancestorBlockNames.length === 0 ) {
+			if ( child.parentBlockNames.length === 0 ) {
+				throw new Error(
+					`Existing compound child graph is invalid: ${ child.blockName } must declare a parent block.`
+				);
+			}
+			continue;
+		}
+
+		for ( let index = 0; index < child.ancestorBlockNames.length; index += 1 ) {
+			const ancestorBlockName = child.ancestorBlockNames[ index ];
+			const ancestorChild = childByBlockName.get( ancestorBlockName );
+
+			if ( ! ancestorChild ) {
+				throw new Error(
+					`Existing compound child graph is invalid: ${ child.blockName } references missing ancestor ${ ancestorBlockName }.`
+				);
+			}
+
+			if ( ! ancestorChild.container ) {
+				throw new Error(
+					`Existing compound child graph is invalid: ${ ancestorChild.blockName } is not declared as a container child but has nested descendants.`
+				);
+			}
+
+			const nextBlockName =
+				child.ancestorBlockNames[ index + 1 ] ?? child.blockName;
+			if ( ancestorChild.directAllowedBlocks.includes( nextBlockName ) ) {
+				continue;
+			}
+
+			throw new Error(
+				`Existing compound child graph is invalid: ${ ancestorChild.blockName } does not currently allow ${ nextBlockName } as a direct child.`
+			);
+		}
+	}
 }
 
 function resolveExistingCompoundChild(
@@ -457,14 +596,8 @@ function validateAncestorChain(
 	for ( let index = 0; index < ancestorChain.length - 1; index += 1 ) {
 		const currentAncestor = ancestorChain[ index ];
 		const nextAncestor = ancestorChain[ index + 1 ];
-		const blockJson = readBlockJsonDocument( currentAncestor.blockJsonPath );
-		const allowedBlocks = Array.isArray( blockJson.allowedBlocks )
-			? blockJson.allowedBlocks.filter(
-				( value ): value is string => typeof value === 'string'
-			)
-			: [];
 
-		if ( allowedBlocks.includes( nextAncestor.blockName ) ) {
+		if ( currentAncestor.directAllowedBlocks.includes( nextAncestor.blockName ) ) {
 			continue;
 		}
 
@@ -472,6 +605,22 @@ function validateAncestorChain(
 			`Invalid ancestor chain: ${ currentAncestor.blockName } does not currently allow ${ nextAncestor.blockName } as a direct child.`
 		);
 	}
+}
+
+function validateNestedAncestorTarget( ancestorChain: ExistingCompoundChild[] ) {
+	const directAncestor = ancestorChain[ ancestorChain.length - 1 ];
+
+	if ( ! directAncestor ) {
+		return;
+	}
+
+	if ( directAncestor.container ) {
+		return;
+	}
+
+	throw new Error(
+		`Cannot nest descendants under ${ directAncestor.blockName } because it is not declared as a container child. Re-add that child with --container or target an existing container child.`
+	);
 }
 
 function findCompoundChildSpecSource(
@@ -526,6 +675,86 @@ function validateAncestorInstantiability(
 			`Cannot nest descendants under ${ ancestor.blockName } because it is hidden and has no seeded template instances. Re-add or promote that child with a visible inserter or a seeded template first.`
 		);
 	}
+}
+
+function formatProjectRelativePath( filePath: string ): string {
+	return path.relative( PROJECT_ROOT, filePath ) || '.';
+}
+
+function buildCompoundChildGraphNodes(
+	existingChildren: ExistingCompoundChild[],
+	prospectiveChild: CompoundChildGraphNode
+): CompoundChildGraphNode[] {
+	return [
+		...existingChildren.map( ( child ) => ( {
+			blockName: child.blockName,
+			container: child.container,
+			directParentBlockName: resolveDirectParentBlockName( child ),
+			isProspective: false,
+			key: child.key,
+			placement: child.placement,
+			supportsInserter: child.supportsInserter,
+			title: child.title,
+		} ) ),
+		prospectiveChild,
+	];
+}
+
+function renderCompoundChildGraphPreview(
+	graphNodes: CompoundChildGraphNode[],
+	plannedWritePaths: string[],
+	options: {
+		dryRun: boolean;
+	}
+): string {
+	const childrenByParent = new Map< string, CompoundChildGraphNode[] >();
+
+	for ( const graphNode of graphNodes ) {
+		const existingChildren = childrenByParent.get( graphNode.directParentBlockName ) ?? [];
+		existingChildren.push( graphNode );
+		childrenByParent.set( graphNode.directParentBlockName, existingChildren );
+	}
+
+	const renderChildLines = (
+		parentBlockName: string,
+		indent: string
+	): string[] => {
+		const directChildren = [ ...( childrenByParent.get( parentBlockName ) ?? [] ) ].sort(
+			( left, right ) => left.key.localeCompare( right.key )
+		);
+
+		return directChildren.flatMap( ( child ) => {
+			const labels = [
+				child.isProspective ? 'new' : 'existing',
+				child.placement === 'root' ? 'root' : 'nested',
+				child.container ? 'container' : 'leaf',
+				child.supportsInserter ? 'visible' : 'hidden',
+			];
+			const line = `${ indent }- ${ child.key } -> ${ child.blockName } [${ labels.join( ', ' ) }]`;
+			return [ line, ...renderChildLines( child.blockName, `${ indent }  ` ) ];
+		} );
+	};
+
+	return [
+		'Compound child graph preview',
+		`Parent block: ${ PARENT_BLOCK_NAME }`,
+		...renderChildLines( PARENT_BLOCK_NAME, '' ),
+		'',
+		'Planned writes',
+		...plannedWritePaths.map( ( plannedWritePath ) => `- ${ plannedWritePath }` ),
+		options.dryRun ? '' : '',
+		options.dryRun
+			? 'Dry run only; no files were written.'
+			: 'Applying these updates now.',
+	]
+		.filter( ( line, index, lines ) => {
+			if ( line.length > 0 ) {
+				return true;
+			}
+
+			return index > 0 && lines[ index - 1 ].length > 0;
+		} )
+		.join( '\n' );
 }
 
 function updateAllowedBlocks(
@@ -948,6 +1177,7 @@ function main() {
 	const {
 		ancestorValues,
 		container,
+		dryRun,
 		inserter,
 		slug,
 		title,
@@ -959,6 +1189,7 @@ function main() {
 	}
 
 	const existingChildren = listExistingCompoundChildren();
+	validateExistingCompoundChildGraph( existingChildren );
 	const ancestorChain = ensureUniqueAncestorChain(
 		ancestorValues.map( ( value ) =>
 			resolveExistingCompoundChild( value, existingChildren )
@@ -996,7 +1227,7 @@ function main() {
 	}
 
 	validateAncestorInstantiability( childrenFile, ancestorChain );
-
+	validateNestedAncestorTarget( ancestorChain );
 	const supportsInserter =
 		inserter === 'visible'
 			? true
@@ -1006,6 +1237,47 @@ function main() {
 	const placement = ancestorChain.length > 0 ? 'nested' : 'root';
 	const seedTemplate = supportsInserter || container || ancestorChain.length > 0;
 	const directAllowedBlocks: string[] = [];
+	const directAncestor = ancestorChain[ ancestorChain.length - 1 ];
+	const plannedWritePaths = [
+		formatProjectRelativePath( path.join( childDir, 'block.json' ) ),
+		formatProjectRelativePath( path.join( childDir, 'types.ts' ) ),
+		formatProjectRelativePath( path.join( childDir, 'typia.manifest.json' ) ),
+		formatProjectRelativePath( path.join( childDir, 'block-metadata.ts' ) ),
+		formatProjectRelativePath( path.join( childDir, 'manifest-document.ts' ) ),
+		formatProjectRelativePath( path.join( childDir, 'manifest-defaults-document.ts' ) ),
+		formatProjectRelativePath( path.join( childDir, 'hooks.ts' ) ),
+		formatProjectRelativePath( path.join( childDir, 'validators.ts' ) ),
+		formatProjectRelativePath( path.join( childDir, 'edit.tsx' ) ),
+		formatProjectRelativePath( path.join( childDir, 'save.tsx' ) ),
+		formatProjectRelativePath( path.join( childDir, 'index.tsx' ) ),
+		formatProjectRelativePath( childrenFile ),
+		formatProjectRelativePath( blockConfigFile ),
+		formatProjectRelativePath(
+			placement === 'root' ? PARENT_BLOCK_JSON_PATH : directAncestor.blockJsonPath
+		),
+	];
+
+	console.log(
+		renderCompoundChildGraphPreview(
+			buildCompoundChildGraphNodes( existingChildren, {
+				blockName: childBlockName,
+				container,
+				directParentBlockName:
+					directAncestor?.blockName ?? PARENT_BLOCK_NAME,
+				isProspective: true,
+				key: normalizedSlug,
+				placement,
+				supportsInserter,
+				title: childTitle,
+			} ),
+			plannedWritePaths,
+			{ dryRun }
+		)
+	);
+
+	if ( dryRun ) {
+		return;
+	}
 
 	fs.mkdirSync( childDir, { recursive: true } );
 

--- a/packages/wp-typia-project-tools/tests/scaffold-compound.test.ts
+++ b/packages/wp-typia-project-tools/tests/scaffold-compound.test.ts
@@ -1663,6 +1663,38 @@ describe('@wp-typia/project-tools scaffold compound', () => {
     { timeout: 30_000 },
   );
 
+  test(
+    'compound add-child rejects unknown CLI flags before writing files',
+    async () => {
+      const targetDir = path.join(tempRoot, 'demo-compound-unknown-option');
+
+      await scaffoldProject({
+        projectDir: targetDir,
+        templateId: 'compound',
+        packageManager: 'npm',
+        noInstall: true,
+        answers: {
+          author: 'Test Runner',
+          description: 'Demo compound unknown option workflow',
+          namespace: 'create-block',
+          slug: 'demo-compound-unknown-option',
+          title: 'Demo Compound Unknown Option',
+        },
+      });
+
+      expect(() =>
+        runGeneratedScript(targetDir, 'scripts/add-compound-child.ts', [
+          '--slug',
+          'faq-item',
+          '--title',
+          'FAQ Item',
+          '--dryrun',
+        ]),
+      ).toThrow('Unknown option: --dryrun.');
+    },
+    { timeout: 30_000 },
+  );
+
   test('compound add-child reads live parent metadata from disk', async () => {
     const targetDir = path.join(tempRoot, 'demo-compound-live-parent');
 

--- a/packages/wp-typia-project-tools/tests/scaffold-compound.test.ts
+++ b/packages/wp-typia-project-tools/tests/scaffold-compound.test.ts
@@ -322,6 +322,7 @@ describe('@wp-typia/project-tools scaffold compound', () => {
       expect(parentChildren).toContain(
         'add-child: insert new child specs here',
       );
+      expect(addChildScript).toContain('--dry-run');
       expect(parentStyle).toContain('.wp-block-create-block-demo-compound');
       expect(parentStyle).toContain(
         '.wp-block-create-block-demo-compound-item',
@@ -1309,6 +1310,95 @@ describe('@wp-typia/project-tools scaffold compound', () => {
   );
 
   test(
+    'compound add-child dry-run previews the nested child graph without writing files',
+    async () => {
+      const targetDir = path.join(tempRoot, 'demo-compound-dry-run-preview');
+
+      await scaffoldProject({
+        projectDir: targetDir,
+        templateId: 'compound',
+        packageManager: 'npm',
+        noInstall: true,
+        answers: {
+          author: 'Test Runner',
+          description: 'Demo compound dry-run preview workflow',
+          namespace: 'create-block',
+          slug: 'demo-compound-dry-run-preview',
+          title: 'Demo Compound Dry Run Preview',
+        },
+      });
+
+      runGeneratedScript(targetDir, 'scripts/add-compound-child.ts', [
+        '--slug',
+        'section',
+        '--title',
+        'Section',
+        '--container',
+        '--inserter',
+        'visible',
+      ]);
+
+      const childrenFilePath = path.join(
+        targetDir,
+        'src',
+        'blocks',
+        'demo-compound-dry-run-preview',
+        'children.ts',
+      );
+      const blockConfigPath = path.join(targetDir, 'scripts', 'block-config.ts');
+      const sectionBlockJsonPath = path.join(
+        targetDir,
+        'src',
+        'blocks',
+        'demo-compound-dry-run-preview-section',
+        'block.json',
+      );
+      const clauseDir = path.join(
+        targetDir,
+        'src',
+        'blocks',
+        'demo-compound-dry-run-preview-clause',
+      );
+      const childrenBefore = fs.readFileSync(childrenFilePath, 'utf8');
+      const blockConfigBefore = fs.readFileSync(blockConfigPath, 'utf8');
+      const sectionBlockJsonBefore = fs.readFileSync(sectionBlockJsonPath, 'utf8');
+
+      const dryRunOutput = runGeneratedScript(
+        targetDir,
+        'scripts/add-compound-child.ts',
+        [
+          '--slug',
+          'clause',
+          '--title',
+          'Clause',
+          '--ancestor',
+          'section',
+          '--dry-run',
+        ],
+      );
+
+      expect(dryRunOutput).toContain('Compound child graph preview');
+      expect(dryRunOutput).toContain(
+        '- item -> create-block/demo-compound-dry-run-preview-item [existing, root, leaf, hidden]',
+      );
+      expect(dryRunOutput).toContain(
+        '- section -> create-block/demo-compound-dry-run-preview-section [existing, root, container, visible]',
+      );
+      expect(dryRunOutput).toContain(
+        '  - clause -> create-block/demo-compound-dry-run-preview-clause [new, nested, leaf, visible]',
+      );
+      expect(dryRunOutput).toContain('Dry run only; no files were written.');
+      expect(fs.existsSync(clauseDir)).toBe(false);
+      expect(fs.readFileSync(childrenFilePath, 'utf8')).toBe(childrenBefore);
+      expect(fs.readFileSync(blockConfigPath, 'utf8')).toBe(blockConfigBefore);
+      expect(fs.readFileSync(sectionBlockJsonPath, 'utf8')).toBe(
+        sectionBlockJsonBefore,
+      );
+    },
+    { timeout: 30_000 },
+  );
+
+  test(
     'compound add-child scaffolds visible container children and nested ancestor children',
     async () => {
       const targetDir = path.join(tempRoot, 'demo-compound-nested');
@@ -1327,24 +1417,32 @@ describe('@wp-typia/project-tools scaffold compound', () => {
         },
       });
 
-      runGeneratedScript(targetDir, 'scripts/add-compound-child.ts', [
-        '--slug',
-        'section',
-        '--title',
-        'Section',
-        '--container',
-        '--inserter',
-        'visible',
-      ]);
+      const sectionOutput = runGeneratedScript(
+        targetDir,
+        'scripts/add-compound-child.ts',
+        [
+          '--slug',
+          'section',
+          '--title',
+          'Section',
+          '--container',
+          '--inserter',
+          'visible',
+        ],
+      );
 
-      runGeneratedScript(targetDir, 'scripts/add-compound-child.ts', [
-        '--slug',
-        'clause',
-        '--title',
-        'Clause',
-        '--ancestor',
-        'section',
-      ]);
+      const clauseOutput = runGeneratedScript(
+        targetDir,
+        'scripts/add-compound-child.ts',
+        [
+          '--slug',
+          'clause',
+          '--title',
+          'Clause',
+          '--ancestor',
+          'section',
+        ],
+      );
 
       const parentBlockJson = JSON.parse(
         fs.readFileSync(
@@ -1396,6 +1494,11 @@ describe('@wp-typia/project-tools scaffold compound', () => {
         'create-block/demo-compound-nested-section',
       ]);
       expect(clauseBlockJson.supports.inserter).toBe(true);
+      expect(sectionOutput).toContain('Compound child graph preview');
+      expect(sectionOutput).toContain('Applying these updates now.');
+      expect(clauseOutput).toContain(
+        '  - clause -> create-block/demo-compound-nested-clause [new, nested, leaf, visible]',
+      );
       expect(sectionEdit).toContain('InnerBlocks');
       expect(sectionEdit).toContain('hasNestedChildBlocks( metadata.name )');
       expect(sectionEdit).not.toContain('allowedBlocks={');
@@ -1406,6 +1509,50 @@ describe('@wp-typia/project-tools scaffold compound', () => {
       expect(childrenRegistry).toContain('placement: "nested"');
       expect(childrenRegistry).toContain(
         'create-block/demo-compound-nested-clause',
+      );
+    },
+    { timeout: 30_000 },
+  );
+
+  test(
+    'compound add-child rejects nesting under visible non-container ancestor children',
+    async () => {
+      const targetDir = path.join(tempRoot, 'demo-compound-visible-leaf');
+
+      await scaffoldProject({
+        projectDir: targetDir,
+        templateId: 'compound',
+        packageManager: 'npm',
+        noInstall: true,
+        answers: {
+          author: 'Test Runner',
+          description: 'Demo compound visible leaf workflow',
+          namespace: 'create-block',
+          slug: 'demo-compound-visible-leaf',
+          title: 'Demo Compound Visible Leaf',
+        },
+      });
+
+      runGeneratedScript(targetDir, 'scripts/add-compound-child.ts', [
+        '--slug',
+        'faq-item',
+        '--title',
+        'FAQ Item',
+        '--inserter',
+        'visible',
+      ]);
+
+      expect(() =>
+        runGeneratedScript(targetDir, 'scripts/add-compound-child.ts', [
+          '--slug',
+          'follow-up',
+          '--title',
+          'Follow Up',
+          '--ancestor',
+          'faq-item',
+        ]),
+      ).toThrow(
+        'Cannot nest descendants under create-block/demo-compound-visible-leaf-faq-item because it is not declared as a container child. Re-add that child with --container or target an existing container child.',
       );
     },
     { timeout: 30_000 },
@@ -1448,6 +1595,69 @@ describe('@wp-typia/project-tools scaffold compound', () => {
         ]),
       ).toThrow(
         'Cannot nest descendants under create-block/demo-compound-unreachable-nested-faq-item because it is hidden and has no seeded template instances.',
+      );
+    },
+    { timeout: 30_000 },
+  );
+
+  test(
+    'compound add-child rejects structurally invalid existing child graphs before writing',
+    async () => {
+      const targetDir = path.join(tempRoot, 'demo-compound-invalid-graph');
+
+      await scaffoldProject({
+        projectDir: targetDir,
+        templateId: 'compound',
+        packageManager: 'npm',
+        noInstall: true,
+        answers: {
+          author: 'Test Runner',
+          description: 'Demo compound invalid graph workflow',
+          namespace: 'create-block',
+          slug: 'demo-compound-invalid-graph',
+          title: 'Demo Compound Invalid Graph',
+        },
+      });
+
+      runGeneratedScript(targetDir, 'scripts/add-compound-child.ts', [
+        '--slug',
+        'section',
+        '--title',
+        'Section',
+        '--container',
+        '--inserter',
+        'visible',
+      ]);
+
+      const sectionBlockJsonPath = path.join(
+        targetDir,
+        'src',
+        'blocks',
+        'demo-compound-invalid-graph-section',
+        'block.json',
+      );
+      const sectionBlockJson = JSON.parse(
+        fs.readFileSync(sectionBlockJsonPath, 'utf8'),
+      );
+      delete sectionBlockJson.parent;
+      sectionBlockJson.ancestor = [
+        'create-block/demo-compound-invalid-graph-missing',
+      ];
+      fs.writeFileSync(
+        sectionBlockJsonPath,
+        `${JSON.stringify(sectionBlockJson, null, '\t')}\n`,
+        'utf8',
+      );
+
+      expect(() =>
+        runGeneratedScript(targetDir, 'scripts/add-compound-child.ts', [
+          '--slug',
+          'clause',
+          '--title',
+          'Clause',
+        ]),
+      ).toThrow(
+        'Existing compound child graph is invalid: create-block/demo-compound-invalid-graph-section references missing ancestor create-block/demo-compound-invalid-graph-missing.',
       );
     },
     { timeout: 30_000 },

--- a/packages/wp-typia-project-tools/tests/scaffold-compound.test.ts
+++ b/packages/wp-typia-project-tools/tests/scaffold-compound.test.ts
@@ -1664,6 +1664,107 @@ describe('@wp-typia/project-tools scaffold compound', () => {
   );
 
   test(
+    'compound add-child rejects ancestor routes that do not connect through the current graph',
+    async () => {
+      const targetDir = path.join(tempRoot, 'demo-compound-orphaned-route');
+
+      await scaffoldProject({
+        projectDir: targetDir,
+        templateId: 'compound',
+        packageManager: 'npm',
+        noInstall: true,
+        answers: {
+          author: 'Test Runner',
+          description: 'Demo compound orphaned route workflow',
+          namespace: 'create-block',
+          slug: 'demo-compound-orphaned-route',
+          title: 'Demo Compound Orphaned Route',
+        },
+      });
+
+      runGeneratedScript(targetDir, 'scripts/add-compound-child.ts', [
+        '--slug',
+        'section',
+        '--title',
+        'Section',
+        '--container',
+        '--inserter',
+        'visible',
+      ]);
+
+      runGeneratedScript(targetDir, 'scripts/add-compound-child.ts', [
+        '--slug',
+        'part',
+        '--title',
+        'Part',
+        '--container',
+        '--inserter',
+        'visible',
+      ]);
+
+      runGeneratedScript(targetDir, 'scripts/add-compound-child.ts', [
+        '--slug',
+        'clause',
+        '--title',
+        'Clause',
+        '--ancestor',
+        'section',
+      ]);
+
+      const partBlockJsonPath = path.join(
+        targetDir,
+        'src',
+        'blocks',
+        'demo-compound-orphaned-route-part',
+        'block.json',
+      );
+      const partBlockJson = JSON.parse(
+        fs.readFileSync(partBlockJsonPath, 'utf8'),
+      );
+      partBlockJson.allowedBlocks = [
+        'create-block/demo-compound-orphaned-route-section',
+      ];
+      fs.writeFileSync(
+        partBlockJsonPath,
+        `${JSON.stringify(partBlockJson, null, '\t')}\n`,
+        'utf8',
+      );
+
+      const clauseBlockJsonPath = path.join(
+        targetDir,
+        'src',
+        'blocks',
+        'demo-compound-orphaned-route-clause',
+        'block.json',
+      );
+      const clauseBlockJson = JSON.parse(
+        fs.readFileSync(clauseBlockJsonPath, 'utf8'),
+      );
+      clauseBlockJson.ancestor = [
+        'create-block/demo-compound-orphaned-route-part',
+        'create-block/demo-compound-orphaned-route-section',
+      ];
+      fs.writeFileSync(
+        clauseBlockJsonPath,
+        `${JSON.stringify(clauseBlockJson, null, '\t')}\n`,
+        'utf8',
+      );
+
+      expect(() =>
+        runGeneratedScript(targetDir, 'scripts/add-compound-child.ts', [
+          '--slug',
+          'appendix',
+          '--title',
+          'Appendix',
+        ]),
+      ).toThrow(
+        'Existing compound child graph is invalid: create-block/demo-compound-orphaned-route-section is not on the declared ancestor route for create-block/demo-compound-orphaned-route-clause.',
+      );
+    },
+    { timeout: 30_000 },
+  );
+
+  test(
     'compound add-child rejects unknown CLI flags before writing files',
     async () => {
       const targetDir = path.join(tempRoot, 'demo-compound-unknown-option');


### PR DESCRIPTION
## Context

Compound child scaffolds now support richer nested graphs, but the generated `scripts/add-compound-child.ts` flow still wrote files before users could inspect the resulting hierarchy.

## What Changed

- add `--dry-run` support to generated compound child add scripts so complex nested additions can preview the validated graph and planned writes without mutating files
- validate the current compound child graph before writing, including missing ancestors, non-container descendants, and invalid ancestor routes
- emit a readable graph preview and planned write summary before normal writes as well, while preserving the existing hidden-unseeded ancestor diagnostic
- document the new dry-run preview in compound scaffold onboarding and add regression coverage for nested preview output and invalid graph cases

## Verification

- `bun test packages/wp-typia-project-tools/tests/scaffold-compound.test.ts -t "compound add-child"`
- `bun run --filter @wp-typia/project-tools build`
- `bun run changesets:validate`

Closes #500


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--dry-run` flag for compound child add-flow scripts to preview the resulting nested hierarchy and planned file writes before any file system mutations.
  * Implemented upfront compound child graph validation that fails early when ancestor graphs are structurally invalid.
  * Process now displays planned file write paths prior to making any changes to the file system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->