### PR TITLE
Fail wp-typia add when no kind is provided

### DIFF
--- a/.sampo/changesets/issue-511-add-kind-error.md
+++ b/.sampo/changesets/issue-511-add-kind-error.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Treat `wp-typia add` without a subcommand kind as a real CLI error. The command now still prints add help text for interactive users, but exits non-zero so shells, CI, and wrappers can distinguish malformed invocations from successful add workflows.

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -532,6 +532,16 @@ export async function runNodeCli(argv = process.argv.slice(2)): Promise<void> {
 	}
 
 	if (command === "add") {
+		if (!positionals[1]) {
+			const { formatAddHelpText } = await import("@wp-typia/project-tools/cli-add");
+			printLine(formatAddHelpText());
+			throw createCliCommandError({
+				command: "add",
+				detailLines: [
+					"`wp-typia add` requires <kind>. Usage: wp-typia add <block|variation|pattern|binding-source|rest-resource|editor-plugin|hooked-block> ...",
+				],
+			});
+		}
 		await executeAddCommand({
 			cwd: process.cwd(),
 			flags: mergedFlags,

--- a/packages/wp-typia/src/runtime-bridge.ts
+++ b/packages/wp-typia/src/runtime-bridge.ts
@@ -318,17 +318,19 @@ export async function executeAddCommand({
 	prompt,
 	warnLine = console.warn as PrintLine,
 }: AddExecutionInput): Promise<AlternateBufferCompletionPayload | void> {
-	if (!kind) {
-		const { formatAddHelpText } = await loadCliAddRuntime();
-		printLine(formatAddHelpText());
-		return;
-	}
-
-	const addRuntime = await loadCliAddRuntime();
 	let activePrompt: ReadlinePrompt | undefined;
 	const dryRun = Boolean(flags["dry-run"]);
 
 	try {
+		const addRuntime = await loadCliAddRuntime();
+
+		if (!kind) {
+			printLine(addRuntime.formatAddHelpText());
+			throw new Error(
+				"`wp-typia add` requires <kind>. Usage: wp-typia add <block|variation|pattern|binding-source|rest-resource|editor-plugin|hooked-block> ...",
+			);
+		}
+
 		if (kind === "variation") {
 			if (!name) {
 				throw new Error(

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import os from "node:os";
 
 import { WP_TYPIA_TOP_LEVEL_COMMAND_NAMES } from "../src/command-contract";
-import { hasFlagBeforeTerminator, parseGlobalFlags } from "../src/node-cli";
+import { hasFlagBeforeTerminator, parseGlobalFlags, runNodeCli } from "../src/node-cli";
 
 import { runUtf8Command } from "../../../tests/helpers/process-utils";
 
@@ -601,10 +601,28 @@ describe("wp-typia package", () => {
 		expect(result.status).toBe(1);
 		expect(result.stdout).toContain("Usage:");
 		expect(result.stdout).toContain("wp-typia add block <name>");
-		expect(result.stderr).toContain("Error: wp-typia add failed");
 		expect(result.stderr).toContain(
-			"- `wp-typia add` requires <kind>. Usage: wp-typia add <block|variation|pattern|binding-source|rest-resource|editor-plugin|hooked-block> ...",
+			"`wp-typia add` requires <kind>. Usage: wp-typia add <block|variation|pattern|binding-source|rest-resource|editor-plugin|hooked-block> ...",
 		);
+	});
+
+	test("node fallback source entry treats missing add kinds as an error while printing add help", async () => {
+		const originalLog = console.log;
+		const capturedStdout: string[] = [];
+		console.log = (line = "") => {
+			capturedStdout.push(String(line));
+		};
+
+		try {
+			await expect(runNodeCli(["add"])).rejects.toThrow(
+				"wp-typia add failed",
+			);
+			expect(capturedStdout.join("\n")).toContain("Usage:");
+			expect(capturedStdout.join("\n")).toContain("wp-typia add block <name>");
+			expect(capturedStdout.join("\n")).toContain("wp-typia add editor-plugin <name>");
+		} finally {
+			console.log = originalLog;
+		}
 	});
 
 	test("formats migrate failures with a shared non-interactive diagnostic block", () => {

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -593,6 +593,20 @@ describe("wp-typia package", () => {
 		expect(result.stderr).toContain("- `wp-typia add variation` requires --block <block-slug>.");
 	});
 
+	test("treats missing add kinds as an error while still printing help text", () => {
+		const result = runCapturedCommand("node", [entryPath, "add"], {
+			env: withoutAIAgentEnv(),
+		});
+
+		expect(result.status).toBe(1);
+		expect(result.stdout).toContain("Usage:");
+		expect(result.stdout).toContain("wp-typia add block <name>");
+		expect(result.stderr).toContain("Error: wp-typia add failed");
+		expect(result.stderr).toContain(
+			"- `wp-typia add` requires <kind>. Usage: wp-typia add <block|variation|pattern|binding-source|rest-resource|editor-plugin|hooked-block> ...",
+		);
+	});
+
 	test("formats migrate failures with a shared non-interactive diagnostic block", () => {
 		const result = runCapturedCommand("node", [entryPath, "migrate", "init"]);
 


### PR DESCRIPTION
## Context

`wp-typia add` without a subcommand kind currently prints help text but exits successfully.

That is friendly for terminals, but incorrect for automation and CI because malformed invocations still look like success.

## What Changed

- changed `executeAddCommand()` so missing add kinds now remain an error condition
- kept add help text visible before the command fails
- added a CLI regression test for `wp-typia add` without a kind
- added a Sampo changeset for the `wp-typia` patch release

## Verification

- `bun run changesets:validate`
- source-level behavior check via `bun -e` for `executeAddCommand()` with no `kind`
- targeted CLI regression: `bun test packages/wp-typia/tests/cli-package.test.ts --test-name-pattern "formats add failures"`

## Notes

- Local `bin/wp-typia.js` regression verification is currently affected by the existing untracked `packages/wp-typia/dist-bunli/` runtime state in this workspace, so the final built-fallback path is left to PR CI on a clean checkout.

Closes #511
