### PR TITLE
Harden CLI runtime capabilities and temp-root cleanup

### DIFF
--- a/.sampo/changesets/issue-512-runtime-hardening.md
+++ b/.sampo/changesets/issue-512-runtime-hardening.md
@@ -1,0 +1,6 @@
+---
+npm/wp-typia: patch
+npm/@wp-typia/project-tools: patch
+---
+
+Hardened interactive runtime detection, fallback cleanup behavior, and temporary wp-typia workspace lifecycle handling.

--- a/packages/wp-typia-project-tools/package.json
+++ b/packages/wp-typia-project-tools/package.json
@@ -67,6 +67,11 @@
       "import": "./dist/runtime/schema-core.js",
       "default": "./dist/runtime/schema-core.js"
     },
+    "./temp-roots": {
+      "types": "./dist/runtime/temp-roots.d.ts",
+      "import": "./dist/runtime/temp-roots.js",
+      "default": "./dist/runtime/temp-roots.js"
+    },
     "./workspace-project": {
       "types": "./dist/runtime/workspace-project.d.ts",
       "import": "./dist/runtime/workspace-project.js",

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-block.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-block.ts
@@ -1,6 +1,5 @@
 import fs from "node:fs";
 import { promises as fsp } from "node:fs";
-import os from "node:os";
 import path from "node:path";
 
 import {
@@ -27,6 +26,7 @@ import type { MigrationBlockConfig } from "./migration-types.js";
 import {
 	appendWorkspaceInventoryEntries,
 } from "./workspace-inventory.js";
+import { createManagedTempRoot } from "./temp-roots.js";
 import {
 	resolveWorkspaceProject,
 } from "./workspace-project.js";
@@ -580,6 +580,7 @@ export async function runAddBlockCommand({
 		selectExternalLayerId,
 	});
 	let tempRoot = "";
+	let cleanupTempRoot: (() => Promise<void>) | undefined;
 
 	try {
 		const normalizedSlug = resolveNonEmptyNormalizedBlockSlug({
@@ -589,7 +590,10 @@ export async function runAddBlockCommand({
 		});
 
 		const defaults = getDefaultAnswers(normalizedSlug, resolvedTemplateId);
-		tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "wp-typia-add-block-"));
+		({
+			path: tempRoot,
+			cleanup: cleanupTempRoot,
+		} = await createManagedTempRoot("wp-typia-add-block-"));
 		const tempProjectDir = path.join(tempRoot, normalizedSlug);
 		const blockConfigPath = path.join(workspace.projectDir, "scripts", "block-config.ts");
 		const migrationConfigPath = path.join(workspace.projectDir, "src", "migrations", "config.ts");
@@ -720,8 +724,8 @@ export async function runAddBlockCommand({
 		}
 	} finally {
 		await resolvedExternalLayerSelection.cleanup?.();
-		if (tempRoot) {
-			await fsp.rm(tempRoot, { force: true, recursive: true });
+		if (cleanupTempRoot) {
+			await cleanupTempRoot();
 		}
 	}
 }

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-block.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-block.ts
@@ -723,9 +723,10 @@ export async function runAddBlockCommand({
 			throw error;
 		}
 	} finally {
-		await resolvedExternalLayerSelection.cleanup?.();
-		if (cleanupTempRoot) {
-			await cleanupTempRoot();
+		try {
+			await resolvedExternalLayerSelection.cleanup?.();
+		} finally {
+			await cleanupTempRoot?.();
 		}
 	}
 }

--- a/packages/wp-typia-project-tools/src/runtime/cli-scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-scaffold.ts
@@ -1,6 +1,5 @@
 import fs from "node:fs";
 import { promises as fsp } from "node:fs";
-import os from "node:os";
 import path from "node:path";
 
 import {
@@ -26,6 +25,7 @@ import type {
 } from "./scaffold.js";
 import type { PackageManagerId } from "./package-managers.js";
 import { getPrimaryDevelopmentScript } from "./local-dev-presets.js";
+import { createManagedTempRoot } from "./temp-roots.js";
 import {
 	getOptionalOnboardingNote,
 	getOptionalOnboardingSteps,
@@ -193,7 +193,9 @@ async function buildScaffoldDryRunPlan({
 	result: Awaited<ReturnType<typeof scaffoldProject>>;
 }> {
 	await assertDryRunTargetDirectoryReady(projectDir, allowExistingDir);
-	const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "wp-typia-scaffold-plan-"));
+	const { path: tempRoot, cleanup } = await createManagedTempRoot(
+		"wp-typia-scaffold-plan-",
+	);
 	const previewProjectDir = path.join(tempRoot, "preview-project");
 
 	try {
@@ -228,7 +230,7 @@ async function buildScaffoldDryRunPlan({
 			result,
 		};
 	} finally {
-		await fsp.rm(tempRoot, { force: true, recursive: true });
+		await cleanup();
 	}
 }
 

--- a/packages/wp-typia-project-tools/src/runtime/index.ts
+++ b/packages/wp-typia-project-tools/src/runtime/index.ts
@@ -119,6 +119,14 @@ export {
 	listTemplates,
 } from "./template-registry.js";
 export {
+	STALE_TEMP_ROOT_MAX_AGE_MS,
+	WP_TYPIA_TEMP_ROOT_PREFIX,
+	cleanupManagedTempRoot,
+	cleanupStaleTempRoots,
+	createManagedTempRoot,
+	getTrackedTempRoots,
+} from "./temp-roots.js";
+export {
 	createReadlinePrompt,
 	createCliCommandError,
 	CliDiagnosticError,

--- a/packages/wp-typia-project-tools/src/runtime/temp-roots.ts
+++ b/packages/wp-typia-project-tools/src/runtime/temp-roots.ts
@@ -1,0 +1,137 @@
+import fs from "node:fs";
+import * as fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+export const WP_TYPIA_TEMP_ROOT_PREFIX = "wp-typia-";
+export const STALE_TEMP_ROOT_MAX_AGE_MS = 1000 * 60 * 60 * 24;
+
+const trackedTempRoots = new Set<string>();
+
+let cleanupHandlersInstalled = false;
+let staleCleanupRan = false;
+let signalCleanupInProgress = false;
+
+type TempRootOptions = {
+	maxAgeMs?: number;
+	now?: number;
+	tmpDir?: string;
+};
+
+function getTempDir(tmpDir?: string): string {
+	return tmpDir ?? os.tmpdir();
+}
+
+function cleanupTrackedTempRootsSync(): void {
+	for (const tempRoot of [...trackedTempRoots]) {
+		trackedTempRoots.delete(tempRoot);
+		try {
+			fs.rmSync(tempRoot, { force: true, recursive: true });
+		} catch {}
+	}
+}
+
+function installCleanupHandlers(): void {
+	if (cleanupHandlersInstalled) {
+		return;
+	}
+
+	cleanupHandlersInstalled = true;
+	process.on("exit", cleanupTrackedTempRootsSync);
+
+	for (const [signal, exitCode] of [
+		["SIGHUP", 129],
+		["SIGINT", 130],
+		["SIGTERM", 143],
+	] as const) {
+		process.once(signal, () => {
+			if (signalCleanupInProgress) {
+				return;
+			}
+
+			signalCleanupInProgress = true;
+			cleanupTrackedTempRootsSync();
+			process.exitCode = exitCode;
+			process.exit();
+		});
+	}
+}
+
+export async function cleanupManagedTempRoot(tempRoot: string): Promise<void> {
+	trackedTempRoots.delete(tempRoot);
+	await fsp.rm(tempRoot, { force: true, recursive: true });
+}
+
+export async function cleanupStaleTempRoots({
+	maxAgeMs = STALE_TEMP_ROOT_MAX_AGE_MS,
+	now = Date.now(),
+	tmpDir,
+}: TempRootOptions = {}): Promise<string[]> {
+	const resolvedTmpDir = getTempDir(tmpDir);
+	const removedRoots: string[] = [];
+	const entries = await fsp.readdir(resolvedTmpDir, { withFileTypes: true });
+
+	for (const entry of entries) {
+		if (
+			!entry.isDirectory() ||
+			!entry.name.startsWith(WP_TYPIA_TEMP_ROOT_PREFIX)
+		) {
+			continue;
+		}
+
+		const tempRoot = path.join(resolvedTmpDir, entry.name);
+		if (trackedTempRoots.has(tempRoot)) {
+			continue;
+		}
+
+		let stats;
+		try {
+			stats = await fsp.stat(tempRoot);
+		} catch {
+			continue;
+		}
+
+		if (now - stats.mtimeMs < maxAgeMs) {
+			continue;
+		}
+
+		await fsp.rm(tempRoot, { force: true, recursive: true });
+		removedRoots.push(tempRoot);
+	}
+
+	return removedRoots;
+}
+
+export async function createManagedTempRoot(
+	prefix: string,
+	options: Pick<TempRootOptions, "tmpDir"> = {},
+): Promise<{
+	cleanup: () => Promise<void>;
+	path: string;
+}> {
+	if (!prefix.startsWith(WP_TYPIA_TEMP_ROOT_PREFIX)) {
+		throw new Error(
+			`Managed wp-typia temp roots must use the "${WP_TYPIA_TEMP_ROOT_PREFIX}" prefix.`,
+		);
+	}
+
+	installCleanupHandlers();
+	if (!staleCleanupRan) {
+		staleCleanupRan = true;
+		await cleanupStaleTempRoots({ tmpDir: options.tmpDir });
+	}
+
+	const tempRoot = await fsp.mkdtemp(
+		path.join(getTempDir(options.tmpDir), prefix),
+	);
+	trackedTempRoots.add(tempRoot);
+
+	return {
+		cleanup: async () => cleanupManagedTempRoot(tempRoot),
+		path: tempRoot,
+	};
+}
+
+export function getTrackedTempRoots(): string[] {
+	return [...trackedTempRoots];
+}

--- a/packages/wp-typia-project-tools/src/runtime/temp-roots.ts
+++ b/packages/wp-typia-project-tools/src/runtime/temp-roots.ts
@@ -3,7 +3,14 @@ import * as fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
+/**
+ * Required prefix for managed wp-typia temporary directories.
+ */
 export const WP_TYPIA_TEMP_ROOT_PREFIX = "wp-typia-";
+
+/**
+ * Default age threshold for pruning stale wp-typia temp roots.
+ */
 export const STALE_TEMP_ROOT_MAX_AGE_MS = 1000 * 60 * 60 * 24;
 
 const trackedTempRoots = new Set<string>();
@@ -57,11 +64,22 @@ function installCleanupHandlers(): void {
 	}
 }
 
+/**
+ * Remove a managed temp root and stop tracking it for process-level cleanup.
+ *
+ * @param tempRoot Absolute temporary directory path to remove.
+ */
 export async function cleanupManagedTempRoot(tempRoot: string): Promise<void> {
 	trackedTempRoots.delete(tempRoot);
 	await fsp.rm(tempRoot, { force: true, recursive: true });
 }
 
+/**
+ * Remove stale `wp-typia-*` temp directories from the target temp root.
+ *
+ * @param options Optional temp directory, age threshold, and clock override.
+ * @returns Absolute temp-root paths removed during the cleanup pass.
+ */
 export async function cleanupStaleTempRoots({
 	maxAgeMs = STALE_TEMP_ROOT_MAX_AGE_MS,
 	now = Date.now(),
@@ -95,13 +113,24 @@ export async function cleanupStaleTempRoots({
 			continue;
 		}
 
-		await fsp.rm(tempRoot, { force: true, recursive: true });
-		removedRoots.push(tempRoot);
+		try {
+			await fsp.rm(tempRoot, { force: true, recursive: true });
+			removedRoots.push(tempRoot);
+		} catch {
+			continue;
+		}
 	}
 
 	return removedRoots;
 }
 
+/**
+ * Create a managed wp-typia temp root and install process cleanup handlers.
+ *
+ * @param prefix Temp directory prefix. Must start with `wp-typia-`.
+ * @param options Optional temp directory override.
+ * @returns The created temp-root path plus an async cleanup helper.
+ */
 export async function createManagedTempRoot(
 	prefix: string,
 	options: Pick<TempRootOptions, "tmpDir"> = {},
@@ -132,6 +161,11 @@ export async function createManagedTempRoot(
 	};
 }
 
+/**
+ * Snapshot the currently tracked temp roots for diagnostics and tests.
+ *
+ * @returns Absolute paths for temp roots currently registered for cleanup.
+ */
 export function getTrackedTempRoots(): string[] {
 	return [...trackedTempRoots];
 }

--- a/packages/wp-typia-project-tools/src/runtime/template-builtins.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-builtins.ts
@@ -277,9 +277,7 @@ async function materializeBuiltInTemplateSource(
 		features: template.features,
 		format: "wp-typia",
 		templateDir,
-		cleanup: async () => {
-			await cleanup();
-		},
+		cleanup,
 	};
 }
 

--- a/packages/wp-typia-project-tools/src/runtime/template-builtins.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-builtins.ts
@@ -1,8 +1,8 @@
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { promises as fsp } from "node:fs";
 
+import { createManagedTempRoot } from "./temp-roots.js";
 import {
 	getTemplateById,
 	SHARED_BASE_TEMPLATE_ROOT,
@@ -251,7 +251,9 @@ async function materializeBuiltInTemplateSource(
 		templateId,
 		layerDirs,
 	);
-	const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "wp-typia-template-"));
+	const { path: tempRoot, cleanup } = await createManagedTempRoot(
+		"wp-typia-template-",
+	);
 	const templateDir = path.join(tempRoot, templateId);
 
 	try {
@@ -264,7 +266,7 @@ async function materializeBuiltInTemplateSource(
 			});
 		}
 	} catch (error) {
-		await fsp.rm(tempRoot, { force: true, recursive: true });
+		await cleanup();
 		throw error;
 	}
 
@@ -276,7 +278,7 @@ async function materializeBuiltInTemplateSource(
 		format: "wp-typia",
 		templateDir,
 		cleanup: async () => {
-			await fsp.rm(tempRoot, { force: true, recursive: true });
+			await cleanup();
 		},
 	};
 }

--- a/packages/wp-typia-project-tools/src/runtime/template-source-external.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-external.ts
@@ -2,12 +2,12 @@
 
 import fs from 'node:fs'
 import { promises as fsp } from 'node:fs'
-import os from 'node:os'
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 
 import { isPlainObject, type UnknownRecord } from './object-utils.js'
 import { toSegmentPascalCase } from './string-case.js'
+import { createManagedTempRoot } from './temp-roots.js'
 import { copyRawDirectory, copyRenderedDirectory } from './template-render.js'
 import type {
   ExternalTemplateConfig,
@@ -268,12 +268,9 @@ export async function renderCreateBlockExternalTemplate(
     variantConfig,
   )
 
-  const tempRoot = await fsp.mkdtemp(
-    path.join(os.tmpdir(), 'wp-typia-create-block-external-'),
+  const { path: tempRoot, cleanup } = await createManagedTempRoot(
+    'wp-typia-create-block-external-',
   )
-  const cleanup = async () => {
-    await fsp.rm(tempRoot, { force: true, recursive: true })
-  }
 
   try {
     const renderedRoot = path.join(tempRoot, 'rendered')

--- a/packages/wp-typia-project-tools/src/runtime/template-source-remote.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-remote.ts
@@ -14,6 +14,29 @@ import type {
   TemplateVariableContext,
 } from './template-source-contracts.js'
 
+async function cleanupSeedRootPair(
+  cleanup: () => Promise<void>,
+  seedCleanup?: (() => Promise<void>) | undefined,
+): Promise<void> {
+  let cleanupError: unknown
+
+  try {
+    await cleanup()
+  } catch (error) {
+    cleanupError = error
+  }
+
+  try {
+    await seedCleanup?.()
+  } catch (error) {
+    cleanupError ??= error
+  }
+
+  if (cleanupError !== undefined) {
+    throw cleanupError
+  }
+}
+
 function getDefaultCategoryFromBlockJson(
   blockJson: Record<string, unknown>,
 ): string {
@@ -125,16 +148,13 @@ export async function normalizeWpTypiaTemplateSeed(
       })
     }
   } catch (error) {
-    await cleanup()
+    await Promise.allSettled([cleanup(), seed.cleanup?.()])
     throw error
   }
 
   return {
     blockDir: normalizedDir,
-    cleanup: async () => {
-      await cleanup()
-      await seed.cleanup?.()
-    },
+    cleanup: async () => cleanupSeedRootPair(cleanup, seed.cleanup),
     rootDir: normalizedDir,
     selectedVariant: seed.selectedVariant,
     warnings: seed.warnings,
@@ -463,16 +483,10 @@ export async function normalizeCreateBlockSubset(
       selectedVariant: seed.selectedVariant ?? null,
       templateDir,
       warnings: seed.warnings ?? [],
-      cleanup: async () => {
-        await cleanup()
-        if (seed.cleanup) {
-          await seed.cleanup()
-        }
-      },
+      cleanup: async () => cleanupSeedRootPair(cleanup, seed.cleanup),
     }
   } catch (error) {
-    await cleanup()
-    await seed.cleanup?.()
+    await Promise.allSettled([cleanup(), seed.cleanup?.()])
     throw error
   }
 }

--- a/packages/wp-typia-project-tools/src/runtime/template-source-remote.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-remote.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs'
 import { promises as fsp } from 'node:fs'
-import os from 'node:os'
 import path from 'node:path'
 
 import {
@@ -8,6 +7,7 @@ import {
   isOmittableBuiltInTemplateLayerDir,
 } from './template-builtins.js'
 import { copyRawDirectory } from './template-render.js'
+import { createManagedTempRoot } from './temp-roots.js'
 import type {
   ResolvedTemplateSource,
   SeedSource,
@@ -100,8 +100,8 @@ export function getTemplateProjectType(sourceDir: string): string | null {
 export async function normalizeWpTypiaTemplateSeed(
   seed: SeedSource,
 ): Promise<SeedSource> {
-  const tempRoot = await fsp.mkdtemp(
-    path.join(os.tmpdir(), 'wp-typia-template-source-'),
+  const { path: tempRoot, cleanup } = await createManagedTempRoot(
+    'wp-typia-template-source-',
   )
   const normalizedDir = path.join(tempRoot, 'template')
   try {
@@ -125,14 +125,14 @@ export async function normalizeWpTypiaTemplateSeed(
       })
     }
   } catch (error) {
-    await fsp.rm(tempRoot, { force: true, recursive: true })
+    await cleanup()
     throw error
   }
 
   return {
     blockDir: normalizedDir,
     cleanup: async () => {
-      await fsp.rm(tempRoot, { force: true, recursive: true })
+      await cleanup()
       await seed.cleanup?.()
     },
     rootDir: normalizedDir,
@@ -387,8 +387,8 @@ export async function normalizeCreateBlockSubset(
   seed: SeedSource,
   context: TemplateVariableContext,
 ): Promise<ResolvedTemplateSource> {
-  const tempRoot = await fsp.mkdtemp(
-    path.join(os.tmpdir(), 'wp-typia-remote-template-'),
+  const { path: tempRoot, cleanup } = await createManagedTempRoot(
+    'wp-typia-remote-template-',
   )
   try {
     const templateDir = path.join(tempRoot, 'template')
@@ -464,14 +464,14 @@ export async function normalizeCreateBlockSubset(
       templateDir,
       warnings: seed.warnings ?? [],
       cleanup: async () => {
-        await fsp.rm(tempRoot, { force: true, recursive: true })
+        await cleanup()
         if (seed.cleanup) {
           await seed.cleanup()
         }
       },
     }
   } catch (error) {
-    await fsp.rm(tempRoot, { force: true, recursive: true })
+    await cleanup()
     await seed.cleanup?.()
     throw error
   }

--- a/packages/wp-typia-project-tools/src/runtime/template-source-seeds.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-seeds.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs'
 import { promises as fsp } from 'node:fs'
 import { createRequire } from 'node:module'
-import os from 'node:os'
 import path from 'node:path'
 import { execFileSync } from 'node:child_process'
 
@@ -13,6 +12,7 @@ import {
   PROJECT_TOOLS_PACKAGE_ROOT,
 } from './template-registry.js'
 import { isPlainObject } from './object-utils.js'
+import { createManagedTempRoot } from './temp-roots.js'
 import type {
   GitHubTemplateLocator,
   NpmTemplateLocator,
@@ -99,12 +99,9 @@ async function fetchNpmTemplateSource(
     )
   }
 
-  const tempRoot = await fsp.mkdtemp(
-    path.join(os.tmpdir(), 'wp-typia-template-source-'),
+  const { path: tempRoot, cleanup } = await createManagedTempRoot(
+    'wp-typia-template-source-',
   )
-  const cleanup = async () => {
-    await fsp.rm(tempRoot, { force: true, recursive: true })
-  }
 
   try {
     const tarballResponse = await fetch(tarballUrl)
@@ -259,12 +256,9 @@ export async function assertNoSymlinks(sourceDir: string): Promise<void> {
 async function resolveGitHubTemplateSource(
   locator: GitHubTemplateLocator,
 ): Promise<SeedSource> {
-  const remoteRoot = await fsp.mkdtemp(
-    path.join(os.tmpdir(), 'wp-typia-template-source-'),
+  const { path: remoteRoot, cleanup } = await createManagedTempRoot(
+    'wp-typia-template-source-',
   )
-  const cleanup = async () => {
-    await fsp.rm(remoteRoot, { force: true, recursive: true })
-  }
   const checkoutDir = path.join(remoteRoot, 'source')
 
   try {

--- a/packages/wp-typia-project-tools/tests/temp-roots.test.ts
+++ b/packages/wp-typia-project-tools/tests/temp-roots.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+	cleanupStaleTempRoots,
+	createManagedTempRoot,
+	getTrackedTempRoots,
+} from "../src/runtime/temp-roots.js";
+
+describe("@wp-typia/project-tools temp root management", () => {
+	const testRoots: string[] = [];
+
+	afterEach(async () => {
+		for (const testRoot of testRoots.splice(0)) {
+			await fs.promises.rm(testRoot, { force: true, recursive: true });
+		}
+	});
+
+	test("tracks managed temp roots until cleanup runs", async () => {
+		const tmpDir = await fs.promises.mkdtemp(
+			path.join(os.tmpdir(), "wp-typia-temp-roots-test-"),
+		);
+		testRoots.push(tmpDir);
+
+		const managed = await createManagedTempRoot("wp-typia-temp-root-", {
+			tmpDir,
+		});
+
+		expect(fs.existsSync(managed.path)).toBe(true);
+		expect(getTrackedTempRoots()).toContain(managed.path);
+
+		await managed.cleanup();
+
+		expect(fs.existsSync(managed.path)).toBe(false);
+		expect(getTrackedTempRoots()).not.toContain(managed.path);
+	});
+
+	test("stale cleanup prunes old wp-typia temp roots without touching fresh or unrelated dirs", async () => {
+		const tmpDir = await fs.promises.mkdtemp(
+			path.join(os.tmpdir(), "wp-typia-temp-roots-stale-"),
+		);
+		testRoots.push(tmpDir);
+
+		const staleRoot = path.join(tmpDir, "wp-typia-stale-root");
+		const freshRoot = path.join(tmpDir, "wp-typia-fresh-root");
+		const unrelatedRoot = path.join(tmpDir, "unrelated-root");
+		await fs.promises.mkdir(staleRoot);
+		await fs.promises.mkdir(freshRoot);
+		await fs.promises.mkdir(unrelatedRoot);
+
+		const now = Date.now();
+		const staleDate = new Date(now - 10_000);
+		await fs.promises.utimes(staleRoot, staleDate, staleDate);
+
+		const removedRoots = await cleanupStaleTempRoots({
+			maxAgeMs: 5_000,
+			now,
+			tmpDir,
+		});
+
+		expect(removedRoots).toContain(staleRoot);
+		expect(fs.existsSync(staleRoot)).toBe(false);
+		expect(fs.existsSync(freshRoot)).toBe(true);
+		expect(fs.existsSync(unrelatedRoot)).toBe(true);
+	});
+});

--- a/packages/wp-typia/src/cli.ts
+++ b/packages/wp-typia/src/cli.ts
@@ -118,7 +118,7 @@ export async function runCliEntrypoint(argv = process.argv.slice(2)): Promise<vo
 		await main(argv);
 	} catch (error) {
 		console.error(`Error: ${await formatCliError(error)}`);
-		process.exit(1);
+		process.exitCode = 1;
 	}
 }
 

--- a/packages/wp-typia/src/commands/add.ts
+++ b/packages/wp-typia/src/commands/add.ts
@@ -9,10 +9,9 @@ import {
 import { getAddBlockDefaults } from "../config";
 import { resolveBundledModuleHref } from "../render-loader";
 import { executeAddCommand } from "../runtime-bridge";
+import { supportsInteractiveTui } from "../runtime-capabilities";
 import type { WpTypiaRenderArgs } from "./render-types";
 import { LazyFlow } from "../ui/lazy-flow";
-
-const supportsInteractiveTui = typeof Bun !== "undefined";
 
 function loadAddFlow() {
 	return import(
@@ -39,7 +38,7 @@ export const addCommand = defineCommand({
 	},
 	name: "add",
 	options: addOptions,
-	...(supportsInteractiveTui
+	...(supportsInteractiveTui()
 		? {
 				render: (args: WpTypiaRenderArgs) => {
 					const config =

--- a/packages/wp-typia/src/commands/create.ts
+++ b/packages/wp-typia/src/commands/create.ts
@@ -9,10 +9,9 @@ import {
 import { getCreateDefaults } from "../config";
 import { resolveBundledModuleHref } from "../render-loader";
 import { executeCreateCommand } from "../runtime-bridge";
+import { supportsInteractiveTui } from "../runtime-capabilities";
 import type { WpTypiaRenderArgs } from "./render-types";
 import { LazyFlow } from "../ui/lazy-flow";
-
-const supportsInteractiveTui = typeof Bun !== "undefined";
 
 function loadCreateFlow() {
 	return import(
@@ -46,7 +45,7 @@ export const createCommand = defineCommand({
 	},
 	name: "create",
 	options: createOptions,
-	...(supportsInteractiveTui
+	...(supportsInteractiveTui()
 		? {
 				render: (args: WpTypiaRenderArgs) => {
 					const config =

--- a/packages/wp-typia/src/commands/migrate.ts
+++ b/packages/wp-typia/src/commands/migrate.ts
@@ -8,10 +8,9 @@ import {
 } from "../command-option-metadata";
 import { resolveBundledModuleHref } from "../render-loader";
 import { executeMigrateCommand } from "../runtime-bridge";
+import { supportsInteractiveTui } from "../runtime-capabilities";
 import type { WpTypiaRenderArgs } from "./render-types";
 import { LazyFlow } from "../ui/lazy-flow";
-
-const supportsInteractiveTui = typeof Bun !== "undefined";
 
 function loadMigrateFlow() {
 	return import(
@@ -37,7 +36,7 @@ export const migrateCommand = defineCommand({
 	},
 	name: "migrate",
 	options: migrateOptions,
-	...(supportsInteractiveTui
+	...(supportsInteractiveTui()
 		? {
 				render: (args: WpTypiaRenderArgs) =>
 					createElement(LazyFlow, {

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -586,6 +586,6 @@ export async function runNodeCliEntrypoint(argv = process.argv.slice(2)): Promis
 		await runNodeCli(argv);
 	} catch (error) {
 		console.error(`Error: ${await formatCliDiagnosticError(error)}`);
-		process.exit(1);
+		process.exitCode = 1;
 	}
 }

--- a/packages/wp-typia/src/runtime-bridge-add-dry-run.ts
+++ b/packages/wp-typia/src/runtime-bridge-add-dry-run.ts
@@ -1,7 +1,8 @@
 import fs from "node:fs";
 import { promises as fsp } from "node:fs";
-import os from "node:os";
 import path from "node:path";
+
+import { createManagedTempRoot } from "@wp-typia/project-tools/temp-roots";
 
 type WorkspaceFileOperation = `delete ${string}` | `update ${string}` | `write ${string}`;
 
@@ -147,7 +148,9 @@ export async function simulateWorkspaceAddDryRun<T>({
 	const { resolveWorkspaceProject } = await import("@wp-typia/project-tools/workspace-project");
 	const workspace = resolveWorkspaceProject(cwd);
 	const relativeCwd = path.relative(workspace.projectDir, path.resolve(cwd));
-	const tempRoot = await fsp.mkdtemp(path.join(os.tmpdir(), "wp-typia-add-plan-"));
+	const { path: tempRoot, cleanup } = await createManagedTempRoot(
+		"wp-typia-add-plan-",
+	);
 	const simulatedProjectDir = path.join(tempRoot, "workspace");
 
 	try {
@@ -167,6 +170,6 @@ export async function simulateWorkspaceAddDryRun<T>({
 			result,
 		};
 	} finally {
-		await fsp.rm(tempRoot, { force: true, recursive: true });
+		await cleanup();
 	}
 }

--- a/packages/wp-typia/src/runtime-bridge.ts
+++ b/packages/wp-typia/src/runtime-bridge.ts
@@ -12,6 +12,7 @@ import {
 	printCompletionPayload,
 	toExternalLayerPromptOptions,
 } from "./runtime-bridge-output";
+import { isInteractiveTerminal } from "./runtime-capabilities";
 export {
 	buildCreateCompletionPayload,
 	buildCreateDryRunPayload,
@@ -198,7 +199,7 @@ export async function executeCreateCommand({
 		loadCliTemplatesRuntime(),
 	]);
 	const shouldPrompt =
-		interactive ?? (!Boolean(flags.yes) && Boolean(process.stdin.isTTY) && Boolean(process.stdout.isTTY));
+		interactive ?? (!Boolean(flags.yes) && isInteractiveTerminal());
 	const activePrompt = shouldPrompt ? (prompt ?? createReadlinePrompt()) : undefined;
 	const shouldPromptForExternalLayerSelection =
 		Boolean(activePrompt) && activePrompt !== prompt;
@@ -650,7 +651,7 @@ export async function executeAddCommand({
 		const shouldPromptForLayerSelection =
 			Boolean(externalLayerSource) &&
 			!Boolean(externalLayerId) &&
-			(interactive ?? (Boolean(process.stdin.isTTY) && Boolean(process.stdout.isTTY)));
+			(interactive ?? isInteractiveTerminal());
 		const promptRuntime = shouldPromptForLayerSelection
 			? await loadCliPromptRuntime()
 			: undefined;

--- a/packages/wp-typia/src/runtime-capabilities.ts
+++ b/packages/wp-typia/src/runtime-capabilities.ts
@@ -9,6 +9,9 @@ type RuntimeCapabilityOptions = {
 	term?: string | undefined;
 };
 
+/**
+ * Detect whether the current runtime can safely prompt on an interactive terminal.
+ */
 export function isInteractiveTerminal({
 	stdin = process.stdin,
 	stdout = process.stdout,
@@ -17,6 +20,9 @@ export function isInteractiveTerminal({
 	return Boolean(stdin?.isTTY) && Boolean(stdout?.isTTY) && term !== "dumb";
 }
 
+/**
+ * Detect whether the Bun-powered TUI runtime should be enabled for this process.
+ */
 export function supportsInteractiveTui(
 	options: RuntimeCapabilityOptions = {},
 ): boolean {

--- a/packages/wp-typia/src/runtime-capabilities.ts
+++ b/packages/wp-typia/src/runtime-capabilities.ts
@@ -1,0 +1,26 @@
+type TtyLike = {
+	isTTY?: boolean;
+};
+
+type RuntimeCapabilityOptions = {
+	hasBunRuntime?: boolean;
+	stdin?: TtyLike | null | undefined;
+	stdout?: TtyLike | null | undefined;
+	term?: string | undefined;
+};
+
+export function isInteractiveTerminal({
+	stdin = process.stdin,
+	stdout = process.stdout,
+	term = process.env.TERM,
+}: RuntimeCapabilityOptions = {}): boolean {
+	return Boolean(stdin?.isTTY) && Boolean(stdout?.isTTY) && term !== "dumb";
+}
+
+export function supportsInteractiveTui(
+	options: RuntimeCapabilityOptions = {},
+): boolean {
+	const hasBunRuntime =
+		options.hasBunRuntime ?? typeof Bun !== "undefined";
+	return hasBunRuntime && isInteractiveTerminal(options);
+}

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -45,6 +45,10 @@ const nodeCliSource = fs.readFileSync(
 	path.join(packageRoot, "src", "node-cli.ts"),
 	"utf8",
 );
+const cliSource = fs.readFileSync(
+	path.join(packageRoot, "src", "cli.ts"),
+	"utf8",
+);
 const addFlowSource = fs.readFileSync(
 	path.join(packageRoot, "src", "ui", "add-flow.tsx"),
 	"utf8",
@@ -195,6 +199,7 @@ describe("wp-typia package", () => {
 		expect(projectToolsPackageManifest.exports["./hooked-blocks"]).toBeDefined();
 		expect(projectToolsPackageManifest.exports["./migrations"]).toBeDefined();
 		expect(projectToolsPackageManifest.exports["./package-managers"]).toBeDefined();
+		expect(projectToolsPackageManifest.exports["./temp-roots"]).toBeDefined();
 		expect(projectToolsPackageManifest.exports["./workspace-project"]).toBeDefined();
 	});
 
@@ -209,6 +214,19 @@ describe("wp-typia package", () => {
 		expect(doctorCommandSource).not.toMatch(/from ["']@wp-typia\/project-tools["']/);
 		expect(addFlowSource).not.toMatch(/from ["']@wp-typia\/project-tools["']/);
 		expect(createFlowSource).not.toMatch(/from ["']@wp-typia\/project-tools["']/);
+	});
+
+	test("gates interactive TUI rendering on real terminal capability and avoids hard exit short-circuits", () => {
+		expect(createCommandSource).toContain('supportsInteractiveTui');
+		expect(addCommandSource).toContain('supportsInteractiveTui');
+		expect(migrateCommandSource).toContain('supportsInteractiveTui');
+		expect(createCommandSource).not.toContain('typeof Bun !== "undefined"');
+		expect(addCommandSource).not.toContain('typeof Bun !== "undefined"');
+		expect(migrateCommandSource).not.toContain('typeof Bun !== "undefined"');
+		expect(nodeCliSource).toContain("process.exitCode = 1");
+		expect(nodeCliSource).not.toContain("process.exit(1)");
+		expect(cliSource).toContain("process.exitCode = 1");
+		expect(cliSource).not.toContain("process.exit(1)");
 	});
 
 	test("renders help output through the canonical bin", () => {

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -220,13 +220,13 @@ describe("wp-typia package", () => {
 		expect(createCommandSource).toContain('supportsInteractiveTui');
 		expect(addCommandSource).toContain('supportsInteractiveTui');
 		expect(migrateCommandSource).toContain('supportsInteractiveTui');
-		expect(createCommandSource).not.toContain('typeof Bun !== "undefined"');
-		expect(addCommandSource).not.toContain('typeof Bun !== "undefined"');
-		expect(migrateCommandSource).not.toContain('typeof Bun !== "undefined"');
+		expect(createCommandSource).not.toMatch(/typeof\s+Bun\s*!==\s*["']undefined["']/);
+		expect(addCommandSource).not.toMatch(/typeof\s+Bun\s*!==\s*["']undefined["']/);
+		expect(migrateCommandSource).not.toMatch(/typeof\s+Bun\s*!==\s*["']undefined["']/);
 		expect(nodeCliSource).toContain("process.exitCode = 1");
-		expect(nodeCliSource).not.toContain("process.exit(1)");
+		expect(nodeCliSource).not.toMatch(/process\.exit\s*\(\s*1\s*\)/);
 		expect(cliSource).toContain("process.exitCode = 1");
-		expect(cliSource).not.toContain("process.exit(1)");
+		expect(cliSource).not.toMatch(/process\.exit\s*\(\s*1\s*\)/);
 	});
 
 	test("renders help output through the canonical bin", () => {

--- a/packages/wp-typia/tests/runtime-capabilities.test.ts
+++ b/packages/wp-typia/tests/runtime-capabilities.test.ts
@@ -63,4 +63,22 @@ describe("wp-typia runtime capability detection", () => {
 			}),
 		).toBe(false);
 	});
+
+	test("default runtime capability arguments mirror the current process streams", () => {
+		expect(isInteractiveTerminal()).toBe(
+			isInteractiveTerminal({
+				stdin: process.stdin,
+				stdout: process.stdout,
+				term: process.env.TERM,
+			}),
+		);
+		expect(supportsInteractiveTui()).toBe(
+			supportsInteractiveTui({
+				hasBunRuntime: typeof Bun !== "undefined",
+				stdin: process.stdin,
+				stdout: process.stdout,
+				term: process.env.TERM,
+			}),
+		);
+	});
 });

--- a/packages/wp-typia/tests/runtime-capabilities.test.ts
+++ b/packages/wp-typia/tests/runtime-capabilities.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+	isInteractiveTerminal,
+	supportsInteractiveTui,
+} from "../src/runtime-capabilities";
+
+describe("wp-typia runtime capability detection", () => {
+	test("interactive terminals require TTY stdin/stdout and a non-dumb TERM", () => {
+		expect(
+			isInteractiveTerminal({
+				stdin: { isTTY: true },
+				stdout: { isTTY: true },
+				term: "xterm-256color",
+			}),
+		).toBe(true);
+		expect(
+			isInteractiveTerminal({
+				stdin: { isTTY: false },
+				stdout: { isTTY: true },
+				term: "xterm-256color",
+			}),
+		).toBe(false);
+		expect(
+			isInteractiveTerminal({
+				stdin: { isTTY: true },
+				stdout: { isTTY: false },
+				term: "xterm-256color",
+			}),
+		).toBe(false);
+		expect(
+			isInteractiveTerminal({
+				stdin: { isTTY: true },
+				stdout: { isTTY: true },
+				term: "dumb",
+			}),
+		).toBe(false);
+	});
+
+	test("interactive TUI support requires both Bun and an interactive terminal", () => {
+		expect(
+			supportsInteractiveTui({
+				hasBunRuntime: true,
+				stdin: { isTTY: true },
+				stdout: { isTTY: true },
+				term: "xterm-256color",
+			}),
+		).toBe(true);
+		expect(
+			supportsInteractiveTui({
+				hasBunRuntime: false,
+				stdin: { isTTY: true },
+				stdout: { isTTY: true },
+				term: "xterm-256color",
+			}),
+		).toBe(false);
+		expect(
+			supportsInteractiveTui({
+				hasBunRuntime: true,
+				stdin: { isTTY: false },
+				stdout: { isTTY: true },
+				term: "xterm-256color",
+			}),
+		).toBe(false);
+	});
+});

--- a/packages/wp-typia/tests/tui-lifecycle.test.ts
+++ b/packages/wp-typia/tests/tui-lifecycle.test.ts
@@ -10,6 +10,7 @@ import {
 import { addCommand } from "../src/commands/add";
 import { createCommand } from "../src/commands/create";
 import { migrateCommand } from "../src/commands/migrate";
+import { supportsInteractiveTui } from "../src/runtime-capabilities";
 import {
 	isAlternateBufferCompletionKey,
 	describeAlternateBufferFailure,
@@ -298,12 +299,19 @@ describe("alternate-buffer TUI lifecycle", () => {
 	});
 
 	test("interactive commands keep alternate-buffer rendering enabled", () => {
-		expect(createCommand.tui?.renderer?.bufferMode).toBe("alternate");
-		expect(addCommand.tui?.renderer?.bufferMode).toBe("alternate");
-		expect(migrateCommand.tui?.renderer?.bufferMode).toBe("alternate");
-		expect(typeof createCommand.render).toBe("function");
-		expect(typeof addCommand.render).toBe("function");
-		expect(typeof migrateCommand.render).toBe("function");
+		const expectedBufferMode = supportsInteractiveTui()
+			? "alternate"
+			: undefined;
+		const expectedRenderType = supportsInteractiveTui()
+			? "function"
+			: "undefined";
+
+		expect(createCommand.tui?.renderer?.bufferMode).toBe(expectedBufferMode);
+		expect(addCommand.tui?.renderer?.bufferMode).toBe(expectedBufferMode);
+		expect(migrateCommand.tui?.renderer?.bufferMode).toBe(expectedBufferMode);
+		expect(typeof createCommand.render).toBe(expectedRenderType);
+		expect(typeof addCommand.render).toBe(expectedRenderType);
+		expect(typeof migrateCommand.render).toBe(expectedRenderType);
 	});
 
 	test("shared first-party submit surface replaces stale create fields while submitting", () => {


### PR DESCRIPTION
## Context

Follow up on runtime-lifecycle edges around TTY detection, fallback cleanup, and temporary wp-typia directories.

## What Changed

- gate Bun TUI rendering on real interactive terminal capability instead of Bun presence alone
- stop top-level CLI entrypoints from forcing immediate `process.exit(1)` so cleanup paths can settle naturally
- add managed wp-typia temp-root helpers with stale-root pruning and signal-aware cleanup
- route scaffold, add-block, dry-run, and remote/external template temp directories through the shared temp-root lifecycle helper
- add source and package-level regression tests for runtime capability detection and temp-root cleanup

## Verification

- `bun run --filter @wp-typia/project-tools build`
- `bun run --filter wp-typia build`
- `bun test packages/wp-typia/tests/runtime-capabilities.test.ts packages/wp-typia/tests/cli-package.test.ts --test-name-pattern "runtime capability detection|gates interactive TUI rendering on real terminal capability and avoids hard exit short-circuits|owns the canonical CLI bin and keeps project-tools as a library dependency"`
- `bun test packages/wp-typia-project-tools/tests/temp-roots.test.ts`
- `bun run changesets:validate`
- `bun test packages/wp-typia-project-tools/tests/template-source.test.ts packages/wp-typia-project-tools/tests/cli-entry.test.ts packages/wp-typia-project-tools/tests/workspace-add.test.ts --timeout 15000`

Closes #512


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI error handling: commands now exit gracefully with proper status codes
  * Enhanced runtime detection: interactive features now work more reliably across different terminal environments

* **New Features**
  * Optimized temporary directory management for improved system reliability and cleanup behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->