### PR TITLE
Stabilize delayed invalidation follow-up coverage

### DIFF
--- a/packages/wp-typia-rest/tests/react.test.tsx
+++ b/packages/wp-typia-rest/tests/react.test.tsx
@@ -530,11 +530,12 @@ describe("@wp-typia/rest/react", () => {
 		client.invalidate(endpoint, request);
 		await flush();
 		resolveFirstFetch({ count: 1 });
+		await flush();
 
 		await waitForAssertion(() => {
 			expect(fetchCount).toBe(2);
 			expect(rendered.current.data).toEqual({ count: 2 });
-		}, 5_000);
+		}, 10_000);
 
 		await rendered.unmount();
 	});
@@ -589,12 +590,13 @@ describe("@wp-typia/rest/react", () => {
 		client.invalidate(endpoint, request);
 		await flush();
 		rejectFirstFetch(new Error("offline"));
+		await flush();
 
 		await waitForAssertion(() => {
 			expect(fetchCount).toBe(2);
 			expect(rendered.current.data).toEqual({ count: 2 });
 			expect(rendered.current.error).toBeNull();
-		}, 5_000);
+		}, 10_000);
 
 		await rendered.unmount();
 	});


### PR DESCRIPTION
## Context

Follow up on the `main` post-merge CI regression from #522. The delayed invalidation follow-up coverage in `@wp-typia/rest` was timing out intermittently in GitHub Actions even though the runtime path stayed green locally.

## What Changed

- give the delayed invalidation follow-up tests one extra flush after resolving or rejecting the in-flight request
- widen the assertion timeout window for the delayed resolve and delayed reject follow-up cases so CI scheduling jitter does not trip the coverage lane

## Verification

- `bun run --filter @wp-typia/rest test:coverage`
- `bun run changesets:validate`
- repeated `bun test packages/wp-typia-rest/tests/react.test.tsx --test-name-pattern "invalidate preserves follow-up fetches when an older request fails late"`

Closes #523
