### PR TITLE
Fix linked reference smoke workspace dependency rewrites

### DIFF
--- a/scripts/lib/generated-project-smoke-core.mjs
+++ b/scripts/lib/generated-project-smoke-core.mjs
@@ -170,6 +170,7 @@ export function rewriteWorkspaceDependencies(projectDir, packageManager) {
 	const localApiClientDependency = `file:${path.resolve(repoRoot, "packages/wp-typia-api-client")}`;
 	const localBlockRuntimeDependency = `file:${path.resolve(repoRoot, "packages/wp-typia-block-runtime")}`;
 	const localBlockTypesDependency = `file:${path.resolve(repoRoot, "packages/wp-typia-block-types")}`;
+	const localProjectToolsDependency = `file:${path.resolve(repoRoot, "packages/wp-typia-project-tools")}`;
 	const localRestDependency = `file:${path.resolve(repoRoot, "packages/wp-typia-rest")}`;
 	const localCliDependency = `file:${path.resolve(repoRoot, "packages/wp-typia")}`;
 
@@ -211,9 +212,18 @@ export function rewriteWorkspaceDependencies(projectDir, packageManager) {
 		"@wp-typia/rest",
 		"wp-typia",
 	];
+	const hasProjectToolsDependency =
+		packageJson.devDependencies?.["@wp-typia/project-tools"] ||
+		packageJson.dependencies?.["@wp-typia/project-tools"];
 	const hasApiClientDependency =
 		packageJson.devDependencies?.["@wp-typia/api-client"] ||
 		packageJson.dependencies?.["@wp-typia/api-client"];
+	const shouldSeedProjectToolsInDevDependencies = linkedRuntimePackages.some(
+		(packageName) => packageJson.devDependencies?.[packageName],
+	);
+	const shouldSeedProjectToolsInDependencies = linkedRuntimePackages.some(
+		(packageName) => packageJson.dependencies?.[packageName],
+	);
 	const shouldSeedApiClientInDevDependencies = linkedRuntimePackages.some(
 		(packageName) => packageJson.devDependencies?.[packageName],
 	);
@@ -235,11 +245,26 @@ export function rewriteWorkspaceDependencies(projectDir, packageManager) {
 		}
 	}
 
+	if (!hasProjectToolsDependency) {
+		if (shouldSeedProjectToolsInDevDependencies) {
+			packageJson.devDependencies = {
+				...(packageJson.devDependencies ?? {}),
+				"@wp-typia/project-tools": localProjectToolsDependency,
+			};
+		} else if (shouldSeedProjectToolsInDependencies) {
+			packageJson.dependencies = {
+				...(packageJson.dependencies ?? {}),
+				"@wp-typia/project-tools": localProjectToolsDependency,
+			};
+		}
+	}
+
 	packageJson.overrides = {
 		...(packageJson.overrides ?? {}),
 		"@wp-typia/block-runtime": localBlockRuntimeDependency,
 		"@wp-typia/api-client": localApiClientDependency,
 		"@wp-typia/block-types": localBlockTypesDependency,
+		"@wp-typia/project-tools": localProjectToolsDependency,
 		"@wp-typia/rest": localRestDependency,
 		"wp-typia": localCliDependency,
 	};
@@ -250,6 +275,7 @@ export function rewriteWorkspaceDependencies(projectDir, packageManager) {
 			"@wp-typia/block-runtime": localBlockRuntimeDependency,
 			"@wp-typia/api-client": localApiClientDependency,
 			"@wp-typia/block-types": localBlockTypesDependency,
+			"@wp-typia/project-tools": localProjectToolsDependency,
 			"@wp-typia/rest": localRestDependency,
 			"wp-typia": localCliDependency,
 		},
@@ -259,6 +285,7 @@ export function rewriteWorkspaceDependencies(projectDir, packageManager) {
 		"@wp-typia/block-runtime": localBlockRuntimeDependency,
 		"@wp-typia/api-client": localApiClientDependency,
 		"@wp-typia/block-types": localBlockTypesDependency,
+		"@wp-typia/project-tools": localProjectToolsDependency,
 		"@wp-typia/rest": localRestDependency,
 		"wp-typia": localCliDependency,
 	};

--- a/tests/unit/generated-project-smoke-reference-lane.test.ts
+++ b/tests/unit/generated-project-smoke-reference-lane.test.ts
@@ -83,7 +83,7 @@ test("CI generated smoke matrix includes the checked-in example lanes", () => {
 	expect(ciWorkflow).toContain('--example-project "${{ matrix.example_project }}"');
 });
 
-test("workspace dependency rewrite seeds api-client for linked Bun reference examples", async () => {
+test("workspace dependency rewrite seeds local runtime packages for linked Bun reference examples", async () => {
 	const projectDir = fs.mkdtempSync(
 		join(os.tmpdir(), "wp-typia-generated-smoke-reference-"),
 	);
@@ -129,10 +129,19 @@ test("workspace dependency rewrite seeds api-client for linked Bun reference exa
 	expect(rewrittenPackageJson.devDependencies["@wp-typia/block-runtime"]).toContain(
 		"packages/wp-typia-block-runtime",
 	);
+	expect(rewrittenPackageJson.devDependencies["@wp-typia/project-tools"]).toContain(
+		"packages/wp-typia-project-tools",
+	);
 	expect(rewrittenPackageJson.devDependencies["@wp-typia/rest"]).toContain(
 		"packages/wp-typia-rest",
 	);
 	expect(rewrittenPackageJson.devDependencies["wp-typia"]).toContain(
 		"packages/wp-typia",
+	);
+	expect(rewrittenPackageJson.overrides["@wp-typia/project-tools"]).toContain(
+		"packages/wp-typia-project-tools",
+	);
+	expect(rewrittenPackageJson.resolutions["@wp-typia/project-tools"]).toContain(
+		"packages/wp-typia-project-tools",
 	);
 });


### PR DESCRIPTION
## Context

`main` CI is failing in the `Generated Project Smoke (smoke-reference-my-typia-block-bun)` lane after `#524`. The copied reference example rewrites local runtime packages for the Bun-linked smoke run, but it still leaves `@wp-typia/project-tools` on the published dependency tree.

## What Changed

- seed local `@wp-typia/project-tools` into rewritten example dependencies when linked runtime packages are present
- pin `@wp-typia/project-tools` in `overrides`, `pnpm.overrides`, and `resolutions` alongside the other linked runtime packages
- extend the reference-lane regression test to lock the new rewrite behavior

## Verification

- `bun test tests/unit/generated-project-smoke-reference-lane.test.ts`
- `node scripts/run-generated-project-smoke.mjs --runtime bun --example-project my-typia-block --package-manager bun --project-name smoke-reference-my-typia-block-bun-fix`
- `bun run changesets:validate`

Closes #525

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced local workspace dependency management and resolution for improved project setup configuration.

* **Tests**
  * Updated test assertions to validate proper dependency resolution and package configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->