### PR TITLE
Allow local project-tools smoke rewrites in generated package boundary checks

### DIFF
--- a/scripts/lib/generated-project-smoke-assertions.mjs
+++ b/scripts/lib/generated-project-smoke-assertions.mjs
@@ -213,15 +213,33 @@ function assertGeneratedRuntimeImports(projectDir) {
 	}
 }
 
-function assertGeneratedPackageBoundary(projectDir) {
+function isLocalProjectToolsRewrite(value) {
+	return (
+		typeof value === "string" &&
+		value.startsWith("file:") &&
+		/[\\/]packages[\\/]wp-typia-project-tools(?:$|[\\/])/u.test(value)
+	);
+}
+
+export function assertGeneratedPackageBoundary(projectDir) {
 	const packageJsonPath = path.join(projectDir, "package.json");
 	const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
 
-	if (packageJson.dependencies?.["@wp-typia/project-tools"]) {
-		throw new Error("Expected generated project dependencies to omit @wp-typia/project-tools");
+	if (
+		packageJson.dependencies?.["@wp-typia/project-tools"] &&
+		!isLocalProjectToolsRewrite(packageJson.dependencies["@wp-typia/project-tools"])
+	) {
+		throw new Error(
+			"Expected generated project dependencies to omit @wp-typia/project-tools unless smoke rewrites pinned it to the local workspace package",
+		);
 	}
-	if (packageJson.devDependencies?.["@wp-typia/project-tools"]) {
-		throw new Error("Expected generated project devDependencies to omit @wp-typia/project-tools");
+	if (
+		packageJson.devDependencies?.["@wp-typia/project-tools"] &&
+		!isLocalProjectToolsRewrite(packageJson.devDependencies["@wp-typia/project-tools"])
+	) {
+		throw new Error(
+			"Expected generated project devDependencies to omit @wp-typia/project-tools unless smoke rewrites pinned it to the local workspace package",
+		);
 	}
 	for (const [scriptName, scriptValue] of Object.entries(packageJson.scripts ?? {})) {
 		if (typeof scriptValue !== "string") {

--- a/tests/unit/generated-project-smoke-reference-lane.test.ts
+++ b/tests/unit/generated-project-smoke-reference-lane.test.ts
@@ -145,3 +145,74 @@ test("workspace dependency rewrite seeds local runtime packages for linked Bun r
 		"packages/wp-typia-project-tools",
 	);
 });
+
+test("generated project smoke assertions accept local project-tools smoke rewrites", async () => {
+	const projectDir = fs.mkdtempSync(
+		join(os.tmpdir(), "wp-typia-generated-smoke-boundary-"),
+	);
+	tempDirs.push(projectDir);
+
+	fs.writeFileSync(
+		join(projectDir, "package.json"),
+		`${JSON.stringify(
+			{
+				name: "demo-smoke-boundary",
+				private: true,
+				devDependencies: {
+					"@wp-typia/project-tools":
+						"file:/Users/imjlk/repos/imjlk/wp-typia-boilerplate/packages/wp-typia-project-tools",
+				},
+				scripts: {
+					build: "wp-scripts build",
+				},
+			},
+			null,
+			2,
+		)}\n`,
+		"utf8",
+	);
+
+	const { assertGeneratedPackageBoundary } = (await import(
+		new URL("../../scripts/lib/generated-project-smoke-assertions.mjs", import.meta.url).href
+	)) as {
+		assertGeneratedPackageBoundary: (projectDir: string) => void;
+	};
+
+	expect(() => assertGeneratedPackageBoundary(projectDir)).not.toThrow();
+});
+
+test("generated project smoke assertions still reject published project-tools dependencies", async () => {
+	const projectDir = fs.mkdtempSync(
+		join(os.tmpdir(), "wp-typia-generated-smoke-boundary-reject-"),
+	);
+	tempDirs.push(projectDir);
+
+	fs.writeFileSync(
+		join(projectDir, "package.json"),
+		`${JSON.stringify(
+			{
+				name: "demo-smoke-boundary-reject",
+				private: true,
+				devDependencies: {
+					"@wp-typia/project-tools": "^0.19.0",
+				},
+				scripts: {
+					build: "wp-scripts build",
+				},
+			},
+			null,
+			2,
+		)}\n`,
+		"utf8",
+	);
+
+	const { assertGeneratedPackageBoundary } = (await import(
+		new URL("../../scripts/lib/generated-project-smoke-assertions.mjs", import.meta.url).href
+	)) as {
+		assertGeneratedPackageBoundary: (projectDir: string) => void;
+	};
+
+	expect(() => assertGeneratedPackageBoundary(projectDir)).toThrow(
+		/omit @wp-typia\/project-tools unless smoke rewrites pinned it to the local workspace package/,
+	);
+});

--- a/tests/unit/generated-project-smoke-reference-lane.test.ts
+++ b/tests/unit/generated-project-smoke-reference-lane.test.ts
@@ -159,8 +159,11 @@ test("generated project smoke assertions accept local project-tools smoke rewrit
 				name: "demo-smoke-boundary",
 				private: true,
 				devDependencies: {
-					"@wp-typia/project-tools":
-						"file:/Users/imjlk/repos/imjlk/wp-typia-boilerplate/packages/wp-typia-project-tools",
+					"@wp-typia/project-tools": `file:${join(
+						repoRoot,
+						"packages",
+						"wp-typia-project-tools",
+					)}`,
 				},
 				scripts: {
 					build: "wp-scripts build",


### PR DESCRIPTION
## Context

`main` CI broke again after `#526`, but the runtime rewrite itself is correct. The follow-up failure came from `generated-project-smoke-assertions.mjs`, which still treated any `@wp-typia/project-tools` dependency as a hard boundary violation even when smoke rewrites intentionally pinned it to the local workspace package.

## What Changed

- allow `assertGeneratedPackageBoundary()` to accept local `file:` rewrites for `@wp-typia/project-tools` that point back to the repo workspace package
- keep rejecting published or accidental `@wp-typia/project-tools` dependencies in generated projects
- add unit coverage for both the allowed local rewrite case and the rejected published dependency case

## Verification

- `bun test tests/unit/generated-project-smoke-reference-lane.test.ts`
- `node scripts/run-generated-project-smoke.mjs --runtime node --package-manager npm --template @wp-typia/create-workspace-template --project-name smoke-workspace-add-binding-source-npm --add-binding-source-name hero-data`
- `bun run changesets:validate`

Closes #527

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced package boundary validation to allow local workspace file rewrites while continuing to reject published package versions.

* **Tests**
  * Added unit tests for package boundary assertion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->