### PR TITLE
Improve standalone doctor, add, sync, and missing-artifact guidance

### DIFF
--- a/.sampo/changesets/issue-516-standalone-guidance.md
+++ b/.sampo/changesets/issue-516-standalone-guidance.md
@@ -1,0 +1,6 @@
+---
+npm/wp-typia: patch
+npm/@wp-typia/project-tools: patch
+---
+
+Improved doctor scope messaging, add completion guidance, sync and dry-run help text, and missing bundled-artifact diagnostics across standalone CLI flows.

--- a/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace.ts
@@ -625,7 +625,7 @@ export function getWorkspaceDoctorChecks(cwd: string): DoctorCheck[] {
 		checks.push(
 			createDoctorScopeCheck(
 				"fail",
-				"Environment checks ran, but workspace discovery could not continue. Fix the nearby workspace package metadata and rerun `wp-typia doctor`.",
+				"Scope: blocked before workspace checks. Environment checks ran, but workspace discovery could not continue. Fix the nearby workspace package metadata and rerun `wp-typia doctor`.",
 			),
 		);
 		checks.push(
@@ -642,7 +642,7 @@ export function getWorkspaceDoctorChecks(cwd: string): DoctorCheck[] {
 			checks.push(
 				createDoctorScopeCheck(
 					"fail",
-					"Environment checks ran, but workspace diagnostics could not continue because a nearby wp-typia workspace candidate is invalid. Fix the workspace package metadata and rerun `wp-typia doctor`.",
+					"Scope: blocked before workspace checks. Environment checks ran, but workspace diagnostics could not continue because a nearby wp-typia workspace candidate is invalid. Fix the workspace package metadata and rerun `wp-typia doctor`.",
 				),
 			);
 			checks.push(
@@ -656,7 +656,7 @@ export function getWorkspaceDoctorChecks(cwd: string): DoctorCheck[] {
 			checks.push(
 				createDoctorScopeCheck(
 					"pass",
-					"No official wp-typia workspace root was detected, so this run only covered environment readiness. Re-run `wp-typia doctor` from a workspace root if you expected package metadata, inventory, or generated artifact checks.",
+					"Scope: environment-only. No official wp-typia workspace root was detected, so this run only covered environment readiness. Re-run `wp-typia doctor` from a workspace root if you expected package metadata, inventory, or generated artifact checks.",
 				),
 			);
 		}
@@ -666,7 +666,7 @@ export function getWorkspaceDoctorChecks(cwd: string): DoctorCheck[] {
 	checks.push(
 		createDoctorScopeCheck(
 			"pass",
-			`Official workspace detected for ${workspace.workspace.namespace}; environment readiness checks ran and workspace-scoped diagnostics are enabled for the package metadata, inventory, source-tree drift, and any configured migration hint rows below.`,
+			`Scope: full workspace diagnostics for ${workspace.workspace.namespace}. Environment readiness checks ran and workspace-scoped diagnostics are enabled for the package metadata, inventory, source-tree drift, and any configured migration hint rows below.`,
 		),
 	);
 

--- a/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
@@ -34,6 +34,7 @@ test("doctor reports environment-only scope outside official workspace roots", a
   const scopeCheck = checks.find((check) => check.label === "Doctor scope");
 
   expect(scopeCheck?.status).toBe("pass");
+  expect(scopeCheck?.detail).toContain("Scope: environment-only");
   expect(scopeCheck?.detail).toContain("only covered environment readiness");
   expect(scopeCheck?.detail).toContain("workspace root");
   expect(
@@ -67,6 +68,7 @@ test("doctor reports invalid nearby workspace metadata before workspace checks",
   );
 
   expect(scopeCheck?.status).toBe("fail");
+  expect(scopeCheck?.detail).toContain("Scope: blocked before workspace checks");
   expect(scopeCheck?.detail).toContain("workspace diagnostics could not continue");
   expect(scopeCheck?.detail).toContain("rerun `wp-typia doctor`");
   expect(metadataCheck?.status).toBe("fail");
@@ -87,6 +89,7 @@ test("doctor reports workspace discovery failures before workspace checks", asyn
   );
 
   expect(scopeCheck?.status).toBe("fail");
+  expect(scopeCheck?.detail).toContain("Scope: blocked before workspace checks");
   expect(scopeCheck?.detail).toContain("workspace discovery could not continue");
   expect(scopeCheck?.detail).toContain("rerun `wp-typia doctor`");
   expect(metadataCheck?.status).toBe("fail");

--- a/packages/wp-typia/.bunli/commands.gen.ts
+++ b/packages/wp-typia/.bunli/commands.gen.ts
@@ -54,7 +54,7 @@ const metadata: Record<GeneratedNames, GeneratedCommandMeta> = {
     },
   'sync': {
       name: 'sync',
-      description: 'Run the common generated-project sync workflow.',
+      description: 'Run the generated-project sync workflow from a scaffolded project or official workspace root.',
       path: './src/commands/sync'
     },
   'templates': {

--- a/packages/wp-typia/src/command-option-metadata.ts
+++ b/packages/wp-typia/src/command-option-metadata.ts
@@ -25,7 +25,8 @@ export const CREATE_OPTION_METADATA = {
 	},
 	"dry-run": {
 		argumentKind: "flag",
-		description: "Preview scaffold output without writing files to the target directory.",
+		description:
+			"Preview scaffold output for a logical <project-dir> without writing files to the target directory.",
 		type: "boolean",
 	},
 	"external-layer-id": {
@@ -126,7 +127,8 @@ export const ADD_OPTION_METADATA = {
 	},
 	"dry-run": {
 		argumentKind: "flag",
-		description: "Preview workspace file updates without writing them.",
+		description:
+			"Preview workspace file updates and completion guidance without writing them.",
 		type: "boolean",
 	},
 	"external-layer-id": {

--- a/packages/wp-typia/src/commands/add.ts
+++ b/packages/wp-typia/src/commands/add.ts
@@ -19,7 +19,9 @@ function loadAddFlow() {
 			"./ui/add-flow.js",
 			"../ui/add-flow.js",
 			"../ui/add-flow.tsx",
-		]),
+		], {
+			moduleLabel: "the add-flow UI",
+		}),
 	).then((module) => ({ default: module.AddFlow }));
 }
 

--- a/packages/wp-typia/src/commands/create.ts
+++ b/packages/wp-typia/src/commands/create.ts
@@ -19,7 +19,9 @@ function loadCreateFlow() {
 			"./ui/create-flow.js",
 			"../ui/create-flow.js",
 			"../ui/create-flow.tsx",
-		]),
+		], {
+			moduleLabel: "the create-flow UI",
+		}),
 	).then((module) => ({ default: module.CreateFlow }));
 }
 
@@ -34,7 +36,10 @@ export const createCommand = defineCommand({
 			const { createCliCommandError } = await import("@wp-typia/project-tools/cli-diagnostics");
 			throw createCliCommandError({
 				command: "create",
-				detailLines: ["`wp-typia create` requires <project-dir>."],
+				detailLines: [
+					"`wp-typia create` requires <project-dir>.",
+					"`--dry-run` still needs a logical project directory name because wp-typia derives slugs, package names, and planned file paths from it.",
+				],
 			});
 		}
 		await executeCreateCommand({

--- a/packages/wp-typia/src/commands/migrate.ts
+++ b/packages/wp-typia/src/commands/migrate.ts
@@ -18,7 +18,9 @@ function loadMigrateFlow() {
 			"./ui/migrate-flow.js",
 			"../ui/migrate-flow.js",
 			"../ui/migrate-flow.tsx",
-		]),
+		], {
+			moduleLabel: "the migrate-flow UI",
+		}),
 	).then((module) => ({ default: module.MigrateFlow }));
 }
 

--- a/packages/wp-typia/src/commands/sync.ts
+++ b/packages/wp-typia/src/commands/sync.ts
@@ -4,7 +4,8 @@ import { z } from "zod";
 import { executeSyncCommand } from "../runtime-bridge";
 
 export const syncCommand = defineCommand({
-	description: "Run the common generated-project sync workflow.",
+	description:
+		"Run the generated-project sync workflow from a scaffolded project or official workspace root.",
 	handler: async (args) => {
 		await executeSyncCommand({
 			check: Boolean(args.flags.check),

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -519,7 +519,10 @@ export async function runNodeCli(argv = process.argv.slice(2)): Promise<void> {
 		if (!projectDir) {
 			throw createCliCommandError({
 				command: "create",
-				detailLines: ["`wp-typia create` requires <project-dir>."],
+				detailLines: [
+					"`wp-typia create` requires <project-dir>.",
+					"`--dry-run` still needs a logical project directory name because wp-typia derives slugs, package names, and planned file paths from it.",
+				],
 			});
 		}
 		await executeCreateCommand({

--- a/packages/wp-typia/src/render-loader.ts
+++ b/packages/wp-typia/src/render-loader.ts
@@ -1,7 +1,13 @@
 import fs from "node:fs";
 import { fileURLToPath } from "node:url";
 
-export function resolveBundledModuleHref(baseUrl: string, candidates: string[]): string {
+export function resolveBundledModuleHref(
+	baseUrl: string,
+	candidates: string[],
+	options: {
+		moduleLabel?: string;
+	} = {},
+): string {
 	for (const candidate of candidates) {
 		const url = new URL(candidate, baseUrl);
 		if (fs.existsSync(fileURLToPath(url))) {
@@ -9,5 +15,16 @@ export function resolveBundledModuleHref(baseUrl: string, candidates: string[]):
 		}
 	}
 
-	return new URL(candidates[0]!, baseUrl).href;
+	const missingCandidates = candidates.map((candidate) =>
+		fileURLToPath(new URL(candidate, baseUrl)),
+	);
+	const label = options.moduleLabel ?? "bundled wp-typia runtime module";
+	throw new Error(
+		[
+			`Missing bundled build artifacts for ${label}.`,
+			"None of the expected files were found:",
+			...missingCandidates.map((candidatePath) => `- ${candidatePath}`),
+			"Run `bun run --filter wp-typia build` in a source checkout, or reinstall the published package/standalone binary if its bundled files are missing.",
+		].join("\n"),
+	);
 }

--- a/packages/wp-typia/src/runtime-bridge-output.ts
+++ b/packages/wp-typia/src/runtime-bridge-output.ts
@@ -1,8 +1,12 @@
+import fs from "node:fs";
+import path from "node:path";
+
 import packageJson from "../package.json";
 import { formatPackageExecCommand } from "@wp-typia/project-tools/package-managers";
 import type { AlternateBufferCompletionPayload } from "./ui/alternate-buffer-lifecycle";
 
 type PrintLine = (line: string) => void;
+type PackageManagerId = "bun" | "npm" | "pnpm" | "yarn";
 
 export type CreateProgressPayload = {
 	detail: string;
@@ -175,6 +179,39 @@ export function buildCreateDryRunPayload(flow: {
 	};
 }
 
+function inferProjectPackageManager(projectDir: string): PackageManagerId {
+	try {
+		const packageJsonPath = path.join(projectDir, "package.json");
+		if (fs.existsSync(packageJsonPath)) {
+			const manifest = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as {
+				packageManager?: string;
+			};
+			if (manifest.packageManager?.startsWith("bun@")) return "bun";
+			if (manifest.packageManager?.startsWith("pnpm@")) return "pnpm";
+			if (manifest.packageManager?.startsWith("yarn@")) return "yarn";
+			if (manifest.packageManager?.startsWith("npm@")) return "npm";
+		}
+	} catch {}
+
+	if (
+		fs.existsSync(path.join(projectDir, "bun.lock")) ||
+		fs.existsSync(path.join(projectDir, "bun.lockb"))
+	) {
+		return "bun";
+	}
+	if (fs.existsSync(path.join(projectDir, "pnpm-lock.yaml"))) {
+		return "pnpm";
+	}
+	if (
+		fs.existsSync(path.join(projectDir, "yarn.lock")) ||
+		fs.existsSync(path.join(projectDir, ".yarnrc.yml"))
+	) {
+		return "yarn";
+	}
+
+	return "npm";
+}
+
 /**
  * Builds the completion payload shown after a migrate command succeeds.
  *
@@ -208,13 +245,20 @@ export function buildAddCompletionPayload(options: {
 		| "pattern"
 		| "rest-resource"
 		| "variation";
+	packageManager?: PackageManagerId;
 	projectDir: string;
 	values: Record<string, string>;
 	warnings?: string[];
 }): AlternateBufferCompletionPayload {
-	const verificationLines = ["wp-typia doctor"];
+	const verificationLines = [
+		formatPackageExecCommand(
+			options.packageManager ?? inferProjectPackageManager(options.projectDir),
+			`wp-typia@${packageJson.version}`,
+			"doctor",
+		),
+	];
 	const verificationNote =
-		"Run doctor for a quick inventory and generated-artifact check after the add workflow.";
+		"Run doctor via your package manager for a quick inventory and generated-artifact check after the add workflow.";
 
 	switch (options.kind) {
 		case "variation":

--- a/packages/wp-typia/src/runtime-bridge-output.ts
+++ b/packages/wp-typia/src/runtime-bridge-output.ts
@@ -212,9 +212,20 @@ export function buildAddCompletionPayload(options: {
 	values: Record<string, string>;
 	warnings?: string[];
 }): AlternateBufferCompletionPayload {
+	const verificationLines = ["wp-typia doctor"];
+	const verificationNote =
+		"Run doctor for a quick inventory and generated-artifact check after the add workflow.";
+
 	switch (options.kind) {
 		case "variation":
 			return {
+				nextSteps: [
+					`Review src/blocks/${options.values.blockSlug}/variations/${options.values.variationSlug}.ts.`,
+					"Run your workspace build or dev command to pick up the new variation.",
+				],
+				optionalLines: verificationLines,
+				optionalNote: verificationNote,
+				optionalTitle: "Verify workspace health (optional):",
 				summaryLines: [
 					`Variation: ${options.values.variationSlug}`,
 					`Target block: ${options.values.blockSlug}`,
@@ -224,6 +235,13 @@ export function buildAddCompletionPayload(options: {
 			};
 		case "pattern":
 			return {
+				nextSteps: [
+					`Review src/patterns/${options.values.patternSlug}.php.`,
+					"Run your workspace build or dev command to verify the new pattern registration.",
+				],
+				optionalLines: verificationLines,
+				optionalNote: verificationNote,
+				optionalTitle: "Verify workspace health (optional):",
 				summaryLines: [
 					`Pattern: ${options.values.patternSlug}`,
 					`Project directory: ${options.projectDir}`,
@@ -232,6 +250,13 @@ export function buildAddCompletionPayload(options: {
 			};
 		case "binding-source":
 			return {
+				nextSteps: [
+					`Review src/bindings/${options.values.bindingSourceSlug}/server.php and src/bindings/${options.values.bindingSourceSlug}/editor.ts.`,
+					"Run your workspace build or dev command to verify the binding source hooks and editor registration.",
+				],
+				optionalLines: verificationLines,
+				optionalNote: verificationNote,
+				optionalTitle: "Verify workspace health (optional):",
 				summaryLines: [
 					`Binding source: ${options.values.bindingSourceSlug}`,
 					`Project directory: ${options.projectDir}`,
@@ -240,6 +265,13 @@ export function buildAddCompletionPayload(options: {
 			};
 		case "rest-resource":
 			return {
+				nextSteps: [
+					`Review src/rest/${options.values.restResourceSlug}/ and inc/rest/${options.values.restResourceSlug}.php.`,
+					"Run your workspace build or dev command to verify the generated REST resource contract.",
+				],
+				optionalLines: verificationLines,
+				optionalNote: verificationNote,
+				optionalTitle: "Verify workspace health (optional):",
 				summaryLines: [
 					`REST resource: ${options.values.restResourceSlug}`,
 					`Namespace: ${options.values.namespace}`,
@@ -250,6 +282,13 @@ export function buildAddCompletionPayload(options: {
 			};
 		case "editor-plugin":
 			return {
+				nextSteps: [
+					`Review src/editor-plugins/${options.values.editorPluginSlug}/.`,
+					"Run your workspace build or dev command to verify the new editor plugin registration.",
+				],
+				optionalLines: verificationLines,
+				optionalNote: verificationNote,
+				optionalTitle: "Verify workspace health (optional):",
 				summaryLines: [
 					`Editor plugin: ${options.values.editorPluginSlug}`,
 					`Slot: ${options.values.slot}`,
@@ -259,6 +298,13 @@ export function buildAddCompletionPayload(options: {
 			};
 		case "hooked-block":
 			return {
+				nextSteps: [
+					`Review src/blocks/${options.values.blockSlug}/block.json for the new blockHooks entry.`,
+					"Run your workspace build or dev command to verify the updated hooked-block metadata.",
+				],
+				optionalLines: verificationLines,
+				optionalNote: verificationNote,
+				optionalTitle: "Verify workspace health (optional):",
 				summaryLines: [
 					`Block: ${options.values.blockSlug}`,
 					`Anchor: ${options.values.anchorBlockName}`,
@@ -269,6 +315,13 @@ export function buildAddCompletionPayload(options: {
 			};
 		default:
 			return {
+				nextSteps: [
+					"Review the generated sources under src/blocks/ and the updated scripts/block-config.ts entry.",
+					"Run your workspace build or dev command to verify the new scaffolded block family.",
+				],
+				optionalLines: verificationLines,
+				optionalNote: verificationNote,
+				optionalTitle: "Verify workspace health (optional):",
 				summaryLines: [
 					`Blocks: ${options.values.blockSlugs}`,
 					`Template family: ${options.values.templateId}`,

--- a/packages/wp-typia/src/runtime-bridge-sync.ts
+++ b/packages/wp-typia/src/runtime-bridge-sync.ts
@@ -52,7 +52,7 @@ function formatInstallCommand(packageManagerId: PackageManagerId): string {
 
 function getSyncRootError(cwd: string): Error {
 	return new Error(
-		`No generated wp-typia project root was found at ${cwd}. Run \`wp-typia sync\` from a scaffolded project or official workspace root.`,
+		`No generated wp-typia project root was found at ${cwd}. Run \`wp-typia sync\` from a scaffolded project or official workspace root that already contains generated sync scripts. If you expected this directory to work, cd into the scaffold root first or rerun the scaffold before syncing.`,
 	);
 }
 

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -386,7 +386,9 @@ describe("wp-typia package", () => {
 				runUtf8Command("node", [entryPath, "sync"], {
 					cwd: tempRoot,
 				}),
-			).toThrow(/Run `wp-typia sync` from a scaffolded project or official workspace root/);
+			).toThrow(
+				/run `wp-typia sync` from a scaffolded project or official workspace root that already contains generated sync scripts/i,
+			);
 		} finally {
 			fs.rmSync(tempRoot, { force: true, recursive: true });
 		}
@@ -577,6 +579,9 @@ describe("wp-typia package", () => {
 		expect(() => runUtf8Command("node", [entryPath, "create"])).toThrow(
 			"`wp-typia create` requires <project-dir>.",
 		);
+		expect(() => runUtf8Command("node", [entryPath, "create", "--dry-run"])).toThrow(
+			/`--dry-run` still needs a logical project directory name/,
+		);
 	});
 
 	test("rejects typo-like positional alias invocations with extra arguments", () => {
@@ -600,6 +605,9 @@ describe("wp-typia package", () => {
 		expect(result.stderr).toContain("Error: wp-typia create failed");
 		expect(result.stderr).toContain("Summary: Unable to complete the requested create workflow.");
 		expect(result.stderr).toContain("- `wp-typia create` requires <project-dir>.");
+		expect(result.stderr).toContain(
+			"`--dry-run` still needs a logical project directory name",
+		);
 	});
 
 	test("formats add failures with a shared non-interactive diagnostic block", () => {
@@ -708,6 +716,7 @@ describe("wp-typia package", () => {
 
 			expect(result.status).toBe(0);
 			expect(result.stdout).toContain("PASS Doctor scope:");
+			expect(result.stdout).toContain("Scope: environment-only.");
 			expect(result.stdout).toContain("only covered environment readiness");
 			expect(result.stdout).toContain("workspace root");
 			expect(result.stdout).toContain("PASS wp-typia doctor summary:");
@@ -732,14 +741,14 @@ describe("wp-typia package", () => {
 			expect(result.status).toBe(0);
 			expect(result.stdout).toContain(
 				[
-					"PASS Doctor scope: No official wp-typia workspace root",
-					"  was detected, so this run only covered environment",
+					"PASS Doctor scope: Scope: environment-only. No",
+					"  official wp-typia workspace root was detected, so",
 				].join("\n"),
 			);
 			expect(result.stdout).toContain(
 				[
-					"  readiness. Re-run `wp-typia doctor` from a workspace",
-					"  root if you expected package metadata, inventory, or",
+					"  this run only covered environment readiness. Re-run",
+					"  `wp-typia doctor` from a workspace root if you",
 				].join("\n"),
 			);
 			expect(result.stdout).toContain("PASS wp-typia doctor summary:");

--- a/packages/wp-typia/tests/completion-output.test.ts
+++ b/packages/wp-typia/tests/completion-output.test.ts
@@ -8,6 +8,10 @@ import {
 	buildMigrationCompletionPayload,
 	printCompletionPayload,
 } from "../src/runtime-bridge";
+import {
+	buildAddCompletionPayload,
+	buildAddDryRunPayload,
+} from "../src/runtime-bridge-output";
 
 describe("alternate-buffer completion output helpers", () => {
 	test("create completion payload preserves reviewable next steps and optional onboarding", () => {
@@ -206,5 +210,52 @@ describe("alternate-buffer completion output helpers", () => {
 		expect(payload.summaryLines).toContain(
 			"Dependency install: already skipped via --no-install",
 		);
+	});
+
+	test("add completion payload now includes reviewable next steps and doctor guidance", () => {
+		const payload = buildAddCompletionPayload({
+			kind: "binding-source",
+			projectDir: "/tmp/demo-workspace",
+			values: {
+				bindingSourceSlug: "hero-data",
+			},
+		});
+
+		expect(payload.title).toBe("✅ Added binding source");
+		expect(payload.summaryLines).toEqual([
+			"Binding source: hero-data",
+			"Project directory: /tmp/demo-workspace",
+		]);
+		expect(payload.nextSteps).toEqual([
+			"Review src/bindings/hero-data/server.php and src/bindings/hero-data/editor.ts.",
+			"Run your workspace build or dev command to verify the binding source hooks and editor registration.",
+		]);
+		expect(payload.optionalTitle).toBe("Verify workspace health (optional):");
+		expect(payload.optionalLines).toEqual(["wp-typia doctor"]);
+		expect(payload.optionalNote).toContain("inventory and generated-artifact check");
+	});
+
+	test("dry-run add payload preserves the richer add completion guidance", () => {
+		const payload = buildAddDryRunPayload({
+			completion: buildAddCompletionPayload({
+				kind: "block",
+				projectDir: "/tmp/demo-workspace",
+				values: {
+					blockSlugs: "faq, faq-item",
+					templateId: "compound",
+				},
+			}),
+			fileOperations: ["write src/blocks/faq/block.json"],
+		});
+
+		expect(payload.title).toBe("🧪 Dry run for workspace block");
+		expect(payload.summaryLines).toEqual([
+			"Blocks: faq, faq-item",
+			"Template family: compound",
+			"Project directory: /tmp/demo-workspace",
+		]);
+		expect(payload.warningLines).toBeUndefined();
+		expect(payload.optionalTitle).toBe("Planned workspace updates (1):");
+		expect(payload.optionalLines).toEqual(["write src/blocks/faq/block.json"]);
 	});
 });

--- a/packages/wp-typia/tests/completion-output.test.ts
+++ b/packages/wp-typia/tests/completion-output.test.ts
@@ -215,6 +215,7 @@ describe("alternate-buffer completion output helpers", () => {
 	test("add completion payload now includes reviewable next steps and doctor guidance", () => {
 		const payload = buildAddCompletionPayload({
 			kind: "binding-source",
+			packageManager: "npm",
 			projectDir: "/tmp/demo-workspace",
 			values: {
 				bindingSourceSlug: "hero-data",
@@ -231,7 +232,9 @@ describe("alternate-buffer completion output helpers", () => {
 			"Run your workspace build or dev command to verify the binding source hooks and editor registration.",
 		]);
 		expect(payload.optionalTitle).toBe("Verify workspace health (optional):");
-		expect(payload.optionalLines).toEqual(["wp-typia doctor"]);
+		expect(payload.optionalLines).toEqual([
+			`npx --yes wp-typia@${packageJson.version} doctor`,
+		]);
 		expect(payload.optionalNote).toContain("inventory and generated-artifact check");
 	});
 
@@ -239,6 +242,7 @@ describe("alternate-buffer completion output helpers", () => {
 		const payload = buildAddDryRunPayload({
 			completion: buildAddCompletionPayload({
 				kind: "block",
+				packageManager: "npm",
 				projectDir: "/tmp/demo-workspace",
 				values: {
 					blockSlugs: "faq, faq-item",

--- a/packages/wp-typia/tests/render-loader.test.ts
+++ b/packages/wp-typia/tests/render-loader.test.ts
@@ -34,18 +34,18 @@ test("resolveBundledModuleHref reports missing bundled artifacts directly", () =
 	fs.mkdirSync(baseDir, { recursive: true });
 	fs.writeFileSync(path.join(baseDir, "entry.mjs"), "", "utf8");
 
-	expect(() =>
+	let error: Error | undefined;
+	try {
 		resolveBundledModuleHref(
 			pathToFileURL(path.join(baseDir, "entry.mjs")).href,
 			["./ui/add-flow.js", "./ui/add-flow.tsx"],
 			{ moduleLabel: "the add-flow UI" },
-		),
-	).toThrow(/Missing bundled build artifacts for the add-flow UI/);
-	expect(() =>
-		resolveBundledModuleHref(
-			pathToFileURL(path.join(baseDir, "entry.mjs")).href,
-			["./ui/add-flow.js", "./ui/add-flow.tsx"],
-			{ moduleLabel: "the add-flow UI" },
-		),
-	).toThrow(/bun run --filter wp-typia build/);
+		);
+	} catch (caught) {
+		error = caught as Error;
+	}
+
+	expect(error).toBeInstanceOf(Error);
+	expect(error?.message).toMatch(/Missing bundled build artifacts for the add-flow UI/);
+	expect(error?.message).toMatch(/bun run --filter wp-typia build/);
 });

--- a/packages/wp-typia/tests/render-loader.test.ts
+++ b/packages/wp-typia/tests/render-loader.test.ts
@@ -1,0 +1,51 @@
+import { afterAll, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { resolveBundledModuleHref } from "../src/render-loader";
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "wp-typia-render-loader-"));
+
+afterAll(() => {
+	fs.rmSync(tempRoot, { force: true, recursive: true });
+});
+
+test("resolveBundledModuleHref returns the first existing candidate", () => {
+	const baseDir = path.join(tempRoot, "existing-candidate");
+	fs.mkdirSync(path.join(baseDir, "ui"), { recursive: true });
+	fs.writeFileSync(path.join(baseDir, "entry.mjs"), "", "utf8");
+	fs.writeFileSync(path.join(baseDir, "ui", "create-flow.js"), "export {};\n", "utf8");
+
+	const resolved = resolveBundledModuleHref(
+		pathToFileURL(path.join(baseDir, "entry.mjs")).href,
+		["./ui/create-flow.js", "./ui/create-flow.tsx"],
+		{ moduleLabel: "the create-flow UI" },
+	);
+
+	expect(resolved).toBe(
+		pathToFileURL(path.join(baseDir, "ui", "create-flow.js")).href,
+	);
+});
+
+test("resolveBundledModuleHref reports missing bundled artifacts directly", () => {
+	const baseDir = path.join(tempRoot, "missing-candidates");
+	fs.mkdirSync(baseDir, { recursive: true });
+	fs.writeFileSync(path.join(baseDir, "entry.mjs"), "", "utf8");
+
+	expect(() =>
+		resolveBundledModuleHref(
+			pathToFileURL(path.join(baseDir, "entry.mjs")).href,
+			["./ui/add-flow.js", "./ui/add-flow.tsx"],
+			{ moduleLabel: "the add-flow UI" },
+		),
+	).toThrow(/Missing bundled build artifacts for the add-flow UI/);
+	expect(() =>
+		resolveBundledModuleHref(
+			pathToFileURL(path.join(baseDir, "entry.mjs")).href,
+			["./ui/add-flow.js", "./ui/add-flow.tsx"],
+			{ moduleLabel: "the add-flow UI" },
+		),
+	).toThrow(/bun run --filter wp-typia build/);
+});


### PR DESCRIPTION
## Context

Follow-up to the recent standalone/runtime polish work. The remaining rough edges were mostly user-facing: doctor scope rows were still a little opaque, `wp-typia add` success output was sparse, missing bundled UI artifacts still surfaced as generic module resolution failures, and standalone create/sync help text could be more explicit about required context.

## What Changed

- made doctor scope rows explicitly call out environment-only vs blocked-before-workspace-checks vs full workspace diagnostics
- enriched add completion payloads with concrete next-step guidance plus an optional `wp-typia doctor` follow-up
- turned missing bundled UI artifact lookups into direct diagnostics with explicit rebuild/reinstall guidance
- clarified create `--dry-run` / `<project-dir>` messaging and sync-root guidance
- regenerated Bunli command metadata and added targeted tests for completion output and render-loader failures

## Verification

- `bun test packages/wp-typia/tests/completion-output.test.ts packages/wp-typia/tests/render-loader.test.ts packages/wp-typia/tests/cli-package.test.ts packages/wp-typia/tests/runtime-bridge-sync.test.ts packages/wp-typia-project-tools/tests/workspace-doctor.test.ts`
- `bun run --filter wp-typia build`
- `bun run --filter @wp-typia/project-tools build`
- `bun run --filter @wp-typia/project-tools test:coverage`
- `bun run changesets:validate`

Closes #516


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added completion guidance for the add command with next steps and optional verification instructions.

* **Improvements**
  * Enhanced error messages with clearer guidance for missing project directories and sync locations.
  * Improved doctor scope messaging with explicit scope indicators for environment and workspace checks.
  * Updated CLI help text and command descriptions for better clarity on when workflows can run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->