### PR TITLE
Refactor CLI command metadata, parsing, and add-subcommand execution

### DIFF
--- a/.sampo/changesets/issue-513-command-metadata-primitives.md
+++ b/.sampo/changesets/issue-513-command-metadata-primitives.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Refactored the `wp-typia` CLI to derive more parser behavior, create/add/migrate initial values, and add-subcommand execution flow from shared command metadata primitives so new command-surface changes require fewer parallel edits.

--- a/packages/wp-typia/src/command-contract.ts
+++ b/packages/wp-typia/src/command-contract.ts
@@ -1,6 +1,7 @@
 import path from 'node:path'
 import {
   ADD_OPTION_METADATA,
+  buildCommandOptionParser,
   collectOptionNamesByType,
   CREATE_OPTION_METADATA,
   GLOBAL_OPTION_METADATA,
@@ -41,6 +42,14 @@ export const WP_TYPIA_TOP_LEVEL_COMMAND_NAMES = [
   'mcp',
 ] as const;
 
+const SHARED_OPTION_PARSER = buildCommandOptionParser(
+  ADD_OPTION_METADATA,
+  GLOBAL_OPTION_METADATA,
+  CREATE_OPTION_METADATA,
+  MIGRATE_OPTION_METADATA,
+  TEMPLATES_OPTION_METADATA,
+);
+
 const STRING_OPTION_NAMES_BY_COMMAND = {
   add: new Set(collectOptionNamesByType(ADD_OPTION_METADATA, 'string')),
   create: new Set(collectOptionNamesByType(CREATE_OPTION_METADATA, 'string')),
@@ -53,17 +62,9 @@ const GLOBAL_STRING_OPTION_NAMES = new Set(
 );
 
 const SHORT_OPTION_NAMES_WITH_VALUES = new Set<string>(
-  Object.values({
-    ...ADD_OPTION_METADATA,
-    ...GLOBAL_OPTION_METADATA,
-    ...CREATE_OPTION_METADATA,
-    ...MIGRATE_OPTION_METADATA,
-    ...TEMPLATES_OPTION_METADATA,
-  })
-    .filter((option) => option.type === 'string')
-    .flatMap((option) =>
-      'short' in option && typeof option.short === 'string' ? [option.short] : [],
-    ),
+  [...SHARED_OPTION_PARSER.shortFlagMap.entries()]
+    .filter(([, option]) => option.type === 'string')
+    .map(([short]) => short),
 );
 
 function isLongOptionValueConsumer(optionName: string): boolean {

--- a/packages/wp-typia/src/command-option-metadata.ts
+++ b/packages/wp-typia/src/command-option-metadata.ts
@@ -8,6 +8,19 @@ export type CommandOptionMetadata = {
 };
 
 type CommandOptionMetadataMap = Record<string, CommandOptionMetadata>;
+type ParsedCommandArgv = {
+	flags: Record<string, unknown>;
+	positionals: string[];
+};
+type ShortOptionDescriptor = {
+	name: string;
+	type: CommandOptionMetadata["type"];
+};
+type CommandOptionParser = {
+	booleanOptionNames: Set<string>;
+	shortFlagMap: Map<string, ShortOptionDescriptor>;
+	stringOptionNames: Set<string>;
+};
 
 /**
  * Shared `wp-typia create` option metadata used by both the Bunli command
@@ -283,4 +296,142 @@ export function formatNodeFallbackOptionHelp(
 		const short = option.short ? `, -${option.short}` : "";
 		return `- --${name}${short}: ${option.description}`;
 	});
+}
+
+export function buildCommandOptionParser(
+	...metadataMaps: CommandOptionMetadataMap[]
+): CommandOptionParser {
+	const metadata: CommandOptionMetadataMap = Object.assign({}, ...metadataMaps);
+
+	return {
+		booleanOptionNames: new Set(collectOptionNamesByType(metadata, "boolean")),
+		shortFlagMap: new Map<string, ShortOptionDescriptor>(
+			Object.entries(metadata).flatMap(([name, option]) =>
+				option.short
+					? [[option.short, { name, type: option.type }] as const]
+					: [],
+			),
+		),
+		stringOptionNames: new Set(collectOptionNamesByType(metadata, "string")),
+	};
+}
+
+export function parseCommandArgvWithMetadata(
+	argv: string[],
+	options: {
+		extraBooleanOptionNames?: Iterable<string>;
+		parser: CommandOptionParser;
+	},
+): ParsedCommandArgv {
+	const flags: Record<string, unknown> = {};
+	const positionals: string[] = [];
+	const booleanOptionNames = new Set(options.parser.booleanOptionNames);
+
+	for (const optionName of options.extraBooleanOptionNames ?? []) {
+		booleanOptionNames.add(optionName);
+	}
+
+	for (let index = 0; index < argv.length; index += 1) {
+		const arg = argv[index];
+		if (!arg) {
+			continue;
+		}
+
+		if (arg === "--") {
+			positionals.push(...argv.slice(index + 1));
+			break;
+		}
+
+		if (arg.length === 2 && arg.startsWith("-")) {
+			const shortFlag = options.parser.shortFlagMap.get(arg.slice(1));
+			if (!shortFlag) {
+				throw new Error(`Unknown option \`${arg}\`.`);
+			}
+			if (shortFlag.type === "boolean") {
+				flags[shortFlag.name] = true;
+				continue;
+			}
+			const next = argv[index + 1];
+			if (!next || next.startsWith("-")) {
+				throw new Error(`\`${arg}\` requires a value.`);
+			}
+			flags[shortFlag.name] = next;
+			index += 1;
+			continue;
+		}
+
+		if (arg.startsWith("--")) {
+			const option = arg.slice(2);
+			const separatorIndex = option.indexOf("=");
+			const rawName =
+				separatorIndex === -1 ? option : option.slice(0, separatorIndex);
+			const inlineValue =
+				separatorIndex === -1 ? undefined : option.slice(separatorIndex + 1);
+			if (booleanOptionNames.has(rawName)) {
+				flags[rawName] = true;
+				continue;
+			}
+			if (!options.parser.stringOptionNames.has(rawName)) {
+				throw new Error(`Unknown option \`--${rawName}\`.`);
+			}
+			if (inlineValue !== undefined) {
+				if (!inlineValue) {
+					throw new Error(`\`--${rawName}\` requires a value.`);
+				}
+				flags[rawName] = inlineValue;
+				continue;
+			}
+			const next = argv[index + 1];
+			if (!next || next.startsWith("-")) {
+				throw new Error(`\`--${rawName}\` requires a value.`);
+			}
+			flags[rawName] = next;
+			index += 1;
+			continue;
+		}
+
+		if (arg.startsWith("-")) {
+			throw new Error(`Unknown option \`${arg}\`.`);
+		}
+
+		positionals.push(arg);
+	}
+
+	return {
+		flags,
+		positionals,
+	};
+}
+
+export function resolveCommandOptionValues<
+	TMetadata extends CommandOptionMetadataMap,
+>(
+	metadata: TMetadata,
+	options: {
+		defaults?: Record<string, unknown>;
+		flags?: Record<string, unknown>;
+		optionNames?: Iterable<keyof TMetadata | string>;
+	},
+): Record<string, string | boolean | undefined> {
+	const resolved: Record<string, string | boolean | undefined> = {};
+	const optionNames =
+		options.optionNames ?? (Object.keys(metadata) as Array<keyof TMetadata>);
+
+	for (const optionName of optionNames) {
+		const name = String(optionName);
+		const descriptor = metadata[name];
+		if (!descriptor) {
+			continue;
+		}
+
+		const value = options.flags?.[name] ?? options.defaults?.[name];
+		if (descriptor.type === "boolean") {
+			resolved[name] = Boolean(value ?? false);
+			continue;
+		}
+
+		resolved[name] = typeof value === "string" ? value : undefined;
+	}
+
+	return resolved;
 }

--- a/packages/wp-typia/src/commands/add.ts
+++ b/packages/wp-typia/src/commands/add.ts
@@ -5,6 +5,7 @@ import { defineCommand } from "@bunli/core";
 import {
 	ADD_OPTION_METADATA,
 	buildCommandOptions,
+	resolveCommandOptionValues,
 } from "../command-option-metadata";
 import { getAddBlockDefaults } from "../config";
 import { resolveBundledModuleHref } from "../render-loader";
@@ -48,25 +49,19 @@ export const addCommand = defineCommand({
 						typeof args.context.store.wpTypiaUserConfig === "object"
 							? getAddBlockDefaults(args.context.store.wpTypiaUserConfig)
 							: {};
+					const initialValues = resolveCommandOptionValues(ADD_OPTION_METADATA, {
+						defaults: config,
+						flags: args.flags as Record<string, unknown>,
+						optionNames: Object.keys(ADD_OPTION_METADATA).filter(
+							(optionName) => optionName !== "dry-run",
+						),
+					});
 					return createElement(LazyFlow, {
 						loader: loadAddFlow,
 						props: {
 							cwd: args.cwd,
 							initialValues: {
-								"alternate-render-targets":
-									(args.flags["alternate-render-targets"] as string | undefined) ??
-									config["alternate-render-targets"],
-								"data-storage":
-									(args.flags["data-storage"] as string | undefined) ??
-									config["data-storage"],
-								"external-layer-id":
-									(args.flags["external-layer-id"] as string | undefined) ??
-									config["external-layer-id"],
-								"external-layer-source":
-									(args.flags["external-layer-source"] as string | undefined) ??
-									config["external-layer-source"],
-								anchor: (args.flags.anchor as string | undefined) ?? "",
-								block: (args.flags.block as string | undefined) ?? "",
+								...initialValues,
 								kind:
 									(args.positional[0] as
 										| "block"
@@ -77,16 +72,9 @@ export const addCommand = defineCommand({
 										| "editor-plugin"
 										| "hooked-block"
 										| undefined) ?? "block",
-								methods: (args.flags.methods as string | undefined) ?? "",
 								name: args.positional[1] ?? "",
-								namespace: (args.flags.namespace as string | undefined) ?? "",
-								"persistence-policy":
-									(args.flags["persistence-policy"] as string | undefined) ??
-									config["persistence-policy"],
-								position: (args.flags.position as string | undefined) ?? "after",
-								slot: (args.flags.slot as string | undefined) ?? "PluginSidebar",
-								template:
-									(args.flags.template as string | undefined) ?? config.template,
+								position: initialValues.position ?? "after",
+								slot: initialValues.slot ?? "PluginSidebar",
 							},
 						},
 					});

--- a/packages/wp-typia/src/commands/create.ts
+++ b/packages/wp-typia/src/commands/create.ts
@@ -5,6 +5,7 @@ import { defineCommand } from "@bunli/core";
 import {
 	buildCommandOptions,
 	CREATE_OPTION_METADATA,
+	resolveCommandOptionValues,
 } from "../command-option-metadata";
 import { getCreateDefaults } from "../config";
 import { resolveBundledModuleHref } from "../render-loader";
@@ -58,65 +59,17 @@ export const createCommand = defineCommand({
 						typeof args.context.store.wpTypiaUserConfig === "object"
 							? getCreateDefaults(args.context.store.wpTypiaUserConfig)
 							: {};
+					const initialValues = resolveCommandOptionValues(CREATE_OPTION_METADATA, {
+						defaults: config,
+						flags: args.flags as Record<string, unknown>,
+					});
 					return createElement(LazyFlow, {
 						loader: loadCreateFlow,
 						props: {
 							cwd: args.cwd,
 							initialValues: {
-								"alternate-render-targets":
-									(args.flags["alternate-render-targets"] as string | undefined) ??
-									config["alternate-render-targets"],
-								"data-storage":
-									(args.flags["data-storage"] as string | undefined) ??
-									config["data-storage"],
-								"dry-run": Boolean(
-									args.flags["dry-run"] ?? config["dry-run"] ?? false,
-								),
-								"external-layer-id":
-									(args.flags["external-layer-id"] as string | undefined) ??
-									config["external-layer-id"],
-								"external-layer-source":
-									(args.flags["external-layer-source"] as string | undefined) ??
-									config["external-layer-source"],
-								namespace:
-									(args.flags.namespace as string | undefined) ?? config.namespace,
-								"no-install": Boolean(
-									args.flags["no-install"] ?? config["no-install"] ?? false,
-								),
-								"package-manager":
-									(args.flags["package-manager"] as string | undefined) ??
-									config["package-manager"],
-								"persistence-policy":
-									(args.flags["persistence-policy"] as string | undefined) ??
-									config["persistence-policy"],
-								"php-prefix":
-									(args.flags["php-prefix"] as string | undefined) ??
-									config["php-prefix"],
-								"query-post-type":
-									(args.flags["query-post-type"] as string | undefined) ??
-									config["query-post-type"],
+								...initialValues,
 								"project-dir": args.positional[0] ?? "",
-								template:
-									(args.flags.template as string | undefined) ?? config.template,
-								"text-domain":
-									(args.flags["text-domain"] as string | undefined) ??
-									config["text-domain"],
-								variant:
-									(args.flags.variant as string | undefined) ?? config.variant,
-								"with-migration-ui": Boolean(
-									args.flags["with-migration-ui"] ??
-										config["with-migration-ui"] ??
-										false,
-								),
-								"with-test-preset": Boolean(
-									args.flags["with-test-preset"] ??
-										config["with-test-preset"] ??
-										false,
-								),
-								"with-wp-env": Boolean(
-									args.flags["with-wp-env"] ?? config["with-wp-env"] ?? false,
-								),
-								yes: Boolean(args.flags.yes ?? config.yes ?? false),
 							},
 						},
 					});

--- a/packages/wp-typia/src/commands/migrate.ts
+++ b/packages/wp-typia/src/commands/migrate.ts
@@ -5,6 +5,7 @@ import { defineCommand } from "@bunli/core";
 import {
 	buildCommandOptions,
 	MIGRATE_OPTION_METADATA,
+	resolveCommandOptionValues,
 } from "../command-option-metadata";
 import { resolveBundledModuleHref } from "../render-loader";
 import { executeMigrateCommand } from "../runtime-bridge";
@@ -40,13 +41,17 @@ export const migrateCommand = defineCommand({
 	options: migrateOptions,
 	...(supportsInteractiveTui()
 		? {
-				render: (args: WpTypiaRenderArgs) =>
-					createElement(LazyFlow, {
+				render: (args: WpTypiaRenderArgs) => {
+					const initialValues = resolveCommandOptionValues(MIGRATE_OPTION_METADATA, {
+						flags: args.flags as Record<string, unknown>,
+					});
+
+					return createElement(LazyFlow, {
 						loader: loadMigrateFlow,
 						props: {
 							cwd: args.cwd,
 							initialValues: {
-								all: Boolean(args.flags.all ?? false),
+								...initialValues,
 								command:
 									(args.positional[0] as
 										| "init"
@@ -60,24 +65,13 @@ export const migrateCommand = defineCommand({
 										| "fixtures"
 										| "fuzz"
 										| undefined) ?? "plan",
-								"current-migration-version": args.flags[
-									"current-migration-version"
-								] as string | undefined,
-								force: Boolean(args.flags.force ?? false),
-								"from-migration-version": args.flags[
-									"from-migration-version"
-								] as string | undefined,
-								iterations: args.flags.iterations as string | undefined,
-								"migration-version": args.flags[
-									"migration-version"
-								] as string | undefined,
-								seed: args.flags.seed as string | undefined,
 								"to-migration-version":
-									(args.flags["to-migration-version"] as string | undefined) ??
+									(initialValues["to-migration-version"] as string | undefined) ??
 									"current",
 							},
 						},
-					}),
+					});
+				},
 				tui: {
 					renderer: {
 						bufferMode: "alternate" as const,

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -7,11 +7,13 @@ import {
 } from "@wp-typia/project-tools/cli-diagnostics";
 import {
 	ADD_OPTION_METADATA,
-	collectOptionNamesByType,
+	buildCommandOptionParser,
 	CREATE_OPTION_METADATA,
 	formatNodeFallbackOptionHelp,
 	GLOBAL_OPTION_METADATA,
 	MIGRATE_OPTION_METADATA,
+	parseCommandArgvWithMetadata,
+	resolveCommandOptionValues,
 	TEMPLATES_OPTION_METADATA,
 } from "./command-option-metadata";
 import {
@@ -48,47 +50,14 @@ type GlobalFlags = {
 	id?: string;
 };
 
-type ParsedArgv = {
-	flags: Record<string, unknown>;
-	positionals: string[];
-};
-
-const STRING_FLAG_NAMES = new Set([
-	...collectOptionNamesByType(GLOBAL_OPTION_METADATA, "string"),
-	...collectOptionNamesByType(CREATE_OPTION_METADATA, "string"),
-	...collectOptionNamesByType(ADD_OPTION_METADATA, "string"),
-	...collectOptionNamesByType(MIGRATE_OPTION_METADATA, "string"),
-	...collectOptionNamesByType(TEMPLATES_OPTION_METADATA, "string"),
-]);
-
-const BOOLEAN_FLAG_NAMES = new Set([
-	...collectOptionNamesByType(CREATE_OPTION_METADATA, "boolean"),
-	...collectOptionNamesByType(ADD_OPTION_METADATA, "boolean"),
-	...collectOptionNamesByType(MIGRATE_OPTION_METADATA, "boolean"),
-	"check",
-	"help",
-	"version",
-]);
-
-const SHORT_FLAG_MAP = new Map<
-	string,
-	{
-		name: string;
-		type: "boolean" | "string";
-	}
->(
-	Object.entries({
-		...GLOBAL_OPTION_METADATA,
-		...CREATE_OPTION_METADATA,
-		...ADD_OPTION_METADATA,
-		...MIGRATE_OPTION_METADATA,
-		...TEMPLATES_OPTION_METADATA,
-	}).flatMap(([name, option]) =>
-		"short" in option && typeof option.short === "string"
-			? [[option.short, { name, type: option.type }] as const]
-			: [],
-	),
+const NODE_FALLBACK_OPTION_PARSER = buildCommandOptionParser(
+	GLOBAL_OPTION_METADATA,
+	CREATE_OPTION_METADATA,
+	ADD_OPTION_METADATA,
+	MIGRATE_OPTION_METADATA,
+	TEMPLATES_OPTION_METADATA,
 );
+const NODE_FALLBACK_BOOLEAN_OPTION_NAMES = ["check", "help", "version"] as const;
 
 const NODE_FALLBACK_RUNTIME_SUMMARY_LINES = [
 	"Runtime: Node fallback",
@@ -184,96 +153,27 @@ async function applyNodeFallbackConfigDefaults(
 	}
 
 	if (command === "create") {
-		return {
-			...getCreateDefaults(config),
-			...flags,
-		};
+		return resolveCommandOptionValues(CREATE_OPTION_METADATA, {
+			defaults: getCreateDefaults(config),
+			flags,
+		});
 	}
 
 	if (command === "add" && subcommand === "block") {
-		return {
-			...getAddBlockDefaults(config),
-			...flags,
-		};
+		return resolveCommandOptionValues(ADD_OPTION_METADATA, {
+			defaults: getAddBlockDefaults(config),
+			flags,
+		});
 	}
 
 	return flags;
 }
 
-function parseArgv(argv: string[]): ParsedArgv {
-	const flags: Record<string, unknown> = {};
-	const positionals: string[] = [];
-
-	for (let index = 0; index < argv.length; index += 1) {
-		const arg = argv[index];
-		if (!arg) {
-			continue;
-		}
-
-		if (arg === "--") {
-			positionals.push(...argv.slice(index + 1));
-			break;
-		}
-
-		if (arg.length === 2 && arg.startsWith("-")) {
-			const shortFlag = SHORT_FLAG_MAP.get(arg.slice(1));
-			if (!shortFlag) {
-				throw new Error(`Unknown option \`${arg}\`.`);
-			}
-			if (shortFlag.type === "boolean") {
-				flags[shortFlag.name] = true;
-				continue;
-			}
-			const next = argv[index + 1];
-			if (!next || next.startsWith("-")) {
-				throw new Error(`\`${arg}\` requires a value.`);
-			}
-			flags[shortFlag.name] = next;
-			index += 1;
-			continue;
-		}
-
-		if (arg.startsWith("--")) {
-			const option = arg.slice(2);
-			const separatorIndex = option.indexOf("=");
-			const rawName =
-				separatorIndex === -1 ? option : option.slice(0, separatorIndex);
-			const inlineValue =
-				separatorIndex === -1 ? undefined : option.slice(separatorIndex + 1);
-			if (BOOLEAN_FLAG_NAMES.has(rawName)) {
-				flags[rawName] = true;
-				continue;
-			}
-			if (!STRING_FLAG_NAMES.has(rawName)) {
-				throw new Error(`Unknown option \`--${rawName}\`.`);
-			}
-			if (inlineValue !== undefined) {
-				if (!inlineValue) {
-					throw new Error(`\`--${rawName}\` requires a value.`);
-				}
-				flags[rawName] = inlineValue;
-				continue;
-			}
-			const next = argv[index + 1];
-			if (!next || next.startsWith("-")) {
-				throw new Error(`\`--${rawName}\` requires a value.`);
-			}
-			flags[rawName] = next;
-			index += 1;
-			continue;
-		}
-
-		if (arg.startsWith("-")) {
-			throw new Error(`Unknown option \`${arg}\`.`);
-		}
-
-		positionals.push(arg);
-	}
-
-	return {
-		flags,
-		positionals,
-	};
+function parseArgv(argv: string[]) {
+	return parseCommandArgvWithMetadata(argv, {
+		extraBooleanOptionNames: NODE_FALLBACK_BOOLEAN_OPTION_NAMES,
+		parser: NODE_FALLBACK_OPTION_PARSER,
+	});
 }
 
 function renderGeneralHelp() {

--- a/packages/wp-typia/src/runtime-bridge.ts
+++ b/packages/wp-typia/src/runtime-bridge.ts
@@ -138,6 +138,47 @@ function pushFlag(argv: string[], name: string, value: unknown): void {
 	argv.push(`--${name}`, String(value));
 }
 
+async function executeWorkspaceAddWithOptionalDryRun<TResult>(options: {
+	buildCompletion: (
+		result: TResult,
+	) => ReturnType<typeof buildAddCompletionPayload>;
+	cwd: string;
+	dryRun: boolean;
+	emitOutput: boolean | undefined;
+	execute: (cwd: string) => Promise<TResult>;
+	printLine: PrintLine;
+	warnLine?: PrintLine;
+}): Promise<AlternateBufferCompletionPayload | void> {
+	const simulated = options.dryRun
+		? await simulateWorkspaceAddDryRun({
+				cwd: options.cwd,
+				execute: options.execute,
+			})
+		: null;
+	const result = simulated?.result ?? (await options.execute(options.cwd));
+	const completion = options.buildCompletion(result);
+
+	if (!options.dryRun) {
+		return emitCompletion(completion, {
+			emitOutput: options.emitOutput ?? true,
+			printLine: options.printLine,
+			warnLine: options.warnLine,
+		});
+	}
+
+	return emitCompletion(
+		buildAddDryRunPayload({
+			completion,
+			fileOperations: simulated!.fileOperations,
+		}),
+		{
+			emitOutput: options.emitOutput ?? true,
+			printLine: options.printLine,
+			warnLine: options.warnLine,
+		},
+	);
+}
+
 const PACKAGE_MANAGER_PROMPT_OPTIONS = [
 	{ label: "npm", value: "npm", hint: "Use npm" },
 	{ label: "pnpm", value: "pnpm", hint: "Use pnpm" },
@@ -344,43 +385,29 @@ export async function executeAddCommand({
 				throw new Error("`wp-typia add variation` requires --block <block-slug>.");
 			}
 
-			const simulated = dryRun
-				? await simulateWorkspaceAddDryRun({
-						cwd,
-						execute: (simulatedCwd) =>
-							addRuntime.runAddVariationCommand({
-								blockName: blockSlug,
-								cwd: simulatedCwd,
-								variationName: name,
-							}),
-					})
-				: null;
-			const result =
-				simulated?.result ??
-				(await addRuntime.runAddVariationCommand({
-					blockName: blockSlug,
-					cwd,
-					variationName: name,
-				}));
-			const completion = buildAddCompletionPayload({
-				kind: "variation",
-				projectDir: result.projectDir,
-				values: {
-					blockSlug: result.blockSlug,
-					variationSlug: result.variationSlug,
-				},
+			return executeWorkspaceAddWithOptionalDryRun<
+				Awaited<ReturnType<typeof addRuntime.runAddVariationCommand>>
+			>({
+				buildCompletion: (result) =>
+					buildAddCompletionPayload({
+						kind: "variation",
+						projectDir: result.projectDir,
+						values: {
+							blockSlug: result.blockSlug,
+							variationSlug: result.variationSlug,
+						},
+					}),
+				cwd,
+				dryRun,
+				emitOutput,
+				execute: (targetCwd) =>
+					addRuntime.runAddVariationCommand({
+						blockName: blockSlug,
+						cwd: targetCwd,
+						variationName: name,
+					}),
+				printLine,
 			});
-			if (!dryRun) {
-				return emitCompletion(completion, { emitOutput, printLine });
-			}
-
-			return emitCompletion(
-				buildAddDryRunPayload({
-					completion,
-					fileOperations: simulated!.fileOperations,
-				}),
-				{ emitOutput, printLine },
-			);
 		}
 
 		if (kind === "pattern") {
@@ -390,40 +417,27 @@ export async function executeAddCommand({
 				);
 			}
 
-			const simulated = dryRun
-				? await simulateWorkspaceAddDryRun({
-						cwd,
-						execute: (simulatedCwd) =>
-							addRuntime.runAddPatternCommand({
-								cwd: simulatedCwd,
-								patternName: name,
-							}),
-					})
-				: null;
-			const result =
-				simulated?.result ??
-				(await addRuntime.runAddPatternCommand({
-					cwd,
-					patternName: name,
-				}));
-			const completion = buildAddCompletionPayload({
-				kind: "pattern",
-				projectDir: result.projectDir,
-				values: {
-					patternSlug: result.patternSlug,
-				},
+			return executeWorkspaceAddWithOptionalDryRun<
+				Awaited<ReturnType<typeof addRuntime.runAddPatternCommand>>
+			>({
+				buildCompletion: (result) =>
+					buildAddCompletionPayload({
+						kind: "pattern",
+						projectDir: result.projectDir,
+						values: {
+							patternSlug: result.patternSlug,
+						},
+					}),
+				cwd,
+				dryRun,
+				emitOutput,
+				execute: (targetCwd) =>
+					addRuntime.runAddPatternCommand({
+						cwd: targetCwd,
+						patternName: name,
+					}),
+				printLine,
 			});
-			if (!dryRun) {
-				return emitCompletion(completion, { emitOutput, printLine });
-			}
-
-			return emitCompletion(
-				buildAddDryRunPayload({
-					completion,
-					fileOperations: simulated!.fileOperations,
-				}),
-				{ emitOutput, printLine },
-			);
 		}
 
 		if (kind === "binding-source") {
@@ -433,40 +447,27 @@ export async function executeAddCommand({
 				);
 			}
 
-			const simulated = dryRun
-				? await simulateWorkspaceAddDryRun({
-						cwd,
-						execute: (simulatedCwd) =>
-							addRuntime.runAddBindingSourceCommand({
-								bindingSourceName: name,
-								cwd: simulatedCwd,
-							}),
-					})
-				: null;
-			const result =
-				simulated?.result ??
-				(await addRuntime.runAddBindingSourceCommand({
-					bindingSourceName: name,
-					cwd,
-				}));
-			const completion = buildAddCompletionPayload({
-				kind: "binding-source",
-				projectDir: result.projectDir,
-				values: {
-					bindingSourceSlug: result.bindingSourceSlug,
-				},
+			return executeWorkspaceAddWithOptionalDryRun<
+				Awaited<ReturnType<typeof addRuntime.runAddBindingSourceCommand>>
+			>({
+				buildCompletion: (result) =>
+					buildAddCompletionPayload({
+						kind: "binding-source",
+						projectDir: result.projectDir,
+						values: {
+							bindingSourceSlug: result.bindingSourceSlug,
+						},
+					}),
+				cwd,
+				dryRun,
+				emitOutput,
+				execute: (targetCwd) =>
+					addRuntime.runAddBindingSourceCommand({
+						bindingSourceName: name,
+						cwd: targetCwd,
+					}),
+				printLine,
 			});
-			if (!dryRun) {
-				return emitCompletion(completion, { emitOutput, printLine });
-			}
-
-			return emitCompletion(
-				buildAddDryRunPayload({
-					completion,
-					fileOperations: simulated!.fileOperations,
-				}),
-				{ emitOutput, printLine },
-			);
 		}
 
 		if (kind === "rest-resource") {
@@ -478,46 +479,31 @@ export async function executeAddCommand({
 
 			const methods = readOptionalStringFlag(flags, "methods");
 			const namespace = readOptionalStringFlag(flags, "namespace");
-			const simulated = dryRun
-				? await simulateWorkspaceAddDryRun({
-						cwd,
-						execute: (simulatedCwd) =>
-							addRuntime.runAddRestResourceCommand({
-								cwd: simulatedCwd,
-								methods,
-								namespace,
-								restResourceName: name,
-							}),
-					})
-				: null;
-			const result =
-				simulated?.result ??
-				(await addRuntime.runAddRestResourceCommand({
-					cwd,
-					methods,
-					namespace,
-					restResourceName: name,
-				}));
-			const completion = buildAddCompletionPayload({
-				kind: "rest-resource",
-				projectDir: result.projectDir,
-				values: {
-					methods: result.methods.join(", "),
-					namespace: result.namespace,
-					restResourceSlug: result.restResourceSlug,
-				},
+			return executeWorkspaceAddWithOptionalDryRun<
+				Awaited<ReturnType<typeof addRuntime.runAddRestResourceCommand>>
+			>({
+				buildCompletion: (result) =>
+					buildAddCompletionPayload({
+						kind: "rest-resource",
+						projectDir: result.projectDir,
+						values: {
+							methods: result.methods.join(", "),
+							namespace: result.namespace,
+							restResourceSlug: result.restResourceSlug,
+						},
+					}),
+				cwd,
+				dryRun,
+				emitOutput,
+				execute: (targetCwd) =>
+					addRuntime.runAddRestResourceCommand({
+						cwd: targetCwd,
+						methods,
+						namespace,
+						restResourceName: name,
+					}),
+				printLine,
 			});
-			if (!dryRun) {
-				return emitCompletion(completion, { emitOutput, printLine });
-			}
-
-			return emitCompletion(
-				buildAddDryRunPayload({
-					completion,
-					fileOperations: simulated!.fileOperations,
-				}),
-				{ emitOutput, printLine },
-			);
 		}
 
 		if (kind === "editor-plugin") {
@@ -528,43 +514,29 @@ export async function executeAddCommand({
 			}
 
 			const slot = readOptionalStringFlag(flags, "slot");
-			const simulated = dryRun
-				? await simulateWorkspaceAddDryRun({
-						cwd,
-						execute: (simulatedCwd) =>
-							addRuntime.runAddEditorPluginCommand({
-								cwd: simulatedCwd,
-								editorPluginName: name,
-								slot,
-							}),
-					})
-				: null;
-			const result =
-				simulated?.result ??
-				(await addRuntime.runAddEditorPluginCommand({
-					cwd,
-					editorPluginName: name,
-					slot,
-				}));
-			const completion = buildAddCompletionPayload({
-				kind: "editor-plugin",
-				projectDir: result.projectDir,
-				values: {
-					editorPluginSlug: result.editorPluginSlug,
-					slot: result.slot,
-				},
+			return executeWorkspaceAddWithOptionalDryRun<
+				Awaited<ReturnType<typeof addRuntime.runAddEditorPluginCommand>>
+			>({
+				buildCompletion: (result) =>
+					buildAddCompletionPayload({
+						kind: "editor-plugin",
+						projectDir: result.projectDir,
+						values: {
+							editorPluginSlug: result.editorPluginSlug,
+							slot: result.slot,
+						},
+					}),
+				cwd,
+				dryRun,
+				emitOutput,
+				execute: (targetCwd) =>
+					addRuntime.runAddEditorPluginCommand({
+						cwd: targetCwd,
+						editorPluginName: name,
+						slot,
+					}),
+				printLine,
 			});
-			if (!dryRun) {
-				return emitCompletion(completion, { emitOutput, printLine });
-			}
-
-			return emitCompletion(
-				buildAddDryRunPayload({
-					completion,
-					fileOperations: simulated!.fileOperations,
-				}),
-				{ emitOutput, printLine },
-			);
 		}
 
 		if (kind === "hooked-block") {
@@ -586,46 +558,31 @@ export async function executeAddCommand({
 				);
 			}
 
-			const simulated = dryRun
-				? await simulateWorkspaceAddDryRun({
-						cwd,
-						execute: (simulatedCwd) =>
-							addRuntime.runAddHookedBlockCommand({
-								anchorBlockName,
-								blockName: name,
-								cwd: simulatedCwd,
-								position,
-							}),
-					})
-				: null;
-			const result =
-				simulated?.result ??
-				(await addRuntime.runAddHookedBlockCommand({
-					anchorBlockName,
-					blockName: name,
-					cwd,
-					position,
-				}));
-			const completion = buildAddCompletionPayload({
-				kind: "hooked-block",
-				projectDir: result.projectDir,
-				values: {
-					anchorBlockName: result.anchorBlockName,
-					blockSlug: result.blockSlug,
-					position: result.position,
-				},
+			return executeWorkspaceAddWithOptionalDryRun<
+				Awaited<ReturnType<typeof addRuntime.runAddHookedBlockCommand>>
+			>({
+				buildCompletion: (result) =>
+					buildAddCompletionPayload({
+						kind: "hooked-block",
+						projectDir: result.projectDir,
+						values: {
+							anchorBlockName: result.anchorBlockName,
+							blockSlug: result.blockSlug,
+							position: result.position,
+						},
+					}),
+				cwd,
+				dryRun,
+				emitOutput,
+				execute: (targetCwd) =>
+					addRuntime.runAddHookedBlockCommand({
+						anchorBlockName,
+						blockName: name,
+						cwd: targetCwd,
+						position,
+					}),
+				printLine,
 			});
-			if (!dryRun) {
-				return emitCompletion(completion, { emitOutput, printLine });
-			}
-
-			return emitCompletion(
-				buildAddDryRunPayload({
-					completion,
-					fileOperations: simulated!.fileOperations,
-				}),
-				{ emitOutput, printLine },
-			);
 		}
 
 		if (kind !== "block") {
@@ -673,73 +630,45 @@ export async function executeAddCommand({
 			| "persistence"
 			| "compound";
 
-		const simulated = dryRun
-			? await simulateWorkspaceAddDryRun({
-					cwd,
-					execute: (simulatedCwd) =>
-						addRuntime.runAddBlockCommand({
-							alternateRenderTargets,
-							blockName: name,
-							cwd: simulatedCwd,
-							dataStorageMode,
-							externalLayerId,
-							externalLayerSource,
-							innerBlocksPreset,
-							persistencePolicy,
-							selectExternalLayerId: selectPrompt
-								? (options) =>
-										selectPrompt.select(
-											"Select an external layer",
-											toExternalLayerPromptOptions(options),
-											1,
-										)
-								: undefined,
-							templateId: resolvedTemplateId,
-						}),
-				})
-			: null;
-		const result =
-			simulated?.result ??
-			(await addRuntime.runAddBlockCommand({
-				alternateRenderTargets,
-				blockName: name,
-				cwd,
-				dataStorageMode,
-				externalLayerId,
-				externalLayerSource,
-				innerBlocksPreset,
-				persistencePolicy,
-				selectExternalLayerId: selectPrompt
-					? (options) =>
-							selectPrompt.select(
-								"Select an external layer",
-								toExternalLayerPromptOptions(options),
-								1,
-							)
-					: undefined,
-				templateId: resolvedTemplateId,
-			}));
-
-		const completion = buildAddCompletionPayload({
-			kind: "block",
-			projectDir: result.projectDir,
-			values: {
-				blockSlugs: result.blockSlugs.join(", "),
-				templateId: result.templateId,
-			},
-			warnings: result.warnings,
+		return executeWorkspaceAddWithOptionalDryRun<
+			Awaited<ReturnType<typeof addRuntime.runAddBlockCommand>>
+		>({
+			buildCompletion: (result) =>
+				buildAddCompletionPayload({
+					kind: "block",
+					projectDir: result.projectDir,
+					values: {
+						blockSlugs: result.blockSlugs.join(", "),
+						templateId: result.templateId,
+					},
+					warnings: result.warnings,
+				}),
+			cwd,
+			dryRun,
+			emitOutput,
+			execute: (targetCwd) =>
+				addRuntime.runAddBlockCommand({
+					alternateRenderTargets,
+					blockName: name,
+					cwd: targetCwd,
+					dataStorageMode,
+					externalLayerId,
+					externalLayerSource,
+					innerBlocksPreset,
+					persistencePolicy,
+					selectExternalLayerId: selectPrompt
+						? (options) =>
+								selectPrompt.select(
+									"Select an external layer",
+									toExternalLayerPromptOptions(options),
+									1,
+								)
+						: undefined,
+					templateId: resolvedTemplateId,
+				}),
+			printLine,
+			warnLine,
 		});
-		if (!dryRun) {
-			return emitCompletion(completion, { emitOutput, printLine, warnLine });
-		}
-
-		return emitCompletion(
-			buildAddDryRunPayload({
-				completion,
-				fileOperations: simulated!.fileOperations,
-			}),
-			{ emitOutput, printLine, warnLine },
-		);
 	} catch (error) {
 		if (!shouldWrapCliCommandError({ emitOutput })) {
 			throw error;

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -217,6 +217,17 @@ describe("wp-typia package", () => {
 		expect(createFlowSource).not.toMatch(/from ["']@wp-typia\/project-tools["']/);
 	});
 
+	test("derives fallback parsing and first-party initial values from shared metadata helpers", () => {
+		expect(nodeCliSource).toContain("parseCommandArgvWithMetadata");
+		expect(nodeCliSource).toContain("resolveCommandOptionValues");
+		expect(nodeCliSource).not.toContain("const STRING_FLAG_NAMES = new Set([");
+		expect(nodeCliSource).not.toContain("const BOOLEAN_FLAG_NAMES = new Set([");
+		expect(nodeCliSource).not.toContain("const SHORT_FLAG_MAP = new Map<");
+		expect(createCommandSource).toContain("resolveCommandOptionValues");
+		expect(addCommandSource).toContain("resolveCommandOptionValues");
+		expect(migrateCommandSource).toContain("resolveCommandOptionValues");
+	});
+
 	test("gates interactive TUI rendering on real terminal capability and avoids hard exit short-circuits", () => {
 		expect(createCommandSource).toContain('supportsInteractiveTui');
 		expect(addCommandSource).toContain('supportsInteractiveTui');

--- a/packages/wp-typia/tests/command-option-metadata.test.ts
+++ b/packages/wp-typia/tests/command-option-metadata.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+	ADD_OPTION_METADATA,
+	buildCommandOptionParser,
+	CREATE_OPTION_METADATA,
+	GLOBAL_OPTION_METADATA,
+	parseCommandArgvWithMetadata,
+	resolveCommandOptionValues,
+} from "../src/command-option-metadata";
+
+describe("command option metadata helpers", () => {
+	test("parses string and boolean flags from shared metadata", () => {
+		const parsed = parseCommandArgvWithMetadata(
+			["--dry-run", "-t", "basic", "-y", "demo-project"],
+			{
+				extraBooleanOptionNames: ["help", "version"],
+				parser: buildCommandOptionParser(
+					GLOBAL_OPTION_METADATA,
+					CREATE_OPTION_METADATA,
+				),
+			},
+		);
+
+		expect(parsed.flags).toEqual({
+			"dry-run": true,
+			template: "basic",
+			yes: true,
+		});
+		expect(parsed.positionals).toEqual(["demo-project"]);
+	});
+
+	test("merges defaults and flags through metadata-backed resolution", () => {
+		const resolved = resolveCommandOptionValues(CREATE_OPTION_METADATA, {
+			defaults: {
+				"dry-run": true,
+				"package-manager": "npm",
+				template: "basic",
+			},
+			flags: {
+				"package-manager": "bun",
+			},
+		});
+
+		expect(resolved["dry-run"]).toBe(true);
+		expect(resolved["no-install"]).toBe(false);
+		expect(resolved["package-manager"]).toBe("bun");
+		expect(resolved.template).toBe("basic");
+	});
+
+	test("supports option subsets for add-flow initial values", () => {
+		const resolved = resolveCommandOptionValues(ADD_OPTION_METADATA, {
+			defaults: {
+				"data-storage": "post-meta",
+				"dry-run": true,
+				template: "persistence",
+			},
+			flags: {
+				"external-layer-source": "./layers",
+			},
+			optionNames: Object.keys(ADD_OPTION_METADATA).filter(
+				(optionName) => optionName !== "dry-run",
+			),
+		});
+
+		expect(resolved["data-storage"]).toBe("post-meta");
+		expect(resolved["external-layer-source"]).toBe("./layers");
+		expect(resolved.template).toBe("persistence");
+		expect("dry-run" in resolved).toBe(false);
+	});
+});


### PR DESCRIPTION
## Context

The CLI still duplicated several shared command-surface concepts across the Bunli runtime, the Node fallback, and add-subcommand execution paths.

## What Changed

- derived more Node fallback parsing behavior from shared command option metadata helpers
- derived create/add/migrate first-party initial values from metadata-backed option resolution
- refactored repeated add-subcommand dry-run/completion branches behind a shared helper
- added helper-focused regression coverage plus boundary assertions for the shared metadata path

## Verification

- bun run --filter wp-typia build
- bun test packages/wp-typia/tests/command-option-metadata.test.ts packages/wp-typia/tests/cli-package.test.ts packages/wp-typia/tests/create-command.test.ts packages/wp-typia/tests/tui-lifecycle.test.ts
- bun run changesets:validate
- confirmed main CI run 24766901817 completed successfully before starting this PR

Closes #513