### PR TITLE
Document scaffolded project toolchain and version policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ npx wp-typia create my-block --template @scope/create-block-template --variant h
 - [Formatting Toolchain Policy](https://imjlk.github.io/wp-typia/maintainers/formatting-toolchain-policy/)
 - [Maintenance Automation Policy](https://imjlk.github.io/wp-typia/maintainers/maintenance-automation-policy/)
 - [Package Manifest Policy](https://imjlk.github.io/wp-typia/maintainers/package-manifest-policy/)
+- [Scaffold Toolchain Policy](https://imjlk.github.io/wp-typia/maintainers/scaffold-toolchain-policy/)
 - [TypeScript Strictness Policy](https://imjlk.github.io/wp-typia/maintainers/typescript-strictness-policy/)
 - [Upgrade Guide](UPGRADE.md)
 - [License](LICENSE)

--- a/apps/docs/src/content/docs/maintainers/scaffold-toolchain-policy.md
+++ b/apps/docs/src/content/docs/maintainers/scaffold-toolchain-policy.md
@@ -1,0 +1,79 @@
+---
+title: 'Scaffold Toolchain Policy'
+---
+
+`wp-typia` treats scaffolded project toolchain defaults as an explicit maintainer
+policy rather than a collection of historical template decisions.
+
+## Package-manager fields
+
+Scaffolded projects follow two different rules depending on the selected
+package manager:
+
+- `bun`, `pnpm`, and `yarn` scaffolds emit an exact `packageManager` field from
+  `packages/wp-typia-project-tools/src/runtime/package-managers.ts`
+- `npm` scaffolds intentionally omit the `packageManager` field
+
+Why the split exists:
+
+- non-npm managers depend more heavily on an explicit package-manager selector
+  and lockfile semantics, so the scaffold records the exact tool that its
+  generated scripts expect
+- npm remains the broadest compatibility path because it ships with Node by
+  default, so npm scaffolds avoid pinning a specific npm patch line into the
+  generated project manifest
+- when the repository updates one of those exact package-manager strings, the
+  same PR should update the runtime definition, any scaffold assertions, and
+  this document together
+
+## Node runtime signaling
+
+First-party scaffolds intentionally do **not** emit `.nvmrc`, `.node-version`,
+or a package-level `engines.node` field today.
+
+That is an explicit choice, not an omission:
+
+- `.nvmrc` and `.node-version` are shell-manager-specific hints rather than
+  universal package metadata
+- the scaffold already owns generated README guidance plus CLI `doctor` and
+  sync diagnostics for runtime expectations
+- adding helper files later is still allowed, but it should happen as a
+  deliberate repository-wide policy change rather than template-by-template
+  drift
+
+If we decide to add Node version helper files later, the change should update
+this document, scaffold tests, and generated README guidance in the same PR.
+
+## `@wp-typia/*` dependency strategy
+
+Generated package manifests use the versions resolved by
+`packages/wp-typia-project-tools/src/runtime/package-versions.ts`.
+
+The current policy is:
+
+- scaffolded `@wp-typia/*` package dependencies use caret ranges
+- those ranges are sourced from the canonical package manifests that ship with
+  the current CLI release
+- exact pins are reserved for places where the generated output must name a
+  specific CLI release, such as `npx wp-typia@<version>` guidance in generated
+  documentation
+
+Why caret ranges are still the default for scaffolded package manifests:
+
+- the `@wp-typia/*` family is still on `0.x`, so caret ranges stay inside the
+  current minor line and avoid silent cross-minor upgrades
+- patch-level updates within that minor line are usually the right maintenance
+  default for scaffolded projects
+- the CLI and generated tests already validate the current package surface
+  against that ranged dependency strategy before release
+
+## Practical summary
+
+When touching scaffolded package metadata:
+
+- keep `packageManager` exact for `bun`, `pnpm`, and `yarn`
+- keep `packageManager` omitted for `npm`
+- do not add `.nvmrc`, `.node-version`, or `engines.node` to first-party
+  scaffolds unless this policy changes explicitly
+- keep generated `@wp-typia/*` dependencies on caret ranges sourced from
+  `package-versions.ts`

--- a/packages/wp-typia-project-tools/tests/scaffold-toolchain-policy.test.ts
+++ b/packages/wp-typia-project-tools/tests/scaffold-toolchain-policy.test.ts
@@ -1,0 +1,104 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { scaffoldProject } from "../src/runtime/index.js";
+import { getPackageManager } from "../src/runtime/package-managers.js";
+import {
+	apiClientPackageVersion,
+	blockTypesPackageVersion,
+	cleanupScaffoldTempRoot,
+	createScaffoldTempRoot,
+	normalizedBlockRuntimePackageVersion,
+	restPackageVersion,
+} from "./helpers/scaffold-test-harness.js";
+
+describe("@wp-typia/project-tools scaffold toolchain policy", () => {
+	const tempRoot = createScaffoldTempRoot("wp-typia-scaffold-toolchain-policy-");
+
+	afterAll(() => {
+		cleanupScaffoldTempRoot(tempRoot);
+	});
+
+	test("npm scaffolds omit packageManager and Node helper version files", async () => {
+		const targetDir = path.join(tempRoot, "demo-toolchain-npm");
+
+		await scaffoldProject({
+			projectDir: targetDir,
+			templateId: "basic",
+			packageManager: "npm",
+			noInstall: true,
+			answers: {
+				author: "Test Runner",
+				description: "Toolchain policy npm scaffold",
+				namespace: "demo-space",
+				slug: "demo-toolchain-npm",
+				title: "Demo Toolchain Npm",
+			},
+		});
+
+		const packageJson = JSON.parse(
+			fs.readFileSync(path.join(targetDir, "package.json"), "utf8"),
+		) as {
+			devDependencies: Record<string, string>;
+			engines?: Record<string, string>;
+			packageManager?: string;
+		};
+
+		expect(packageJson.packageManager).toBeUndefined();
+		expect(packageJson.engines).toBeUndefined();
+		expect(fs.existsSync(path.join(targetDir, ".nvmrc"))).toBe(false);
+		expect(fs.existsSync(path.join(targetDir, ".node-version"))).toBe(false);
+		expect(packageJson.devDependencies["@wp-typia/block-runtime"]).toBe(
+			normalizedBlockRuntimePackageVersion,
+		);
+		expect(packageJson.devDependencies["@wp-typia/block-types"]).toBe(
+			blockTypesPackageVersion,
+		);
+		expect(packageJson.devDependencies["@wp-typia/block-runtime"]).toMatch(/^\^/);
+		expect(packageJson.devDependencies["@wp-typia/block-types"]).toMatch(/^\^/);
+	});
+
+	test("non-npm scaffolds keep the exact packageManager selector but still use ranged wp-typia deps", async () => {
+		const targetDir = path.join(tempRoot, "demo-toolchain-bun");
+
+		await scaffoldProject({
+			projectDir: targetDir,
+			templateId: "persistence",
+			packageManager: "bun",
+			noInstall: true,
+			answers: {
+				author: "Test Runner",
+				dataStorageMode: "custom-table",
+				description: "Toolchain policy bun scaffold",
+				namespace: "demo-space",
+				persistencePolicy: "authenticated",
+				slug: "demo-toolchain-bun",
+				title: "Demo Toolchain Bun",
+			},
+		});
+
+		const packageJson = JSON.parse(
+			fs.readFileSync(path.join(targetDir, "package.json"), "utf8"),
+		) as {
+			devDependencies: Record<string, string>;
+			engines?: Record<string, string>;
+			packageManager?: string;
+		};
+
+		expect(packageJson.packageManager).toBe(
+			getPackageManager("bun").packageManagerField,
+		);
+		expect(packageJson.engines).toBeUndefined();
+		expect(fs.existsSync(path.join(targetDir, ".nvmrc"))).toBe(false);
+		expect(fs.existsSync(path.join(targetDir, ".node-version"))).toBe(false);
+		expect(packageJson.devDependencies["@wp-typia/api-client"]).toBe(
+			apiClientPackageVersion,
+		);
+		expect(packageJson.devDependencies["@wp-typia/rest"]).toBe(
+			restPackageVersion,
+		);
+		expect(packageJson.devDependencies["@wp-typia/api-client"]).toMatch(/^\^/);
+		expect(packageJson.devDependencies["@wp-typia/rest"]).toMatch(/^\^/);
+	});
+});


### PR DESCRIPTION
## Context

Scaffolded projects already encode package-manager, Node runtime, and `@wp-typia/*` version choices, but the rationale was still implicit.

## What Changed

- documented the scaffolded toolchain policy in one maintainer doc
- linked the new policy from the root README policy list
- added a focused scaffold policy regression test that locks package-manager field behavior, Node helper-file absence, and ranged `@wp-typia/*` dependency strategy

## Verification

- bun test packages/wp-typia-project-tools/tests/scaffold-toolchain-policy.test.ts
- bun run changesets:validate
- attempted `bun run docs:build:site` locally, but it is currently blocked by pre-existing typedoc/type-smoke failures in `packages/wp-typia-block-types/src/blocks/registration.ts` and `tests/type-smoke/block-types-smoke.ts`

Closes #514

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added Scaffold Toolchain Policy guide specifying how package manager selection and dependency versions are handled in generated projects, with practical implementation checklist.
  * Updated documentation navigation to include new policy reference.

* **Tests**
  * Added tests verifying scaffold toolchain policy compliance across different configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->