### PR TITLE
Harden external template trust diagnostics

### DIFF
--- a/.sampo/changesets/issue-515-external-template-trust.md
+++ b/.sampo/changesets/issue-515-external-template-trust.md
@@ -1,0 +1,6 @@
+---
+npm/wp-typia: patch
+npm/@wp-typia/project-tools: patch
+---
+
+Made external-template trust more explicit during scaffolding and surfaced clearer diagnostics when remote template package metadata is malformed.

--- a/packages/wp-typia-project-tools/src/runtime/template-source-external.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-external.ts
@@ -23,6 +23,8 @@ export const EXTERNAL_TEMPLATE_ENTRY_CANDIDATES = [
   'index.cjs',
   'index.mjs',
 ] as const
+export const EXTERNAL_TEMPLATE_TRUST_WARNING =
+  'External template configs execute trusted JavaScript during scaffolding. Review the template source before using local paths, GitHub repos, or npm packages you do not already trust.'
 const TEMPLATE_WARNING_MESSAGE =
   'wp-typia owns package/tooling/sync setup for generated projects, so this external template setting is ignored.'
 
@@ -80,7 +82,7 @@ async function loadExternalTemplateConfig<
     )
   }
 
-  const warnings: string[] = []
+  const warnings: string[] = [EXTERNAL_TEMPLATE_TRUST_WARNING]
   for (const ignoredKey of [
     'wpScripts',
     'wpEnv',

--- a/packages/wp-typia-project-tools/src/runtime/template-source-remote.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-remote.ts
@@ -82,7 +82,10 @@ export function getDefaultCategory(sourceDir: string): string {
 
 function readTemplatePackageJson(
   sourceDir: string,
-): { wpTypia?: { projectType?: string } } | null {
+): {
+  packageJson: { wpTypia?: { projectType?: unknown } }
+  sourcePath: string
+} | null {
   for (const candidate of [
     path.join(sourceDir, 'package.json.mustache'),
     path.join(sourceDir, 'package.json'),
@@ -92,11 +95,18 @@ function readTemplatePackageJson(
     }
 
     try {
-      return JSON.parse(fs.readFileSync(candidate, 'utf8')) as {
-        wpTypia?: { projectType?: string }
+      return {
+        packageJson: JSON.parse(fs.readFileSync(candidate, 'utf8')) as {
+          wpTypia?: { projectType?: unknown }
+        },
+        sourcePath: candidate,
       }
-    } catch {
-      continue
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Unknown parse failure'
+      throw new Error(
+        `Failed to parse template metadata file "${candidate}": ${message}`,
+      )
     }
   }
 
@@ -108,10 +118,22 @@ function readTemplatePackageJson(
  * manifest and return it when present.
  */
 export function getTemplateProjectType(sourceDir: string): string | null {
-  const packageJson = readTemplatePackageJson(sourceDir)
-  return typeof packageJson?.wpTypia?.projectType === 'string'
-    ? packageJson.wpTypia.projectType
-    : null
+  const packageJsonEntry = readTemplatePackageJson(sourceDir)
+  if (!packageJsonEntry) {
+    return null
+  }
+
+  const projectType = packageJsonEntry.packageJson.wpTypia?.projectType
+  if (projectType === undefined) {
+    return null
+  }
+  if (typeof projectType !== 'string' || projectType.trim().length === 0) {
+    throw new Error(
+      `Template metadata file "${packageJsonEntry.sourcePath}" defines wpTypia.projectType, but it must be a non-empty string.`,
+    )
+  }
+
+  return projectType
 }
 
 /**

--- a/packages/wp-typia-project-tools/tests/cli-entry.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-entry.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, describe, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { cleanupScaffoldTempRoot, createBlockSubsetFixturePath, createScaffoldTempRoot, entryPath, getCommandErrorMessage, runCapturedCli, runCli, scaffoldOfficialWorkspace, templateLayerAmbiguousFixturePath, templateLayerFixturePath } from "./helpers/scaffold-test-harness.js";
+import { cleanupScaffoldTempRoot, createBlockExternalFixturePath, createBlockSubsetFixturePath, createScaffoldTempRoot, entryPath, getCommandErrorMessage, runCapturedCli, runCli, scaffoldOfficialWorkspace, templateLayerAmbiguousFixturePath, templateLayerFixturePath } from "./helpers/scaffold-test-harness.js";
 import { formatHelpText, getDoctorChecks, getNextSteps, getOptionalOnboarding, runScaffoldFlow } from "../src/runtime/cli-core.js";
 import { collectScaffoldAnswers } from "../src/runtime/scaffold.js";
 import { getQuickStartWorkflowNote } from "../src/runtime/scaffold-onboarding.js";
@@ -255,6 +255,25 @@ test("runScaffoldFlow prompts for an external layer when multiple public roots a
   expect(fs.readFileSync(path.join(flow.projectDir, "beta.txt"), "utf8")).toContain(
     "beta layer"
   );
+});
+
+test("runScaffoldFlow surfaces explicit trust warnings for executable external templates", async () => {
+  const flow = await runScaffoldFlow({
+    cwd: tempRoot,
+    noInstall: true,
+    packageManager: "npm",
+    projectInput: "demo-external-template-warning",
+    templateId: createBlockExternalFixturePath,
+    yes: true,
+  });
+
+  expect(
+    flow.result.warnings.some((warning) =>
+      warning.includes(
+        "External template configs execute trusted JavaScript during scaffolding."
+      )
+    )
+  ).toBe(true);
 });
 
 test("optional onboarding derives sync steps from available custom-template scripts", () => {

--- a/packages/wp-typia-project-tools/tests/template-source.test.ts
+++ b/packages/wp-typia-project-tools/tests/template-source.test.ts
@@ -7,6 +7,7 @@ import { getTemplateVariables, scaffoldProject } from "../src/runtime/index.js";
 import { resolveTemplateId } from "../src/runtime/scaffold.js";
 import { copyRenderedDirectory } from "../src/runtime/template-render.js";
 import { parseGitHubTemplateLocator, parseNpmTemplateLocator, parseTemplateLocator } from "../src/runtime/template-source.js";
+import { EXTERNAL_TEMPLATE_TRUST_WARNING } from "../src/runtime/template-source-external.js";
 
 describe("@wp-typia/project-tools template sources", () => {
   const tempRoot = createScaffoldTempRoot("wp-typia-template-source-");
@@ -160,7 +161,7 @@ test("local official external template configs scaffold with the default variant
   );
 
   expect(result.selectedVariant).toBe("standard");
-  expect(result.warnings ?? []).toEqual([]);
+  expect(result.warnings ?? []).toContain(EXTERNAL_TEMPLATE_TRUST_WARNING);
   expect(
     fs.existsSync(path.join(targetDir, "assets", "remote-note.txt"))
   ).toBe(true);
@@ -358,7 +359,7 @@ test("external template workspace variants scaffold richer wp-typia workspaces w
   const readme = fs.readFileSync(path.join(targetDir, "README.md"), "utf8");
 
   expect(result.selectedVariant).toBe("workspace");
-  expect(result.warnings ?? []).toEqual([]);
+  expect(result.warnings ?? []).toContain(EXTERNAL_TEMPLATE_TRUST_WARNING);
   expect(packageJson.wpTypia).toEqual({
     projectType: "workspace",
     templatePackage: "@scope/external-workspace-template",
@@ -433,6 +434,68 @@ test("external template scaffolds honor explicit repository reference overrides"
   );
   expect(generatedEdit).toContain("CLI package: fork-owner/fork-typia");
   expect(generatedEdit).not.toContain("yourusername/wp-typia");
+});
+
+test("malformed remote package metadata surfaces a direct parse diagnostic", async () => {
+  const fixtureDir = path.join(tempRoot, "create-block-subset-invalid-package-json");
+  fs.cpSync(createBlockSubsetFixturePath, fixtureDir, { recursive: true });
+  fs.writeFileSync(path.join(fixtureDir, "package.json"), "{\n", "utf8");
+
+  await expect(
+    scaffoldProject({
+      projectDir: path.join(tempRoot, "demo-invalid-remote-package-json"),
+      templateId: fixtureDir,
+      packageManager: "npm",
+      noInstall: true,
+      answers: {
+        author: "Test Runner",
+        description: "Invalid remote package metadata",
+        namespace: "create-block",
+        slug: "demo-invalid-remote-package-json",
+        title: "Invalid Remote Package Json",
+      },
+    })
+  ).rejects.toThrow(
+    /Failed to parse template metadata file ".*package\.json":/
+  );
+});
+
+test("malformed remote projectType metadata surfaces a direct validation diagnostic", async () => {
+  const fixtureDir = path.join(tempRoot, "create-block-subset-invalid-project-type");
+  fs.cpSync(createBlockSubsetFixturePath, fixtureDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(fixtureDir, "package.json"),
+    JSON.stringify(
+      {
+        name: "@scope/remote-template",
+        version: "0.0.0",
+        wpTypia: {
+          projectType: 42,
+        },
+      },
+      null,
+      2
+    ),
+    "utf8"
+  );
+
+  await expect(
+    scaffoldProject({
+      projectDir: path.join(tempRoot, "demo-invalid-remote-project-type"),
+      templateId: fixtureDir,
+      packageManager: "npm",
+      noInstall: true,
+      answers: {
+        author: "Test Runner",
+        description: "Invalid remote project type",
+        namespace: "create-block",
+        slug: "demo-invalid-remote-project-type",
+        title: "Invalid Remote Project Type",
+      },
+    })
+  ).rejects.toThrow(
+    /defines wpTypia\.projectType, but it must be a non-empty string\./
+  );
 });
 
 test("workspace template package identity is defined once and imported by runtime callers", () => {


### PR DESCRIPTION
## Summary
- make executable external-template trust explicit with a runtime warning
- surface malformed remote template metadata with direct parse and validation diagnostics
- cover both template-source and runScaffoldFlow user-facing paths

## Verification
- bun test packages/wp-typia-project-tools/tests/template-source.test.ts
- bun test packages/wp-typia-project-tools/tests/cli-entry.test.ts
- bun run --filter @wp-typia/project-tools build
- bun run changesets:validate

Closes #515
