### PR TITLE
Stabilize late invalidation react tests

### DIFF
--- a/packages/wp-typia-rest/tests/react.test.tsx
+++ b/packages/wp-typia-rest/tests/react.test.tsx
@@ -480,7 +480,10 @@ describe("@wp-typia/rest/react", () => {
 		await rendered.unmount();
 	});
 
-	test("invalidate triggers a follow-up fetch when an older request resolves late", async () => {
+	test(
+		"invalidate triggers a follow-up fetch when an older request resolves late",
+		{ timeout: 15_000 },
+		async () => {
 		let fetchCount = 0;
 		let resolveFirstFetch!: (value: { count: number }) => void;
 		const endpoint = createEndpoint<{ page: number }, { count: number }>({
@@ -540,7 +543,10 @@ describe("@wp-typia/rest/react", () => {
 		await rendered.unmount();
 	});
 
-	test("invalidate preserves follow-up fetches when an older request fails late", async () => {
+	test(
+		"invalidate preserves follow-up fetches when an older request fails late",
+		{ timeout: 15_000 },
+		async () => {
 		let fetchCount = 0;
 		let rejectFirstFetch!: (error: Error) => void;
 		const endpoint = createEndpoint<{ page: number }, { count: number }>({

--- a/packages/wp-typia-rest/tests/react.test.tsx
+++ b/packages/wp-typia-rest/tests/react.test.tsx
@@ -482,7 +482,6 @@ describe("@wp-typia/rest/react", () => {
 
 	test(
 		"invalidate triggers a follow-up fetch when an older request resolves late",
-		{ timeout: 15_000 },
 		async () => {
 		let fetchCount = 0;
 		let resolveFirstFetch!: (value: { count: number }) => void;
@@ -541,11 +540,12 @@ describe("@wp-typia/rest/react", () => {
 		}, 10_000);
 
 		await rendered.unmount();
-	});
+		},
+		{ timeout: 15_000 },
+	);
 
 	test(
 		"invalidate preserves follow-up fetches when an older request fails late",
-		{ timeout: 15_000 },
 		async () => {
 		let fetchCount = 0;
 		let rejectFirstFetch!: (error: Error) => void;
@@ -605,7 +605,9 @@ describe("@wp-typia/rest/react", () => {
 		}, 10_000);
 
 		await rendered.unmount();
-	});
+		},
+		{ timeout: 15_000 },
+	);
 
 	test("useEndpointMutation invalidates matching queries after a successful mutation", async () => {
 		let serverCount = 0;


### PR DESCRIPTION
## Summary
- give the two late-invalidation react tests an explicit Bun test timeout budget
- keep the rest of the react query invalidation assertions unchanged
- harden the exact @wp-typia/rest coverage lane that failed on main run `24784413494`

## Verification
- bun run --filter @wp-typia/rest test:coverage

Refs: main run `24784413494`
