### PR TITLE
Refactor scaffold template variables into template-aware groups

### DIFF
--- a/.sampo/changesets/issue-518-template-variable-groups.md
+++ b/.sampo/changesets/issue-518-template-variable-groups.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Attached template-family-aware grouped scaffold variable metadata while preserving the flat string view used by rendering and external template flows.

--- a/packages/wp-typia-project-tools/src/runtime/block-generator-service-spec.ts
+++ b/packages/wp-typia-project-tools/src/runtime/block-generator-service-spec.ts
@@ -29,8 +29,10 @@ import {
 	buildFrontendCssClassName,
 	resolveScaffoldIdentifiers,
 } from "./scaffold-identifiers.js";
+import { attachScaffoldTemplateVariableGroups } from "./scaffold-template-variable-groups.js";
 import type {
 	DataStorageMode,
+	FlatScaffoldTemplateVariables,
 	PersistencePolicy,
 	ScaffoldAnswers,
 	ScaffoldProgressEvent,
@@ -300,6 +302,8 @@ export function buildTemplateVariablesFromBlockSpec(spec: BlockSpec): ScaffoldTe
 	const compoundInnerBlocksPreset = spec.compound.innerBlocksPreset;
 	const compoundInnerBlocksPresetDefinition =
 		getCompoundInnerBlocksPresetDefinition(compoundInnerBlocksPreset);
+	const compoundInnerBlocksOrientation: "" | "horizontal" | "vertical" =
+		compoundInnerBlocksPresetDefinition.orientation ?? "";
 	const persistenceEnabled = spec.persistence.enabled;
 	const dataStorageMode = persistenceEnabled ? spec.persistence.dataStorageMode : "custom-table";
 	const persistencePolicy = persistenceEnabled
@@ -307,7 +311,7 @@ export function buildTemplateVariablesFromBlockSpec(spec: BlockSpec): ScaffoldTe
 		: "authenticated";
 	const queryVariationNamespace = `${namespace}/${slug}`;
 
-	return {
+	const flatVariables: FlatScaffoldTemplateVariables = {
 		alternateRenderTargetsCsv: formatAlternateRenderTargets(
 			alternateRenderTargets,
 		),
@@ -328,8 +332,7 @@ export function buildTemplateVariablesFromBlockSpec(spec: BlockSpec): ScaffoldTe
 			spec.template.family === "compound" && persistenceEnabled ? "true" : "false",
 		compoundInnerBlocksDirectInsert:
 			compoundInnerBlocksPresetDefinition.directInsert ? "true" : "false",
-		compoundInnerBlocksOrientation:
-			compoundInnerBlocksPresetDefinition.orientation ?? "",
+		compoundInnerBlocksOrientation: compoundInnerBlocksOrientation,
 		compoundInnerBlocksOrientationExpression:
 			compoundInnerBlocksPresetDefinition.orientation
 				? `'${compoundInnerBlocksPresetDefinition.orientation}'`
@@ -415,4 +418,217 @@ export function buildTemplateVariablesFromBlockSpec(spec: BlockSpec): ScaffoldTe
 		titleCase: pascalCase,
 		persistencePolicy,
 	};
+
+	const shared = {
+		author: spec.project.author,
+		blockMetadataVersion: BUILTIN_BLOCK_METADATA_VERSION,
+		category: spec.metadata.category,
+		cssClassName,
+		description: spec.metadata.description,
+		descriptionJson: flatVariables.descriptionJson,
+		frontendCssClassName: flatVariables.frontendCssClassName,
+		icon: spec.metadata.icon,
+		keyword: spec.metadata.keyword,
+		namespace,
+		pascalCase,
+		phpPrefix,
+		phpPrefixUpper,
+		slug,
+		slugCamelCase: flatVariables.slugCamelCase,
+		slugKebabCase: slug,
+		slugSnakeCase,
+		textDomain,
+		title,
+		titleCase: pascalCase,
+		titleJson: flatVariables.titleJson,
+		versions: {
+			apiClient: apiClientPackageVersion,
+			blockRuntime: blockRuntimePackageVersion,
+			blockTypes: blockTypesPackageVersion,
+			projectTools: projectToolsPackageVersion,
+			rest: restPackageVersion,
+		},
+	};
+	const alternateRenderTargetsGroup = {
+		csv: flatVariables.alternateRenderTargetsCsv,
+		enabled: alternateRenderTargets.length > 0,
+		hasEmail: hasAlternateEmailRenderTarget,
+		hasMjml: hasAlternateMjmlRenderTarget,
+		hasPlainText: hasAlternatePlainTextRenderTarget,
+		json: flatVariables.alternateRenderTargetsJson,
+		targets: alternateRenderTargets,
+	};
+	const compoundGroup = {
+		child: {
+			category: COMPOUND_CHILD_BLOCK_METADATA_DEFAULTS.category,
+			cssClassName: compoundChildCssClassName,
+			icon: COMPOUND_CHILD_BLOCK_METADATA_DEFAULTS.icon,
+			title: compoundChildTitle,
+			titleJson: JSON.stringify(compoundChildTitle),
+		},
+		enabled: true as const,
+		innerBlocks: {
+			description: compoundInnerBlocksPresetDefinition.description,
+			directInsert: compoundInnerBlocksPresetDefinition.directInsert,
+			label: compoundInnerBlocksPresetDefinition.label,
+			orientation: compoundInnerBlocksOrientation,
+			orientationExpression:
+				compoundInnerBlocksPresetDefinition.orientation
+					? `'${compoundInnerBlocksPresetDefinition.orientation}'`
+					: "undefined",
+			preset: compoundInnerBlocksPreset,
+			templateLockExpression:
+				compoundInnerBlocksPresetDefinition.templateLock === false
+					? "false"
+					: `'${compoundInnerBlocksPresetDefinition.templateLock}'`,
+		},
+		persistenceEnabled: persistenceEnabled,
+	};
+	const persistenceGroup = persistenceEnabled
+		? {
+				auth: {
+					bootstrapCredentialDeclarations:
+						flatVariables.bootstrapCredentialDeclarations,
+					descriptionJson: flatVariables.persistencePolicyDescriptionJson,
+					intent: flatVariables.restWriteAuthIntent,
+					isAuthenticated: persistencePolicy === "authenticated",
+					isPublic: persistencePolicy === "public",
+					mechanism: flatVariables.restWriteAuthMechanism,
+					mode: flatVariables.restWriteAuthMode,
+					publicWriteRequestIdDeclaration:
+						flatVariables.publicWriteRequestIdDeclaration,
+				},
+				dataStorageMode,
+				enabled: true as const,
+				policy: persistencePolicy,
+				scope: spec.persistence.scope,
+		  }
+		: null;
+	const queryLoopGroup = {
+		allowedControls: spec.queryLoop.allowedControls,
+		allowedControlsJson: flatVariables.queryAllowedControlsJson,
+		enabled: true as const,
+		postType: spec.queryLoop.postType,
+		postTypeJson: flatVariables.queryPostTypeJson,
+		variationNamespace: queryVariationNamespace,
+		variationNamespaceJson: flatVariables.queryVariationNamespaceJson,
+	};
+
+	switch (spec.template.family) {
+		case "basic":
+			return attachScaffoldTemplateVariableGroups(flatVariables, {
+				alternateRenderTargets: alternateRenderTargetsGroup,
+				compound: {
+					enabled: false,
+					persistenceEnabled: false,
+				},
+				persistence: {
+					enabled: false,
+					scope: "none",
+				},
+				queryLoop: {
+					enabled: false,
+				},
+				shared,
+				template: {
+					description: spec.template.description,
+				},
+				templateFamily: "basic",
+			});
+		case "interactivity":
+			return attachScaffoldTemplateVariableGroups(flatVariables, {
+				alternateRenderTargets: alternateRenderTargetsGroup,
+				compound: {
+					enabled: false,
+					persistenceEnabled: false,
+				},
+				persistence: {
+					enabled: false,
+					scope: "none",
+				},
+				queryLoop: {
+					enabled: false,
+				},
+				shared,
+				template: {
+					description: spec.template.description,
+				},
+				templateFamily: "interactivity",
+			});
+		case "persistence": {
+			if (persistenceGroup === null) {
+				throw new Error(
+					"Persistence scaffolds must provide persistence template variables.",
+				);
+			}
+			return attachScaffoldTemplateVariableGroups(flatVariables, {
+				alternateRenderTargets: alternateRenderTargetsGroup,
+				compound: {
+					enabled: false,
+					persistenceEnabled: false,
+				},
+				persistence: {
+					...persistenceGroup,
+					scope: "single",
+				},
+				queryLoop: {
+					enabled: false,
+				},
+				shared,
+				template: {
+					description: spec.template.description,
+				},
+				templateFamily: "persistence",
+			});
+		}
+		case "compound": {
+			const compoundPersistenceGroup =
+				persistenceGroup === null
+					? {
+							enabled: false as const,
+							scope: "none" as const,
+					  }
+					: {
+							...persistenceGroup,
+							scope: "compound-parent" as const,
+					  };
+			return attachScaffoldTemplateVariableGroups(flatVariables, {
+				alternateRenderTargets: alternateRenderTargetsGroup,
+				compound: compoundGroup,
+				persistence: compoundPersistenceGroup,
+				queryLoop: {
+					enabled: false,
+				},
+				shared,
+				template: {
+					description: spec.template.description,
+				},
+				templateFamily: "compound",
+			});
+		}
+		case "query-loop":
+			return attachScaffoldTemplateVariableGroups(flatVariables, {
+				alternateRenderTargets: alternateRenderTargetsGroup,
+				compound: {
+					enabled: false,
+					persistenceEnabled: false,
+				},
+				persistence: {
+					enabled: false,
+					scope: "none",
+				},
+				queryLoop: queryLoopGroup,
+				shared,
+				template: {
+					description: spec.template.description,
+				},
+				templateFamily: "query-loop",
+			});
+		default: {
+			const unreachableTemplateFamily: never = spec.template.family;
+			throw new Error(
+				`Unhandled scaffold template family: ${unreachableTemplateFamily}`,
+			);
+		}
+	}
 }

--- a/packages/wp-typia-project-tools/src/runtime/built-in-block-artifacts.ts
+++ b/packages/wp-typia-project-tools/src/runtime/built-in-block-artifacts.ts
@@ -18,6 +18,7 @@ import {
 	buildInteractivityTypesSource,
 	buildPersistenceTypesSource,
 } from "./built-in-block-artifact-types.js";
+import { getScaffoldTemplateVariableGroups } from "./scaffold-template-variable-groups.js";
 
 export interface BuiltInBlockArtifact {
 	blockJsonDocument: Record<string, unknown>;
@@ -141,7 +142,9 @@ function buildCompoundParentArtifact(
 	variables: ScaffoldTemplateVariables,
 ): BuiltInBlockArtifact {
 	const attributes = buildCompoundParentAttributes(variables);
-	const persistenceEnabled = variables.compoundPersistenceEnabled === "true";
+	const compoundGroup = getScaffoldTemplateVariableGroups(variables).compound;
+	const persistenceEnabled =
+		compoundGroup.enabled && compoundGroup.persistenceEnabled;
 
 	return {
 		blockJsonDocument: {

--- a/packages/wp-typia-project-tools/src/runtime/built-in-block-code-artifacts.ts
+++ b/packages/wp-typia-project-tools/src/runtime/built-in-block-code-artifacts.ts
@@ -40,6 +40,7 @@ import {
 	QUERY_LOOP_INDEX_TEMPLATE,
 	SHARED_HOOKS_TEMPLATE,
 } from "./built-in-block-code-templates.js";
+import { getScaffoldTemplateVariableGroups } from "./scaffold-template-variable-groups.js";
 import { renderMustacheTemplateString } from "./template-render.js";
 
 /**
@@ -221,8 +222,9 @@ function buildCompoundCodeArtifacts(
 ): BuiltInCodeArtifact[] {
 	const parentBasePath = `src/blocks/${variables.slugKebabCase}`;
 	const childBasePath = `src/blocks/${variables.slugKebabCase}-item`;
+	const compoundGroup = getScaffoldTemplateVariableGroups(variables).compound;
 	const compoundPersistenceEnabled =
-		variables.compoundPersistenceEnabled === "true";
+		compoundGroup.enabled && compoundGroup.persistenceEnabled;
 
 	return ensureUniqueArtifactPaths([
 		createCodeArtifact("src/hooks.ts", SHARED_HOOKS_TEMPLATE, variables),

--- a/packages/wp-typia-project-tools/src/runtime/index.ts
+++ b/packages/wp-typia-project-tools/src/runtime/index.ts
@@ -26,12 +26,24 @@ export type {
 export {
 	scaffoldProject,
 	collectScaffoldAnswers,
+	getScaffoldTemplateVariableGroups,
 	getDefaultAnswers,
 	getTemplateVariables,
 	resolvePackageManagerId,
 	resolveTemplateId,
 } from "./scaffold.js";
 export { BlockGeneratorService } from "./block-generator-service.js";
+export type {
+	BasicScaffoldTemplateVariableGroups,
+	CompoundScaffoldTemplateVariableGroups,
+	ExternalScaffoldTemplateVariableGroups,
+	FlatScaffoldTemplateVariables,
+	InteractivityScaffoldTemplateVariableGroups,
+	PersistenceScaffoldTemplateVariableGroups,
+	QueryLoopScaffoldTemplateVariableGroups,
+	ScaffoldTemplateFamily,
+	ScaffoldTemplateVariableGroups,
+} from "./scaffold.js";
 export type {
 	ApplyBlockInput,
 	BlockGenerationTarget,

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-bootstrap.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-bootstrap.ts
@@ -18,6 +18,7 @@ import {
 	PROJECT_TOOLS_PACKAGE_ROOT,
 } from "./template-registry.js";
 import type { BuiltInTemplateId } from "./template-registry.js";
+import { getScaffoldTemplateVariableGroups } from "./scaffold-template-variable-groups.js";
 
 const EPHEMERAL_NODE_MODULES_LINK_TYPE = process.platform === "win32" ? "junction" : "dir";
 
@@ -111,9 +112,12 @@ export async function seedBuiltInPersistenceArtifacts(
 	templateId: BuiltInTemplateId,
 	variables: ScaffoldTemplateVariables,
 ): Promise<void> {
+	const compoundGroup = getScaffoldTemplateVariableGroups(variables).compound;
 	const needsPersistenceArtifacts =
 		templateId === "persistence" ||
-		(templateId === "compound" && variables.compoundPersistenceEnabled === "true");
+		(templateId === "compound" &&
+			compoundGroup.enabled &&
+			compoundGroup.persistenceEnabled);
 
 	if (!needsPersistenceArtifacts) {
 		return;

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-documents.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-documents.ts
@@ -17,6 +17,7 @@ import {
 } from './package-managers.js';
 import { getPackageVersions } from './package-versions.js';
 import type { ScaffoldTemplateVariables } from './scaffold.js';
+import { getScaffoldTemplateVariableGroups } from './scaffold-template-variable-groups.js';
 
 /**
  * Builds the generated README markdown for one scaffolded project.
@@ -41,28 +42,31 @@ export function buildReadme(
     withWpEnv?: boolean;
   } = {},
 ): string {
+  const variableGroups = getScaffoldTemplateVariableGroups(variables);
+  const compoundPersistenceEnabled =
+    variableGroups.compound.enabled &&
+    variableGroups.compound.persistenceEnabled;
   const optionalOnboardingSteps = getOptionalOnboardingSteps(packageManager, templateId, {
-    compoundPersistenceEnabled: variables.compoundPersistenceEnabled === 'true',
+    compoundPersistenceEnabled,
   });
   const initialCommitCommands = getInitialCommitCommands();
   const sourceOfTruthNote = getTemplateSourceOfTruthNote(templateId, {
-    compoundPersistenceEnabled: variables.compoundPersistenceEnabled === 'true',
+    compoundPersistenceEnabled,
   });
-  const compoundPersistenceEnabled = variables.compoundPersistenceEnabled === 'true';
   const publicPersistencePolicyNote =
-    variables.isPublicPersistencePolicy === 'true'
+    variableGroups.persistence.enabled && variableGroups.persistence.auth.isPublic
       ? 'Public persistence writes use signed short-lived tokens, per-request ids, and coarse rate limiting by default. Add application-specific abuse controls before using the same pattern for high-value metrics or experiments.'
       : null;
   const alternateRenderTargetSection =
-    variables.hasAlternateRenderTargets === 'true'
+    variableGroups.alternateRenderTargets.enabled
       ? `## Alternate Render Targets\n\nThis scaffold keeps \`${templateId === 'compound' ? `src/blocks/${variables.slugKebabCase}/render.php` : 'src/render.php'}\` as the default web render boundary and also generates ${[
-          variables.hasAlternateEmailRenderTarget === 'true'
+          variableGroups.alternateRenderTargets.hasEmail
             ? `\`${templateId === 'compound' ? `src/blocks/${variables.slugKebabCase}/render-email.php` : 'src/render-email.php'}\``
             : null,
-          variables.hasAlternateMjmlRenderTarget === 'true'
+          variableGroups.alternateRenderTargets.hasMjml
             ? `\`${templateId === 'compound' ? `src/blocks/${variables.slugKebabCase}/render-mjml.php` : 'src/render-mjml.php'}\``
             : null,
-          variables.hasAlternatePlainTextRenderTarget === 'true'
+          variableGroups.alternateRenderTargets.hasPlainText
             ? `\`${templateId === 'compound' ? `src/blocks/${variables.slugKebabCase}/render-text.php` : 'src/render-text.php'}\``
             : null,
         ]

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-template-variable-groups.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-template-variable-groups.ts
@@ -1,0 +1,235 @@
+export const SCAFFOLD_TEMPLATE_VARIABLE_GROUPS = Symbol(
+	"wp-typia.scaffold-template-variable-groups",
+);
+
+export type ScaffoldTemplateFamily =
+	| "basic"
+	| "interactivity"
+	| "persistence"
+	| "compound"
+	| "query-loop"
+	| "external";
+
+export interface ScaffoldSharedTemplateVariableGroup {
+	author: string;
+	blockMetadataVersion: string;
+	category: string;
+	cssClassName: string;
+	description: string;
+	descriptionJson: string;
+	frontendCssClassName: string;
+	icon: string;
+	keyword: string;
+	namespace: string;
+	pascalCase: string;
+	phpPrefix: string;
+	phpPrefixUpper: string;
+	slug: string;
+	slugCamelCase: string;
+	slugKebabCase: string;
+	slugSnakeCase: string;
+	textDomain: string;
+	title: string;
+	titleCase: string;
+	titleJson: string;
+	versions: {
+		apiClient: string;
+		blockRuntime: string;
+		blockTypes: string;
+		projectTools: string;
+		rest: string;
+	};
+}
+
+export interface ScaffoldAlternateRenderTargetVariableGroup {
+	csv: string;
+	enabled: boolean;
+	hasEmail: boolean;
+	hasMjml: boolean;
+	hasPlainText: boolean;
+	json: string;
+	targets: readonly string[];
+}
+
+export interface DisabledScaffoldCompoundVariableGroup {
+	enabled: false;
+	persistenceEnabled: false;
+}
+
+export interface EnabledScaffoldCompoundVariableGroup {
+	child: {
+		category: string;
+		cssClassName: string;
+		icon: string;
+		title: string;
+		titleJson: string;
+	};
+	enabled: true;
+	innerBlocks: {
+		description: string;
+		directInsert: boolean;
+		label: string;
+		orientation: "" | "horizontal" | "vertical";
+		orientationExpression: string;
+		preset: string;
+		templateLockExpression: string;
+	};
+	persistenceEnabled: boolean;
+}
+
+export type ScaffoldCompoundVariableGroup =
+	| DisabledScaffoldCompoundVariableGroup
+	| EnabledScaffoldCompoundVariableGroup;
+
+export interface DisabledScaffoldPersistenceVariableGroup {
+	enabled: false;
+	scope: "none";
+}
+
+export interface EnabledScaffoldPersistenceVariableGroup {
+	auth: {
+		bootstrapCredentialDeclarations: string;
+		descriptionJson: string;
+		intent: "authenticated" | "public-write-protected";
+		isAuthenticated: boolean;
+		isPublic: boolean;
+		mechanism: "public-signed-token" | "rest-nonce";
+		mode: "authenticated-rest-nonce" | "public-signed-token";
+		publicWriteRequestIdDeclaration: string;
+	};
+	dataStorageMode: "custom-table" | "post-meta";
+	enabled: true;
+	policy: "authenticated" | "public";
+	scope: "compound-parent" | "single";
+}
+
+export type ScaffoldPersistenceVariableGroup =
+	| DisabledScaffoldPersistenceVariableGroup
+	| EnabledScaffoldPersistenceVariableGroup;
+
+export interface DisabledScaffoldQueryLoopVariableGroup {
+	enabled: false;
+}
+
+export interface EnabledScaffoldQueryLoopVariableGroup {
+	allowedControls: readonly string[];
+	allowedControlsJson: string;
+	enabled: true;
+	postType: string;
+	postTypeJson: string;
+	variationNamespace: string;
+	variationNamespaceJson: string;
+}
+
+export type ScaffoldQueryLoopVariableGroup =
+	| DisabledScaffoldQueryLoopVariableGroup
+	| EnabledScaffoldQueryLoopVariableGroup;
+
+interface ScaffoldTemplateVariableGroupsBase {
+	alternateRenderTargets: ScaffoldAlternateRenderTargetVariableGroup;
+	shared: ScaffoldSharedTemplateVariableGroup;
+	template: {
+		description: string;
+	};
+}
+
+export interface BasicScaffoldTemplateVariableGroups
+	extends ScaffoldTemplateVariableGroupsBase {
+	compound: DisabledScaffoldCompoundVariableGroup;
+	persistence: DisabledScaffoldPersistenceVariableGroup;
+	queryLoop: DisabledScaffoldQueryLoopVariableGroup;
+	templateFamily: "basic";
+}
+
+export interface InteractivityScaffoldTemplateVariableGroups
+	extends ScaffoldTemplateVariableGroupsBase {
+	compound: DisabledScaffoldCompoundVariableGroup;
+	persistence: DisabledScaffoldPersistenceVariableGroup;
+	queryLoop: DisabledScaffoldQueryLoopVariableGroup;
+	templateFamily: "interactivity";
+}
+
+export interface PersistenceScaffoldTemplateVariableGroups
+	extends ScaffoldTemplateVariableGroupsBase {
+	compound: DisabledScaffoldCompoundVariableGroup;
+	persistence: EnabledScaffoldPersistenceVariableGroup & {
+		scope: "single";
+	};
+	queryLoop: DisabledScaffoldQueryLoopVariableGroup;
+	templateFamily: "persistence";
+}
+
+export interface CompoundScaffoldTemplateVariableGroups
+	extends ScaffoldTemplateVariableGroupsBase {
+	compound: EnabledScaffoldCompoundVariableGroup;
+	persistence:
+		| DisabledScaffoldPersistenceVariableGroup
+		| (EnabledScaffoldPersistenceVariableGroup & {
+				scope: "compound-parent";
+		  });
+	queryLoop: DisabledScaffoldQueryLoopVariableGroup;
+	templateFamily: "compound";
+}
+
+export interface QueryLoopScaffoldTemplateVariableGroups
+	extends ScaffoldTemplateVariableGroupsBase {
+	compound: DisabledScaffoldCompoundVariableGroup;
+	persistence: DisabledScaffoldPersistenceVariableGroup;
+	queryLoop: EnabledScaffoldQueryLoopVariableGroup;
+	templateFamily: "query-loop";
+}
+
+export interface ExternalScaffoldTemplateVariableGroups
+	extends ScaffoldTemplateVariableGroupsBase {
+	compound: DisabledScaffoldCompoundVariableGroup;
+	persistence: DisabledScaffoldPersistenceVariableGroup;
+	queryLoop: DisabledScaffoldQueryLoopVariableGroup;
+	templateFamily: "external";
+}
+
+export type ScaffoldTemplateVariableGroups =
+	| BasicScaffoldTemplateVariableGroups
+	| InteractivityScaffoldTemplateVariableGroups
+	| PersistenceScaffoldTemplateVariableGroups
+	| CompoundScaffoldTemplateVariableGroups
+	| QueryLoopScaffoldTemplateVariableGroups
+	| ExternalScaffoldTemplateVariableGroups;
+
+export interface ScaffoldTemplateVariableGroupsCarrier {
+	readonly [SCAFFOLD_TEMPLATE_VARIABLE_GROUPS]: ScaffoldTemplateVariableGroups;
+}
+
+export type CompoundScaffoldTemplateVariablesLike =
+	ScaffoldTemplateVariableGroupsCarrier & {
+		slugKebabCase: string;
+	};
+
+export type PersistenceScaffoldTemplateVariablesLike =
+	ScaffoldTemplateVariableGroupsCarrier & {
+		namespace: string;
+		pascalCase: string;
+		slugKebabCase: string;
+		title: string;
+	};
+
+export function attachScaffoldTemplateVariableGroups<
+	TVariables extends Record<string, string>,
+>(
+	variables: TVariables,
+	groups: ScaffoldTemplateVariableGroups,
+): TVariables & ScaffoldTemplateVariableGroupsCarrier {
+	Object.defineProperty(variables, SCAFFOLD_TEMPLATE_VARIABLE_GROUPS, {
+		configurable: false,
+		enumerable: false,
+		value: groups,
+		writable: false,
+	});
+
+	return variables as TVariables & ScaffoldTemplateVariableGroupsCarrier;
+}
+
+export function getScaffoldTemplateVariableGroups(
+	variables: ScaffoldTemplateVariableGroupsCarrier,
+): ScaffoldTemplateVariableGroups {
+	return variables[SCAFFOLD_TEMPLATE_VARIABLE_GROUPS];
+}

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-template-variable-groups.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-template-variable-groups.ts
@@ -133,21 +133,20 @@ interface ScaffoldTemplateVariableGroupsBase {
 	};
 }
 
-export interface BasicScaffoldTemplateVariableGroups
-	extends ScaffoldTemplateVariableGroupsBase {
+type DisabledTemplateFamilyGroups<
+	TFamily extends "basic" | "interactivity" | "external",
+> = ScaffoldTemplateVariableGroupsBase & {
 	compound: DisabledScaffoldCompoundVariableGroup;
 	persistence: DisabledScaffoldPersistenceVariableGroup;
 	queryLoop: DisabledScaffoldQueryLoopVariableGroup;
-	templateFamily: "basic";
-}
+	templateFamily: TFamily;
+};
 
-export interface InteractivityScaffoldTemplateVariableGroups
-	extends ScaffoldTemplateVariableGroupsBase {
-	compound: DisabledScaffoldCompoundVariableGroup;
-	persistence: DisabledScaffoldPersistenceVariableGroup;
-	queryLoop: DisabledScaffoldQueryLoopVariableGroup;
-	templateFamily: "interactivity";
-}
+export type BasicScaffoldTemplateVariableGroups =
+	DisabledTemplateFamilyGroups<"basic">;
+
+export type InteractivityScaffoldTemplateVariableGroups =
+	DisabledTemplateFamilyGroups<"interactivity">;
 
 export interface PersistenceScaffoldTemplateVariableGroups
 	extends ScaffoldTemplateVariableGroupsBase {
@@ -179,13 +178,8 @@ export interface QueryLoopScaffoldTemplateVariableGroups
 	templateFamily: "query-loop";
 }
 
-export interface ExternalScaffoldTemplateVariableGroups
-	extends ScaffoldTemplateVariableGroupsBase {
-	compound: DisabledScaffoldCompoundVariableGroup;
-	persistence: DisabledScaffoldPersistenceVariableGroup;
-	queryLoop: DisabledScaffoldQueryLoopVariableGroup;
-	templateFamily: "external";
-}
+export type ExternalScaffoldTemplateVariableGroups =
+	DisabledTemplateFamilyGroups<"external">;
 
 export type ScaffoldTemplateVariableGroups =
 	| BasicScaffoldTemplateVariableGroups

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-template-variables.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-template-variables.ts
@@ -9,6 +9,7 @@ import {
   resolveScaffoldIdentifiers,
 } from './scaffold-identifiers.js';
 import type {
+  FlatScaffoldTemplateVariables,
   ScaffoldAnswers,
   ScaffoldTemplateVariables,
 } from './scaffold.js';
@@ -29,6 +30,7 @@ import {
   toPascalCase,
   toSnakeCase,
 } from './string-case.js';
+import { attachScaffoldTemplateVariableGroups } from "./scaffold-template-variable-groups.js";
 
 /**
  * Build the normalized template variables used by scaffold rendering.
@@ -100,7 +102,7 @@ export function getTemplateVariables(
       ? answers.persistencePolicy ?? 'authenticated'
       : 'authenticated';
 
-  return {
+  const flatVariables: FlatScaffoldTemplateVariables = {
     alternateRenderTargetsCsv: '',
     alternateRenderTargetsJson: '[]',
     apiClientPackageVersion,
@@ -191,4 +193,61 @@ export function getTemplateVariables(
     titleCase: pascalCase,
     persistencePolicy,
   };
+
+  return attachScaffoldTemplateVariableGroups(flatVariables, {
+    alternateRenderTargets: {
+      csv: '',
+      enabled: false,
+      hasEmail: false,
+      hasMjml: false,
+      hasPlainText: false,
+      json: '[]',
+      targets: [],
+    },
+    compound: {
+      enabled: false,
+      persistenceEnabled: false,
+    },
+    persistence: {
+      enabled: false,
+      scope: 'none',
+    },
+    queryLoop: {
+      enabled: false,
+    },
+    shared: {
+      author: answers.author.trim(),
+      blockMetadataVersion: BUILTIN_BLOCK_METADATA_VERSION,
+      category: metadataDefaults?.category ?? template?.defaultCategory ?? 'widgets',
+      cssClassName,
+      description,
+      descriptionJson: JSON.stringify(description),
+      frontendCssClassName: buildFrontendCssClassName(cssClassName),
+      icon: metadataDefaults?.icon ?? 'smiley',
+      keyword: slug.replace(/-/g, ' '),
+      namespace,
+      pascalCase,
+      phpPrefix,
+      phpPrefixUpper,
+      slug,
+      slugCamelCase: pascalCase.charAt(0).toLowerCase() + pascalCase.slice(1),
+      slugKebabCase: slug,
+      slugSnakeCase,
+      textDomain,
+      title,
+      titleCase: pascalCase,
+      titleJson: JSON.stringify(title),
+      versions: {
+        apiClient: apiClientPackageVersion,
+        blockRuntime: blockRuntimePackageVersion,
+        blockTypes: blockTypesPackageVersion,
+        projectTools: projectToolsPackageVersion,
+        rest: restPackageVersion,
+      },
+    },
+    template: {
+      description: template?.description ?? 'External scaffold template variables',
+    },
+    templateFamily: 'external',
+  });
 }

--- a/packages/wp-typia-project-tools/src/runtime/scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold.ts
@@ -41,6 +41,10 @@ import {
 import {
 } from "./scaffold-answer-resolution.js";
 import { getTemplateVariables } from "./scaffold-template-variables.js";
+import { getScaffoldTemplateVariableGroups } from "./scaffold-template-variable-groups.js";
+import type {
+	ScaffoldTemplateVariableGroupsCarrier,
+} from "./scaffold-template-variable-groups.js";
 import {
 	assertExternalLayerCompositionOptions,
 } from "./cli-validation.js";
@@ -79,7 +83,7 @@ export type PersistencePolicy = (typeof PERSISTENCE_POLICIES)[number];
 /**
  * Normalized template variables shared by built-in and remote scaffold flows.
  */
-export interface ScaffoldTemplateVariables extends Record<string, string> {
+export interface FlatScaffoldTemplateVariables extends Record<string, string> {
 	alternateRenderTargetsCsv: string;
 	alternateRenderTargetsJson: string;
 	apiClientPackageVersion: string;
@@ -144,6 +148,10 @@ export interface ScaffoldTemplateVariables extends Record<string, string> {
 	titleCase: string;
 	persistencePolicy: PersistencePolicy;
 }
+
+export interface ScaffoldTemplateVariables
+	extends FlatScaffoldTemplateVariables,
+		ScaffoldTemplateVariableGroupsCarrier {}
 
 /**
  * Resolve scaffold template input from either built-in template ids or custom
@@ -248,6 +256,18 @@ export {
 	resolveTemplateId,
 } from "./scaffold-answer-resolution.js";
 export { getTemplateVariables } from "./scaffold-template-variables.js";
+export {
+	getScaffoldTemplateVariableGroups,
+	type BasicScaffoldTemplateVariableGroups,
+	type CompoundScaffoldTemplateVariableGroups,
+	type ExternalScaffoldTemplateVariableGroups,
+	type InteractivityScaffoldTemplateVariableGroups,
+	type PersistenceScaffoldTemplateVariableGroups,
+	type QueryLoopScaffoldTemplateVariableGroups,
+	type ScaffoldTemplateFamily,
+	type ScaffoldTemplateVariableGroups,
+	type ScaffoldTemplateVariableGroupsCarrier,
+} from "./scaffold-template-variable-groups.js";
 
 export function isDataStorageMode(value: string): value is DataStorageMode {
 	return (DATA_STORAGE_MODES as readonly string[]).includes(value);
@@ -448,8 +468,11 @@ export async function scaffoldProject({
 	);
 	await normalizePackageJson(projectDir, resolvedPackageManager);
 	if (isBuiltInTemplate) {
+		const variableGroups = getScaffoldTemplateVariableGroups(variables);
 		await applyGeneratedProjectDxPackageJson({
-			compoundPersistenceEnabled: variables.compoundPersistenceEnabled === "true",
+			compoundPersistenceEnabled:
+				variableGroups.compound.enabled &&
+				variableGroups.compound.persistenceEnabled,
 			packageManager: resolvedPackageManager,
 			projectDir,
 			templateId: resolvedTemplateId,

--- a/packages/wp-typia-project-tools/src/runtime/template-source.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source.ts
@@ -26,6 +26,8 @@ import {
 import {
   assertBuiltInTemplateVariantAllowed,
 } from './cli-validation.js'
+import type { ScaffoldTemplateVariables } from './scaffold.js'
+import { getScaffoldTemplateVariableGroups } from './scaffold-template-variable-groups.js'
 
 export type {
   GitHubTemplateLocator,
@@ -45,18 +47,24 @@ export { resolveTemplateSeed } from './template-source-seeds.js'
 export async function resolveTemplateSource(
   templateId: string,
   cwd: string,
-  variables: { [key: string]: string },
+  variables: ScaffoldTemplateVariables,
   variant?: string,
 ): Promise<ResolvedTemplateSource> {
   if (isBuiltInTemplateId(templateId)) {
+    const variableGroups = getScaffoldTemplateVariableGroups(variables)
     assertBuiltInTemplateVariantAllowed({
       templateId,
       variant,
     })
     return resolveBuiltInTemplateSource(templateId, {
-      persistenceEnabled: variables.compoundPersistenceEnabled === 'true',
+      persistenceEnabled:
+        variableGroups.compound.enabled &&
+        variableGroups.compound.persistenceEnabled,
       persistencePolicy:
-        variables.persistencePolicy === 'public' ? 'public' : 'authenticated',
+        variableGroups.persistence.enabled &&
+        variableGroups.persistence.policy === 'public'
+          ? 'public'
+          : 'authenticated',
     })
   }
 

--- a/packages/wp-typia-project-tools/tests/scaffold-template-variable-groups.test.ts
+++ b/packages/wp-typia-project-tools/tests/scaffold-template-variable-groups.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+	getScaffoldTemplateVariableGroups,
+	getTemplateVariables,
+} from "../src/runtime/index.js";
+import {
+	buildTemplateVariablesFromBlockSpec,
+	createBuiltInBlockSpec,
+} from "../src/runtime/block-generator-service-spec.js";
+
+describe("scaffold template variable groups", () => {
+	test("persistence scaffolds expose a single-scope persistence group", () => {
+		const variables = getTemplateVariables("persistence", {
+			author: "Test Runner",
+			description: "Persistence scaffold",
+			namespace: "demo",
+			phpPrefix: "demo_block",
+			slug: "demo-persistence",
+			textDomain: "demo-persistence",
+			title: "Demo Persistence",
+		});
+		const groups = getScaffoldTemplateVariableGroups(variables);
+
+		expect(groups.templateFamily).toBe("persistence");
+		expect(groups.compound.enabled).toBe(false);
+		expect(groups.queryLoop.enabled).toBe(false);
+		expect(groups.persistence.enabled).toBe(true);
+		if (!groups.persistence.enabled) {
+			throw new Error("Expected persistence group to be enabled");
+		}
+		expect(groups.persistence.scope).toBe("single");
+		expect(groups.persistence.policy).toBe("authenticated");
+		expect(groups.persistence.auth.isAuthenticated).toBe(true);
+	});
+
+	test("compound specs attach compound and alternate render-target groups", () => {
+		const spec = createBuiltInBlockSpec({
+			alternateRenderTargets: "email,mjml",
+			answers: {
+				author: "Test Runner",
+				compoundInnerBlocksPreset: "horizontal",
+				description: "Compound scaffold",
+				namespace: "demo",
+				phpPrefix: "demo_block",
+				slug: "demo-compound",
+				textDomain: "demo-compound",
+				title: "Demo Compound",
+			},
+			dataStorageMode: "custom-table",
+			persistencePolicy: "public",
+			templateId: "compound",
+			withMigrationUi: false,
+			withTestPreset: false,
+			withWpEnv: false,
+		});
+		const variables = buildTemplateVariablesFromBlockSpec(spec);
+		const groups = getScaffoldTemplateVariableGroups(variables);
+
+		expect(groups.templateFamily).toBe("compound");
+		expect(groups.compound.enabled).toBe(true);
+		if (!groups.compound.enabled) {
+			throw new Error("Expected compound group to be enabled");
+		}
+		expect(groups.compound.persistenceEnabled).toBe(true);
+		expect(groups.compound.innerBlocks.preset).toBe("horizontal");
+		expect(groups.alternateRenderTargets.enabled).toBe(true);
+		expect(groups.alternateRenderTargets.targets).toEqual(["email", "mjml"]);
+		expect(groups.alternateRenderTargets.hasEmail).toBe(true);
+		expect(groups.alternateRenderTargets.hasPlainText).toBe(false);
+		expect(groups.persistence.enabled).toBe(true);
+		if (!groups.persistence.enabled) {
+			throw new Error("Expected persistence group to be enabled");
+		}
+		expect(groups.persistence.scope).toBe("compound-parent");
+		expect(groups.persistence.policy).toBe("public");
+	});
+
+	test("query loop scaffolds expose the query-loop-specific group", () => {
+		const variables = getTemplateVariables("query-loop", {
+			author: "Test Runner",
+			description: "Query loop scaffold",
+			namespace: "demo",
+			phpPrefix: "demo_block",
+			queryPostType: "page",
+			slug: "demo-query-loop",
+			textDomain: "demo-query-loop",
+			title: "Demo Query Loop",
+		});
+		const groups = getScaffoldTemplateVariableGroups(variables);
+
+		expect(groups.templateFamily).toBe("query-loop");
+		expect(groups.queryLoop.enabled).toBe(true);
+		if (!groups.queryLoop.enabled) {
+			throw new Error("Expected query-loop group to be enabled");
+		}
+		expect(groups.queryLoop.postType).toBe("page");
+		expect(groups.queryLoop.variationNamespace).toBe("demo/demo-query-loop");
+		expect(groups.persistence.enabled).toBe(false);
+	});
+
+	test("external template variables keep the flat bag and mark the external family", () => {
+		const variables = getTemplateVariables("github:demo/example", {
+			author: "Test Runner",
+			description: "External scaffold",
+			namespace: "demo",
+			phpPrefix: "demo_block",
+			slug: "demo-external",
+			textDomain: "demo-external",
+			title: "Demo External",
+		});
+		const groups = getScaffoldTemplateVariableGroups(variables);
+
+		expect(groups.templateFamily).toBe("external");
+		expect(groups.persistence.enabled).toBe(false);
+		expect(groups.queryLoop.enabled).toBe(false);
+		expect(groups.compound.enabled).toBe(false);
+		expect(variables.title).toBe("Demo External");
+		expect(variables.slugKebabCase).toBe("demo-external");
+	});
+});

--- a/packages/wp-typia-project-tools/tests/scaffold-template-variable-groups.test.ts
+++ b/packages/wp-typia-project-tools/tests/scaffold-template-variable-groups.test.ts
@@ -64,10 +64,11 @@ describe("scaffold template variable groups", () => {
 		}
 		expect(groups.compound.persistenceEnabled).toBe(true);
 		expect(groups.compound.innerBlocks.preset).toBe("horizontal");
-		expect(groups.alternateRenderTargets.enabled).toBe(true);
-		expect(groups.alternateRenderTargets.targets).toEqual(["email", "mjml"]);
-		expect(groups.alternateRenderTargets.hasEmail).toBe(true);
-		expect(groups.alternateRenderTargets.hasPlainText).toBe(false);
+			expect(groups.alternateRenderTargets.enabled).toBe(true);
+			expect(groups.alternateRenderTargets.targets).toEqual(["email", "mjml"]);
+			expect(groups.alternateRenderTargets.hasEmail).toBe(true);
+			expect(groups.alternateRenderTargets.hasMjml).toBe(true);
+			expect(groups.alternateRenderTargets.hasPlainText).toBe(false);
 		expect(groups.persistence.enabled).toBe(true);
 		if (!groups.persistence.enabled) {
 			throw new Error("Expected persistence group to be enabled");

--- a/tests/helpers/scaffold-template-variables.ts
+++ b/tests/helpers/scaffold-template-variables.ts
@@ -1,9 +1,14 @@
-import type { ScaffoldTemplateVariables } from "../../packages/wp-typia-project-tools/src/runtime/scaffold";
+import type {
+	FlatScaffoldTemplateVariables,
+	ScaffoldTemplateFamily,
+	ScaffoldTemplateVariables,
+} from "../../packages/wp-typia-project-tools/src/runtime/scaffold";
+import { attachScaffoldTemplateVariableGroups } from "../../packages/wp-typia-project-tools/src/runtime/scaffold-template-variable-groups";
 
 export function createTestScaffoldTemplateVariables(
-	overrides: Partial<ScaffoldTemplateVariables> = {},
+	overrides: Partial<FlatScaffoldTemplateVariables> = {},
 ): ScaffoldTemplateVariables {
-	const base: ScaffoldTemplateVariables = {
+	const base: FlatScaffoldTemplateVariables = {
 		alternateRenderTargetsCsv: "",
 		alternateRenderTargetsJson: "[]",
 		apiClientPackageVersion: "^0.2.0",
@@ -73,8 +78,256 @@ export function createTestScaffoldTemplateVariables(
 		titleJson: JSON.stringify("Demo Block"),
 	};
 
-	return {
+	const variables: FlatScaffoldTemplateVariables = {
 		...base,
-		...overrides,
-	} as ScaffoldTemplateVariables;
+	};
+
+	for (const [key, value] of Object.entries(overrides)) {
+		if (value !== undefined) {
+			variables[key] = value;
+		}
+	}
+
+	const family = inferTemplateFamily(overrides);
+	const compoundPersistenceEnabled =
+		family === "compound" && variables.compoundPersistenceEnabled === "true";
+	const persistenceEnabled =
+		family === "persistence" || compoundPersistenceEnabled;
+	const alternateRenderTargets = {
+		csv: variables.alternateRenderTargetsCsv,
+		enabled: variables.hasAlternateRenderTargets === "true",
+		hasEmail: variables.hasAlternateEmailRenderTarget === "true",
+		hasMjml: variables.hasAlternateMjmlRenderTarget === "true",
+		hasPlainText: variables.hasAlternatePlainTextRenderTarget === "true",
+		json: variables.alternateRenderTargetsJson,
+		targets: JSON.parse(variables.alternateRenderTargetsJson) as string[],
+	};
+	const shared = {
+		author: variables.author,
+		blockMetadataVersion: variables.blockMetadataVersion,
+		category: variables.category,
+		cssClassName: variables.cssClassName,
+		description: variables.description,
+		descriptionJson: variables.descriptionJson,
+		frontendCssClassName: variables.frontendCssClassName,
+		icon: variables.icon,
+		keyword: variables.keyword,
+		namespace: variables.namespace,
+		pascalCase: variables.pascalCase,
+		phpPrefix: variables.phpPrefix,
+		phpPrefixUpper: variables.phpPrefixUpper,
+		slug: variables.slug,
+		slugCamelCase: variables.slugCamelCase,
+		slugKebabCase: variables.slugKebabCase,
+		slugSnakeCase: variables.slugSnakeCase,
+		textDomain: variables.textDomain,
+		title: variables.title,
+		titleCase: variables.titleCase,
+		titleJson: variables.titleJson,
+		versions: {
+			apiClient: variables.apiClientPackageVersion,
+			blockRuntime: variables.blockRuntimePackageVersion,
+			blockTypes: variables.blockTypesPackageVersion,
+			projectTools: variables.projectToolsPackageVersion,
+			rest: variables.restPackageVersion,
+		},
+	};
+	const template = {
+		description: variables.description,
+	};
+
+	switch (family) {
+		case "query-loop":
+			return attachScaffoldTemplateVariableGroups(variables, {
+				alternateRenderTargets,
+				compound: {
+					enabled: false,
+					persistenceEnabled: false,
+				},
+				persistence: {
+					enabled: false,
+					scope: "none",
+				},
+				queryLoop: {
+					allowedControls: JSON.parse(
+						variables.queryAllowedControlsJson,
+					) as string[],
+					allowedControlsJson: variables.queryAllowedControlsJson,
+					enabled: true,
+					postType: variables.queryPostType,
+					postTypeJson: variables.queryPostTypeJson,
+					variationNamespace: variables.queryVariationNamespace,
+					variationNamespaceJson: variables.queryVariationNamespaceJson,
+				},
+				shared,
+				template,
+				templateFamily: "query-loop",
+			});
+		case "compound":
+			return attachScaffoldTemplateVariableGroups(variables, {
+				alternateRenderTargets,
+				compound: {
+					child: {
+						category: variables.compoundChildCategory,
+						cssClassName: variables.compoundChildCssClassName,
+						icon: variables.compoundChildIcon,
+						title: variables.compoundChildTitle,
+						titleJson: variables.compoundChildTitleJson,
+					},
+					enabled: true,
+					innerBlocks: {
+						description: variables.compoundInnerBlocksPresetDescription,
+						directInsert:
+							variables.compoundInnerBlocksDirectInsert === "true",
+						label: variables.compoundInnerBlocksPresetLabel,
+						orientation:
+							variables.compoundInnerBlocksOrientation === "horizontal" ||
+							variables.compoundInnerBlocksOrientation === "vertical"
+								? variables.compoundInnerBlocksOrientation
+								: "",
+						orientationExpression:
+							variables.compoundInnerBlocksOrientationExpression,
+						preset: variables.compoundInnerBlocksPreset,
+						templateLockExpression:
+							variables.compoundInnerBlocksTemplateLockExpression,
+					},
+					persistenceEnabled: compoundPersistenceEnabled,
+				},
+				persistence: compoundPersistenceEnabled
+					? {
+							auth: {
+								bootstrapCredentialDeclarations:
+									variables.bootstrapCredentialDeclarations,
+								descriptionJson: variables.persistencePolicyDescriptionJson,
+								intent: variables.restWriteAuthIntent,
+								isAuthenticated:
+									variables.isAuthenticatedPersistencePolicy === "true",
+								isPublic: variables.isPublicPersistencePolicy === "true",
+								mechanism: variables.restWriteAuthMechanism,
+								mode: variables.restWriteAuthMode,
+								publicWriteRequestIdDeclaration:
+									variables.publicWriteRequestIdDeclaration,
+							},
+							dataStorageMode: variables.dataStorageMode,
+							enabled: true,
+							policy: variables.persistencePolicy,
+							scope: "compound-parent",
+					  }
+					: {
+							enabled: false,
+							scope: "none",
+					  },
+				queryLoop: {
+					enabled: false,
+				},
+				shared,
+				template,
+				templateFamily: "compound",
+			});
+		case "persistence":
+			return attachScaffoldTemplateVariableGroups(variables, {
+				alternateRenderTargets,
+				compound: {
+					enabled: false,
+					persistenceEnabled: false,
+				},
+				persistence: {
+					auth: {
+						bootstrapCredentialDeclarations:
+							variables.bootstrapCredentialDeclarations,
+						descriptionJson: variables.persistencePolicyDescriptionJson,
+						intent: variables.restWriteAuthIntent,
+						isAuthenticated:
+							variables.isAuthenticatedPersistencePolicy === "true",
+						isPublic: variables.isPublicPersistencePolicy === "true",
+						mechanism: variables.restWriteAuthMechanism,
+						mode: variables.restWriteAuthMode,
+						publicWriteRequestIdDeclaration:
+							variables.publicWriteRequestIdDeclaration,
+					},
+					dataStorageMode: variables.dataStorageMode,
+					enabled: true,
+					policy: variables.persistencePolicy,
+					scope: "single",
+				},
+				queryLoop: {
+					enabled: false,
+				},
+				shared,
+				template,
+				templateFamily: "persistence",
+			});
+		case "basic":
+		case "interactivity":
+		case "external":
+			return attachScaffoldTemplateVariableGroups(variables, {
+				alternateRenderTargets,
+				compound: {
+					enabled: false,
+					persistenceEnabled: false,
+				},
+				persistence: {
+					enabled: false,
+					scope: "none",
+				},
+				queryLoop: {
+					enabled: false,
+				},
+				shared,
+				template,
+				templateFamily:
+					family === "basic"
+						? "basic"
+						: family === "interactivity"
+							? "interactivity"
+							: "external",
+			});
+		default: {
+			const unreachableFamily: never = family;
+			throw new Error(`Unhandled template family: ${unreachableFamily}`);
+		}
+	}
+}
+
+function inferTemplateFamily(
+	overrides: Partial<FlatScaffoldTemplateVariables>,
+): ScaffoldTemplateFamily {
+	const overrideKeys = Object.keys(overrides);
+
+	if (
+		overrideKeys.some(
+			(key) =>
+				key === "queryAllowedControlsJson" ||
+				key === "queryPostType" ||
+				key === "queryPostTypeJson" ||
+				key === "queryVariationNamespace" ||
+				key === "queryVariationNamespaceJson",
+		)
+	) {
+		return "query-loop";
+	}
+
+	if (overrideKeys.some((key) => key.startsWith("compound"))) {
+		return "compound";
+	}
+
+	if (
+		overrideKeys.some(
+			(key) =>
+				key === "bootstrapCredentialDeclarations" ||
+				key === "dataStorageMode" ||
+				key === "isAuthenticatedPersistencePolicy" ||
+				key === "isPublicPersistencePolicy" ||
+				key === "persistencePolicy" ||
+				key === "persistencePolicyDescriptionJson" ||
+				key === "publicWriteRequestIdDeclaration" ||
+				key === "restWriteAuthIntent" ||
+				key === "restWriteAuthMechanism" ||
+				key === "restWriteAuthMode",
+		)
+	) {
+		return "persistence";
+	}
+
+	return "basic";
 }

--- a/tests/helpers/scaffold-template-variables.ts
+++ b/tests/helpers/scaffold-template-variables.ts
@@ -6,8 +6,14 @@ import type {
 import { attachScaffoldTemplateVariableGroups } from "../../packages/wp-typia-project-tools/src/runtime/scaffold-template-variable-groups";
 
 export function createTestScaffoldTemplateVariables(
-	overrides: Partial<FlatScaffoldTemplateVariables> = {},
+	overrides: Partial<FlatScaffoldTemplateVariables> & {
+		templateFamily?: ScaffoldTemplateFamily;
+	} = {},
 ): ScaffoldTemplateVariables {
+	const {
+		templateFamily,
+		...flatOverrides
+	} = overrides;
 	const base: FlatScaffoldTemplateVariables = {
 		alternateRenderTargetsCsv: "",
 		alternateRenderTargetsJson: "[]",
@@ -82,13 +88,13 @@ export function createTestScaffoldTemplateVariables(
 		...base,
 	};
 
-	for (const [key, value] of Object.entries(overrides)) {
+	for (const [key, value] of Object.entries(flatOverrides)) {
 		if (value !== undefined) {
 			variables[key] = value;
 		}
 	}
 
-	const family = inferTemplateFamily(overrides);
+	const family = templateFamily ?? inferTemplateFamily(flatOverrides);
 	const compoundPersistenceEnabled =
 		family === "compound" && variables.compoundPersistenceEnabled === "true";
 	const persistenceEnabled =


### PR DESCRIPTION
## Summary
- attach symbol-backed template-family-aware scaffold variable groups while preserving the flat string bag
- update scaffold consumers to read grouped persistence/compound/query metadata instead of repeated string flag checks
- add regression coverage for grouped variable views and test helpers

## Testing
- bun run --filter @wp-typia/project-tools build
- bun test packages/wp-typia-project-tools/tests/scaffold-template-variable-groups.test.ts packages/wp-typia-project-tools/tests/template-source.test.ts packages/wp-typia-project-tools/tests/scaffold-runtime-boundaries.test.ts packages/wp-typia-project-tools/tests/scaffold-persistence.test.ts packages/wp-typia-project-tools/tests/scaffold-compound.test.ts
- bun test tests/unit/local-dev-presets.test.ts tests/unit/starter-manifests.test.ts
- bun run changesets:validate

Closes #518

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced structured grouping system for scaffold template variables, organizing metadata by template family (persistence, compound, query-loop, etc.) for improved organization and configuration handling.

* **Tests**
  * Added comprehensive test suite for template variable group functionality across all supported template families.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->