### PR TITLE
Polish CLI output markers and Bun guidance

### DIFF
--- a/packages/wp-typia/bin/wp-typia.js
+++ b/packages/wp-typia/bin/wp-typia.js
@@ -20,6 +20,8 @@ const longValueOptionSet = new Set(longValueOptions);
 const shortValueOptionSet = new Set(shortValueOptions);
 const buildScriptEntrypoint = path.join(packageRoot, "scripts", "build-bunli-runtime.ts");
 const sourceCliEntrypoint = path.join(packageRoot, "src", "cli.ts");
+const standaloneGuidance =
+	"Prefer not to install Bun? Use the standalone wp-typia binary from the GitHub release assets.";
 
 function firstPositional(argv) {
 	for (let index = 0; index < argv.length; index += 1) {
@@ -102,20 +104,20 @@ if (hasWorkingBun && hasBuiltRuntime && shouldUseFullRuntime) {
 if (shouldUseFullRuntime) {
 	if (!hasBuiltRuntime) {
 		console.error(
-			"❌ wp-typia could not locate its built CLI runtime. Reinstall the published package, or run `bun run build` when using a source checkout.",
+			"Error: wp-typia could not locate its built CLI runtime. Reinstall the published package, or run `bun run build` when using a source checkout.",
 		);
 		process.exit(1);
 	}
 
 	console.error(
-		`❌ wp-typia ${command} requires Bun. Install Bun locally, run with bunx, or set BUN_BIN to a working Bun executable.`,
+		`Error: wp-typia ${command} requires Bun. Install Bun locally, run with bunx, or set BUN_BIN to a working Bun executable. ${standaloneGuidance}`,
 	);
 	process.exit(1);
 }
 
 if (!hasBuiltRuntime || !fs.existsSync(nodeCliEntrypoint)) {
 	console.error(
-		"❌ wp-typia could not locate its Node fallback runtime. Reinstall the published package, or run `bun run build` when using a source checkout.",
+		"Error: wp-typia could not locate its Node fallback runtime. Reinstall the published package, or run `bun run build` when using a source checkout.",
 	);
 	process.exit(1);
 }

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -58,11 +58,13 @@ const NODE_FALLBACK_OPTION_PARSER = buildCommandOptionParser(
 	TEMPLATES_OPTION_METADATA,
 );
 const NODE_FALLBACK_BOOLEAN_OPTION_NAMES = ["check", "help", "version"] as const;
+const STANDALONE_GUIDANCE_LINE =
+	"Prefer not to install Bun? Use the standalone wp-typia binary from the GitHub release assets.";
 
 const NODE_FALLBACK_RUNTIME_SUMMARY_LINES = [
 	"Runtime: Node fallback",
 	"Human-readable fallback for common non-interactive create/add/migrate flows, doctor, sync, templates, --help, and --version when Bun is unavailable.",
-	"Install Bun 1.3.11+ or use `bunx wp-typia ...` for the full Bunli/OpenTUI runtime and Bun-only command surfaces such as `skills`, `completions`, and `mcp`.",
+	`Install Bun 1.3.11+ or use \`bunx wp-typia ...\` for the full Bunli/OpenTUI runtime and Bun-only command surfaces such as \`skills\`, \`completions\`, and \`mcp\`. ${STANDALONE_GUIDANCE_LINE}`,
 ];
 
 function printLine(line = "") {
@@ -313,7 +315,7 @@ function renderUnsupportedCommand(command: string) {
 			[
 				`The Bun-free fallback runtime does not support \`${command}\` yet.`,
 				"Supported without Bun: `--version`, `--help`, non-interactive `create`/`add`/`migrate`, `doctor`, `sync`, `templates list`, and `templates inspect`.",
-				"Install Bun 1.3.11+ or use `bunx wp-typia ...` for the full Bunli-powered runtime.",
+				`Install Bun 1.3.11+ or use \`bunx wp-typia ...\` for the full Bunli-powered runtime. ${STANDALONE_GUIDANCE_LINE}`,
 			].join(" "),
 		],
 		summary: "This command requires the Bun-powered runtime.",

--- a/packages/wp-typia/src/output-markers.ts
+++ b/packages/wp-typia/src/output-markers.ts
@@ -3,7 +3,6 @@ export type OutputMarkerKind = 'dryRun' | 'progress' | 'success' | 'warning';
 export type OutputMarkerOptions = {
   env?: NodeJS.ProcessEnv;
   forceAscii?: boolean;
-  platform?: NodeJS.Platform;
   term?: string | undefined;
 };
 

--- a/packages/wp-typia/src/output-markers.ts
+++ b/packages/wp-typia/src/output-markers.ts
@@ -1,0 +1,116 @@
+export type OutputMarkerKind = 'dryRun' | 'progress' | 'success' | 'warning';
+
+export type OutputMarkerOptions = {
+  env?: NodeJS.ProcessEnv;
+  forceAscii?: boolean;
+  platform?: NodeJS.Platform;
+  term?: string | undefined;
+};
+
+const UNICODE_OUTPUT_MARKERS: Record<OutputMarkerKind, string> = {
+  dryRun: '🧪',
+  progress: '⏳',
+  success: '✅',
+  warning: '⚠️',
+};
+
+const ASCII_OUTPUT_MARKERS: Record<OutputMarkerKind, string> = {
+  dryRun: '[dry-run]',
+  progress: '[...]',
+  success: '[ok]',
+  warning: '[!]',
+};
+
+const ASCII_ENV_TRUTHY_VALUES = new Set(['1', 'on', 'true', 'yes']);
+const ASCII_ENV_FALSY_VALUES = new Set(['0', 'off', 'false', 'no']);
+
+function escapeRegExp(source: string): string {
+  return source.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function readAsciiPreferenceFromEnv(
+  env: NodeJS.ProcessEnv,
+): boolean | undefined {
+  const rawValue = env.WP_TYPIA_ASCII;
+  if (typeof rawValue !== 'string') {
+    return undefined;
+  }
+
+  const normalizedValue = rawValue.trim().toLowerCase();
+  if (ASCII_ENV_TRUTHY_VALUES.has(normalizedValue)) {
+    return true;
+  }
+  if (ASCII_ENV_FALSY_VALUES.has(normalizedValue)) {
+    return false;
+  }
+
+  return undefined;
+}
+
+export function prefersAsciiOutput(options: OutputMarkerOptions = {}): boolean {
+  if (options.forceAscii) {
+    return true;
+  }
+
+  const env = options.env ?? process.env;
+  const envPreference = readAsciiPreferenceFromEnv(env);
+  if (envPreference !== undefined) {
+    return envPreference;
+  }
+
+  const term = options.term ?? env.TERM;
+  if (term === 'dumb') {
+    return true;
+  }
+
+  const locale = (env.LC_ALL ?? env.LC_CTYPE ?? env.LANG ?? '').toUpperCase();
+  if (locale.includes('UTF-8') || locale.includes('UTF8')) {
+    return false;
+  }
+  if (locale === 'C' || locale === 'POSIX') {
+    return true;
+  }
+  if (
+    locale.includes('ASCII') ||
+    locale.includes('ANSI_X3') ||
+    locale.includes('8859')
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+export function getOutputMarker(
+  kind: OutputMarkerKind,
+  options: OutputMarkerOptions = {},
+): string {
+  return prefersAsciiOutput(options)
+    ? ASCII_OUTPUT_MARKERS[kind]
+    : UNICODE_OUTPUT_MARKERS[kind];
+}
+
+export function formatOutputMarker(
+  kind: OutputMarkerKind,
+  text: string,
+  options: OutputMarkerOptions = {},
+): string {
+  return `${getOutputMarker(kind, options)} ${text}`;
+}
+
+export function stripLeadingOutputMarker(
+  text: string,
+  kind?: OutputMarkerKind,
+): string {
+  const markers = kind
+    ? [UNICODE_OUTPUT_MARKERS[kind], ASCII_OUTPUT_MARKERS[kind]]
+    : Array.from(
+        new Set([
+          ...Object.values(UNICODE_OUTPUT_MARKERS),
+          ...Object.values(ASCII_OUTPUT_MARKERS),
+        ]),
+      );
+  const markerPattern = markers.map((marker) => escapeRegExp(marker)).join('|');
+
+  return text.replace(new RegExp(`^(?:${markerPattern})\\s*`, 'u'), '');
+}

--- a/packages/wp-typia/src/runtime-bridge-output.ts
+++ b/packages/wp-typia/src/runtime-bridge-output.ts
@@ -4,6 +4,11 @@ import path from "node:path";
 import packageJson from "../package.json";
 import { formatPackageExecCommand } from "@wp-typia/project-tools/package-managers";
 import type { AlternateBufferCompletionPayload } from "./ui/alternate-buffer-lifecycle";
+import {
+	formatOutputMarker,
+	type OutputMarkerOptions,
+	stripLeadingOutputMarker,
+} from "./output-markers";
 
 type PrintLine = (line: string) => void;
 type PackageManagerId = "bun" | "npm" | "pnpm" | "yarn";
@@ -29,6 +34,7 @@ type ExternalLayerSelectOption = {
 export function printCompletionPayload(
 	payload: AlternateBufferCompletionPayload,
 	options: {
+		markerOptions?: OutputMarkerOptions;
 		printLine?: PrintLine;
 		warnLine?: PrintLine;
 	} = {},
@@ -40,7 +46,7 @@ export function printCompletionPayload(
 		printLine(line);
 	}
 	for (const warning of payload.warningLines ?? []) {
-		warnLine(`⚠️ ${warning}`);
+		warnLine(formatOutputMarker("warning", warning, options.markerOptions));
 	}
 
 	const hasDetails =
@@ -79,8 +85,15 @@ export function printCompletionPayload(
  * @param payload User-facing scaffold progress payload.
  * @returns A single readable status line.
  */
-export function formatCreateProgressLine(payload: CreateProgressPayload): string {
-	return `⏳ ${payload.title}: ${payload.detail}`;
+export function formatCreateProgressLine(
+	payload: CreateProgressPayload,
+	markerOptions?: OutputMarkerOptions,
+): string {
+	return formatOutputMarker(
+		"progress",
+		`${payload.title}: ${payload.detail}`,
+		markerOptions,
+	);
 }
 
 /**
@@ -104,7 +117,9 @@ export function buildCreateCompletionPayload(flow: {
 		};
 		warnings: string[];
 	};
-}): AlternateBufferCompletionPayload {
+},
+markerOptions?: OutputMarkerOptions,
+): AlternateBufferCompletionPayload {
 	const verificationSteps = [
 		formatPackageExecCommand(
 			flow.packageManager as "bun" | "npm" | "pnpm" | "yarn",
@@ -123,7 +138,11 @@ export function buildCreateCompletionPayload(flow: {
 			? [`Template variant: ${flow.result.selectedVariant}`]
 			: undefined,
 		summaryLines: [`Project directory: ${flow.projectDir}`],
-		title: `✅ Created ${flow.result.variables.title} in ${flow.projectDir}`,
+		title: formatOutputMarker(
+			"success",
+			`Created ${flow.result.variables.title} in ${flow.projectDir}`,
+			markerOptions,
+		),
 		warningLines: flow.result.warnings,
 	};
 }
@@ -149,7 +168,9 @@ export function buildCreateDryRunPayload(flow: {
 		};
 		warnings: string[];
 	};
-}): AlternateBufferCompletionPayload {
+},
+markerOptions?: OutputMarkerOptions,
+): AlternateBufferCompletionPayload {
 	let dependencyInstallLine: string;
 	switch (flow.plan.dependencyInstall) {
 		case "skipped-by-flag":
@@ -174,7 +195,11 @@ export function buildCreateDryRunPayload(flow: {
 			`Package manager: ${flow.packageManager}`,
 			dependencyInstallLine,
 		],
-		title: `🧪 Dry run for ${flow.result.variables.title} at ${flow.projectDir}`,
+		title: formatOutputMarker(
+			"dryRun",
+			`Dry run for ${flow.result.variables.title} at ${flow.projectDir}`,
+			markerOptions,
+		),
 		warningLines: flow.result.warnings,
 	};
 }
@@ -221,12 +246,18 @@ function inferProjectPackageManager(projectDir: string): PackageManagerId {
 export function buildMigrationCompletionPayload(options: {
 	command: string;
 	lines: string[];
-}): AlternateBufferCompletionPayload {
+},
+markerOptions?: OutputMarkerOptions,
+): AlternateBufferCompletionPayload {
 	const summaryLines = options.lines.filter((line) => line.trim().length > 0);
 
 	return {
 		summaryLines,
-		title: `✅ Completed wp-typia migrate ${options.command}`,
+		title: formatOutputMarker(
+			"success",
+			`Completed wp-typia migrate ${options.command}`,
+			markerOptions,
+		),
 	};
 }
 
@@ -249,7 +280,9 @@ export function buildAddCompletionPayload(options: {
 	projectDir: string;
 	values: Record<string, string>;
 	warnings?: string[];
-}): AlternateBufferCompletionPayload {
+},
+markerOptions?: OutputMarkerOptions,
+): AlternateBufferCompletionPayload {
 	const verificationLines = [
 		formatPackageExecCommand(
 			options.packageManager ?? inferProjectPackageManager(options.projectDir),
@@ -275,7 +308,11 @@ export function buildAddCompletionPayload(options: {
 					`Target block: ${options.values.blockSlug}`,
 					`Project directory: ${options.projectDir}`,
 				],
-				title: "✅ Added workspace variation",
+				title: formatOutputMarker(
+					"success",
+					"Added workspace variation",
+					markerOptions,
+				),
 			};
 		case "pattern":
 			return {
@@ -290,7 +327,11 @@ export function buildAddCompletionPayload(options: {
 					`Pattern: ${options.values.patternSlug}`,
 					`Project directory: ${options.projectDir}`,
 				],
-				title: "✅ Added workspace pattern",
+				title: formatOutputMarker(
+					"success",
+					"Added workspace pattern",
+					markerOptions,
+				),
 			};
 		case "binding-source":
 			return {
@@ -305,7 +346,11 @@ export function buildAddCompletionPayload(options: {
 					`Binding source: ${options.values.bindingSourceSlug}`,
 					`Project directory: ${options.projectDir}`,
 				],
-				title: "✅ Added binding source",
+				title: formatOutputMarker(
+					"success",
+					"Added binding source",
+					markerOptions,
+				),
 			};
 		case "rest-resource":
 			return {
@@ -322,7 +367,11 @@ export function buildAddCompletionPayload(options: {
 					`Methods: ${options.values.methods}`,
 					`Project directory: ${options.projectDir}`,
 				],
-				title: "✅ Added plugin-level REST resource",
+				title: formatOutputMarker(
+					"success",
+					"Added plugin-level REST resource",
+					markerOptions,
+				),
 			};
 		case "editor-plugin":
 			return {
@@ -338,7 +387,11 @@ export function buildAddCompletionPayload(options: {
 					`Slot: ${options.values.slot}`,
 					`Project directory: ${options.projectDir}`,
 				],
-				title: "✅ Added editor plugin",
+				title: formatOutputMarker(
+					"success",
+					"Added editor plugin",
+					markerOptions,
+				),
 			};
 		case "hooked-block":
 			return {
@@ -355,7 +408,11 @@ export function buildAddCompletionPayload(options: {
 					`Position: ${options.values.position}`,
 					`Project directory: ${options.projectDir}`,
 				],
-				title: "✅ Added blockHooks metadata",
+				title: formatOutputMarker(
+					"success",
+					"Added blockHooks metadata",
+					markerOptions,
+				),
 			};
 		default:
 			return {
@@ -371,7 +428,11 @@ export function buildAddCompletionPayload(options: {
 					`Template family: ${options.values.templateId}`,
 					`Project directory: ${options.projectDir}`,
 				],
-				title: "✅ Added workspace block",
+				title: formatOutputMarker(
+					"success",
+					"Added workspace block",
+					markerOptions,
+				),
 				warningLines: options.warnings,
 			};
 	}
@@ -386,8 +447,13 @@ export function buildAddCompletionPayload(options: {
 export function buildAddDryRunPayload(options: {
 	completion: AlternateBufferCompletionPayload;
 	fileOperations: string[];
-}): AlternateBufferCompletionPayload {
-	const normalizedTitle = options.completion.title.replace(/^✅\s*Added\s*/u, "");
+},
+markerOptions?: OutputMarkerOptions,
+): AlternateBufferCompletionPayload {
+	const normalizedTitle = stripLeadingOutputMarker(
+		options.completion.title,
+		"success",
+	).replace(/^Added\s*/u, "");
 
 	return {
 		optionalLines: options.fileOperations,
@@ -396,7 +462,11 @@ export function buildAddDryRunPayload(options: {
 		optionalTitle: `Planned workspace updates (${options.fileOperations.length}):`,
 		preambleLines: options.completion.preambleLines,
 		summaryLines: options.completion.summaryLines,
-		title: `🧪 Dry run for ${normalizedTitle || "workspace add command"}`,
+		title: formatOutputMarker(
+			"dryRun",
+			`Dry run for ${normalizedTitle || "workspace add command"}`,
+			markerOptions,
+		),
 		warningLines: options.completion.warningLines,
 	};
 }

--- a/packages/wp-typia/src/ui/first-party-form-layout.tsx
+++ b/packages/wp-typia/src/ui/first-party-form-layout.tsx
@@ -13,6 +13,7 @@ import {
   useTuiTheme,
 } from '@bunli/tui';
 
+import { formatOutputMarker } from '../output-markers';
 import type { AlternateBufferCompletionPayload } from './alternate-buffer-lifecycle';
 import {
   isCompletionEndKey,
@@ -246,7 +247,7 @@ export function FirstPartyCompletionViewport({
         ),
         ...(completion.warningLines ?? []).map((line, index) =>
           createElement('text', {
-            content: `⚠️ ${line}`,
+            content: formatOutputMarker('warning', line),
             fg: tokens.textWarning,
             key: `warning:${index}`,
           }),

--- a/packages/wp-typia/src/ui/first-party-form-layout.tsx
+++ b/packages/wp-typia/src/ui/first-party-form-layout.tsx
@@ -13,7 +13,10 @@ import {
   useTuiTheme,
 } from '@bunli/tui';
 
-import { formatOutputMarker } from '../output-markers';
+import {
+  formatOutputMarker,
+  type OutputMarkerOptions,
+} from '../output-markers';
 import type { AlternateBufferCompletionPayload } from './alternate-buffer-lifecycle';
 import {
   isCompletionEndKey,
@@ -137,9 +140,11 @@ export function FirstPartyFormViewport({
 
 export function FirstPartyCompletionViewport({
   completion,
+  markerOptions,
   viewportHeight,
 }: {
   completion: AlternateBufferCompletionPayload;
+  markerOptions?: OutputMarkerOptions;
   viewportHeight: number;
 }) {
   const { tokens } = useTuiTheme();
@@ -247,7 +252,7 @@ export function FirstPartyCompletionViewport({
         ),
         ...(completion.warningLines ?? []).map((line, index) =>
           createElement('text', {
-            content: formatOutputMarker('warning', line),
+            content: formatOutputMarker('warning', line, markerOptions),
             fg: tokens.textWarning,
             key: `warning:${index}`,
           }),

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -322,6 +322,9 @@ describe("wp-typia package", () => {
 		expect(result.status).toBe(1);
 		expect(result.stdout).toBe("");
 		expect(result.stderr).toContain("requires Bun");
+		expect(result.stderr).toContain(
+			"Install Bun locally, run with bunx, or set BUN_BIN",
+		);
 		expect(result.stderr).toContain("standalone wp-typia binary");
 		expect(result.stderr).toContain("GitHub release assets");
 	});

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -306,11 +306,24 @@ describe("wp-typia package", () => {
 		expect(helpResult.stderr).toBe("");
 		expect(helpResult.stdout).toContain("Canonical CLI package for wp-typia scaffolding");
 		expect(helpResult.stdout).toContain("Runtime: Node fallback");
+		expect(helpResult.stdout).toContain("standalone wp-typia binary");
 		expect(createHelpResult.status).toBe(0);
 		expect(createHelpResult.stderr).toBe("");
 		expect(createHelpResult.stdout).toContain("--external-layer-source");
 		expect(createHelpResult.stdout).toContain("--external-layer-id");
 		expect(createHelpResult.stdout).toContain("--alternate-render-targets");
+	});
+
+	test("guides Bun-only commands toward standalone binaries when Bun is unavailable", () => {
+		const result = runCapturedCommand(process.execPath, [entryPath, "skills", "list"], {
+			env: withoutLocalBunEnv(),
+		});
+
+		expect(result.status).toBe(1);
+		expect(result.stdout).toBe("");
+		expect(result.stderr).toContain("requires Bun");
+		expect(result.stderr).toContain("standalone wp-typia binary");
+		expect(result.stderr).toContain("GitHub release assets");
 	});
 
 	test("keeps value-taking options from being mistaken for Bun-only commands", () => {

--- a/packages/wp-typia/tests/completion-output.test.ts
+++ b/packages/wp-typia/tests/completion-output.test.ts
@@ -13,24 +13,33 @@ import {
 	buildAddDryRunPayload,
 } from "../src/runtime-bridge-output";
 
+const UNICODE_MARKER_OPTIONS = {
+	env: {
+		LANG: "en_US.UTF-8",
+	},
+} as const;
+
 describe("alternate-buffer completion output helpers", () => {
 	test("create completion payload preserves reviewable next steps and optional onboarding", () => {
-		const payload = buildCreateCompletionPayload({
-			nextSteps: ["cd demo-block", "npm install", "npm run dev"],
-			optionalOnboarding: {
-				note: "Run npm run sync before your first commit if you edited types.",
-				steps: ["npm run sync"],
-			},
-			packageManager: "npm",
-			projectDir: "/tmp/demo-block",
-			result: {
-				selectedVariant: "hero",
-				variables: {
-					title: "Demo Block",
+		const payload = buildCreateCompletionPayload(
+			{
+				nextSteps: ["cd demo-block", "npm install", "npm run dev"],
+				optionalOnboarding: {
+					note: "Run npm run sync before your first commit if you edited types.",
+					steps: ["npm run sync"],
 				},
-				warnings: ["This template enables optional migration UI."],
+				packageManager: "npm",
+				projectDir: "/tmp/demo-block",
+				result: {
+					selectedVariant: "hero",
+					variables: {
+						title: "Demo Block",
+					},
+					warnings: ["This template enables optional migration UI."],
+				},
 			},
-		});
+			UNICODE_MARKER_OPTIONS,
+		);
 
 		expect(payload.title).toBe("✅ Created Demo Block in /tmp/demo-block");
 		expect(payload.preambleLines).toEqual(["Template variant: hero"]);
@@ -63,6 +72,7 @@ describe("alternate-buffer completion output helpers", () => {
 				warningLines: ["This template enables optional migration UI."],
 			},
 			{
+				markerOptions: UNICODE_MARKER_OPTIONS,
 				printLine: (line) => printed.push(line),
 				warnLine: (line) => warned.push(line),
 			},
@@ -93,6 +103,7 @@ describe("alternate-buffer completion output helpers", () => {
 				warningLines: ["This template enables optional migration UI."],
 			},
 			{
+				markerOptions: UNICODE_MARKER_OPTIONS,
 				printLine: (line) => printed.push(line),
 			},
 		);
@@ -124,15 +135,18 @@ describe("alternate-buffer completion output helpers", () => {
 	});
 
 	test("migration completion payload keeps rendered lines reviewable in order", () => {
-		const payload = buildMigrationCompletionPayload({
-			command: "plan",
-			lines: [
-				"Current migration version: v3",
-				"Selected migration edge: v1 -> v3",
-				"Next steps:",
-				"  wp-typia migrate scaffold --from-migration-version v1",
-			],
-		});
+		const payload = buildMigrationCompletionPayload(
+			{
+				command: "plan",
+				lines: [
+					"Current migration version: v3",
+					"Selected migration edge: v1 -> v3",
+					"Next steps:",
+					"  wp-typia migrate scaffold --from-migration-version v1",
+				],
+			},
+			UNICODE_MARKER_OPTIONS,
+		);
 
 		expect(payload.title).toBe("✅ Completed wp-typia migrate plan");
 		expect(payload.summaryLines).toEqual([
@@ -148,29 +162,32 @@ describe("alternate-buffer completion output helpers", () => {
 			formatCreateProgressLine({
 				detail: "Copying scaffold files into the target project directory.",
 				title: "Generating project files",
-			}),
+			}, UNICODE_MARKER_OPTIONS),
 		).toBe(
 			"⏳ Generating project files: Copying scaffold files into the target project directory.",
 		);
 	});
 
 	test("dry-run create payload summarizes the planned scaffold without next steps", () => {
-		const payload = buildCreateDryRunPayload({
-			packageManager: "npm",
-			plan: {
-				dependencyInstall: "would-install",
-				files: ["README.md", "package.json", "src/index.tsx"],
-			},
-			projectDir: "/tmp/demo-block",
-			result: {
-				selectedVariant: null,
-				templateId: "basic",
-				variables: {
-					title: "Demo Block",
+		const payload = buildCreateDryRunPayload(
+			{
+				packageManager: "npm",
+				plan: {
+					dependencyInstall: "would-install",
+					files: ["README.md", "package.json", "src/index.tsx"],
 				},
-				warnings: [],
+				projectDir: "/tmp/demo-block",
+				result: {
+					selectedVariant: null,
+					templateId: "basic",
+					variables: {
+						title: "Demo Block",
+					},
+					warnings: [],
+				},
 			},
-		});
+			UNICODE_MARKER_OPTIONS,
+		);
 
 		expect(payload.title).toBe("🧪 Dry run for Demo Block at /tmp/demo-block");
 		expect(payload.summaryLines).toEqual([
@@ -190,22 +207,25 @@ describe("alternate-buffer completion output helpers", () => {
 	});
 
 	test("dry-run create payload preserves the skipped-by-flag dependency wording", () => {
-		const payload = buildCreateDryRunPayload({
-			packageManager: "npm",
-			plan: {
-				dependencyInstall: "skipped-by-flag",
-				files: ["package.json"],
-			},
-			projectDir: "/tmp/demo-block",
-			result: {
-				selectedVariant: null,
-				templateId: "basic",
-				variables: {
-					title: "Demo Block",
+		const payload = buildCreateDryRunPayload(
+			{
+				packageManager: "npm",
+				plan: {
+					dependencyInstall: "skipped-by-flag",
+					files: ["package.json"],
 				},
-				warnings: [],
+				projectDir: "/tmp/demo-block",
+				result: {
+					selectedVariant: null,
+					templateId: "basic",
+					variables: {
+						title: "Demo Block",
+					},
+					warnings: [],
+				},
 			},
-		});
+			UNICODE_MARKER_OPTIONS,
+		);
 
 		expect(payload.summaryLines).toContain(
 			"Dependency install: already skipped via --no-install",
@@ -213,14 +233,17 @@ describe("alternate-buffer completion output helpers", () => {
 	});
 
 	test("add completion payload now includes reviewable next steps and doctor guidance", () => {
-		const payload = buildAddCompletionPayload({
-			kind: "binding-source",
-			packageManager: "npm",
-			projectDir: "/tmp/demo-workspace",
-			values: {
-				bindingSourceSlug: "hero-data",
+		const payload = buildAddCompletionPayload(
+			{
+				kind: "binding-source",
+				packageManager: "npm",
+				projectDir: "/tmp/demo-workspace",
+				values: {
+					bindingSourceSlug: "hero-data",
+				},
 			},
-		});
+			UNICODE_MARKER_OPTIONS,
+		);
 
 		expect(payload.title).toBe("✅ Added binding source");
 		expect(payload.summaryLines).toEqual([
@@ -239,18 +262,24 @@ describe("alternate-buffer completion output helpers", () => {
 	});
 
 	test("dry-run add payload preserves the richer add completion guidance", () => {
-		const payload = buildAddDryRunPayload({
-			completion: buildAddCompletionPayload({
-				kind: "block",
-				packageManager: "npm",
-				projectDir: "/tmp/demo-workspace",
-				values: {
-					blockSlugs: "faq, faq-item",
-					templateId: "compound",
-				},
-			}),
-			fileOperations: ["write src/blocks/faq/block.json"],
-		});
+		const payload = buildAddDryRunPayload(
+			{
+				completion: buildAddCompletionPayload(
+					{
+						kind: "block",
+						packageManager: "npm",
+						projectDir: "/tmp/demo-workspace",
+						values: {
+							blockSlugs: "faq, faq-item",
+							templateId: "compound",
+						},
+					},
+					UNICODE_MARKER_OPTIONS,
+				),
+				fileOperations: ["write src/blocks/faq/block.json"],
+			},
+			UNICODE_MARKER_OPTIONS,
+		);
 
 		expect(payload.title).toBe("🧪 Dry run for workspace block");
 		expect(payload.summaryLines).toEqual([
@@ -261,5 +290,92 @@ describe("alternate-buffer completion output helpers", () => {
 		expect(payload.warningLines).toBeUndefined();
 		expect(payload.optionalTitle).toBe("Planned workspace updates (1):");
 		expect(payload.optionalLines).toEqual(["write src/blocks/faq/block.json"]);
+	});
+
+	test("completion helpers expose ASCII-friendly markers when requested", () => {
+		const payload = buildCreateCompletionPayload(
+			{
+				nextSteps: ["cd demo-block"],
+				optionalOnboarding: {
+					note: "Run npm run sync before your first commit if you edited types.",
+					steps: ["npm run sync"],
+				},
+				packageManager: "npm",
+				projectDir: "/tmp/demo-block",
+				result: {
+					variables: {
+						title: "Demo Block",
+					},
+					warnings: ["This template enables optional migration UI."],
+				},
+			},
+			{ forceAscii: true },
+		);
+		const printed: string[] = [];
+
+		printCompletionPayload(payload, {
+			markerOptions: { forceAscii: true },
+			printLine: (line) => printed.push(line),
+		});
+
+		expect(payload.title).toBe("[ok] Created Demo Block in /tmp/demo-block");
+		expect(printed).toContain("[!] This template enables optional migration UI.");
+		expect(printed).toContain("\n[ok] Created Demo Block in /tmp/demo-block");
+		expect(
+			formatCreateProgressLine(
+				{
+					detail: "Copying scaffold files into the target project directory.",
+					title: "Generating project files",
+				},
+				{ forceAscii: true },
+			),
+		).toBe(
+			"[...] Generating project files: Copying scaffold files into the target project directory.",
+		);
+	});
+
+	test("dry-run payloads can render ASCII-friendly titles", () => {
+		const createPayload = buildCreateDryRunPayload(
+			{
+				packageManager: "npm",
+				plan: {
+					dependencyInstall: "would-install",
+					files: ["README.md"],
+				},
+				projectDir: "/tmp/demo-block",
+				result: {
+					selectedVariant: null,
+					templateId: "basic",
+					variables: {
+						title: "Demo Block",
+					},
+					warnings: [],
+				},
+			},
+			{ forceAscii: true },
+		);
+		const addPayload = buildAddDryRunPayload(
+			{
+				completion: buildAddCompletionPayload(
+					{
+						kind: "block",
+						packageManager: "npm",
+						projectDir: "/tmp/demo-workspace",
+						values: {
+							blockSlugs: "faq, faq-item",
+							templateId: "compound",
+						},
+					},
+					{ forceAscii: true },
+				),
+				fileOperations: ["write src/blocks/faq/block.json"],
+			},
+			{ forceAscii: true },
+		);
+
+		expect(createPayload.title).toBe(
+			"[dry-run] Dry run for Demo Block at /tmp/demo-block",
+		);
+		expect(addPayload.title).toBe("[dry-run] Dry run for workspace block");
 	});
 });

--- a/packages/wp-typia/tests/output-markers.test.ts
+++ b/packages/wp-typia/tests/output-markers.test.ts
@@ -19,7 +19,7 @@ describe('output marker helpers', () => {
 
   test('keeps Unicode markers for UTF-8 locales and modern default Windows', () => {
     expect(prefersAsciiOutput({ env: { LANG: 'en_US.UTF-8' } })).toBe(false);
-    expect(prefersAsciiOutput({ env: {}, platform: 'win32' })).toBe(false);
+    expect(prefersAsciiOutput({ env: { WP_TYPIA_ASCII: '0' } })).toBe(false);
     expect(getOutputMarker('success', { forceAscii: true })).toBe('[ok]');
     expect(getOutputMarker('success', { env: { LANG: 'en_US.UTF-8' } })).toBe(
       '✅',

--- a/packages/wp-typia/tests/output-markers.test.ts
+++ b/packages/wp-typia/tests/output-markers.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  formatOutputMarker,
+  getOutputMarker,
+  prefersAsciiOutput,
+  stripLeadingOutputMarker,
+} from '../src/output-markers';
+
+describe('output marker helpers', () => {
+  test('prefers ASCII markers for explicit overrides and non-UTF locales', () => {
+    expect(prefersAsciiOutput({ forceAscii: true })).toBe(true);
+    expect(prefersAsciiOutput({ env: { LANG: 'C' } })).toBe(true);
+    expect(prefersAsciiOutput({ env: { TERM: 'dumb' } })).toBe(true);
+    expect(prefersAsciiOutput({ env: { LANG: 'en_US.ISO-8859-1' } })).toBe(
+      true,
+    );
+  });
+
+  test('keeps Unicode markers for UTF-8 locales and modern default Windows', () => {
+    expect(prefersAsciiOutput({ env: { LANG: 'en_US.UTF-8' } })).toBe(false);
+    expect(prefersAsciiOutput({ env: {}, platform: 'win32' })).toBe(false);
+    expect(getOutputMarker('success', { forceAscii: true })).toBe('[ok]');
+    expect(getOutputMarker('success', { env: { LANG: 'en_US.UTF-8' } })).toBe(
+      '✅',
+    );
+  });
+
+  test('formats and strips status markers across Unicode and ASCII styles', () => {
+    expect(
+      formatOutputMarker('warning', 'Needs attention', { forceAscii: true }),
+    ).toBe('[!] Needs attention');
+    expect(
+      stripLeadingOutputMarker('✅ Added workspace block', 'success'),
+    ).toBe('Added workspace block');
+    expect(
+      stripLeadingOutputMarker('[ok] Added workspace block', 'success'),
+    ).toBe('Added workspace block');
+  });
+});


### PR DESCRIPTION
## Summary
- add ASCII-friendly output marker helpers for completion, progress, and warning text
- reuse those markers across CLI completion output and first-party completion surfaces
- improve Bun-missing guidance to point users at the standalone `wp-typia` binary path

## Testing
- `bun run build` (in `packages/wp-typia`)
- `bun test tests/output-markers.test.ts tests/completion-output.test.ts tests/tui-lifecycle.test.ts`
- `bun test tests/cli-package.test.ts`

Closes #545

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ASCII-friendly output in terminals without Unicode support.
  * New guidance messaging directs users to the standalone wp-typia binary from GitHub releases.

* **Improvements**
  * Standardized error messages with consistent formatting across different runtime scenarios.
  * Enhanced output formatting for progress and completion messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->