### PR TITLE
Improve add/sync structured output and preview ergonomics

### DIFF
--- a/apps/docs/src/content/docs/reference/api.md
+++ b/apps/docs/src/content/docs/reference/api.md
@@ -439,13 +439,14 @@ metadata for top-level string attributes via `tags.Source<"html" | "text" |
 
 Generated projects now expose `sync` as the common-case metadata refresh
 entrypoint, with `sync-types` still available for advanced/manual runs. `sync`
-supports `--check` only and simply orchestrates the same generated sync steps
-that `build`, `start`, and `typecheck` expect. `sync-types` stays warn-only by
-default, supports `-- --fail-on-lossy` when CI should fail only on lossy
-WordPress projections, and supports `-- --strict --report json` when CI should
-fail on all warnings while reading a machine-friendly JSON report from stdout.
-Hard source-analysis and unsupported type failures still exit non-zero
-regardless of mode.
+supports `--check` for verification runs and `--dry-run` for command previews
+without executing the generated sync scripts, while still orchestrating the
+same generated sync steps that `build`, `start`, and `typecheck` expect when it
+does run. `sync-types` stays warn-only by default, supports `-- --fail-on-lossy`
+when CI should fail only on lossy WordPress projections, and supports
+`-- --strict --report json` when CI should fail on all warnings while reading a
+machine-friendly JSON report from stdout. Hard source-analysis and unsupported
+type failures still exit non-zero regardless of mode.
 
 If you need the same behavior programmatically, `@wp-typia/block-runtime/metadata-core`
 also exposes `runSyncBlockMetadata(...)` alongside the lower-level

--- a/packages/wp-typia/src/command-option-metadata.ts
+++ b/packages/wp-typia/src/command-option-metadata.ts
@@ -224,6 +224,24 @@ export const MIGRATE_OPTION_METADATA = {
 } as const satisfies CommandOptionMetadataMap;
 
 /**
+ * Shared `wp-typia sync` option metadata used by both runtime entry paths.
+ */
+export const SYNC_OPTION_METADATA = {
+	check: {
+		argumentKind: "flag",
+		description:
+			"Check generated artifacts without writing changes. Advanced sync-types-only flags stay on sync-types.",
+		type: "boolean",
+	},
+	"dry-run": {
+		argumentKind: "flag",
+		description:
+			"Preview the generated sync commands that would run without executing them.",
+		type: "boolean",
+	},
+} as const satisfies CommandOptionMetadataMap;
+
+/**
  * Shared `wp-typia templates` option metadata.
  */
 export const TEMPLATES_OPTION_METADATA = {

--- a/packages/wp-typia/src/commands/add.ts
+++ b/packages/wp-typia/src/commands/add.ts
@@ -32,6 +32,23 @@ export const addCommand = defineCommand({
 	defaultFormat: "toon",
 	description: "Extend an official wp-typia workspace with blocks, variations, patterns, binding sources, plugin-level REST resources, editor plugins, or hooked blocks.",
 	handler: async (args) => {
+		const prefersStructuredOutput =
+			(args.formatExplicit && args.format !== "toon") ||
+			args.agent ||
+			Boolean(args.context?.store?.isAIAgent);
+		if (prefersStructuredOutput) {
+			const completion = await executeAddCommand({
+				cwd: args.cwd,
+				emitOutput: false,
+				flags: args.flags as Record<string, unknown>,
+				interactive: false,
+				kind: args.positional[0],
+				name: args.positional[1],
+			});
+			args.output({ completion });
+			return;
+		}
+
 		await executeAddCommand({
 			cwd: args.cwd,
 			flags: args.flags as Record<string, unknown>,

--- a/packages/wp-typia/src/commands/sync.ts
+++ b/packages/wp-typia/src/commands/sync.ts
@@ -1,18 +1,48 @@
 import { defineCommand } from "@bunli/core";
-import { z } from "zod";
 
 import { createCliCommandError } from "@wp-typia/project-tools/cli-diagnostics";
+import {
+	buildCommandOptions,
+	SYNC_OPTION_METADATA,
+} from "../command-option-metadata";
 import { executeSyncCommand } from "../runtime-bridge";
+import {
+	buildSyncDryRunPayload,
+	printCompletionPayload,
+} from "../runtime-bridge-output";
 
 export const syncCommand = defineCommand({
 	description:
 		"Run the generated-project sync workflow from a scaffolded project or official workspace root.",
 	handler: async (args) => {
+		const check = Boolean(args.flags.check);
+		const dryRun = Boolean(args.flags["dry-run"]);
+		const prefersStructuredOutput =
+			(args.formatExplicit && args.format !== "toon") ||
+			args.agent ||
+			Boolean(args.context?.store?.isAIAgent);
+
 		try {
-			await executeSyncCommand({
-				check: Boolean(args.flags.check),
+			const sync = await executeSyncCommand({
+				captureOutput: prefersStructuredOutput && !dryRun,
+				check,
 				cwd: args.cwd,
+				dryRun,
 			});
+			if (prefersStructuredOutput) {
+				args.output({ sync });
+				return;
+			}
+			if (dryRun) {
+				printCompletionPayload(
+					buildSyncDryRunPayload({
+						check: sync.check,
+						packageManager: sync.packageManager,
+						plannedCommands: sync.plannedCommands,
+						projectDir: sync.projectDir,
+					}),
+				);
+			}
 		} catch (error) {
 			throw createCliCommandError({
 				command: "sync",
@@ -21,14 +51,7 @@ export const syncCommand = defineCommand({
 		}
 	},
 	name: "sync",
-	options: {
-		check: {
-			argumentKind: "flag" as const,
-			description:
-				"Check generated artifacts without writing changes. Advanced sync-types-only flags stay on sync-types.",
-			schema: z.boolean().default(false),
-		},
-	},
+	options: buildCommandOptions(SYNC_OPTION_METADATA),
 });
 
 export default syncCommand;

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -490,14 +490,22 @@ export async function runNodeCli(argv = process.argv.slice(2)): Promise<void> {
 			});
 		}
 		if (mergedFlags.format === "json") {
-			const completion = await executeAddCommand({
-				cwd: process.cwd(),
-				emitOutput: false,
-				flags: mergedFlags,
-				interactive: false,
-				kind: positionals[1],
-				name: positionals[2],
-			});
+			let completion;
+			try {
+				completion = await executeAddCommand({
+					cwd: process.cwd(),
+					emitOutput: false,
+					flags: mergedFlags,
+					interactive: false,
+					kind: positionals[1],
+					name: positionals[2],
+				});
+			} catch (error) {
+				throw createCliCommandError({
+					command: "add",
+					error,
+				});
+			}
 			printLine(
 				JSON.stringify(
 					{

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -14,6 +14,7 @@ import {
 	MIGRATE_OPTION_METADATA,
 	parseCommandArgvWithMetadata,
 	resolveCommandOptionValues,
+	SYNC_OPTION_METADATA,
 	TEMPLATES_OPTION_METADATA,
 } from "./command-option-metadata";
 import {
@@ -37,6 +38,10 @@ import {
 	executeTemplatesCommand,
 } from "./runtime-bridge";
 import {
+	buildSyncDryRunPayload,
+	printCompletionPayload,
+} from "./runtime-bridge-output";
+import {
 	WP_TYPIA_CANONICAL_CREATE_USAGE,
 	WP_TYPIA_CANONICAL_MIGRATE_USAGE,
 	WP_TYPIA_FUTURE_COMMAND_TREE,
@@ -55,9 +60,10 @@ const NODE_FALLBACK_OPTION_PARSER = buildCommandOptionParser(
 	CREATE_OPTION_METADATA,
 	ADD_OPTION_METADATA,
 	MIGRATE_OPTION_METADATA,
+	SYNC_OPTION_METADATA,
 	TEMPLATES_OPTION_METADATA,
 );
-const NODE_FALLBACK_BOOLEAN_OPTION_NAMES = ["check", "help", "version"] as const;
+const NODE_FALLBACK_BOOLEAN_OPTION_NAMES = ["help", "version"] as const;
 const STANDALONE_GUIDANCE_LINE =
 	"Prefer not to install Bun? Use the standalone wp-typia binary from the GitHub release assets.";
 
@@ -155,17 +161,23 @@ async function applyNodeFallbackConfigDefaults(
 	}
 
 	if (command === "create") {
-		return resolveCommandOptionValues(CREATE_OPTION_METADATA, {
-			defaults: getCreateDefaults(config),
-			flags,
-		});
+		return {
+			...flags,
+			...resolveCommandOptionValues(CREATE_OPTION_METADATA, {
+				defaults: getCreateDefaults(config),
+				flags,
+			}),
+		};
 	}
 
 	if (command === "add" && subcommand === "block") {
-		return resolveCommandOptionValues(ADD_OPTION_METADATA, {
-			defaults: getAddBlockDefaults(config),
-			flags,
-		});
+		return {
+			...flags,
+			...resolveCommandOptionValues(ADD_OPTION_METADATA, {
+				defaults: getAddBlockDefaults(config),
+				flags,
+			}),
+		};
 	}
 
 	return flags;
@@ -239,6 +251,17 @@ function renderMigrateHelp() {
 		"",
 		"Supported flags:",
 		...formatNodeFallbackOptionHelp(MIGRATE_OPTION_METADATA),
+	]);
+}
+
+function renderSyncHelp() {
+	printBlock([
+		"Usage: wp-typia sync",
+		"",
+		...NODE_FALLBACK_RUNTIME_SUMMARY_LINES,
+		"",
+		"Supported flags:",
+		...formatNodeFallbackOptionHelp(SYNC_OPTION_METADATA),
 	]);
 }
 
@@ -382,6 +405,10 @@ export async function runNodeCli(argv = process.argv.slice(2)): Promise<void> {
 			renderMigrateHelp();
 			return;
 		}
+		if (command === "sync") {
+			renderSyncHelp();
+			return;
+		}
 		renderGeneralHelp();
 		return;
 	}
@@ -462,6 +489,26 @@ export async function runNodeCli(argv = process.argv.slice(2)): Promise<void> {
 				],
 			});
 		}
+		if (mergedFlags.format === "json") {
+			const completion = await executeAddCommand({
+				cwd: process.cwd(),
+				emitOutput: false,
+				flags: mergedFlags,
+				interactive: false,
+				kind: positionals[1],
+				name: positionals[2],
+			});
+			printLine(
+				JSON.stringify(
+					{
+						completion,
+					},
+					null,
+					2,
+				),
+			);
+			return;
+		}
 		await executeAddCommand({
 			cwd: process.cwd(),
 			flags: mergedFlags,
@@ -492,10 +539,34 @@ export async function runNodeCli(argv = process.argv.slice(2)): Promise<void> {
 
 	if (command === "sync") {
 		try {
-			await executeSyncCommand({
+			const sync = await executeSyncCommand({
+				captureOutput: mergedFlags.format === "json" && !Boolean(mergedFlags["dry-run"]),
 				check: Boolean(mergedFlags.check),
 				cwd: process.cwd(),
+				dryRun: Boolean(mergedFlags["dry-run"]),
 			});
+			if (mergedFlags.format === "json") {
+				printLine(
+					JSON.stringify(
+						{
+							sync,
+						},
+						null,
+						2,
+					),
+				);
+				return;
+			}
+			if (sync.dryRun) {
+				printCompletionPayload(
+					buildSyncDryRunPayload({
+						check: sync.check,
+						packageManager: sync.packageManager,
+						plannedCommands: sync.plannedCommands,
+						projectDir: sync.projectDir,
+					}),
+				);
+			}
 		} catch (error) {
 			throw createCliCommandError({
 				command: "sync",

--- a/packages/wp-typia/src/runtime-bridge-output.ts
+++ b/packages/wp-typia/src/runtime-bridge-output.ts
@@ -472,6 +472,43 @@ markerOptions?: OutputMarkerOptions,
 }
 
 /**
+ * Builds the completion payload shown after a dry-run sync preview.
+ *
+ * @param options Planned sync execution metadata plus the preview command list.
+ * @returns A structured alternate-buffer completion payload.
+ */
+export function buildSyncDryRunPayload(options: {
+	check: boolean;
+	packageManager: PackageManagerId;
+	plannedCommands: Array<{
+		displayCommand: string;
+	}>;
+	projectDir: string;
+},
+markerOptions?: OutputMarkerOptions,
+): AlternateBufferCompletionPayload {
+	return {
+		optionalLines: options.plannedCommands.map((command) => command.displayCommand),
+		optionalNote: options.check
+			? "No sync scripts were executed because --dry-run was enabled. Re-run `wp-typia sync --check` to verify generated artifacts without rewriting them."
+			: "No sync scripts were executed because --dry-run was enabled. Re-run without --dry-run to apply generated-file updates, or add --check to verify without rewriting.",
+		optionalTitle: `Planned sync commands (${options.plannedCommands.length}):`,
+		summaryLines: [
+			`Project directory: ${options.projectDir}`,
+			`Package manager: ${options.packageManager}`,
+			options.check
+				? "Execution mode: would run generated sync scripts in verification mode."
+				: "Execution mode: would run generated sync scripts in apply mode.",
+		],
+		title: formatOutputMarker(
+			"dryRun",
+			"Dry run for wp-typia sync",
+			markerOptions,
+		),
+	};
+}
+
+/**
  * Prints a block of text lines using a shared line printer.
  *
  * @param lines Lines to print in order.

--- a/packages/wp-typia/src/runtime-bridge-sync.ts
+++ b/packages/wp-typia/src/runtime-bridge-sync.ts
@@ -23,7 +23,6 @@ export type SyncPlannedCommand = {
 	args: string[];
 	command: string;
 	displayCommand: string;
-	script: string;
 	scriptName: SyncScriptName;
 };
 
@@ -240,7 +239,6 @@ function createSyncPlannedCommand(
 			scriptName,
 			extraArgs.join(" "),
 		),
-		script,
 		scriptName,
 	};
 }

--- a/packages/wp-typia/src/runtime-bridge-sync.ts
+++ b/packages/wp-typia/src/runtime-bridge-sync.ts
@@ -45,6 +45,7 @@ export type SyncExecutionResult = {
 
 const SYNC_INSTALL_MARKERS = ["node_modules", ".pnp.cjs", ".pnp.loader.mjs"] as const;
 const LOCAL_SYNC_TOOL_PATTERN = /(^|[\s;&|()])(?:tsx|wp-scripts)(?=($|[\s;&|()]))/u;
+const CAPTURED_SYNC_OUTPUT_MAX_BUFFER = 16 * 1024 * 1024;
 
 function formatRunScript(
 	packageManagerId: PackageManagerId,
@@ -271,6 +272,7 @@ function runProjectScript(
 	const result = spawnSync(plannedCommand.command, plannedCommand.args, {
 		cwd: project.cwd,
 		encoding: options.captureOutput ? "utf8" : undefined,
+		...(options.captureOutput ? { maxBuffer: CAPTURED_SYNC_OUTPUT_MAX_BUFFER } : {}),
 		shell: process.platform === "win32",
 		stdio: options.captureOutput ? "pipe" : "inherit",
 	});

--- a/packages/wp-typia/src/runtime-bridge-sync.ts
+++ b/packages/wp-typia/src/runtime-bridge-sync.ts
@@ -3,17 +3,44 @@ import fs from "node:fs";
 import path from "node:path";
 
 type PackageManagerId = "bun" | "npm" | "pnpm" | "yarn";
+type SyncScriptName = "sync" | "sync-rest" | "sync-types";
 
 type SyncExecutionInput = {
+	captureOutput?: boolean;
 	check?: boolean;
 	cwd: string;
+	dryRun?: boolean;
 };
 
 type SyncProjectContext = {
 	cwd: string;
 	packageJsonPath: string;
 	packageManager: PackageManagerId;
-	scripts: Partial<Record<"sync" | "sync-rest" | "sync-types", string>>;
+	scripts: Partial<Record<SyncScriptName, string>>;
+};
+
+export type SyncPlannedCommand = {
+	args: string[];
+	command: string;
+	displayCommand: string;
+	script: string;
+	scriptName: SyncScriptName;
+};
+
+export type SyncExecutedCommand = SyncPlannedCommand & {
+	exitCode: number;
+	stderr?: string;
+	stdout?: string;
+};
+
+export type SyncExecutionResult = {
+	check: boolean;
+	dryRun: boolean;
+	executedCommands?: SyncExecutedCommand[];
+	packageJsonPath: string;
+	packageManager: PackageManagerId;
+	plannedCommands: SyncPlannedCommand[];
+	projectDir: string;
 };
 
 const SYNC_INSTALL_MARKERS = ["node_modules", ".pnp.cjs", ".pnp.loader.mjs"] as const;
@@ -188,14 +215,14 @@ function getPackageManagerRunInvocation(
 	}
 }
 
-function runProjectScript(
+function createSyncPlannedCommand(
 	project: SyncProjectContext,
-	scriptName: "sync" | "sync-rest" | "sync-types",
+	scriptName: SyncScriptName,
 	extraArgs: string[],
-): void {
+): SyncPlannedCommand | null {
 	const script = project.scripts[scriptName];
 	if (!script) {
-		return;
+		return null;
 	}
 
 	const invocation = getPackageManagerRunInvocation(
@@ -204,44 +231,110 @@ function runProjectScript(
 		extraArgs,
 	);
 
-	const result = spawnSync(invocation.command, invocation.args, {
+	return {
+		args: invocation.args,
+		command: invocation.command,
+		displayCommand: formatRunScript(
+			project.packageManager,
+			scriptName,
+			extraArgs.join(" "),
+		),
+		script,
+		scriptName,
+	};
+}
+
+function buildSyncPlannedCommands(
+	project: SyncProjectContext,
+	extraArgs: string[],
+): SyncPlannedCommand[] {
+	if (project.scripts.sync) {
+		return [createSyncPlannedCommand(project, "sync", extraArgs)!];
+	}
+
+	const plannedCommands = [createSyncPlannedCommand(project, "sync-types", extraArgs)!];
+	const syncRestCommand = createSyncPlannedCommand(project, "sync-rest", extraArgs);
+	if (syncRestCommand) {
+		plannedCommands.push(syncRestCommand);
+	}
+
+	return plannedCommands;
+}
+
+function runProjectScript(
+	project: SyncProjectContext,
+	plannedCommand: SyncPlannedCommand,
+	options: {
+		captureOutput: boolean;
+	},
+): SyncExecutedCommand {
+	const result = spawnSync(plannedCommand.command, plannedCommand.args, {
 		cwd: project.cwd,
+		encoding: options.captureOutput ? "utf8" : undefined,
 		shell: process.platform === "win32",
-		stdio: "inherit",
+		stdio: options.captureOutput ? "pipe" : "inherit",
 	});
+	const stderr =
+		options.captureOutput && typeof result.stderr === "string"
+			? result.stderr
+			: undefined;
+	const stdout =
+		options.captureOutput && typeof result.stdout === "string"
+			? result.stdout
+			: undefined;
 
 	if (result.error || result.status !== 0) {
 		throw new Error(
-			`\`${formatRunScript(project.packageManager, scriptName, extraArgs.join(" "))}\` failed.`,
+			`\`${plannedCommand.displayCommand}\` failed.`,
 			{
-				cause: result.error,
+				cause: result.error ?? (stderr ? new Error(stderr.trim()) : undefined),
 			},
 		);
 	}
+
+	return {
+		...plannedCommand,
+		exitCode: result.status ?? 0,
+		...(stderr !== undefined ? { stderr } : {}),
+		...(stdout !== undefined ? { stdout } : {}),
+	};
 }
 
 /**
  * Executes the generated-project sync flow through the local project scripts.
  *
- * @param options Sync execution options including cwd and optional `--check`.
- * @returns A promise that resolves after the relevant sync scripts complete.
+ * @param options Sync execution options including cwd, optional `--check`, and
+ * optional `--dry-run` preview mode.
+ * @returns A promise that resolves with the planned sync commands and any
+ * executed command output metadata.
  */
 export async function executeSyncCommand({
+	captureOutput = false,
 	check = false,
 	cwd,
-}: SyncExecutionInput): Promise<void> {
+	dryRun = false,
+}: SyncExecutionInput): Promise<SyncExecutionResult> {
 	const project = resolveSyncProjectContext(cwd);
-	assertSyncDependenciesInstalled(project);
 	const extraArgs = check ? ["--check"] : [];
+	const plannedCommands = buildSyncPlannedCommands(project, extraArgs);
+	const result: SyncExecutionResult = {
+		check,
+		dryRun,
+		packageJsonPath: project.packageJsonPath,
+		packageManager: project.packageManager,
+		plannedCommands,
+		projectDir: project.cwd,
+	};
 
-	if (project.scripts.sync) {
-		runProjectScript(project, "sync", extraArgs);
-		return;
+	if (dryRun) {
+		return result;
 	}
 
-	runProjectScript(project, "sync-types", extraArgs);
-
-	if (project.scripts["sync-rest"]) {
-		runProjectScript(project, "sync-rest", extraArgs);
-	}
+	assertSyncDependenciesInstalled(project);
+	result.executedCommands = plannedCommands.map((plannedCommand) =>
+		runProjectScript(project, plannedCommand, {
+			captureOutput,
+		}),
+	);
+	return result;
 }

--- a/packages/wp-typia/src/runtime-bridge.ts
+++ b/packages/wp-typia/src/runtime-bridge.ts
@@ -365,9 +365,12 @@ export async function executeAddCommand({
 
 	try {
 		const addRuntime = await loadCliAddRuntime();
+		const isInteractiveSession = interactive ?? isInteractiveTerminal();
 
 		if (!kind) {
-			printLine(addRuntime.formatAddHelpText());
+			if (emitOutput) {
+				printLine(addRuntime.formatAddHelpText());
+			}
 			throw new Error(
 				"`wp-typia add` requires <kind>. Usage: wp-typia add <block|variation|pattern|binding-source|rest-resource|editor-plugin|hooked-block> ...",
 			);
@@ -593,13 +596,13 @@ export async function executeAddCommand({
 
 		if (!name) {
 			throw new Error(
-				"`wp-typia add block` requires <name>. Usage: wp-typia add block <name> --template <basic|interactivity|persistence|compound>",
+				"`wp-typia add block` requires <name>. Usage: wp-typia add block <name> [--template <basic|interactivity|persistence|compound>]",
 			);
 		}
 
-		if (!flags.template) {
+		if (!flags.template && isInteractiveSession) {
 			throw new Error(
-				"`wp-typia add block` requires --template <basic|interactivity|persistence|compound>.",
+				"`wp-typia add block` requires --template <basic|interactivity|persistence|compound> in interactive terminals. Non-interactive runs default to --template basic.",
 			);
 		}
 
@@ -608,7 +611,7 @@ export async function executeAddCommand({
 		const shouldPromptForLayerSelection =
 			Boolean(externalLayerSource) &&
 			!Boolean(externalLayerId) &&
-			(interactive ?? isInteractiveTerminal());
+			isInteractiveSession;
 		const promptRuntime = shouldPromptForLayerSelection
 			? await loadCliPromptRuntime()
 			: undefined;
@@ -624,11 +627,13 @@ export async function executeAddCommand({
 		const dataStorageMode = readOptionalStringFlag(flags, "data-storage");
 		const innerBlocksPreset = readOptionalStringFlag(flags, "inner-blocks-preset");
 		const persistencePolicy = readOptionalStringFlag(flags, "persistence-policy");
-		const resolvedTemplateId = readOptionalStringFlag(flags, "template") as
-			| "basic"
-			| "interactivity"
-			| "persistence"
-			| "compound";
+		const resolvedTemplateId =
+			(readOptionalStringFlag(flags, "template") as
+				| "basic"
+				| "interactivity"
+				| "persistence"
+				| "compound"
+				| undefined) ?? "basic";
 
 		return executeWorkspaceAddWithOptionalDryRun<
 			Awaited<ReturnType<typeof addRuntime.runAddBlockCommand>>

--- a/packages/wp-typia/tests/add-command.test.ts
+++ b/packages/wp-typia/tests/add-command.test.ts
@@ -1,0 +1,40 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { executeAddCommand } from "../src/runtime-bridge";
+import {
+	linkWorkspaceNodeModules,
+	scaffoldOfficialWorkspace,
+} from "../../wp-typia-project-tools/tests/helpers/scaffold-test-harness.js";
+
+describe("wp-typia add command bridge", () => {
+	const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "wp-typia-add-bridge-"));
+
+	afterAll(() => {
+		fs.rmSync(tempRoot, { force: true, recursive: true });
+	});
+
+	test("defaults add block to the basic template in non-interactive runs", async () => {
+		const projectDir = path.join(tempRoot, "demo-add-basic-default");
+
+		await scaffoldOfficialWorkspace(projectDir);
+		linkWorkspaceNodeModules(projectDir);
+
+		const payload = await executeAddCommand({
+			cwd: projectDir,
+			emitOutput: false,
+			flags: {},
+			interactive: false,
+			kind: "block",
+			name: "promo-card",
+		});
+
+		expect(payload?.title).toContain("Added workspace block");
+		expect(payload?.summaryLines).toContain("Template family: basic");
+		expect(
+			fs.existsSync(path.join(projectDir, "src", "blocks", "promo-card", "block.json")),
+		).toBe(true);
+	});
+});

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -8,6 +8,10 @@ import { WP_TYPIA_TOP_LEVEL_COMMAND_NAMES } from "../src/command-contract";
 import { hasFlagBeforeTerminator, parseGlobalFlags, runNodeCli } from "../src/node-cli";
 
 import { runUtf8Command } from "../../../tests/helpers/process-utils";
+import {
+	linkWorkspaceNodeModules,
+	scaffoldOfficialWorkspace,
+} from "../../wp-typia-project-tools/tests/helpers/scaffold-test-harness.js";
 
 const packageRoot = path.resolve(import.meta.dir, "..");
 const entryPath = path.join(packageRoot, "bin", "wp-typia.js");
@@ -31,6 +35,10 @@ const createCommandSource = fs.readFileSync(
 );
 const addCommandSource = fs.readFileSync(
 	path.join(packageRoot, "src", "commands", "add.ts"),
+	"utf8",
+);
+const syncCommandSource = fs.readFileSync(
+	path.join(packageRoot, "src", "commands", "sync.ts"),
 	"utf8",
 );
 const migrateCommandSource = fs.readFileSync(
@@ -360,11 +368,13 @@ describe("wp-typia package", () => {
 	test("derives Bunli and Node fallback option metadata from the same source", () => {
 		expect(createCommandSource).toContain("buildCommandOptions(CREATE_OPTION_METADATA)");
 		expect(addCommandSource).toContain("buildCommandOptions(ADD_OPTION_METADATA)");
+		expect(syncCommandSource).toContain("buildCommandOptions(SYNC_OPTION_METADATA)");
 		expect(migrateCommandSource).toContain("buildCommandOptions(MIGRATE_OPTION_METADATA)");
 		expect(templatesCommandSource).toContain("buildCommandOptions(TEMPLATES_OPTION_METADATA)");
 		expect(nodeCliSource).toContain('from "./command-option-metadata"');
 		expect(nodeCliSource).toContain("formatNodeFallbackOptionHelp(CREATE_OPTION_METADATA)");
 		expect(nodeCliSource).toContain("formatNodeFallbackOptionHelp(ADD_OPTION_METADATA)");
+		expect(nodeCliSource).toContain("formatNodeFallbackOptionHelp(SYNC_OPTION_METADATA)");
 		expect(nodeCliSource).toContain("formatNodeFallbackOptionHelp(MIGRATE_OPTION_METADATA)");
 		expect(nodeCliSource).toContain("formatNodeFallbackOptionHelp(TEMPLATES_OPTION_METADATA)");
 	});
@@ -583,6 +593,60 @@ describe("wp-typia package", () => {
 		}
 	});
 
+	test("previews sync commands without running scripts in Node fallback dry-run JSON mode", () => {
+		const { fixtureRoot, logPath } = createSyncFixture({
+			scripts: {
+				"sync-rest": "node scripts/record.mjs sync-rest",
+				"sync-types": "node scripts/record.mjs sync-types",
+			},
+			withSyncRestMarker: true,
+		});
+
+		try {
+			const result = runCapturedCommand(
+				process.execPath,
+				[entryPath, "sync", "--dry-run", "--format", "json"],
+				{
+					cwd: fixtureRoot,
+					env: withoutLocalBunEnv(),
+				},
+			);
+			const parsed = parseJsonObjectFromOutput<{
+				sync?: {
+					dryRun?: boolean;
+					executedCommands?: unknown[];
+					plannedCommands?: Array<{ displayCommand?: string }>;
+				};
+			}>(result.stdout);
+
+			expect(result.status).toBe(0);
+			expect(parsed.sync?.dryRun).toBe(true);
+			expect(parsed.sync?.executedCommands).toBeUndefined();
+			expect(parsed.sync?.plannedCommands).toMatchObject([
+				{
+					displayCommand: "npm run sync-types",
+				},
+				{
+					displayCommand: "npm run sync-rest",
+				},
+			]);
+			expect(readSyncLog(logPath)).toEqual([]);
+		} finally {
+			fs.rmSync(fixtureRoot, { force: true, recursive: true });
+		}
+	});
+
+	test("renders sync help with preview-oriented dry-run guidance in Node fallback", () => {
+		const result = runCapturedCommand(process.execPath, [entryPath, "sync", "--help"], {
+			env: withoutLocalBunEnv(),
+		});
+
+		expect(result.status).toBe(0);
+		expect(result.stdout).toContain("Usage: wp-typia sync");
+		expect(result.stdout).toContain("--check");
+		expect(result.stdout).toContain("--dry-run");
+	});
+
 	test("rejects the removed migrations alias with actionable guidance", () => {
 		expect(() => runUtf8Command("node", [entryPath, "migrations", "plan"])).toThrow(
 			/removed in favor of `wp-typia migrate`/,
@@ -676,6 +740,40 @@ describe("wp-typia package", () => {
 		expect(result.stderr).toContain("Error: wp-typia add failed");
 		expect(result.stderr).toContain("Summary: Unable to complete the requested add workflow.");
 		expect(result.stderr).toContain("- `wp-typia add variation` requires --block <block-slug>.");
+	});
+
+	test("emits structured add completion output in Node fallback JSON mode", async () => {
+		const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), "wp-typia-add-json-"));
+
+		try {
+			await scaffoldOfficialWorkspace(projectDir);
+			linkWorkspaceNodeModules(projectDir);
+
+			const result = runCapturedCommand(
+				process.execPath,
+				[entryPath, "add", "block", "promo-card", "--format", "json"],
+				{
+					cwd: projectDir,
+					env: withoutLocalBunEnv(),
+				},
+			);
+			const parsed = parseJsonObjectFromOutput<{
+				completion?: {
+					summaryLines?: string[];
+					title?: string;
+				};
+			}>(result.stdout);
+
+			expect(result.status).toBe(0);
+			expect(result.stderr).toBe("");
+			expect(parsed.completion?.title).toContain("Added workspace block");
+			expect(parsed.completion?.summaryLines).toContain("Template family: basic");
+			expect(
+				fs.existsSync(path.join(projectDir, "src", "blocks", "promo-card", "block.json")),
+			).toBe(true);
+		} finally {
+			fs.rmSync(projectDir, { force: true, recursive: true });
+		}
 	});
 
 	test("emits a machine-readable outside-project-root error code for sync in Node fallback JSON mode", () => {

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -776,6 +776,27 @@ describe("wp-typia package", () => {
 		}
 	});
 
+	test("preserves add diagnostic metadata in Node fallback JSON mode on failure", () => {
+		const result = runCapturedCommand(
+			process.execPath,
+			[entryPath, "add", "variation", "promo-card", "--format", "json"],
+			{
+				env: withoutLocalBunEnv(),
+			},
+		);
+		const parsed = parseJsonObjectFromOutput<{
+			error?: { code?: string; command?: string; kind?: string };
+			ok?: boolean;
+		}>(result.stderr);
+
+		expect(result.status).toBe(1);
+		expect(result.stdout).toBe("");
+		expect(parsed.ok).toBe(false);
+		expect(parsed.error?.kind).toBe("command-execution");
+		expect(parsed.error?.command).toBe("add");
+		expect(parsed.error?.code).toBe("missing-argument");
+	});
+
 	test("emits a machine-readable outside-project-root error code for sync in Node fallback JSON mode", () => {
 		const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "wp-typia-sync-json-"));
 

--- a/packages/wp-typia/tests/command-option-metadata.test.ts
+++ b/packages/wp-typia/tests/command-option-metadata.test.ts
@@ -7,6 +7,7 @@ import {
 	GLOBAL_OPTION_METADATA,
 	parseCommandArgvWithMetadata,
 	resolveCommandOptionValues,
+	SYNC_OPTION_METADATA,
 } from "../src/command-option-metadata";
 
 describe("command option metadata helpers", () => {
@@ -67,5 +68,21 @@ describe("command option metadata helpers", () => {
 		expect(resolved["external-layer-source"]).toBe("./layers");
 		expect(resolved.template).toBe("persistence");
 		expect("dry-run" in resolved).toBe(false);
+	});
+
+	test("parses sync preview flags from shared metadata", () => {
+		const parsed = parseCommandArgvWithMetadata(["--dry-run", "--check"], {
+			extraBooleanOptionNames: ["help", "version"],
+			parser: buildCommandOptionParser(
+				GLOBAL_OPTION_METADATA,
+				SYNC_OPTION_METADATA,
+			),
+		});
+
+		expect(parsed.flags).toEqual({
+			check: true,
+			"dry-run": true,
+		});
+		expect(parsed.positionals).toEqual([]);
 	});
 });

--- a/packages/wp-typia/tests/completion-output.test.ts
+++ b/packages/wp-typia/tests/completion-output.test.ts
@@ -11,6 +11,7 @@ import {
 import {
 	buildAddCompletionPayload,
 	buildAddDryRunPayload,
+	buildSyncDryRunPayload,
 } from "../src/runtime-bridge-output";
 
 const UNICODE_MARKER_OPTIONS = {
@@ -290,6 +291,33 @@ describe("alternate-buffer completion output helpers", () => {
 		expect(payload.warningLines).toBeUndefined();
 		expect(payload.optionalTitle).toBe("Planned workspace updates (1):");
 		expect(payload.optionalLines).toEqual(["write src/blocks/faq/block.json"]);
+	});
+
+	test("dry-run sync payload previews the generated sync commands", () => {
+		const payload = buildSyncDryRunPayload(
+			{
+				check: true,
+				packageManager: "npm",
+				plannedCommands: [
+					{
+						displayCommand: "npm run sync -- --check",
+					},
+				],
+				projectDir: "/tmp/demo-workspace",
+			},
+			UNICODE_MARKER_OPTIONS,
+		);
+
+		expect(payload.title).toBe("🧪 Dry run for wp-typia sync");
+		expect(payload.summaryLines).toEqual([
+			"Project directory: /tmp/demo-workspace",
+			"Package manager: npm",
+			"Execution mode: would run generated sync scripts in verification mode.",
+		]);
+		expect(payload.optionalTitle).toBe("Planned sync commands (1):");
+		expect(payload.optionalLines).toEqual(["npm run sync -- --check"]);
+		expect(payload.optionalNote).toContain("--dry-run");
+		expect(payload.optionalNote).toContain("--check");
 	});
 
 	test("completion helpers expose ASCII-friendly markers when requested", () => {

--- a/packages/wp-typia/tests/runtime-bridge-sync.test.ts
+++ b/packages/wp-typia/tests/runtime-bridge-sync.test.ts
@@ -7,28 +7,45 @@ import { executeSyncCommand } from "../src/runtime-bridge-sync";
 
 const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "wp-typia-sync-bridge-"));
 
-afterAll(() => {
-	fs.rmSync(tempRoot, { force: true, recursive: true });
-});
-
-test("sync fails early with install guidance when local dependencies are missing", async () => {
-	const projectDir = path.join(tempRoot, "demo-sync-no-install");
+function writeSyncFixture(options: {
+	name: string;
+	scripts: Record<string, string>;
+	withInstallMarker?: boolean;
+}) {
+	const projectDir = path.join(tempRoot, options.name);
 	fs.mkdirSync(projectDir, { recursive: true });
 	fs.writeFileSync(
 		path.join(projectDir, "package.json"),
 		JSON.stringify(
 			{
-				name: "demo-sync-no-install",
+				name: options.name,
 				packageManager: "npm@10.9.0",
-				scripts: {
-					sync: "tsx scripts/sync-project.ts",
-				},
+				scripts: options.scripts,
 			},
 			null,
 			2,
 		),
 		"utf8",
 	);
+	if (options.withInstallMarker) {
+		fs.mkdirSync(path.join(projectDir, "node_modules"), {
+			recursive: true,
+		});
+	}
+	return projectDir;
+}
+
+afterAll(() => {
+	fs.rmSync(tempRoot, { force: true, recursive: true });
+});
+
+test("sync fails early with install guidance when local dependencies are missing", async () => {
+	const projectDir = writeSyncFixture({
+		name: "demo-sync-no-install",
+		scripts: {
+			sync: "tsx scripts/sync-project.ts",
+		},
+	});
 
 	const error = await executeSyncCommand({ cwd: projectDir }).catch((thrown) => thrown);
 
@@ -36,4 +53,69 @@ test("sync fails early with install guidance when local dependencies are missing
 	expect((error as Error).message).toContain("npm install");
 	expect((error as Error).message).toContain("wp-typia sync");
 	expect((error as Error).message).toContain("tsx");
+});
+
+test("dry-run sync previews commands without requiring installed dependencies", async () => {
+	const projectDir = writeSyncFixture({
+		name: "demo-sync-dry-run-preview",
+		scripts: {
+			sync: "tsx scripts/sync-project.ts",
+		},
+	});
+
+	const result = await executeSyncCommand({
+		check: true,
+		cwd: projectDir,
+		dryRun: true,
+	});
+
+	expect(result.dryRun).toBe(true);
+	expect(result.executedCommands).toBeUndefined();
+	expect(result.plannedCommands).toEqual([
+		{
+			args: ["run", "sync", "--", "--check"],
+			command: "npm",
+			displayCommand: "npm run sync -- --check",
+			script: "tsx scripts/sync-project.ts",
+			scriptName: "sync",
+		},
+	]);
+});
+
+test("sync can capture executed script output for structured callers", async () => {
+	const projectDir = writeSyncFixture({
+		name: "demo-sync-capture-output",
+		scripts: {
+			sync: "node scripts/record.mjs sync",
+		},
+		withInstallMarker: true,
+	});
+	const scriptsDir = path.join(projectDir, "scripts");
+	fs.mkdirSync(scriptsDir, { recursive: true });
+	fs.writeFileSync(
+		path.join(scriptsDir, "record.mjs"),
+		[
+			"const [, , label] = process.argv;",
+			"console.log(`ran:${label}`);",
+			"console.error(`stderr:${label}`);",
+		].join("\n"),
+		"utf8",
+	);
+
+	const result = await executeSyncCommand({
+		captureOutput: true,
+		cwd: projectDir,
+	});
+
+	expect(result.executedCommands).toHaveLength(1);
+	expect(result.executedCommands?.[0]).toMatchObject({
+		args: ["run", "sync"],
+		command: "npm",
+		displayCommand: "npm run sync",
+		exitCode: 0,
+		script: "node scripts/record.mjs sync",
+		scriptName: "sync",
+		stderr: "stderr:sync\n",
+	});
+	expect(result.executedCommands?.[0]?.stdout).toContain("ran:sync\n");
 });

--- a/packages/wp-typia/tests/runtime-bridge-sync.test.ts
+++ b/packages/wp-typia/tests/runtime-bridge-sync.test.ts
@@ -76,7 +76,6 @@ test("dry-run sync previews commands without requiring installed dependencies", 
 			args: ["run", "sync", "--", "--check"],
 			command: "npm",
 			displayCommand: "npm run sync -- --check",
-			script: "tsx scripts/sync-project.ts",
 			scriptName: "sync",
 		},
 	]);
@@ -113,7 +112,6 @@ test("sync can capture executed script output for structured callers", async () 
 		command: "npm",
 		displayCommand: "npm run sync",
 		exitCode: 0,
-		script: "node scripts/record.mjs sync",
 		scriptName: "sync",
 		stderr: "stderr:sync\n",
 	});


### PR DESCRIPTION
## Summary
- default non-interactive `wp-typia add block` runs to the `basic` template while keeping interactive prompts explicit
- expose structured add completion output in both the Bunli command path and the Node fallback runtime
- add `wp-typia sync --dry-run` command previews plus structured sync output/captured execution metadata

## Testing
- bun test packages/wp-typia/tests/command-option-metadata.test.ts packages/wp-typia/tests/completion-output.test.ts packages/wp-typia/tests/runtime-bridge-sync.test.ts packages/wp-typia/tests/add-command.test.ts
- bun test packages/wp-typia/tests/cli-package.test.ts
- bun test packages/wp-typia/tests/bunli-prep.test.ts packages/wp-typia/tests/runtime-bridge-boundaries.test.ts
- bun run build

Closes #544

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * `sync` command now supports `--dry-run` flag to preview planned commands without executing them
  * Added structured JSON output via `--format json` for both `sync` and `add` commands
  * Dry-run preview displays project details, package manager info, and planned command list

* **Documentation**
  * Updated API reference to document `sync` command flag options and behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->