### PR TITLE
Polish scaffold discovery and onboarding ergonomics

### DIFF
--- a/packages/wp-typia-project-tools/src/runtime/cli-scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-scaffold.ts
@@ -28,6 +28,7 @@ import { getPrimaryDevelopmentScript } from "./local-dev-presets.js";
 import { createManagedTempRoot } from "./temp-roots.js";
 import {
 	getOptionalOnboardingNote,
+	getOptionalOnboardingShortNote,
 	getOptionalOnboardingSteps,
 } from "./scaffold-onboarding.js";
 import { formatNonEmptyTargetDirectoryError } from "./scaffold-bootstrap.js";
@@ -63,6 +64,7 @@ interface GetOptionalOnboardingOptions {
 
 interface OptionalOnboardingGuidance {
 	note: string;
+	shortNote: string;
 	steps: string[];
 }
 
@@ -561,6 +563,10 @@ export function getOptionalOnboarding({
 }: GetOptionalOnboardingOptions): OptionalOnboardingGuidance {
 	return {
 		note: getOptionalOnboardingNote(packageManager, templateId, {
+			availableScripts,
+			compoundPersistenceEnabled,
+		}),
+		shortNote: getOptionalOnboardingShortNote(packageManager, templateId, {
 			availableScripts,
 			compoundPersistenceEnabled,
 		}),

--- a/packages/wp-typia-project-tools/src/runtime/cli-templates.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-templates.ts
@@ -1,13 +1,13 @@
 import {
+	OFFICIAL_WORKSPACE_TEMPLATE_ALIAS,
 	OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE,
+	getUserFacingTemplateId,
 	getTemplateById,
 	getTemplateSelectOptions,
 	isBuiltInTemplateId,
 	listTemplates,
 } from "./template-registry.js";
 import type { TemplateDefinition } from "./template-registry.js";
-
-const WORKSPACE_TEMPLATE_ALIAS = "workspace";
 
 /**
  * Format one line of template list output for a built-in template.
@@ -16,7 +16,7 @@ const WORKSPACE_TEMPLATE_ALIAS = "workspace";
  * @returns One-line summary text for `templates list`.
  */
 export function formatTemplateSummary(template: TemplateDefinition): string {
-	return `${template.id.padEnd(14)} ${template.description}`;
+	return `${getUserFacingTemplateId(template.id).padEnd(14)} ${template.description}`;
 }
 
 /**
@@ -27,6 +27,10 @@ export function formatTemplateSummary(template: TemplateDefinition): string {
  */
 export function formatTemplateFeatures(template: TemplateDefinition): string {
 	const lines = [`  Features: ${template.features.join(" • ")}`];
+	const bestForHint = getTemplateBestForHint(template);
+	if (bestForHint) {
+		lines.push(`  Best for: ${bestForHint}`);
+	}
 	const capabilityHints = getTemplateCapabilityHints(template);
 	if (capabilityHints.length > 0) {
 		lines.push(`  Supports: ${capabilityHints.join(" • ")}`);
@@ -37,7 +41,7 @@ export function formatTemplateFeatures(template: TemplateDefinition): string {
 	}
 	if (template.id === OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE) {
 		lines.push(
-			`  Alias: ${WORKSPACE_TEMPLATE_ALIAS} (\`--template ${WORKSPACE_TEMPLATE_ALIAS}\`)`,
+			`  Alias: ${OFFICIAL_WORKSPACE_TEMPLATE_ALIAS} (\`--template ${OFFICIAL_WORKSPACE_TEMPLATE_ALIAS}\`)`,
 		);
 	}
 	return lines.join("\n");
@@ -56,8 +60,9 @@ export function formatTemplateFeatures(template: TemplateDefinition): string {
  */
 export function formatTemplateDetails(template: TemplateDefinition): string {
 	const detailLines = [
-		template.id,
+		getUserFacingTemplateId(template.id),
 		`Summary: ${template.description}`,
+		`Best for: ${getTemplateBestForHint(template)}`,
 		...getTemplateIdentityLines(template),
 		`Category: ${template.defaultCategory}`,
 	];
@@ -82,6 +87,26 @@ export function formatTemplateDetails(template: TemplateDefinition): string {
 	detailLines.push(`Features: ${template.features.join(", ")}`);
 
 	return detailLines.join("\n");
+}
+
+function getTemplateBestForHint(template: TemplateDefinition): string {
+	if (template.id === "basic") {
+		return "minimal static-first block scaffolds with Typia validation and the lightest default surface";
+	}
+	if (template.id === "interactivity") {
+		return "interactive single-block experiences that keep client-side state and actions inside one scaffold";
+	}
+	if (template.id === "persistence") {
+		return "typed REST-backed blocks that need persistence-aware reads, writes, and schema refresh workflows";
+	}
+	if (template.id === "compound") {
+		return "parent-and-child block families that own nested authoring conventions and optional persistence wiring";
+	}
+	if (template.id === "query-loop") {
+		return "create-time `core/query` variations with connected starter patterns instead of `add block` families";
+	}
+
+	return "official multi-block workspaces that extend through `wp-typia add ...` and workspace doctor flows";
 }
 
 function getTemplateCapabilityHints(template: TemplateDefinition): string[] {
@@ -118,8 +143,8 @@ function getTemplateIdentityLines(template: TemplateDefinition): string[] {
 	if (template.id === OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE) {
 		return [
 			"Identity:",
+			`  - User-facing alias: ${OFFICIAL_WORKSPACE_TEMPLATE_ALIAS} (\`--template ${OFFICIAL_WORKSPACE_TEMPLATE_ALIAS}\`)`,
 			`  - Official package: ${OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE}`,
-			`  - Alias: ${WORKSPACE_TEMPLATE_ALIAS} (\`--template ${WORKSPACE_TEMPLATE_ALIAS}\`)`,
 			"Type: official workspace scaffold",
 		];
 	}

--- a/packages/wp-typia-project-tools/src/runtime/cli-templates.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-templates.ts
@@ -149,6 +149,15 @@ function getTemplateIdentityLines(template: TemplateDefinition): string[] {
 		];
 	}
 
+	if (template.id === "query-loop") {
+		return [
+			"Identity:",
+			"  - Built-in template id: query-loop",
+			"Type: create-time core/query variation scaffold",
+			"Output model: variation-only scaffold; does not generate block.json or Typia manifests",
+		];
+	}
+
 	return [
 		"Identity:",
 		`  - Built-in template id: ${template.id}`,

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-documents.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-documents.ts
@@ -1,8 +1,8 @@
 import { getPrimaryDevelopmentScript } from './local-dev-presets.js';
 import {
-  getCompoundExtensionWorkflowSection,
-  getInitialCommitCommands,
-  getInitialCommitNote,
+	getCompoundExtensionWorkflowSection,
+	getInitialCommitCommands,
+	getInitialCommitNote,
   getOptionalOnboardingNote,
   getOptionalOnboardingSteps,
   getQuickStartWorkflowNote,
@@ -18,6 +18,33 @@ import {
 import { getPackageVersions } from './package-versions.js';
 import type { ScaffoldTemplateVariables } from './scaffold.js';
 import { getScaffoldTemplateVariableGroups } from './scaffold-template-variable-groups.js';
+import {
+	OFFICIAL_WORKSPACE_TEMPLATE_ALIAS,
+	OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE,
+	isBuiltInTemplateId,
+} from './template-registry.js';
+
+function formatReadmeTemplateIdentity(templateId: string): string {
+	if (templateId === OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE) {
+		return [
+			`- Alias: ${OFFICIAL_WORKSPACE_TEMPLATE_ALIAS}`,
+			`- Package: ${OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE}`,
+			'- Type: official workspace scaffold',
+		].join('\n');
+	}
+
+	if (templateId === 'query-loop') {
+		return ['- Family: query-loop', '- Type: create-time core/query variation scaffold'].join(
+			'\n',
+		);
+	}
+
+	if (isBuiltInTemplateId(templateId)) {
+		return [`- Family: ${templateId}`, '- Type: built-in block scaffold'].join('\n');
+	}
+
+	return [`- Template id: ${templateId}`, '- Type: custom or external scaffold'].join('\n');
+}
 
 /**
  * Builds the generated README markdown for one scaffolded project.
@@ -112,7 +139,7 @@ ${variables.description}
 
 ## Template
 
-${templateId}
+${formatReadmeTemplateIdentity(templateId)}
 
 ## Quick Start
 

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-documents.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-documents.ts
@@ -22,10 +22,13 @@ import {
 	OFFICIAL_WORKSPACE_TEMPLATE_ALIAS,
 	OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE,
 	isBuiltInTemplateId,
+	normalizeTemplateLookupId,
 } from './template-registry.js';
 
 function formatReadmeTemplateIdentity(templateId: string): string {
-	if (templateId === OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE) {
+	const normalizedTemplateId = normalizeTemplateLookupId(templateId);
+
+	if (normalizedTemplateId === OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE) {
 		return [
 			`- Alias: ${OFFICIAL_WORKSPACE_TEMPLATE_ALIAS}`,
 			`- Package: ${OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE}`,
@@ -33,14 +36,14 @@ function formatReadmeTemplateIdentity(templateId: string): string {
 		].join('\n');
 	}
 
-	if (templateId === 'query-loop') {
+	if (normalizedTemplateId === 'query-loop') {
 		return ['- Family: query-loop', '- Type: create-time core/query variation scaffold'].join(
 			'\n',
 		);
 	}
 
-	if (isBuiltInTemplateId(templateId)) {
-		return [`- Family: ${templateId}`, '- Type: built-in block scaffold'].join('\n');
+	if (isBuiltInTemplateId(normalizedTemplateId)) {
+		return [`- Family: ${normalizedTemplateId}`, '- Type: built-in block scaffold'].join('\n');
 	}
 
 	return [`- Template id: ${templateId}`, '- Type: custom or external scaffold'].join('\n');

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-onboarding.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-onboarding.ts
@@ -194,6 +194,46 @@ export function getOptionalOnboardingNote(
 }
 
 /**
+ * Returns a shorter optional onboarding note suitable for create completion output.
+ */
+export function getOptionalOnboardingShortNote(
+	packageManager: PackageManagerId,
+	templateId = "basic",
+	options: SyncOnboardingOptions = {},
+): string {
+	const doctorCommand = getDoctorVerificationCommand(packageManager);
+
+	if (templateId === "query-loop") {
+		return `No sync step is generated for this Query Loop scaffold. Edit the variation files directly, then rerun ${formatRunScript(packageManager, "build")}, ${formatRunScript(packageManager, "typecheck")}, or ${doctorCommand} when you want a review pass.`;
+	}
+
+	const optionalSyncScripts = getOptionalSyncScriptNames(templateId, options);
+	const developmentScript = getPrimaryDevelopmentScript(templateId);
+	const devCommand = formatRunScript(packageManager, developmentScript);
+	const isCustomTemplate =
+		!isBuiltInTemplateId(templateId) &&
+		templateId !== OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE;
+
+	if (isCustomTemplate && optionalSyncScripts.length === 0) {
+		return `Follow the template's own artifact-refresh guidance, then use ${doctorCommand} for a quick environment and workspace sanity check.`;
+	}
+
+	if (isCustomTemplate && optionalSyncScripts.length > 0) {
+		const syncSteps = optionalSyncScripts.map((scriptName) =>
+			formatRunScript(packageManager, scriptName),
+		);
+		return `Run ${syncSteps.join(" then ")} before build, typecheck, or ${doctorCommand} when you want a reviewable refresh.`;
+	}
+
+	const syncCommand = formatRunScript(
+		packageManager,
+		optionalSyncScripts.includes("sync") ? "sync" : "sync-types",
+	);
+
+	return `Skip ${syncCommand} during normal ${devCommand} work. Re-run it before build, typecheck, or ${doctorCommand} when you want a reviewable refresh.`;
+}
+
+/**
  * Returns the recommended version-control commands for a fresh scaffold.
  */
 export function getInitialCommitCommands(): string[] {

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-onboarding.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-onboarding.ts
@@ -8,6 +8,7 @@ import { getPrimaryDevelopmentScript } from "./local-dev-presets.js";
 import {
 	OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE,
 	isBuiltInTemplateId,
+	normalizeTemplateLookupId,
 } from "./template-registry.js";
 
 interface SyncOnboardingOptions {
@@ -201,18 +202,19 @@ export function getOptionalOnboardingShortNote(
 	templateId = "basic",
 	options: SyncOnboardingOptions = {},
 ): string {
+	const normalizedTemplateId = normalizeTemplateLookupId(templateId);
 	const doctorCommand = getDoctorVerificationCommand(packageManager);
 
-	if (templateId === "query-loop") {
+	if (normalizedTemplateId === "query-loop") {
 		return `No sync step is generated for this Query Loop scaffold. Edit the variation files directly, then rerun ${formatRunScript(packageManager, "build")}, ${formatRunScript(packageManager, "typecheck")}, or ${doctorCommand} when you want a review pass.`;
 	}
 
-	const optionalSyncScripts = getOptionalSyncScriptNames(templateId, options);
-	const developmentScript = getPrimaryDevelopmentScript(templateId);
+	const optionalSyncScripts = getOptionalSyncScriptNames(normalizedTemplateId, options);
+	const developmentScript = getPrimaryDevelopmentScript(normalizedTemplateId);
 	const devCommand = formatRunScript(packageManager, developmentScript);
 	const isCustomTemplate =
-		!isBuiltInTemplateId(templateId) &&
-		templateId !== OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE;
+		!isBuiltInTemplateId(normalizedTemplateId) &&
+		normalizedTemplateId !== OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE;
 
 	if (isCustomTemplate && optionalSyncScripts.length === 0) {
 		return `Follow the template's own artifact-refresh guidance, then use ${doctorCommand} for a quick environment and workspace sanity check.`;

--- a/packages/wp-typia-project-tools/src/runtime/scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold.ts
@@ -31,9 +31,8 @@ import {
 } from "./scaffold-package-manager-files.js";
 import { copyInterpolatedDirectory } from "./template-render.js";
 import {
-	OFFICIAL_WORKSPACE_TEMPLATE_ALIAS,
-	OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE,
 	isBuiltInTemplateId,
+	normalizeTemplateLookupId,
 } from "./template-registry.js";
 import { resolveTemplateSource } from "./template-source.js";
 import {
@@ -277,9 +276,7 @@ export function isPersistencePolicy(value: string): value is PersistencePolicy {
 }
 
 function normalizeTemplateSelection(templateId: string): string {
-	return templateId === OFFICIAL_WORKSPACE_TEMPLATE_ALIAS
-		? OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE
-		: templateId;
+	return normalizeTemplateLookupId(templateId);
 }
 
 async function reportScaffoldProgress(

--- a/packages/wp-typia-project-tools/src/runtime/scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold.ts
@@ -31,6 +31,7 @@ import {
 } from "./scaffold-package-manager-files.js";
 import { copyInterpolatedDirectory } from "./template-render.js";
 import {
+	OFFICIAL_WORKSPACE_TEMPLATE_ALIAS,
 	OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE,
 	isBuiltInTemplateId,
 } from "./template-registry.js";
@@ -48,8 +49,6 @@ import type {
 import {
 	assertExternalLayerCompositionOptions,
 } from "./cli-validation.js";
-
-const WORKSPACE_TEMPLATE_ALIAS = "workspace";
 
 /**
  * User-facing scaffold answers before template rendering.
@@ -278,7 +277,7 @@ export function isPersistencePolicy(value: string): value is PersistencePolicy {
 }
 
 function normalizeTemplateSelection(templateId: string): string {
-	return templateId === WORKSPACE_TEMPLATE_ALIAS
+	return templateId === OFFICIAL_WORKSPACE_TEMPLATE_ALIAS
 		? OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE
 		: templateId;
 }

--- a/packages/wp-typia-project-tools/src/runtime/template-registry.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-registry.ts
@@ -92,6 +92,7 @@ export const BUILTIN_TEMPLATE_IDS = [
 	"query-loop",
 ] as const;
 export const OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE = "@wp-typia/create-workspace-template";
+export const OFFICIAL_WORKSPACE_TEMPLATE_ALIAS = "workspace";
 export type BuiltInTemplateId = (typeof BUILTIN_TEMPLATE_IDS)[number];
 export type PersistencePolicy = "authenticated" | "public";
 
@@ -154,16 +155,34 @@ export function isBuiltInTemplateId(templateId: string): templateId is BuiltInTe
 	return (BUILTIN_TEMPLATE_IDS as readonly string[]).includes(templateId);
 }
 
+export function isOfficialWorkspaceTemplateAlias(templateId: string): boolean {
+	return templateId === OFFICIAL_WORKSPACE_TEMPLATE_ALIAS;
+}
+
+export function normalizeTemplateLookupId(templateId: string): string {
+	return isOfficialWorkspaceTemplateAlias(templateId)
+		? OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE
+		: templateId;
+}
+
+export function getUserFacingTemplateId(templateId: string): string {
+	return templateId === OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE
+		? OFFICIAL_WORKSPACE_TEMPLATE_ALIAS
+		: templateId;
+}
+
 export function listTemplates(): readonly TemplateDefinition[] {
 	return TEMPLATE_REGISTRY;
 }
 
 export function getTemplateById(templateId: string): TemplateDefinition {
-	const template = TEMPLATE_REGISTRY.find((entry) => entry.id === templateId);
+	const normalizedTemplateId = normalizeTemplateLookupId(templateId);
+	const template = TEMPLATE_REGISTRY.find((entry) => entry.id === normalizedTemplateId);
 	if (!template) {
 		throw new Error(
 			`Unknown template "${templateId}". Expected one of: ${[
 				...TEMPLATE_IDS,
+				OFFICIAL_WORKSPACE_TEMPLATE_ALIAS,
 				OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE,
 			].join(", ")}`,
 		);
@@ -173,12 +192,12 @@ export function getTemplateById(templateId: string): TemplateDefinition {
 
 export function getTemplateSelectOptions(): Array<{
 	label: string;
-	value: TemplateDefinition["id"];
+	value: string;
 	hint: string;
 }> {
 	return TEMPLATE_REGISTRY.map((template) => ({
-		label: template.id,
-		value: template.id,
+		label: getUserFacingTemplateId(template.id),
+		value: getUserFacingTemplateId(template.id),
 		hint: template.features.join(", "),
 	}));
 }

--- a/packages/wp-typia-project-tools/src/runtime/template-registry.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-registry.ts
@@ -155,16 +155,34 @@ export function isBuiltInTemplateId(templateId: string): templateId is BuiltInTe
 	return (BUILTIN_TEMPLATE_IDS as readonly string[]).includes(templateId);
 }
 
+/**
+ * Returns whether a template id matches the user-facing official workspace alias.
+ *
+ * @param templateId Template id or alias supplied by a caller.
+ * @returns `true` when the id is the `workspace` alias.
+ */
 export function isOfficialWorkspaceTemplateAlias(templateId: string): boolean {
 	return templateId === OFFICIAL_WORKSPACE_TEMPLATE_ALIAS;
 }
 
+/**
+ * Converts user-facing template aliases into the registry lookup id.
+ *
+ * @param templateId Template id or alias supplied by a caller.
+ * @returns The registry id used for template resolution.
+ */
 export function normalizeTemplateLookupId(templateId: string): string {
 	return isOfficialWorkspaceTemplateAlias(templateId)
 		? OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE
 		: templateId;
 }
 
+/**
+ * Converts internal template ids into the id shown in human-facing output.
+ *
+ * @param templateId Template id stored in the registry.
+ * @returns The user-facing template id or alias for display.
+ */
 export function getUserFacingTemplateId(templateId: string): string {
 	return templateId === OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE
 		? OFFICIAL_WORKSPACE_TEMPLATE_ALIAS

--- a/packages/wp-typia-project-tools/tests/cli-entry.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-entry.test.ts
@@ -758,7 +758,8 @@ test("node entry exposes templates and doctor commands", () => {
   expect(templatesOutput).toContain("interactivity");
   expect(templatesOutput).toContain("persistence");
   expect(templatesOutput).toContain("compound");
-  expect(templatesOutput).toContain("@wp-typia/create-workspace-template");
+  expect(templatesOutput).toContain("workspace");
+  expect(templatesOutput).not.toContain("@wp-typia/create-workspace-template");
   expect(templatesOutput).not.toContain("advanced");
   expect(templatesOutput).not.toContain("full");
   expect(doctorOutput).toContain('"label": "Bun"');
@@ -882,7 +883,8 @@ test("bun entry exposes templates and doctor commands", () => {
   expect(templatesOutput).toContain("interactivity");
   expect(templatesOutput).toContain("persistence");
   expect(templatesOutput).toContain("compound");
-  expect(templatesOutput).toContain("@wp-typia/create-workspace-template");
+  expect(templatesOutput).toContain("workspace");
+  expect(templatesOutput).not.toContain("@wp-typia/create-workspace-template");
   expect(templatesOutput).not.toContain("advanced");
   expect(templatesOutput).not.toContain("full");
   expect(doctorOutput).toContain('"label": "Bun"');

--- a/packages/wp-typia-project-tools/tests/cli-templates.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-templates.test.ts
@@ -29,15 +29,20 @@ describe("@wp-typia/project-tools template discovery formatting", () => {
 		const basicDetails = formatTemplateDetails(getTemplateById("basic"));
 		const queryLoopDetails = formatTemplateDetails(getTemplateById("query-loop"));
 		const workspaceDetails = formatTemplateDetails(
-			getTemplateById("@wp-typia/create-workspace-template"),
+			getTemplateById("workspace"),
 		);
 
+		expect(basicDetails).toStartWith("basic\n");
+		expect(basicDetails).toContain("Best for:");
 		expect(basicDetails).toContain("Identity:");
 		expect(basicDetails).toContain("Built-in template id: basic");
 		expect(basicDetails).toContain("Logical layers:");
 		expect(basicDetails).toContain("shared/base -> basic overlay");
 		expect(basicDetails).not.toContain("Overlay path:");
 		expect(basicDetails).not.toContain("/templates/basic");
+		expect(queryLoopDetails).toContain(
+			"Best for: create-time `core/query` variations with connected starter patterns instead of `add block` families",
+		);
 		expect(queryLoopDetails).toContain("Notes:");
 		expect(queryLoopDetails).toContain(
 			"Create-time variation scaffold only; use `wp-typia create <project-dir> --template query-loop` instead of `wp-typia add block`.",
@@ -46,8 +51,9 @@ describe("@wp-typia/project-tools template discovery formatting", () => {
 			"Owns a `core/query` variation, so it does not generate `src/types.ts`, `block.json`, or Typia manifests.",
 		);
 
+		expect(workspaceDetails).toStartWith("workspace\n");
+		expect(workspaceDetails).toContain("User-facing alias: workspace (`--template workspace`)");
 		expect(workspaceDetails).toContain("Official package: @wp-typia/create-workspace-template");
-		expect(workspaceDetails).toContain("Alias: workspace (`--template workspace`)");
 		expect(workspaceDetails).toContain("workspace package scaffold");
 		expect(workspaceDetails).not.toContain("Overlay path:");
 	});

--- a/packages/wp-typia-project-tools/tests/cli-templates.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-templates.test.ts
@@ -43,6 +43,10 @@ describe("@wp-typia/project-tools template discovery formatting", () => {
 		expect(queryLoopDetails).toContain(
 			"Best for: create-time `core/query` variations with connected starter patterns instead of `add block` families",
 		);
+		expect(queryLoopDetails).toContain("Type: create-time core/query variation scaffold");
+		expect(queryLoopDetails).toContain(
+			"Output model: variation-only scaffold; does not generate block.json or Typia manifests",
+		);
 		expect(queryLoopDetails).toContain("Notes:");
 		expect(queryLoopDetails).toContain(
 			"Create-time variation scaffold only; use `wp-typia create <project-dir> --template query-loop` instead of `wp-typia add block`.",

--- a/packages/wp-typia-project-tools/tests/scaffold-basic.test.ts
+++ b/packages/wp-typia-project-tools/tests/scaffold-basic.test.ts
@@ -295,6 +295,8 @@ describe('@wp-typia/project-tools scaffold core', () => {
       expect(readme).toContain('npm run dev');
       expect(readme).toContain('npm run start');
       expect(readme).toContain('## Quick Start');
+      expect(readme).toContain('- Family: basic');
+      expect(readme).toContain('- Type: built-in block scaffold');
       expect(readme).toContain('## Build and Verify');
       expect(readme).toContain(
         `npx --yes wp-typia@${wpTypiaPackageManifest.version} doctor`,

--- a/packages/wp-typia-project-tools/tests/scaffold-query-loop.test.ts
+++ b/packages/wp-typia-project-tools/tests/scaffold-query-loop.test.ts
@@ -131,6 +131,8 @@ describe("@wp-typia/project-tools scaffold query-loop", () => {
 			expect(listPatternSource).toContain('"namespace":"demo-space/demo-query-loop"');
 			expect(listPatternSource).toContain('"wpTypiaVariation":"demo-space/demo-query-loop"');
 			expect(readme).toContain("## Build and Verify");
+			expect(readme).toContain("- Family: query-loop");
+			expect(readme).toContain("- Type: create-time core/query variation scaffold");
 			expect(readme).toContain(
 				`npx --yes wp-typia@${wpTypiaPackageManifest.version} doctor`,
 			);

--- a/packages/wp-typia-project-tools/tests/template-source.test.ts
+++ b/packages/wp-typia-project-tools/tests/template-source.test.ts
@@ -522,7 +522,7 @@ test("workspace template package identity is defined once and imported by runtim
   );
   expect(templateSource).toContain("OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE");
   expect(cliScaffold).toContain("OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE");
-  expect(scaffoldRuntime).toContain("OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE");
+  expect(scaffoldRuntime).toContain("normalizeTemplateLookupId");
   expect(templateSource).not.toContain(
     'const OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE = "@wp-typia/create-workspace-template";'
   );

--- a/packages/wp-typia/src/commands/templates.ts
+++ b/packages/wp-typia/src/commands/templates.ts
@@ -33,8 +33,11 @@ export const templatesCommand = defineCommand({
 					return;
 				}
 				if (effectiveSubcommand === "inspect" && id) {
-					const template = templates.find((entry) => entry.id === id);
-					if (!template) {
+					try {
+						const { getTemplateById } = await import("@wp-typia/project-tools/cli-templates");
+						args.output({ template: getTemplateById(id) });
+						return;
+					} catch {
 						emitCliDiagnosticFailure(args, {
 							code: CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
 							command: "templates",
@@ -42,8 +45,6 @@ export const templatesCommand = defineCommand({
 						});
 						return;
 					}
-					args.output({ template });
-					return;
 				}
 			}
 

--- a/packages/wp-typia/src/commands/templates.ts
+++ b/packages/wp-typia/src/commands/templates.ts
@@ -33,11 +33,16 @@ export const templatesCommand = defineCommand({
 					return;
 				}
 				if (effectiveSubcommand === "inspect" && id) {
+					const { getTemplateById } = await import("@wp-typia/project-tools/cli-templates");
+					let template;
 					try {
-						const { getTemplateById } = await import("@wp-typia/project-tools/cli-templates");
-						args.output({ template: getTemplateById(id) });
-						return;
-					} catch {
+						template = getTemplateById(id);
+					} catch (lookupError) {
+						const message =
+							lookupError instanceof Error ? lookupError.message : String(lookupError);
+						if (!message.startsWith("Unknown template")) {
+							throw lookupError;
+						}
 						emitCliDiagnosticFailure(args, {
 							code: CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
 							command: "templates",
@@ -45,6 +50,8 @@ export const templatesCommand = defineCommand({
 						});
 						return;
 					}
+					args.output({ template });
+					return;
 				}
 			}
 

--- a/packages/wp-typia/src/runtime-bridge-output.ts
+++ b/packages/wp-typia/src/runtime-bridge-output.ts
@@ -113,6 +113,7 @@ export function buildCreateCompletionPayload(
     nextSteps: string[];
     optionalOnboarding: {
       note: string;
+      shortNote?: string;
       steps: string[];
     };
     packageManager: string;
@@ -139,7 +140,7 @@ export function buildCreateCompletionPayload(
   return {
     nextSteps: flow.nextSteps,
     optionalLines: verificationSteps,
-    optionalNote: flow.optionalOnboarding.note,
+    optionalNote: flow.optionalOnboarding.shortNote ?? flow.optionalOnboarding.note,
     optionalTitle: 'Verify and sync (optional):',
     preambleLines: flow.result.selectedVariant
       ? [`Template variant: ${flow.result.selectedVariant}`]

--- a/packages/wp-typia/src/runtime-bridge.ts
+++ b/packages/wp-typia/src/runtime-bridge.ts
@@ -824,14 +824,7 @@ export async function executeTemplatesCommand(
     if (!template) {
       throw new Error(`Unknown template "${flags.id}".`);
     }
-    printBlock(
-      [
-        formatTemplateSummary(template),
-        formatTemplateFeatures(template),
-        formatTemplateDetails(template),
-      ],
-      printLine,
-    );
+    printBlock([formatTemplateDetails(template)], printLine);
     return;
   }
 

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -1474,9 +1474,14 @@ describe('wp-typia package', () => {
       entryPath,
       'templates',
       'inspect',
-      '@wp-typia/create-workspace-template',
+      'workspace',
     ]);
 
+    expect(basicOutput).toStartWith('basic\n');
+    expect(basicOutput).not.toContain(
+      'basic          A lightweight WordPress block with Typia validation',
+    );
+    expect(basicOutput).toContain('Best for:');
     expect(basicOutput).toContain('Identity:');
     expect(basicOutput).toContain('Built-in template id: basic');
     expect(basicOutput).toContain('Logical layers:');
@@ -1488,7 +1493,7 @@ describe('wp-typia package', () => {
       'Official package: @wp-typia/create-workspace-template',
     );
     expect(workspaceOutput).toContain(
-      'Alias: workspace (`--template workspace`)',
+      'User-facing alias: workspace (`--template workspace`)',
     );
     expect(workspaceOutput).not.toContain('Overlay path:');
   });
@@ -1534,7 +1539,7 @@ describe('wp-typia package', () => {
       entryPath,
       'templates',
       'inspect',
-      '@wp-typia/create-workspace-template',
+      'workspace',
       '--format',
       'json',
     ]);

--- a/packages/wp-typia/tests/completion-output.test.ts
+++ b/packages/wp-typia/tests/completion-output.test.ts
@@ -27,6 +27,8 @@ describe("alternate-buffer completion output helpers", () => {
 				nextSteps: ["cd demo-block", "npm install", "npm run dev"],
 				optionalOnboarding: {
 					note: "Run npm run sync before your first commit if you edited types.",
+					shortNote:
+						"Skip npm run sync during normal npm run dev work. Re-run it before build, typecheck, or doctor when you want a reviewable refresh.",
 					steps: ["npm run sync"],
 				},
 				packageManager: "npm",
@@ -51,7 +53,7 @@ describe("alternate-buffer completion output helpers", () => {
 			`npx --yes wp-typia@${packageJson.version} doctor`,
 			"npm run sync",
 		]);
-		expect(payload.optionalNote).toContain("npm run sync");
+		expect(payload.optionalNote).toContain("Skip npm run sync during normal npm run dev work.");
 	});
 
 	test("completion printer keeps warning and next-step ordering stable", () => {
@@ -65,7 +67,8 @@ describe("alternate-buffer completion output helpers", () => {
 					`npx --yes wp-typia@${packageJson.version} doctor`,
 					"npm run sync",
 				],
-				optionalNote: "Review the generated metadata before first commit.",
+				optionalNote:
+					"Skip npm run sync during normal npm run dev work. Re-run it before build, typecheck, or doctor when you want a reviewable refresh.",
 				optionalTitle: "Verify and sync (optional):",
 				preambleLines: ["Template variant: hero"],
 				summaryLines: ["Project directory: /tmp/demo-block"],
@@ -90,7 +93,7 @@ describe("alternate-buffer completion output helpers", () => {
 			"\nVerify and sync (optional):",
 			`  npx --yes wp-typia@${packageJson.version} doctor`,
 			"  npm run sync",
-			"Note: Review the generated metadata before first commit.",
+			"Note: Skip npm run sync during normal npm run dev work. Re-run it before build, typecheck, or doctor when you want a reviewable refresh.",
 		]);
 	});
 
@@ -326,6 +329,8 @@ describe("alternate-buffer completion output helpers", () => {
 				nextSteps: ["cd demo-block"],
 				optionalOnboarding: {
 					note: "Run npm run sync before your first commit if you edited types.",
+					shortNote:
+						"Skip npm run sync during normal npm run dev work. Re-run it before build, typecheck, or doctor when you want a reviewable refresh.",
 					steps: ["npm run sync"],
 				},
 				packageManager: "npm",

--- a/tests/unit/scaffold-onboarding.test.ts
+++ b/tests/unit/scaffold-onboarding.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { getPhpRestExtensionPointsSection } from "../../packages/wp-typia-project-tools/src/runtime/scaffold-onboarding";
+import {
+	getOptionalOnboardingShortNote,
+	getPhpRestExtensionPointsSection,
+} from "../../packages/wp-typia-project-tools/src/runtime/scaffold-onboarding";
 
 describe("scaffold-onboarding", () => {
 	test("persistence and compound persistence sections share the common rest guidance", () => {
@@ -35,5 +38,14 @@ describe("scaffold-onboarding", () => {
 				slug: "demo-block",
 			}),
 		).toBeNull();
+	});
+
+	test("workspace alias reuses official workspace short onboarding guidance", () => {
+		expect(getOptionalOnboardingShortNote("npm", "workspace")).toContain(
+			"Skip npm run sync during normal npm run dev work.",
+		);
+		expect(getOptionalOnboardingShortNote("npm", "workspace")).not.toContain(
+			"Follow the template's own artifact-refresh guidance",
+		);
 	});
 });

--- a/tests/unit/template-registry.test.ts
+++ b/tests/unit/template-registry.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 
 import {
 	BUILTIN_TEMPLATE_IDS,
+	OFFICIAL_WORKSPACE_TEMPLATE_ALIAS,
 	OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE,
 	TEMPLATE_IDS,
 	getTemplateById,
@@ -64,6 +65,11 @@ describe("template registry runtime helpers", () => {
 				id: "persistence",
 			}),
 		);
+		expect(getTemplateById(OFFICIAL_WORKSPACE_TEMPLATE_ALIAS)).toEqual(
+			expect.objectContaining({
+				id: OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE,
+			}),
+		);
 		expect(getTemplateSelectOptions()).toEqual([
 			{
 				hint: "Type-safe attributes, Runtime validation, Minimal setup",
@@ -92,8 +98,8 @@ describe("template registry runtime helpers", () => {
 			},
 			{
 				hint: "Workspace inventory, Add block workflows, Workspace doctor and migrate",
-				label: OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE,
-				value: OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE,
+				label: OFFICIAL_WORKSPACE_TEMPLATE_ALIAS,
+				value: OFFICIAL_WORKSPACE_TEMPLATE_ALIAS,
 			},
 		]);
 	});
@@ -133,8 +139,8 @@ describe("template registry runtime helpers", () => {
 	});
 
 	test("throws a helpful error for unknown template ids", () => {
-		expect(() => getTemplateById("workspace")).toThrow(
-			`Unknown template "workspace". Expected one of: basic, interactivity, persistence, compound, query-loop, ${OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE}`,
+		expect(() => getTemplateById("unknown-template")).toThrow(
+			`Unknown template "unknown-template". Expected one of: basic, interactivity, persistence, compound, query-loop, ${OFFICIAL_WORKSPACE_TEMPLATE_ALIAS}, ${OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE}`,
 		);
 	});
 });


### PR DESCRIPTION
## Summary
- make template discovery and inspect output use the human-facing workspace alias with clearer capability hints
- keep create completion guidance concise while preserving deeper onboarding notes in generated docs
- clarify generated README template identity for built-in, query-loop, and workspace scaffolds

## Testing
- bun run typecheck
- cd packages/wp-typia-project-tools && bun run build && bun test tests/cli-templates.test.ts tests/cli-entry.test.ts tests/template-source.test.ts tests/scaffold-basic.test.ts tests/scaffold-query-loop.test.ts
- cd packages/wp-typia && bun run build && bun test tests/completion-output.test.ts tests/cli-package.test.ts

Closes #549

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Template selection now supports user-friendly aliases (e.g., "workspace" instead of package names)
  * Template inspection output displays "Best for:" hints describing template use cases
  * Generated scaffold READMEs include template family and type metadata
  * Onboarding guidance provides more concise, contextual instructions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->