### PR TITLE
Tighten runtime packaging and version cache behavior

### DIFF
--- a/packages/wp-typia-project-tools/src/runtime/package-versions.ts
+++ b/packages/wp-typia-project-tools/src/runtime/package-versions.ts
@@ -22,6 +22,7 @@ interface PackageVersions {
 interface PackageManifestLocation {
 	cacheKey: string;
 	packageJsonPath: string | null;
+	source: string | null;
 }
 
 const require = createRequire(import.meta.url);
@@ -64,18 +65,31 @@ function normalizeExactVersion(value: string | undefined): string {
 	return trimmed.replace(/^[~^<>=]+/, "");
 }
 
+function createContentFingerprint(source: string): string {
+	let hash = 2166136261;
+	for (let index = 0; index < source.length; index += 1) {
+		hash ^= source.charCodeAt(index);
+		hash = Math.imul(hash, 16777619);
+	}
+
+	return (hash >>> 0).toString(16);
+}
+
 function resolvePackageManifestLocation(packageJsonPath: string): PackageManifestLocation {
 	try {
 		const stats = fs.statSync(packageJsonPath);
+		const source = fs.readFileSync(packageJsonPath, "utf8");
 		return {
-			cacheKey: `file:${packageJsonPath}:${stats.mtimeMs}:${stats.size}`,
+			cacheKey: `file:${packageJsonPath}:${stats.ino}:${stats.mtimeMs}:${stats.ctimeMs}:${stats.size}:${createContentFingerprint(source)}`,
 			packageJsonPath,
+			source,
 		};
 	} catch (error) {
 		if (getErrorCode(error) === "ENOENT") {
 			return {
 				cacheKey: `missing-file:${packageJsonPath}`,
 				packageJsonPath: null,
+				source: null,
 			};
 		}
 		throw error;
@@ -83,13 +97,11 @@ function resolvePackageManifestLocation(packageJsonPath: string): PackageManifes
 }
 
 function readPackageManifest(location: PackageManifestLocation): PackageManifest | null {
-	if (!location.packageJsonPath) {
+	if (!location.packageJsonPath || location.source === null) {
 		return null;
 	}
 
-	return JSON.parse(
-		fs.readFileSync(location.packageJsonPath, "utf8"),
-	) as PackageManifest;
+	return JSON.parse(location.source) as PackageManifest;
 }
 
 function resolveInstalledPackageManifestLocation(packageName: string): PackageManifestLocation {
@@ -100,6 +112,7 @@ function resolveInstalledPackageManifestLocation(packageName: string): PackageMa
 			return {
 				cacheKey: `missing-module:${packageName}`,
 				packageJsonPath: null,
+				source: null,
 			};
 		}
 		throw error;
@@ -112,6 +125,13 @@ function composePackageVersionsCacheKey(
 	return locations.map((location) => location.cacheKey).join("|");
 }
 
+/**
+ * Clears the in-memory cache used by `getPackageVersions()`.
+ *
+ * Long-lived processes can call this after regenerating or updating package
+ * manifests when they want the next lookup to recompute version metadata
+ * synchronously from disk.
+ */
 export function invalidatePackageVersionsCache(): void {
 	cachedPackageVersions = null;
 }

--- a/packages/wp-typia-project-tools/src/runtime/package-versions.ts
+++ b/packages/wp-typia-project-tools/src/runtime/package-versions.ts
@@ -19,11 +19,21 @@ interface PackageVersions {
 	wpTypiaPackageVersion: string;
 }
 
+interface PackageManifestLocation {
+	cacheKey: string;
+	packageJsonPath: string | null;
+}
+
 const require = createRequire(import.meta.url);
 const DEFAULT_VERSION_RANGE = "^0.0.0";
 const DEFAULT_EXACT_VERSION = "0.0.0";
 
-let cachedPackageVersions: PackageVersions | null = null;
+let cachedPackageVersions:
+	| {
+			cacheKey: string;
+			versions: PackageVersions;
+	  }
+	| null = null;
 
 function getErrorCode(error: unknown): string | undefined {
 	return typeof error === "object" && error !== null && "code" in error
@@ -54,55 +64,115 @@ function normalizeExactVersion(value: string | undefined): string {
 	return trimmed.replace(/^[~^<>=]+/, "");
 }
 
-function readPackageManifest(packageJsonPath: string): PackageManifest | null {
+function resolvePackageManifestLocation(packageJsonPath: string): PackageManifestLocation {
 	try {
-		return JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as PackageManifest;
+		const stats = fs.statSync(packageJsonPath);
+		return {
+			cacheKey: `file:${packageJsonPath}:${stats.mtimeMs}:${stats.size}`,
+			packageJsonPath,
+		};
 	} catch (error) {
 		if (getErrorCode(error) === "ENOENT") {
-			return null;
+			return {
+				cacheKey: `missing-file:${packageJsonPath}`,
+				packageJsonPath: null,
+			};
 		}
 		throw error;
 	}
 }
 
-function resolveInstalledPackageManifest(packageName: string): PackageManifest | null {
+function readPackageManifest(location: PackageManifestLocation): PackageManifest | null {
+	if (!location.packageJsonPath) {
+		return null;
+	}
+
+	return JSON.parse(
+		fs.readFileSync(location.packageJsonPath, "utf8"),
+	) as PackageManifest;
+}
+
+function resolveInstalledPackageManifestLocation(packageName: string): PackageManifestLocation {
 	try {
-		return readPackageManifest(require.resolve(`${packageName}/package.json`));
+		return resolvePackageManifestLocation(require.resolve(`${packageName}/package.json`));
 	} catch (error) {
 		if (getErrorCode(error) === "MODULE_NOT_FOUND") {
-			return null;
+			return {
+				cacheKey: `missing-module:${packageName}`,
+				packageJsonPath: null,
+			};
 		}
 		throw error;
 	}
+}
+
+function composePackageVersionsCacheKey(
+	locations: readonly PackageManifestLocation[],
+): string {
+	return locations.map((location) => location.cacheKey).join("|");
+}
+
+export function invalidatePackageVersionsCache(): void {
+	cachedPackageVersions = null;
 }
 
 export function getPackageVersions(): PackageVersions {
-	if (cachedPackageVersions) {
-		return cachedPackageVersions;
+	const createManifestLocation = resolvePackageManifestLocation(
+		path.join(PROJECT_TOOLS_PACKAGE_ROOT, "package.json"),
+	);
+	const blockRuntimeManifestLocation = resolvePackageManifestLocation(
+		path.join(PROJECT_TOOLS_PACKAGE_ROOT, "..", "wp-typia-block-runtime", "package.json"),
+	);
+	const wpTypiaManifestLocation = resolvePackageManifestLocation(
+		path.join(PROJECT_TOOLS_PACKAGE_ROOT, "..", "wp-typia", "package.json"),
+	);
+	const installedProjectToolsManifestLocation =
+		resolveInstalledPackageManifestLocation("@wp-typia/project-tools");
+	const installedApiClientManifestLocation =
+		resolveInstalledPackageManifestLocation("@wp-typia/api-client");
+	const installedBlockRuntimeManifestLocation =
+		resolveInstalledPackageManifestLocation("@wp-typia/block-runtime");
+	const installedBlockTypesManifestLocation =
+		resolveInstalledPackageManifestLocation("@wp-typia/block-types");
+	const installedRestManifestLocation =
+		resolveInstalledPackageManifestLocation("@wp-typia/rest");
+	const installedWpTypiaManifestLocation =
+		resolveInstalledPackageManifestLocation("wp-typia");
+	const cacheKey = composePackageVersionsCacheKey([
+		createManifestLocation,
+		blockRuntimeManifestLocation,
+		wpTypiaManifestLocation,
+		installedProjectToolsManifestLocation,
+		installedApiClientManifestLocation,
+		installedBlockRuntimeManifestLocation,
+		installedBlockTypesManifestLocation,
+		installedRestManifestLocation,
+		installedWpTypiaManifestLocation,
+	]);
+
+	if (cachedPackageVersions?.cacheKey === cacheKey) {
+		return cachedPackageVersions.versions;
 	}
 
 	const createManifest =
-		readPackageManifest(path.join(PROJECT_TOOLS_PACKAGE_ROOT, "package.json")) ??
-		resolveInstalledPackageManifest("@wp-typia/project-tools") ??
+		readPackageManifest(createManifestLocation) ??
+		readPackageManifest(installedProjectToolsManifestLocation) ??
 		{};
 	const blockRuntimeManifest =
-		readPackageManifest(
-			path.join(PROJECT_TOOLS_PACKAGE_ROOT, "..", "wp-typia-block-runtime", "package.json"),
-		) ??
-		resolveInstalledPackageManifest("@wp-typia/block-runtime") ??
+		readPackageManifest(blockRuntimeManifestLocation) ??
+		readPackageManifest(installedBlockRuntimeManifestLocation) ??
 		{};
 	const wpTypiaManifest =
-		readPackageManifest(path.join(PROJECT_TOOLS_PACKAGE_ROOT, "..", "wp-typia", "package.json")) ??
-		resolveInstalledPackageManifest("wp-typia") ??
+		readPackageManifest(wpTypiaManifestLocation) ??
+		readPackageManifest(installedWpTypiaManifestLocation) ??
 		{};
 	const blockRuntimeDependencyVersion = normalizeVersionRange(
 		createManifest.dependencies?.["@wp-typia/block-runtime"],
 	);
-
-	cachedPackageVersions = {
+	const versions = {
 		apiClientPackageVersion: normalizeVersionRange(
 			createManifest.dependencies?.["@wp-typia/api-client"] ??
-				resolveInstalledPackageManifest("@wp-typia/api-client")?.version,
+				readPackageManifest(installedApiClientManifestLocation)?.version,
 		),
 		blockRuntimePackageVersion:
 			blockRuntimeDependencyVersion !== DEFAULT_VERSION_RANGE
@@ -110,16 +180,21 @@ export function getPackageVersions(): PackageVersions {
 				: normalizeVersionRange(blockRuntimeManifest.version),
 		blockTypesPackageVersion: normalizeVersionRange(
 			createManifest.dependencies?.["@wp-typia/block-types"] ??
-				resolveInstalledPackageManifest("@wp-typia/block-types")?.version,
+				readPackageManifest(installedBlockTypesManifestLocation)?.version,
 		),
 		projectToolsPackageVersion: normalizeVersionRange(createManifest.version),
 		restPackageVersion: normalizeVersionRange(
 			createManifest.dependencies?.["@wp-typia/rest"] ??
-				resolveInstalledPackageManifest("@wp-typia/rest")?.version,
+				readPackageManifest(installedRestManifestLocation)?.version,
 		),
 		wpTypiaPackageExactVersion: normalizeExactVersion(wpTypiaManifest.version),
 		wpTypiaPackageVersion: normalizeVersionRange(wpTypiaManifest.version),
 	};
 
-	return cachedPackageVersions;
+	cachedPackageVersions = {
+		cacheKey,
+		versions,
+	};
+
+	return versions;
 }

--- a/packages/wp-typia/package.json
+++ b/packages/wp-typia/package.json
@@ -26,8 +26,9 @@
     "standalone:prepare-release-assets": "bun scripts/prepare-standalone-release-assets.ts --input-dir ./.cache/standalone/raw --outdir ./.cache/standalone/release-assets",
     "test": "cd ../wp-typia-project-tools && bun run build && cd ../wp-typia && bun run build && bun test tests/*.test.ts",
     "test:coverage": "cd ../wp-typia-project-tools && bun run build && cd ../wp-typia && bun run build && bun test tests/*.test.ts --coverage --coverage-reporter=lcov --coverage-dir=coverage",
-    "clean": "rm -rf .bunli .cache/standalone dist-bunli dist-standalone",
-    "prepack": "bun run build"
+    "clean": "rm -rf .bunli .cache/standalone .pack-backup dist-bunli dist-standalone",
+    "prepack": "bun run build && node ./scripts/publish-runtime-maps.mjs prepare",
+    "postpack": "node ./scripts/publish-runtime-maps.mjs restore"
   },
   "keywords": [
     "wordpress",

--- a/packages/wp-typia/scripts/publish-runtime-maps.mjs
+++ b/packages/wp-typia/scripts/publish-runtime-maps.mjs
@@ -1,0 +1,112 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_PACKAGE_ROOT = path.resolve(import.meta.dirname, "..");
+
+function getPublishRuntimeMapPaths(packageRoot) {
+	const backupRoot = path.join(packageRoot, ".pack-backup", "runtime-maps");
+
+	return {
+		backupRoot,
+		distRoot: path.join(packageRoot, "dist-bunli"),
+		manifestPath: path.join(backupRoot, "manifest.json"),
+	};
+}
+
+function collectSourceMapRelativePaths(rootDir, currentDir = rootDir) {
+	if (!fs.existsSync(currentDir)) {
+		return [];
+	}
+
+	const relativePaths = [];
+	for (const entry of fs.readdirSync(currentDir, { withFileTypes: true })) {
+		const absolutePath = path.join(currentDir, entry.name);
+		if (entry.isDirectory()) {
+			relativePaths.push(...collectSourceMapRelativePaths(rootDir, absolutePath));
+			continue;
+		}
+		if (!entry.name.endsWith(".map")) {
+			continue;
+		}
+
+		relativePaths.push(path.relative(rootDir, absolutePath));
+	}
+
+	return relativePaths.sort((left, right) => left.localeCompare(right));
+}
+
+export function preparePublishedRuntimeMaps(packageRoot = DEFAULT_PACKAGE_ROOT) {
+	const { backupRoot, distRoot, manifestPath } = getPublishRuntimeMapPaths(packageRoot);
+	const relativePaths = collectSourceMapRelativePaths(distRoot);
+
+	fs.rmSync(backupRoot, { force: true, recursive: true });
+	if (relativePaths.length === 0) {
+		return;
+	}
+
+	for (const relativePath of relativePaths) {
+		const sourcePath = path.join(distRoot, relativePath);
+		const backupPath = path.join(backupRoot, relativePath);
+		fs.mkdirSync(path.dirname(backupPath), { recursive: true });
+		fs.renameSync(sourcePath, backupPath);
+	}
+
+	fs.writeFileSync(
+		manifestPath,
+		`${JSON.stringify({ files: relativePaths }, null, 2)}\n`,
+		"utf8",
+	);
+}
+
+export function restorePublishedRuntimeMaps(packageRoot = DEFAULT_PACKAGE_ROOT) {
+	if (process.env.WP_TYPIA_SKIP_POSTPACK_RESTORE === "1") {
+		return;
+	}
+
+	const { backupRoot, distRoot, manifestPath } = getPublishRuntimeMapPaths(packageRoot);
+	if (!fs.existsSync(manifestPath)) {
+		return;
+	}
+
+	const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+	const relativePaths = Array.isArray(manifest.files)
+		? manifest.files.filter((value) => typeof value === "string")
+		: [];
+
+	for (const relativePath of relativePaths) {
+		const backupPath = path.join(backupRoot, relativePath);
+		if (!fs.existsSync(backupPath)) {
+			continue;
+		}
+
+		const destinationPath = path.join(distRoot, relativePath);
+		fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
+		fs.renameSync(backupPath, destinationPath);
+	}
+
+	fs.rmSync(backupRoot, { force: true, recursive: true });
+}
+
+export function runPublishRuntimeMapsCli({
+	argv = process.argv,
+	packageRoot = DEFAULT_PACKAGE_ROOT,
+} = {}) {
+	const mode = argv[2];
+
+	if (mode === "prepare") {
+		preparePublishedRuntimeMaps(packageRoot);
+		return 0;
+	}
+
+	if (mode === "restore") {
+		restorePublishedRuntimeMaps(packageRoot);
+		return 0;
+	}
+
+	throw new Error(`Unknown publish-runtime-maps mode: ${mode ?? "(missing)"}`);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+	process.exitCode = runPublishRuntimeMapsCli();
+}

--- a/packages/wp-typia/scripts/publish-runtime-maps.mjs
+++ b/packages/wp-typia/scripts/publish-runtime-maps.mjs
@@ -2,7 +2,10 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-const DEFAULT_PACKAGE_ROOT = path.resolve(import.meta.dirname, "..");
+const DEFAULT_PACKAGE_ROOT = path.resolve(
+	path.dirname(fileURLToPath(import.meta.url)),
+	"..",
+);
 
 function getPublishRuntimeMapPaths(packageRoot) {
 	const backupRoot = path.join(packageRoot, ".pack-backup", "runtime-maps");
@@ -38,13 +41,16 @@ function collectSourceMapRelativePaths(rootDir, currentDir = rootDir) {
 
 export function preparePublishedRuntimeMaps(packageRoot = DEFAULT_PACKAGE_ROOT) {
 	const { backupRoot, distRoot, manifestPath } = getPublishRuntimeMapPaths(packageRoot);
-	const relativePaths = collectSourceMapRelativePaths(distRoot);
+	if (!fs.existsSync(distRoot) || !fs.statSync(distRoot).isDirectory()) {
+		throw new Error(`Cannot prepare runtime source maps: missing ${distRoot}`);
+	}
 
-	fs.rmSync(backupRoot, { force: true, recursive: true });
+	const relativePaths = collectSourceMapRelativePaths(distRoot);
 	if (relativePaths.length === 0) {
 		return;
 	}
 
+	fs.rmSync(backupRoot, { force: true, recursive: true });
 	for (const relativePath of relativePaths) {
 		const sourcePath = path.join(distRoot, relativePath);
 		const backupPath = path.join(backupRoot, relativePath);
@@ -76,11 +82,14 @@ export function restorePublishedRuntimeMaps(packageRoot = DEFAULT_PACKAGE_ROOT) 
 
 	for (const relativePath of relativePaths) {
 		const backupPath = path.join(backupRoot, relativePath);
+		const destinationPath = path.join(distRoot, relativePath);
 		if (!fs.existsSync(backupPath)) {
-			continue;
+			if (fs.existsSync(destinationPath)) {
+				continue;
+			}
+			throw new Error(`Missing runtime source map backup: ${relativePath}`);
 		}
 
-		const destinationPath = path.join(distRoot, relativePath);
 		fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
 		fs.renameSync(backupPath, destinationPath);
 	}

--- a/packages/wp-typia/tests/bunli-prep.test.ts
+++ b/packages/wp-typia/tests/bunli-prep.test.ts
@@ -53,7 +53,12 @@ describe('wp-typia Bunli preparation', () => {
     expect(packageManifest.scripts['build:standalone:release']).toBe(
       'bun scripts/build-standalone-runtime.ts --targets darwin-arm64,darwin-x64,linux-arm64,linux-x64,windows-x64 --outdir ./.cache/standalone/raw',
     );
-    expect(packageManifest.scripts.prepack).toBe('bun run build');
+    expect(packageManifest.scripts.prepack).toBe(
+      'bun run build && node ./scripts/publish-runtime-maps.mjs prepare',
+    );
+    expect(packageManifest.scripts.postpack).toBe(
+      'node ./scripts/publish-runtime-maps.mjs restore',
+    );
     expect(packageManifest.scripts.clean).toContain('dist-standalone');
     expect(packageManifest.scripts.clean).toContain('.cache/standalone');
     expect(packageManifest.engines.bun).toBe('>=1.3.11');
@@ -94,6 +99,11 @@ describe('wp-typia Bunli preparation', () => {
     expect(
       fs.existsSync(
         path.join(packageRoot, 'bin', 'routing-metadata.generated.d.ts'),
+      ),
+    ).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(packageRoot, 'scripts', 'publish-runtime-maps.mjs'),
       ),
     ).toBe(true);
   });

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -503,6 +503,9 @@ describe('wp-typia package', () => {
       tarball?.files.some((entry) => entry.path === 'dist-bunli/node-cli.js'),
     ).toBe(true);
     expect(
+      tarball?.files.some((entry) => entry.path.endsWith('.map')),
+    ).toBe(false);
+    expect(
       tarball?.files.some((entry) => entry.path === 'bin/wp-typia.js'),
     ).toBe(true);
     expect(
@@ -529,6 +532,14 @@ describe('wp-typia package', () => {
     expect(tarball?.files.some((entry) => entry.path === 'src/cli.ts')).toBe(
       false,
     );
+    expect(fs.existsSync(path.join(packageRoot, 'dist-bunli', 'cli.js.map'))).toBe(
+      true,
+    );
+    expect(
+      fs.existsSync(
+        path.join(packageRoot, 'dist-bunli', '.bunli', 'commands.gen.js.map'),
+      ),
+    ).toBe(true);
 
     if (tarball?.filename) {
       fs.rmSync(path.join(packageRoot, tarball.filename), { force: true });

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -475,6 +475,10 @@ describe('wp-typia package', () => {
       ['pack', '--json', '--pack-destination', packageRoot],
       {
         cwd: packageRoot,
+        env: {
+          ...process.env,
+          WP_TYPIA_SKIP_POSTPACK_RESTORE: '',
+        },
       },
     );
 

--- a/packages/wp-typia/tests/publish-runtime-maps.test.ts
+++ b/packages/wp-typia/tests/publish-runtime-maps.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+async function loadPublishRuntimeMapsModule(): Promise<{
+	preparePublishedRuntimeMaps(packageRoot?: string): void;
+	restorePublishedRuntimeMaps(packageRoot?: string): void;
+}> {
+	return import(new URL("../scripts/publish-runtime-maps.mjs", import.meta.url).href);
+}
+
+function writeText(filePath: string, content: string) {
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, content, "utf8");
+}
+
+describe("publish runtime maps", () => {
+	test("prepare fails fast when the built runtime directory is missing", async () => {
+		const { preparePublishedRuntimeMaps } = await loadPublishRuntimeMapsModule();
+		const packageRoot = fs.mkdtempSync(
+			path.join(os.tmpdir(), "wp-typia-runtime-maps-missing-"),
+		);
+
+		expect(() => preparePublishedRuntimeMaps(packageRoot)).toThrow(
+			`Cannot prepare runtime source maps: missing ${path.join(packageRoot, "dist-bunli")}`,
+		);
+	});
+
+	test("prepare moves source maps into the backup area and restore moves them back", async () => {
+		const {
+			preparePublishedRuntimeMaps,
+			restorePublishedRuntimeMaps,
+		} = await loadPublishRuntimeMapsModule();
+		const packageRoot = fs.mkdtempSync(
+			path.join(os.tmpdir(), "wp-typia-runtime-maps-roundtrip-"),
+		);
+		const mapPath = path.join(packageRoot, "dist-bunli", "cli.js.map");
+
+		writeText(mapPath, "demo-map");
+		preparePublishedRuntimeMaps(packageRoot);
+
+		expect(fs.existsSync(mapPath)).toBe(false);
+		expect(
+			fs.existsSync(
+				path.join(packageRoot, ".pack-backup", "runtime-maps", "cli.js.map"),
+			),
+		).toBe(true);
+
+		restorePublishedRuntimeMaps(packageRoot);
+
+		expect(fs.existsSync(mapPath)).toBe(true);
+		expect(
+			fs.existsSync(path.join(packageRoot, ".pack-backup", "runtime-maps")),
+		).toBe(false);
+	});
+
+	test("restore fails when a backup entry is missing and the destination was not already restored", async () => {
+		const { restorePublishedRuntimeMaps } = await loadPublishRuntimeMapsModule();
+		const packageRoot = fs.mkdtempSync(
+			path.join(os.tmpdir(), "wp-typia-runtime-maps-missing-backup-"),
+		);
+		const backupRoot = path.join(packageRoot, ".pack-backup", "runtime-maps");
+
+		fs.mkdirSync(backupRoot, { recursive: true });
+		writeText(
+			path.join(backupRoot, "manifest.json"),
+			JSON.stringify({ files: ["cli.js.map"] }, null, 2),
+		);
+		fs.mkdirSync(path.join(packageRoot, "dist-bunli"), { recursive: true });
+
+		expect(() => restorePublishedRuntimeMaps(packageRoot)).toThrow(
+			"Missing runtime source map backup: cli.js.map",
+		);
+	});
+});

--- a/tests/unit/package-versions.test.ts
+++ b/tests/unit/package-versions.test.ts
@@ -21,6 +21,7 @@ async function importPackageVersionsModule(options: {
 	createPackageRoot: string;
 	installedPackageManifests?: Record<string, unknown>;
 }): Promise<{
+	invalidatePackageVersionsCache(): void;
 	getPackageVersions(): {
 		apiClientPackageVersion: string;
 		blockRuntimePackageVersion: string;
@@ -237,5 +238,73 @@ describe("package version helpers", () => {
 			wpTypiaPackageVersion: "^0.0.0",
 		});
 		expect(secondResult).toBe(firstResult);
+	});
+
+	test("recomputes cached versions when the workspace manifest changes", async () => {
+		const createPackageRoot = createTempDir("wp-typia-refreshable-create-root-");
+
+		writeJsonFile(path.join(createPackageRoot, "package.json"), {
+			dependencies: {
+				"@wp-typia/api-client": "~1.2.3",
+				"@wp-typia/block-types": "2.3.4",
+				"@wp-typia/rest": "^3.4.5",
+			},
+			version: "4.5.6",
+		});
+		writeJsonFile(path.join(createPackageRoot, "..", "wp-typia-block-runtime", "package.json"), {
+			version: "7.8.9",
+		});
+
+		const module = await importPackageVersionsModule({
+			createPackageRoot,
+		});
+
+		const firstResult = module.getPackageVersions();
+		writeJsonFile(path.join(createPackageRoot, "package.json"), {
+			dependencies: {
+				"@wp-typia/api-client": "^12.34.56",
+				"@wp-typia/block-types": "2.3.4",
+				"@wp-typia/rest": "^30.40.50",
+			},
+			version: "11.22.33",
+		});
+
+		const secondResult = module.getPackageVersions();
+
+		expect(firstResult).not.toBe(secondResult);
+		expect(secondResult).toEqual({
+			apiClientPackageVersion: "^12.34.56",
+			blockRuntimePackageVersion: "^7.8.9",
+			blockTypesPackageVersion: "^2.3.4",
+			projectToolsPackageVersion: "^11.22.33",
+			restPackageVersion: "^30.40.50",
+			wpTypiaPackageExactVersion: "0.0.0",
+			wpTypiaPackageVersion: "^0.0.0",
+		});
+	});
+
+	test("manual invalidation drops the cached object identity even when manifests stay the same", async () => {
+		const createPackageRoot = createTempDir("wp-typia-manual-cache-reset-");
+
+		writeJsonFile(path.join(createPackageRoot, "package.json"), {
+			dependencies: {
+				"@wp-typia/api-client": "^0.4.0",
+				"@wp-typia/block-runtime": "^0.3.0",
+				"@wp-typia/block-types": "^0.2.0",
+				"@wp-typia/rest": "^0.3.1",
+			},
+			version: "0.11.0",
+		});
+
+		const module = await importPackageVersionsModule({
+			createPackageRoot,
+		});
+
+		const firstResult = module.getPackageVersions();
+		module.invalidatePackageVersionsCache();
+		const secondResult = module.getPackageVersions();
+
+		expect(secondResult).toEqual(firstResult);
+		expect(secondResult).not.toBe(firstResult);
 	});
 });


### PR DESCRIPTION
## Summary
- strip `dist-bunli` source maps from the published `wp-typia` tarball while restoring them locally after pack
- add cache invalidation support to `package-versions` so long-lived processes recompute when package manifests change
- lock the new packaging and cache behavior in unit and package-level tests

## Testing
- bun run typecheck
- bun test tests/unit/package-versions.test.ts
- cd packages/wp-typia && bun test tests/bunli-prep.test.ts tests/cli-package.test.ts

Closes #550

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced package version caching with automatic recomputation when manifest files change.
  * Improved publishing lifecycle to properly manage source map files during package distribution—source maps are now excluded from published packages but remain available in local builds.
  * Added manual cache invalidation capability for package version information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->