### PR TITLE
Add retrofit init planning and external template load guards

### DIFF
--- a/.sampo/changesets/steadfast-firebringer-tuulikki.md
+++ b/.sampo/changesets/steadfast-firebringer-tuulikki.md
@@ -1,0 +1,6 @@
+---
+npm/wp-typia: patch
+npm/@wp-typia/project-tools: patch
+---
+
+Added: retrofit init planning and external template safety guards

--- a/README.md
+++ b/README.md
@@ -169,8 +169,17 @@ wp-typia add hooked-block counter-card --anchor core/post-content --position aft
 
 ## Retrofitting Existing Projects
 
-Today there is still no general-purpose `wp-typia init` command for arbitrary
-existing plugins or block repos.
+`wp-typia init` now exists as a **preview-only** retrofit planner for existing
+plugins or block repos:
+
+```bash
+npx wp-typia init
+```
+
+Today that command does not write files yet. Instead it inspects the current
+directory, reports the detected retrofit layout, and previews the minimum
+dependency/script/file layer needed to adopt the typed `sync` / `doctor`
+workflow incrementally.
 
 The currently supported retrofit path is narrower:
 
@@ -211,6 +220,9 @@ The richer `pluginTemplatesPath` route can seed broader plugin/workspace shapes 
 The remote source is treated as a seed. `wp-typia` still regenerates its own package setup, Typia sync flow, and runtime helpers around it.
 
 External template configs execute trusted JavaScript (`index.js` / `index.cjs` / `index.mjs`) and can run a `transformer(view)` hook before normalization. Only use template sources you trust.
+Remote template metadata, tarball downloads, and executable config loading now
+run behind bounded timeout and size guards so malformed or hostile template
+sources fail more directly instead of blocking the CLI indefinitely.
 
 Remote template examples:
 

--- a/RETROFIT_INIT_DIRECTION.md
+++ b/RETROFIT_INIT_DIRECTION.md
@@ -11,6 +11,8 @@ This note is the stable place to accumulate that direction before a full
 Today the supported entrypoints are intentionally split:
 
 - `wp-typia create` scaffolds a new project or workspace from a known template.
+- `wp-typia init` now previews the minimum retrofit adoption layer for the
+  current project directory, but it still stops short of writing files.
 - `wp-typia add ...` extends an official `wp-typia` workspace after it already
   exists.
 - `wp-typia migrate init` retrofits **migration support only** into projects that
@@ -18,7 +20,8 @@ Today the supported entrypoints are intentionally split:
 
 That means there is still no general-purpose command that takes an arbitrary
 existing WordPress project and adopts the minimum `wp-typia` infrastructure in a
-single supported flow.
+single supported write flow. The current `init` command is the read-only
+planning entrypoint for that future direction.
 
 ## Direction
 
@@ -73,6 +76,8 @@ To keep retrofit predictable, the workflow should prefer:
 ## Relationship To Existing Commands
 
 - `wp-typia create` remains the recommended path for new projects.
+- `wp-typia init` is the current preview-only retrofit planner. A future write
+  mode should grow out of that surface instead of bypassing it.
 - `wp-typia migrate init` remains the migration-only retrofit command for
   supported `wp-typia`-style layouts.
 - a future `wp-typia init` should cover broader typed-artifact adoption, not

--- a/apps/docs/src/content/docs/maintainers/bunli-cli-migration.md
+++ b/apps/docs/src/content/docs/maintainers/bunli-cli-migration.md
@@ -88,6 +88,8 @@ Current stable `error.code` vocabulary:
 - `missing-argument`
 - `missing-build-artifact`
 - `outside-project-root`
+- `template-source-timeout`
+- `template-source-too-large`
 - `unsupported-command`
 
 That same JSON contract should apply both to command-handler failures and to

--- a/apps/docs/src/content/docs/reference/api.md
+++ b/apps/docs/src/content/docs/reference/api.md
@@ -147,6 +147,9 @@ same migration capability flow when they render `wpTypia.projectType:
 "workspace"` in their `package.json.mustache`.
 
 Security note: external template configs are trusted JavaScript and are executed during scaffold normalization. Treat local paths, GitHub locators, and npm package templates with the same trust model as `@wordpress/create-block`.
+Remote metadata fetches, tarball downloads, and executable config loading now
+run behind bounded timeout and size guards so malformed or hostile sources fail
+directly instead of hanging the CLI indefinitely.
 
 That remote-template support is still seed-oriented. Reusable external layer
 packages on top of the built-in shared scaffold graph are now implemented
@@ -169,6 +172,11 @@ wp-typia migrate fixtures --all --force
 wp-typia migrate verify --all
 wp-typia migrate fuzz --all --iterations 25 --seed 1
 ```
+
+For broader existing-project adoption, `wp-typia init [project-dir]` now acts as
+a preview-only retrofit planner. It detects supported single-block and
+multi-block layouts, then prints the minimum dependency, script, generated
+artifact, and follow-up command surface that a future write mode will apply.
 
 For older projects, `wp-typia migrate init --current-migration-version <label>` now
 auto-detects supported retrofit layouts:

--- a/packages/wp-typia-project-tools/package.json
+++ b/packages/wp-typia-project-tools/package.json
@@ -27,6 +27,11 @@
       "import": "./dist/runtime/cli-doctor.js",
       "default": "./dist/runtime/cli-doctor.js"
     },
+    "./cli-init": {
+      "types": "./dist/runtime/cli-init.d.ts",
+      "import": "./dist/runtime/cli-init.js",
+      "default": "./dist/runtime/cli-init.js"
+    },
     "./cli-prompt": {
       "types": "./dist/runtime/cli-prompt.d.ts",
       "import": "./dist/runtime/cli-prompt.js",
@@ -90,7 +95,7 @@
     "prepack": "bun run build && node ./scripts/publish-manifest.mjs prepare",
     "postpack": "node ./scripts/publish-manifest.mjs restore",
     "test": "bun run build && bun test tests/*.test.ts",
-    "test:scaffold-core": "bun run build && bun test tests/block-generator-service.test.ts tests/built-in-block-artifacts.test.ts tests/scaffold-basic.test.ts tests/scaffold-persistence.test.ts tests/template-source.test.ts tests/cli-entry.test.ts tests/cli-prompt.test.ts tests/import-policy.test.ts",
+    "test:scaffold-core": "bun run build && bun test tests/block-generator-service.test.ts tests/built-in-block-artifacts.test.ts tests/scaffold-basic.test.ts tests/scaffold-persistence.test.ts tests/template-source.test.ts tests/init-command.test.ts tests/cli-entry.test.ts tests/cli-prompt.test.ts tests/import-policy.test.ts",
     "test:workspace": "bun run build && bun test tests/workspace-add.test.ts tests/workspace-doctor.test.ts",
     "test:compound": "bun run build && bun test tests/scaffold-compound.test.ts",
     "test:migration-planning": "bun run build && bun test tests/migration-init.test.ts tests/migration-config.test.ts tests/migration-plan-wizard.test.ts",

--- a/packages/wp-typia-project-tools/src/runtime/cli-diagnostics.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-diagnostics.ts
@@ -18,6 +18,8 @@ export const CLI_DIAGNOSTIC_CODES = {
 	MISSING_ARGUMENT: "missing-argument",
 	MISSING_BUILD_ARTIFACT: "missing-build-artifact",
 	OUTSIDE_PROJECT_ROOT: "outside-project-root",
+	TEMPLATE_SOURCE_TIMEOUT: "template-source-timeout",
+	TEMPLATE_SOURCE_TOO_LARGE: "template-source-too-large",
 	UNSUPPORTED_COMMAND: "unsupported-command",
 } as const;
 
@@ -34,6 +36,7 @@ const DEFAULT_CLI_FAILURE_SUMMARIES: Record<string, string> = {
 	add: "Unable to complete the requested add workflow.",
 	create: "Unable to complete the requested create workflow.",
 	doctor: "One or more doctor checks failed.",
+	init: "Unable to preview the requested retrofit init plan.",
 	mcp: "Unable to inspect or sync MCP metadata.",
 	migrate: "Unable to complete the requested migration command.",
 	sync: "Unable to complete the requested sync workflow.",
@@ -235,6 +238,12 @@ function inferCliDiagnosticCode(options: {
 	}
 	if (/dependencies have not been installed yet/u.test(haystack)) {
 		return CLI_DIAGNOSTIC_CODES.DEPENDENCIES_NOT_INSTALLED;
+	}
+	if (/Timed out while .*external template|Timed out while .*npm template|Timed out while .*GitHub template/u.test(haystack)) {
+		return CLI_DIAGNOSTIC_CODES.TEMPLATE_SOURCE_TIMEOUT;
+	}
+	if (/external template size limit/u.test(haystack)) {
+		return CLI_DIAGNOSTIC_CODES.TEMPLATE_SOURCE_TOO_LARGE;
 	}
 	if (options.command === "doctor") {
 		return CLI_DIAGNOSTIC_CODES.DOCTOR_CHECK_FAILED;

--- a/packages/wp-typia-project-tools/src/runtime/cli-help.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-help.ts
@@ -18,6 +18,7 @@ export function formatHelpText(): string {
   wp-typia create <project-dir> [--template persistence] [--external-layer-source <./path|github:owner/repo/path[#ref]|npm-package>] [--external-layer-id <layer-id>] [--alternate-render-targets <email,mjml,plain-text>] [--data-storage <post-meta|custom-table>] [--persistence-policy <authenticated|public>] [--namespace <value>] [--text-domain <value>] [--php-prefix <value>] [--with-migration-ui] [--with-wp-env] [--with-test-preset] [--yes] [--dry-run] [--no-install] [--package-manager <id>]
   wp-typia create <project-dir> [--template compound] [--external-layer-source <./path|github:owner/repo/path[#ref]|npm-package>] [--external-layer-id <layer-id>] [--inner-blocks-preset <freeform|ordered|horizontal|locked-structure>] [--alternate-render-targets <email,mjml,plain-text>] [--data-storage <post-meta|custom-table>] [--persistence-policy <authenticated|public>] [--namespace <value>] [--text-domain <value>] [--php-prefix <value>] [--with-migration-ui] [--with-wp-env] [--with-test-preset] [--yes] [--dry-run] [--no-install] [--package-manager <id>]
   wp-typia <project-dir> [create flags...]
+  wp-typia init [project-dir]
   wp-typia add block <name> --template <basic|interactivity|persistence|compound> [--external-layer-source <./path|github:owner/repo/path[#ref]|npm-package>] [--external-layer-id <layer-id>] [--inner-blocks-preset <freeform|ordered|horizontal|locked-structure>] [--alternate-render-targets <email,mjml,plain-text>] [--data-storage <post-meta|custom-table>] [--persistence-policy <authenticated|public>]
   wp-typia add variation <name> --block <block-slug>
   wp-typia add pattern <name>
@@ -38,6 +39,7 @@ Package managers: ${PACKAGE_MANAGER_IDS.join(", ")}
 Notes:
   \`wp-typia create\` is the canonical scaffold command.
   \`wp-typia <project-dir>\` remains a backward-compatible alias to \`create\` when \`<project-dir>\` is the only positional argument.
+  \`wp-typia init\` is a preview-only retrofit planner for existing projects. It does not write files yet.
   Use \`--template workspace\` as shorthand for \`@wp-typia/create-workspace-template\`, the official empty workspace scaffold behind \`wp-typia add ...\`.
   \`query-loop\` is create-only. Use \`wp-typia create <project-dir> --template query-loop\`; \`wp-typia add block\` accepts only basic, interactivity, persistence, and compound families.
   \`add variation\` uses an existing workspace block from \`scripts/block-config.ts\`.
@@ -47,6 +49,7 @@ Notes:
   \`add editor-plugin\` scaffolds a document-level editor extension under \`src/editor-plugins/\`.
   \`add hooked-block\` patches an existing workspace block's \`block.json\` \`blockHooks\` metadata.
   \`wp-typia doctor\` always checks environment readiness and reports when it only ran environment-level diagnostics; official workspace roots also get inventory and source-tree drift checks.
+  \`wp-typia init\` previews the minimum sync/doctor/migration adoption layer for supported existing layouts before a future write mode exists.
   \`wp-typia migrate doctor --all\` checks migration target alignment, snapshots, fixtures, and generated migration artifacts.
   \`migrate\` is the canonical migration command; \`migrations\` is no longer supported.`;
 }

--- a/packages/wp-typia-project-tools/src/runtime/cli-init.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-init.ts
@@ -1,0 +1,562 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { discoverMigrationInitLayout } from "./migration-project.js";
+import {
+	formatAddDevDependenciesCommand,
+	formatPackageExecCommand,
+	formatRunScript,
+	getPackageManager,
+	transformPackageManagerText,
+	type PackageManagerId,
+} from "./package-managers.js";
+import { getPackageVersions } from "./package-versions.js";
+import {
+	parseWorkspacePackageManagerId,
+	tryResolveWorkspaceProject,
+	type WorkspacePackageJson,
+} from "./workspace-project.js";
+
+type InitPlanAction = "add" | "update";
+type InitPlanStatus = "already-initialized" | "preview";
+type InitPlanLayoutKind =
+	| "generated-project"
+	| "multi-block"
+	| "official-workspace"
+	| "single-block"
+	| "unsupported";
+
+interface InitDependencyChange {
+	action: InitPlanAction;
+	currentValue?: string;
+	name: string;
+	requiredValue: string;
+}
+
+interface InitScriptChange {
+	action: InitPlanAction;
+	currentValue?: string;
+	name: string;
+	requiredValue: string;
+}
+
+interface InitPackageManagerFieldChange {
+	action: InitPlanAction;
+	currentValue?: string;
+	requiredValue: string;
+}
+
+interface InitFilePlan {
+	path: string;
+	purpose: string;
+}
+
+export interface RetrofitInitPlan {
+	commandMode: "preview-only";
+	detectedLayout: {
+		blockNames: string[];
+		description: string;
+		kind: InitPlanLayoutKind;
+	};
+	generatedArtifacts: string[];
+	nextSteps: string[];
+	notes: string[];
+	packageChanges: {
+		addDevDependencies: InitDependencyChange[];
+		packageManagerField?: InitPackageManagerFieldChange;
+		scripts: InitScriptChange[];
+	};
+	plannedFiles: InitFilePlan[];
+	packageManager: PackageManagerId;
+	projectDir: string;
+	projectName: string;
+	status: InitPlanStatus;
+	summary: string;
+}
+
+type ProjectPackageJson = WorkspacePackageJson & {
+	dependencies?: Record<string, string>;
+	devDependencies?: Record<string, string>;
+	private?: boolean;
+	version?: string;
+};
+
+const SUPPORTED_RETROFIT_LAYOUT_NOTE =
+	"Supported retrofit layouts currently mirror the migration bootstrap detector: `src/block.json` + `src/types.ts` + `src/save.tsx`, legacy root `block.json` + `src/types.ts` + `src/save.tsx`, or multi-block `src/blocks/*/block.json` workspaces."
+
+const BASE_RETROFIT_SCRIPTS = {
+	sync: "tsx scripts/sync-project.ts",
+	"sync-types": "tsx scripts/sync-types-to-block-json.ts",
+	typecheck: "bun run sync --check && tsc --noEmit",
+} as const;
+
+const BASE_RETROFIT_DEV_DEPENDENCIES = [
+	"@typia/unplugin",
+	"@wp-typia/block-runtime",
+	"@wp-typia/block-types",
+	"tsx",
+	"typescript",
+	"typia",
+] as const;
+
+function normalizeRelativePath(value: string): string {
+	return value.replace(/\\/gu, "/");
+}
+
+function readProjectPackageJson(projectDir: string): ProjectPackageJson | null {
+	const packageJsonPath = path.join(projectDir, "package.json");
+	if (!fs.existsSync(packageJsonPath)) {
+		return null;
+	}
+
+	return JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as ProjectPackageJson;
+}
+
+function inferInitPackageManager(
+	projectDir: string,
+	packageJson: ProjectPackageJson | null,
+): PackageManagerId {
+	if (packageJson?.packageManager) {
+		return parseWorkspacePackageManagerId(packageJson.packageManager);
+	}
+
+	if (
+		fs.existsSync(path.join(projectDir, "bun.lock")) ||
+		fs.existsSync(path.join(projectDir, "bun.lockb"))
+	) {
+		return "bun";
+	}
+	if (fs.existsSync(path.join(projectDir, "pnpm-lock.yaml"))) {
+		return "pnpm";
+	}
+	if (
+		fs.existsSync(path.join(projectDir, "yarn.lock")) ||
+		fs.existsSync(path.join(projectDir, ".yarnrc.yml"))
+	) {
+		return "yarn";
+	}
+
+	return "npm";
+}
+
+function getWpTypiaCliSpecifier(): string {
+	const versions = getPackageVersions();
+	return versions.wpTypiaPackageExactVersion === "0.0.0"
+		? "wp-typia"
+		: `wp-typia@${versions.wpTypiaPackageExactVersion}`;
+}
+
+function buildRequiredDevDependencyMap(): Record<string, string> {
+	const versions = getPackageVersions();
+	return {
+		"@typia/unplugin": "^12.0.1",
+		"@wp-typia/block-runtime": versions.blockRuntimePackageVersion,
+		"@wp-typia/block-types": versions.blockTypesPackageVersion,
+		tsx: "^4.20.5",
+		typescript: "^5.9.2",
+		typia: "^12.0.1",
+	};
+}
+
+function getExistingDependencyVersion(
+	packageJson: ProjectPackageJson | null,
+	name: string,
+): string | undefined {
+	return packageJson?.devDependencies?.[name] ?? packageJson?.dependencies?.[name];
+}
+
+function buildDependencyChanges(
+	packageJson: ProjectPackageJson | null,
+): InitDependencyChange[] {
+	const requiredDependencies = buildRequiredDevDependencyMap();
+	return BASE_RETROFIT_DEV_DEPENDENCIES.flatMap((name) => {
+		const requiredValue = requiredDependencies[name];
+		const currentValue = getExistingDependencyVersion(packageJson, name);
+
+		if (currentValue === requiredValue) {
+			return [];
+		}
+
+		return [
+			{
+				action: currentValue ? "update" : "add",
+				...(currentValue ? { currentValue } : {}),
+				name,
+				requiredValue,
+			} satisfies InitDependencyChange,
+		];
+	});
+}
+
+function buildScriptChanges(
+	packageJson: ProjectPackageJson | null,
+	packageManager: PackageManagerId,
+): InitScriptChange[] {
+	const scripts = packageJson?.scripts ?? {};
+
+	return Object.entries(BASE_RETROFIT_SCRIPTS).flatMap(
+		([name, commandSource]) => {
+			const requiredValue = transformPackageManagerText(
+				commandSource,
+				packageManager,
+			);
+			const currentValue = scripts[name];
+			if (currentValue === requiredValue) {
+				return [];
+			}
+
+			return [
+				{
+					action: typeof currentValue === "string" ? "update" : "add",
+					...(typeof currentValue === "string" ? { currentValue } : {}),
+					name,
+					requiredValue,
+				} satisfies InitScriptChange,
+			];
+		},
+	);
+}
+
+function buildPackageManagerFieldChange(
+	packageJson: ProjectPackageJson | null,
+	packageManager: PackageManagerId,
+): InitPackageManagerFieldChange | undefined {
+	if (packageManager === "npm") {
+		return undefined;
+	}
+
+	const requiredValue = getPackageManager(packageManager).packageManagerField;
+	const currentValue = packageJson?.packageManager;
+	if (currentValue === requiredValue) {
+		return undefined;
+	}
+
+	return {
+		action: typeof currentValue === "string" ? "update" : "add",
+		...(typeof currentValue === "string" ? { currentValue } : {}),
+		requiredValue,
+	};
+}
+
+function buildGeneratedArtifactPaths(
+	blockJsonFile: string,
+	manifestFile: string,
+): string[] {
+	const manifestDir = path.dirname(manifestFile);
+	const artifactPaths = [
+		blockJsonFile,
+		manifestFile,
+		path.join(manifestDir, "typia.schema.json"),
+		path.join(manifestDir, "typia-validator.php"),
+		path.join(manifestDir, "typia.openapi.json"),
+	];
+
+	return Array.from(
+		new Set(artifactPaths.map((filePath) => normalizeRelativePath(filePath))),
+	);
+}
+
+function buildLayoutDetails(projectDir: string): {
+	blockNames: string[];
+	description: string;
+	generatedArtifacts: string[];
+	kind: InitPlanLayoutKind;
+	notes: string[];
+} {
+	try {
+		const discoveredLayout = discoverMigrationInitLayout(projectDir);
+		if (discoveredLayout.mode === "multi") {
+			return {
+				blockNames: discoveredLayout.blocks.map((block) => block.blockName),
+				description: `Detected a supported multi-block retrofit candidate (${discoveredLayout.blocks.length} targets).`,
+				generatedArtifacts: discoveredLayout.blocks.flatMap((block) =>
+					buildGeneratedArtifactPaths(block.blockJsonFile, block.manifestFile),
+				),
+				kind: "multi-block",
+				notes: [
+					"Migration bootstrap can stay optional. Add it later with `wp-typia migrate init --current-migration-version v1` once the typed sync surface is in place.",
+				],
+			};
+		}
+
+		return {
+			blockNames: [discoveredLayout.block.blockName],
+			description: "Detected a supported single-block retrofit candidate.",
+			generatedArtifacts: buildGeneratedArtifactPaths(
+				discoveredLayout.block.blockJsonFile,
+				discoveredLayout.block.manifestFile,
+			),
+			kind: "single-block",
+			notes:
+				discoveredLayout.block.blockJsonFile === "block.json"
+					? [
+							"Legacy root `block.json` layouts are still supported for retrofit planning, but newer scaffolds keep generated block metadata under `src/`.",
+					  ]
+					: [],
+		};
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		return {
+			blockNames: [],
+			description: "No supported retrofit layout was auto-detected yet.",
+			generatedArtifacts: [],
+			kind: "unsupported",
+			notes: [message, SUPPORTED_RETROFIT_LAYOUT_NOTE],
+		};
+	}
+}
+
+function hasExistingWpTypiaProjectSurface(
+	packageJson: ProjectPackageJson | null,
+): boolean {
+	const scripts = packageJson?.scripts ?? {};
+	const hasSyncSurface =
+		typeof scripts.sync === "string" || typeof scripts["sync-types"] === "string";
+	const hasRuntimeDeps =
+		typeof getExistingDependencyVersion(packageJson, "@wp-typia/block-runtime") ===
+			"string" &&
+		typeof getExistingDependencyVersion(packageJson, "@wp-typia/block-types") ===
+			"string";
+
+	return hasSyncSurface && hasRuntimeDeps;
+}
+
+function buildPlannedFiles(layoutKind: InitPlanLayoutKind): InitFilePlan[] {
+	const plannedFiles: InitFilePlan[] = [
+		{
+			path: "scripts/sync-types-to-block-json.ts",
+			purpose:
+				"Generate block.json and Typia metadata artifacts from the current TypeScript source of truth.",
+		},
+		{
+			path: "scripts/sync-project.ts",
+			purpose:
+				"Provide one shared sync entrypoint that can grow into sync-rest or workspace-aware refresh steps later.",
+		},
+	];
+
+	if (layoutKind === "unsupported") {
+		plannedFiles.unshift({
+			path: "package.json",
+			purpose:
+				"Add the minimum wp-typia devDependencies and scripts once the project matches a supported retrofit layout.",
+		});
+	}
+
+	return plannedFiles;
+}
+
+function buildChangeSummary(
+	changes: Pick<RetrofitInitPlan, "generatedArtifacts" | "packageChanges" | "plannedFiles">,
+): string[] {
+	const lines: string[] = [];
+
+	for (const dependencyChange of changes.packageChanges.addDevDependencies) {
+		lines.push(
+			`devDependency ${dependencyChange.action} ${dependencyChange.name} -> ${dependencyChange.requiredValue}`,
+		);
+	}
+
+	if (changes.packageChanges.packageManagerField) {
+		lines.push(
+			`packageManager ${changes.packageChanges.packageManagerField.action} -> ${changes.packageChanges.packageManagerField.requiredValue}`,
+		);
+	}
+
+	for (const scriptChange of changes.packageChanges.scripts) {
+		lines.push(
+			`script ${scriptChange.action} ${scriptChange.name} -> ${scriptChange.requiredValue}`,
+		);
+	}
+
+	for (const filePlan of changes.plannedFiles) {
+		lines.push(`file add ${filePlan.path} (${filePlan.purpose})`);
+	}
+
+	for (const artifactPath of changes.generatedArtifacts) {
+		lines.push(`generated artifact ${artifactPath}`);
+	}
+
+	return lines;
+}
+
+function buildNextSteps(options: {
+	changeSummaryLines: string[];
+	layoutKind: InitPlanLayoutKind;
+	packageManager: PackageManagerId;
+}): string[] {
+	const cliSpecifier = getWpTypiaCliSpecifier();
+	const syncTypesRun = formatRunScript(options.packageManager, "sync-types");
+	const syncRun = formatRunScript(options.packageManager, "sync");
+	const doctorRun = formatPackageExecCommand(
+		options.packageManager,
+		cliSpecifier,
+		"doctor",
+	);
+	const migrationInitRun = formatPackageExecCommand(
+		options.packageManager,
+		cliSpecifier,
+		"migrate init --current-migration-version v1",
+	);
+	const dependencyInstallCommand = formatAddDevDependenciesCommand(
+		options.packageManager,
+		buildRequiredDevDependencyMapEntries(),
+	);
+
+	if (options.layoutKind === "unsupported") {
+		return [
+			"Align the project to one of the supported retrofit layouts listed below, then rerun `wp-typia init`.",
+			dependencyInstallCommand,
+			syncTypesRun,
+			doctorRun,
+		];
+	}
+
+	const steps = [
+		...(options.changeSummaryLines.length > 0
+			? [
+					"Apply the planned package.json changes and helper files listed below.",
+					dependencyInstallCommand,
+			  ]
+			: []),
+		syncRun,
+		doctorRun,
+		`Optional migration bootstrap: ${migrationInitRun}`,
+	];
+
+	return steps;
+}
+
+function buildRequiredDevDependencyMapEntries(): string[] {
+	return Object.entries(buildRequiredDevDependencyMap()).map(
+		([name, version]) => `${name}@${version.replace(/^workspace:/u, "")}`,
+	);
+}
+
+export function getInitPlan(projectDir: string): RetrofitInitPlan {
+	const resolvedProjectDir = path.resolve(projectDir);
+	const packageJson = readProjectPackageJson(resolvedProjectDir);
+	const packageManager = inferInitPackageManager(resolvedProjectDir, packageJson);
+	const workspace = tryResolveWorkspaceProject(resolvedProjectDir);
+
+	if (workspace) {
+		return {
+			commandMode: "preview-only",
+			detectedLayout: {
+				blockNames: [],
+				description: "Already an official wp-typia workspace.",
+				kind: "official-workspace",
+			},
+			generatedArtifacts: [],
+			nextSteps: [
+				formatPackageExecCommand(packageManager, getWpTypiaCliSpecifier(), "doctor"),
+				"Use `wp-typia add ...` to extend this workspace instead of rerunning init.",
+			],
+			notes: [
+				"The official workspace template already owns inventory, doctor, and add-command workflows.",
+			],
+			packageChanges: {
+				addDevDependencies: [],
+				scripts: [],
+			},
+			plannedFiles: [],
+			packageManager,
+			projectDir: workspace.projectDir,
+			projectName: workspace.packageName,
+			status: "already-initialized",
+			summary:
+				"This directory is already an official wp-typia workspace. No retrofit bootstrap is needed.",
+		};
+	}
+
+	const projectName =
+		typeof packageJson?.name === "string" && packageJson.name.length > 0
+			? packageJson.name
+			: path.basename(resolvedProjectDir);
+	const layout = buildLayoutDetails(resolvedProjectDir);
+	const dependencyChanges = buildDependencyChanges(packageJson);
+	const scriptChanges = buildScriptChanges(packageJson, packageManager);
+	const packageManagerFieldChange = buildPackageManagerFieldChange(
+		packageJson,
+		packageManager,
+	);
+	const rawPlannedFiles =
+		layout.kind === "generated-project" || layout.kind === "official-workspace"
+			? []
+			: buildPlannedFiles(layout.kind);
+	const hasExistingSurface = hasExistingWpTypiaProjectSurface(packageJson);
+	const status: InitPlanStatus =
+		hasExistingSurface &&
+		dependencyChanges.length === 0 &&
+		scriptChanges.length === 0 &&
+		packageManagerFieldChange === undefined
+			? "already-initialized"
+			: "preview";
+	const plannedFiles = status === "already-initialized" ? [] : rawPlannedFiles;
+	const detectedLayout =
+		status === "already-initialized" && hasExistingSurface
+			? {
+					blockNames: layout.blockNames,
+					description:
+						layout.kind === "unsupported"
+							? "Already exposes the minimum wp-typia sync surface."
+							: `Already exposes the minimum wp-typia sync surface for ${layout.kind === "multi-block" ? "a multi-block project" : "a single-block project"}.`,
+					kind: "generated-project" as const,
+			  }
+			: {
+					blockNames: layout.blockNames,
+					description: layout.description,
+					kind: layout.kind,
+			  };
+	const plan: RetrofitInitPlan = {
+		commandMode: "preview-only",
+		detectedLayout,
+		generatedArtifacts:
+			status === "already-initialized" && detectedLayout.kind === "generated-project"
+				? []
+				: layout.generatedArtifacts,
+		nextSteps: buildNextSteps({
+			changeSummaryLines: buildChangeSummary({
+				generatedArtifacts:
+					status === "already-initialized" &&
+					detectedLayout.kind === "generated-project"
+						? []
+						: layout.generatedArtifacts,
+				packageChanges: {
+					addDevDependencies: dependencyChanges,
+					...(packageManagerFieldChange
+						? { packageManagerField: packageManagerFieldChange }
+						: {}),
+					scripts: scriptChanges,
+				},
+				plannedFiles,
+			}),
+			layoutKind: detectedLayout.kind,
+			packageManager,
+		}),
+		notes: Array.from(
+			new Set([
+				"Preview only: `wp-typia init` does not write files yet.",
+				...layout.notes,
+			]),
+		),
+		packageChanges: {
+			addDevDependencies: dependencyChanges,
+			...(packageManagerFieldChange
+				? { packageManagerField: packageManagerFieldChange }
+				: {}),
+			scripts: scriptChanges,
+		},
+		plannedFiles,
+		packageManager,
+		projectDir: resolvedProjectDir,
+		projectName,
+		status,
+		summary:
+			status === "already-initialized"
+				? "This project already exposes the minimum wp-typia retrofit surface."
+				: "This command previews the minimum wp-typia adoption layer for the current project without rewriting it into a full scaffold.",
+	};
+
+	return plan;
+}

--- a/packages/wp-typia-project-tools/src/runtime/external-template-guards.ts
+++ b/packages/wp-typia-project-tools/src/runtime/external-template-guards.ts
@@ -1,0 +1,240 @@
+import fs from "node:fs";
+
+export const TEMPLATE_SOURCE_TIMEOUT_CODE = "template-source-timeout" as const;
+export const TEMPLATE_SOURCE_TOO_LARGE_CODE = "template-source-too-large" as const;
+
+const DEFAULT_EXTERNAL_TEMPLATE_TIMEOUT_MS = 20_000;
+const DEFAULT_EXTERNAL_TEMPLATE_CONFIG_MAX_BYTES = 256 * 1024;
+const DEFAULT_EXTERNAL_TEMPLATE_PACKAGE_JSON_MAX_BYTES = 1 * 1024 * 1024;
+const DEFAULT_EXTERNAL_TEMPLATE_METADATA_MAX_BYTES = 1 * 1024 * 1024;
+const DEFAULT_EXTERNAL_TEMPLATE_TARBALL_MAX_BYTES = 32 * 1024 * 1024;
+
+type TemplateGuardErrorCode =
+	| typeof TEMPLATE_SOURCE_TIMEOUT_CODE
+	| typeof TEMPLATE_SOURCE_TOO_LARGE_CODE;
+
+function parsePositiveIntegerEnv(
+	value: string | undefined,
+	fallback: number,
+): number {
+	if (typeof value !== "string" || value.trim().length === 0) {
+		return fallback;
+	}
+
+	const parsed = Number.parseInt(value, 10);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function createTemplateGuardError<TCode extends TemplateGuardErrorCode>(
+	code: TCode,
+	message: string,
+): Error & { code: TCode } {
+	const error = new Error(message) as Error & { code: TCode };
+	error.code = code;
+	return error;
+}
+
+export function getExternalTemplateTimeoutMs(): number {
+	return parsePositiveIntegerEnv(
+		process.env.WP_TYPIA_EXTERNAL_TEMPLATE_TIMEOUT_MS,
+		DEFAULT_EXTERNAL_TEMPLATE_TIMEOUT_MS,
+	);
+}
+
+export function getExternalTemplateConfigMaxBytes(): number {
+	return parsePositiveIntegerEnv(
+		process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CONFIG_MAX_BYTES,
+		DEFAULT_EXTERNAL_TEMPLATE_CONFIG_MAX_BYTES,
+	);
+}
+
+export function getExternalTemplatePackageJsonMaxBytes(): number {
+	return parsePositiveIntegerEnv(
+		process.env.WP_TYPIA_EXTERNAL_TEMPLATE_PACKAGE_JSON_MAX_BYTES,
+		DEFAULT_EXTERNAL_TEMPLATE_PACKAGE_JSON_MAX_BYTES,
+	);
+}
+
+export function getExternalTemplateMetadataMaxBytes(): number {
+	return parsePositiveIntegerEnv(
+		process.env.WP_TYPIA_EXTERNAL_TEMPLATE_METADATA_MAX_BYTES,
+		DEFAULT_EXTERNAL_TEMPLATE_METADATA_MAX_BYTES,
+	);
+}
+
+export function getExternalTemplateTarballMaxBytes(): number {
+	return parsePositiveIntegerEnv(
+		process.env.WP_TYPIA_EXTERNAL_TEMPLATE_TARBALL_MAX_BYTES,
+		DEFAULT_EXTERNAL_TEMPLATE_TARBALL_MAX_BYTES,
+	);
+}
+
+export function createExternalTemplateTimeoutError(
+	label: string,
+	timeoutMs: number,
+): Error & { code: typeof TEMPLATE_SOURCE_TIMEOUT_CODE } {
+	return createTemplateGuardError(
+		TEMPLATE_SOURCE_TIMEOUT_CODE,
+		`Timed out while ${label} after ${timeoutMs}ms.`,
+	);
+}
+
+export function createExternalTemplateTooLargeError(
+	label: string,
+	maxBytes: number,
+): Error & { code: typeof TEMPLATE_SOURCE_TOO_LARGE_CODE } {
+	return createTemplateGuardError(
+		TEMPLATE_SOURCE_TOO_LARGE_CODE,
+		`${label} exceeded the external template size limit (${maxBytes} bytes).`,
+	);
+}
+
+export function assertExternalTemplateFileSize(
+	filePath: string,
+	options: {
+		label: string;
+		maxBytes: number;
+	},
+): void {
+	const stats = fs.statSync(filePath);
+	if (stats.size > options.maxBytes) {
+		throw createExternalTemplateTooLargeError(options.label, options.maxBytes);
+	}
+}
+
+export async function withExternalTemplateTimeout<T>(
+	label: string,
+	task: Promise<T>,
+	timeoutMs = getExternalTemplateTimeoutMs(),
+): Promise<T> {
+	let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+	const timeoutPromise = new Promise<never>((_, reject) => {
+		timeoutHandle = setTimeout(() => {
+			reject(createExternalTemplateTimeoutError(label, timeoutMs));
+		}, timeoutMs);
+	});
+
+	try {
+		return await Promise.race([task, timeoutPromise]);
+	} finally {
+		if (timeoutHandle) {
+			clearTimeout(timeoutHandle);
+		}
+	}
+}
+
+export async function fetchWithExternalTemplateTimeout(
+	input: string,
+	options: {
+		init?: RequestInit;
+		label: string;
+		timeoutMs?: number;
+	},
+): Promise<Response> {
+	const controller = new AbortController();
+	const timeoutMs = options.timeoutMs ?? getExternalTemplateTimeoutMs();
+	const timeoutHandle = setTimeout(() => controller.abort(), timeoutMs);
+
+	try {
+		return await fetch(input, {
+			...(options.init ?? {}),
+			signal: controller.signal,
+		});
+	} catch (error) {
+		if (
+			error instanceof Error &&
+			(error.name === "AbortError" || error.name === "TimeoutError")
+		) {
+			throw createExternalTemplateTimeoutError(options.label, timeoutMs);
+		}
+		throw error;
+	} finally {
+		clearTimeout(timeoutHandle);
+	}
+}
+
+async function readResponseBodyWithLimit(
+	response: Response,
+	options: {
+		label: string;
+		maxBytes: number;
+	},
+): Promise<Buffer> {
+	const contentLengthHeader = response.headers.get("content-length");
+	if (typeof contentLengthHeader === "string") {
+		const declaredLength = Number.parseInt(contentLengthHeader, 10);
+		if (Number.isFinite(declaredLength) && declaredLength > options.maxBytes) {
+			throw createExternalTemplateTooLargeError(
+				options.label,
+				options.maxBytes,
+			);
+		}
+	}
+
+	if (!response.body) {
+		const buffer = Buffer.from(await response.arrayBuffer());
+		if (buffer.length > options.maxBytes) {
+			throw createExternalTemplateTooLargeError(
+				options.label,
+				options.maxBytes,
+			);
+		}
+		return buffer;
+	}
+
+	const reader = response.body.getReader();
+	const chunks: Buffer[] = [];
+	let totalBytes = 0;
+
+	while (true) {
+		const { done, value } = await reader.read();
+		if (done) {
+			break;
+		}
+		if (!value) {
+			continue;
+		}
+
+		totalBytes += value.byteLength;
+		if (totalBytes > options.maxBytes) {
+			await reader.cancel();
+			throw createExternalTemplateTooLargeError(
+				options.label,
+				options.maxBytes,
+			);
+		}
+
+		chunks.push(Buffer.from(value));
+	}
+
+	return Buffer.concat(chunks);
+}
+
+export async function readJsonResponseWithLimit(
+	response: Response,
+	options: {
+		label: string;
+		maxBytes: number;
+	},
+): Promise<Record<string, unknown>> {
+	const buffer = await readResponseBodyWithLimit(response, options);
+	try {
+		return JSON.parse(buffer.toString("utf8")) as Record<string, unknown>;
+	} catch (error) {
+		throw new Error(
+			`Failed to parse ${options.label}: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+		);
+	}
+}
+
+export async function readBufferResponseWithLimit(
+	response: Response,
+	options: {
+		label: string;
+		maxBytes: number;
+	},
+): Promise<Buffer> {
+	return readResponseBodyWithLimit(response, options);
+}

--- a/packages/wp-typia-project-tools/src/runtime/external-template-guards.ts
+++ b/packages/wp-typia-project-tools/src/runtime/external-template-guards.ts
@@ -104,7 +104,7 @@ export function assertExternalTemplateFileSize(
 
 export async function withExternalTemplateTimeout<T>(
 	label: string,
-	task: Promise<T>,
+	task: Promise<T> | (() => Promise<T>),
 	timeoutMs = getExternalTemplateTimeoutMs(),
 ): Promise<T> {
 	let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
@@ -115,7 +115,8 @@ export async function withExternalTemplateTimeout<T>(
 	});
 
 	try {
-		return await Promise.race([task, timeoutPromise]);
+		const pendingTask = typeof task === "function" ? task() : task;
+		return await Promise.race([pendingTask, timeoutPromise]);
 	} finally {
 		if (timeoutHandle) {
 			clearTimeout(timeoutHandle);

--- a/packages/wp-typia-project-tools/src/runtime/package-managers.ts
+++ b/packages/wp-typia-project-tools/src/runtime/package-managers.ts
@@ -98,6 +98,24 @@ export function formatInstallCommand(packageManagerId: PackageManagerId): string
 }
 
 /**
+ * Format a package-manager-specific devDependency install command.
+ *
+ * @param packageManagerId Package manager identifier.
+ * @param packages Package specifiers to add as devDependencies.
+ * @returns Command string suitable for shell execution.
+ */
+export function formatAddDevDependenciesCommand(
+	packageManagerId: PackageManagerId,
+	packages: string[],
+): string {
+	if (packages.length === 0) {
+		return formatInstallCommand(packageManagerId);
+	}
+
+	return `${packageManagerId} ${DEV_INSTALL_FLAGS[packageManagerId]} ${packages.join(" ")}`;
+}
+
+/**
  * Format a package-manager-specific one-off package execution command.
  *
  * @param packageManagerId Package manager identifier.

--- a/packages/wp-typia-project-tools/src/runtime/template-source-external.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-external.ts
@@ -85,7 +85,7 @@ async function loadExternalTemplateConfig<
   const moduleUrl = `${pathToFileURL(entryPath).href}?mtime=${fs.statSync(entryPath).mtimeMs}`
   const loadedModule = (await withExternalTemplateTimeout(
     `loading external template config "${entryPath}"`,
-    import(moduleUrl),
+    () => import(moduleUrl),
   )) as Record<string, unknown>
   const loadedConfig = loadedModule.default ?? loadedModule
   if (!isPlainObject(loadedConfig)) {
@@ -241,13 +241,14 @@ async function buildExternalTemplateView(
     mergedView[getVariantFlagName(selectedVariant)] = true
   }
 
-  if (!config.transformer) {
+  const transformer = config.transformer
+  if (!transformer) {
     return mergedView
   }
 
   const transformed = await withExternalTemplateTimeout(
     `running external template transformer for "${context.slug}"`,
-    Promise.resolve(config.transformer(mergedView)),
+    () => Promise.resolve(transformer(mergedView)),
   )
   if (!isPlainObject(transformed)) {
     throw new Error(

--- a/packages/wp-typia-project-tools/src/runtime/template-source-external.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-external.ts
@@ -5,6 +5,11 @@ import { promises as fsp } from 'node:fs'
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 
+import {
+  assertExternalTemplateFileSize,
+  getExternalTemplateConfigMaxBytes,
+  withExternalTemplateTimeout,
+} from './external-template-guards.js'
 import { isPlainObject, type UnknownRecord } from './object-utils.js'
 import { toSegmentPascalCase } from './string-case.js'
 import { createManagedTempRoot } from './temp-roots.js'
@@ -73,8 +78,15 @@ async function loadExternalTemplateConfig<
     throw new Error(`No external template config entry found in ${sourceDir}.`)
   }
 
+  assertExternalTemplateFileSize(entryPath, {
+    label: `External template config "${entryPath}"`,
+    maxBytes: getExternalTemplateConfigMaxBytes(),
+  })
   const moduleUrl = `${pathToFileURL(entryPath).href}?mtime=${fs.statSync(entryPath).mtimeMs}`
-  const loadedModule = (await import(moduleUrl)) as Record<string, unknown>
+  const loadedModule = (await withExternalTemplateTimeout(
+    `loading external template config "${entryPath}"`,
+    import(moduleUrl),
+  )) as Record<string, unknown>
   const loadedConfig = loadedModule.default ?? loadedModule
   if (!isPlainObject(loadedConfig)) {
     throw new Error(
@@ -233,7 +245,10 @@ async function buildExternalTemplateView(
     return mergedView
   }
 
-  const transformed = await config.transformer(mergedView)
+  const transformed = await withExternalTemplateTimeout(
+    `running external template transformer for "${context.slug}"`,
+    Promise.resolve(config.transformer(mergedView)),
+  )
   if (!isPlainObject(transformed)) {
     throw new Error(
       'External template transformer(view) must return an object.',

--- a/packages/wp-typia-project-tools/src/runtime/template-source-remote.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-remote.ts
@@ -3,6 +3,10 @@ import { promises as fsp } from 'node:fs'
 import path from 'node:path'
 
 import {
+  assertExternalTemplateFileSize,
+  getExternalTemplatePackageJsonMaxBytes,
+} from './external-template-guards.js'
+import {
   getBuiltInTemplateLayerDirs,
   isOmittableBuiltInTemplateLayerDir,
 } from './template-builtins.js'
@@ -95,6 +99,10 @@ function readTemplatePackageJson(
     }
 
     try {
+      assertExternalTemplateFileSize(candidate, {
+        label: `Template metadata file "${candidate}"`,
+        maxBytes: getExternalTemplatePackageJsonMaxBytes(),
+      })
       return {
         packageJson: JSON.parse(fs.readFileSync(candidate, 'utf8')) as {
           wpTypia?: { projectType?: unknown }

--- a/packages/wp-typia-project-tools/src/runtime/template-source-seeds.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-seeds.ts
@@ -2,11 +2,20 @@ import fs from 'node:fs'
 import { promises as fsp } from 'node:fs'
 import { createRequire } from 'node:module'
 import path from 'node:path'
-import { execFileSync } from 'node:child_process'
+import { spawnSync } from 'node:child_process'
 
 import semver from 'semver'
 import { x as extractTarball } from 'tar'
 
+import {
+  createExternalTemplateTimeoutError,
+  fetchWithExternalTemplateTimeout,
+  getExternalTemplateMetadataMaxBytes,
+  getExternalTemplateTarballMaxBytes,
+  getExternalTemplateTimeoutMs,
+  readBufferResponseWithLimit,
+  readJsonResponseWithLimit,
+} from './external-template-guards.js'
 import {
   OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE,
   PROJECT_TOOLS_PACKAGE_ROOT,
@@ -73,8 +82,12 @@ async function fetchNpmTemplateSource(
   const registryBase = (
     process.env.NPM_CONFIG_REGISTRY ?? 'https://registry.npmjs.org'
   ).replace(/\/$/, '')
-  const metadataResponse = await fetch(
+  const metadataLabel = `fetching npm template metadata for ${locator.raw}`
+  const metadataResponse = await fetchWithExternalTemplateTimeout(
     `${registryBase}/${encodeURIComponent(locator.name)}`,
+    {
+      label: metadataLabel,
+    },
   )
   if (!metadataResponse.ok) {
     throw new Error(
@@ -82,7 +95,10 @@ async function fetchNpmTemplateSource(
     )
   }
 
-  const metadata = (await metadataResponse.json()) as Record<string, unknown>
+  const metadata = await readJsonResponseWithLimit(metadataResponse, {
+    label: `npm template metadata for ${locator.raw}`,
+    maxBytes: getExternalTemplateMetadataMaxBytes(),
+  })
   const resolvedVersion = selectRegistryVersion(metadata, locator)
   const versions = isPlainObject(metadata.versions) ? metadata.versions : {}
   const versionMetadata = versions[resolvedVersion]
@@ -104,7 +120,9 @@ async function fetchNpmTemplateSource(
   )
 
   try {
-    const tarballResponse = await fetch(tarballUrl)
+    const tarballResponse = await fetchWithExternalTemplateTimeout(tarballUrl, {
+      label: `downloading npm template tarball for ${locator.raw}@${resolvedVersion}`,
+    })
     if (!tarballResponse.ok) {
       throw new Error(
         `Failed to download npm template tarball for ${locator.raw}: ${tarballResponse.status}`,
@@ -116,7 +134,10 @@ async function fetchNpmTemplateSource(
     await fsp.mkdir(unpackDir, { recursive: true })
     await fsp.writeFile(
       tarballPath,
-      Buffer.from(await tarballResponse.arrayBuffer()),
+      await readBufferResponseWithLimit(tarballResponse, {
+        label: `npm template tarball for ${locator.raw}@${resolvedVersion}`,
+        maxBytes: getExternalTemplateTarballMaxBytes(),
+      }),
     )
     await extractTarball({
       cwd: unpackDir,
@@ -270,7 +291,40 @@ async function resolveGitHubTemplateSource(
       `https://github.com/${locator.owner}/${locator.repo}.git`,
       checkoutDir,
     )
-    execFileSync('git', args, { stdio: 'ignore' })
+    const cloneTimeoutMs = getExternalTemplateTimeoutMs()
+    const cloneResult = spawnSync('git', args, {
+      stdio: 'ignore',
+      timeout: cloneTimeoutMs,
+    })
+    if (cloneResult.error) {
+      const errorCode =
+        typeof cloneResult.error === 'object' &&
+        cloneResult.error !== null &&
+        'code' in cloneResult.error
+          ? String((cloneResult.error as { code: unknown }).code)
+          : ''
+      if (errorCode === 'ETIMEDOUT') {
+        throw createExternalTemplateTimeoutError(
+          `cloning GitHub template ${locator.owner}/${locator.repo}`,
+          cloneTimeoutMs,
+        )
+      }
+      throw cloneResult.error
+    }
+    if (
+      cloneResult.signal === 'SIGTERM' ||
+      cloneResult.signal === 'SIGKILL'
+    ) {
+      throw createExternalTemplateTimeoutError(
+        `cloning GitHub template ${locator.owner}/${locator.repo}`,
+        cloneTimeoutMs,
+      )
+    }
+    if (cloneResult.status !== 0) {
+      throw new Error(
+        `Failed to clone GitHub template source ${locator.owner}/${locator.repo}.`,
+      )
+    }
 
     const sourceDir = path.resolve(checkoutDir, locator.sourcePath)
     const relativeSourceDir = path.relative(checkoutDir, sourceDir)

--- a/packages/wp-typia-project-tools/tests/init-command.test.ts
+++ b/packages/wp-typia-project-tools/tests/init-command.test.ts
@@ -1,0 +1,111 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { getInitPlan } from "../src/runtime/cli-init.js";
+import { getPackageVersions } from "../src/runtime/package-versions.js";
+import {
+	cleanupScaffoldTempRoot,
+	createScaffoldTempRoot,
+	wpTypiaPackageManifest,
+} from "./helpers/scaffold-test-harness.js";
+
+describe("wp-typia init", () => {
+	const tempRoot = createScaffoldTempRoot("wp-typia-init-plan-");
+
+	afterAll(() => {
+		cleanupScaffoldTempRoot(tempRoot);
+	});
+
+	test("detects single-block retrofit candidates and plans the minimum sync surface", () => {
+		const projectDir = path.join(tempRoot, "retrofit-single-block");
+		fs.mkdirSync(path.join(projectDir, "src"), { recursive: true });
+		fs.writeFileSync(
+			path.join(projectDir, "package.json"),
+			JSON.stringify(
+				{
+					name: "retrofit-single-block",
+					private: true,
+					scripts: {},
+				},
+				null,
+				2,
+			),
+		);
+		fs.writeFileSync(
+			path.join(projectDir, "src", "block.json"),
+			JSON.stringify(
+				{
+					name: "create-block/retrofit-single-block",
+				},
+				null,
+				2,
+			),
+		);
+		fs.writeFileSync(path.join(projectDir, "src", "types.ts"), "export {};\n");
+		fs.writeFileSync(path.join(projectDir, "src", "save.tsx"), "export default null;\n");
+
+		const plan = getInitPlan(projectDir);
+
+		expect(plan.status).toBe("preview");
+		expect(plan.detectedLayout.kind).toBe("single-block");
+		expect(plan.detectedLayout.blockNames).toEqual([
+			"create-block/retrofit-single-block",
+		]);
+		expect(plan.packageChanges.scripts.map((script) => script.name)).toEqual([
+			"sync",
+			"sync-types",
+			"typecheck",
+		]);
+		expect(
+			plan.packageChanges.addDevDependencies.some(
+				(dependency) => dependency.name === "@wp-typia/block-runtime",
+			),
+		).toBe(true);
+		expect(plan.generatedArtifacts).toContain("src/typia.manifest.json");
+		expect(plan.nextSteps).toContain(
+			`npx --yes wp-typia@${wpTypiaPackageManifest.version} doctor`,
+		);
+		expect(plan.notes).toContain(
+			"Preview only: `wp-typia init` does not write files yet.",
+		);
+	});
+
+	test("reports already-initialized projects without planning redundant changes", () => {
+		const projectDir = path.join(tempRoot, "retrofit-already-initialized");
+		const versions = getPackageVersions();
+		fs.mkdirSync(projectDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(projectDir, "package.json"),
+			JSON.stringify(
+				{
+					name: "retrofit-already-initialized",
+					private: true,
+					scripts: {
+						sync: "tsx scripts/sync-project.ts",
+						"sync-types": "tsx scripts/sync-types-to-block-json.ts",
+						typecheck: "npm run sync -- --check && tsc --noEmit",
+					},
+					devDependencies: {
+						"@typia/unplugin": "^12.0.1",
+						"@wp-typia/block-runtime": versions.blockRuntimePackageVersion,
+						"@wp-typia/block-types": versions.blockTypesPackageVersion,
+						tsx: "^4.20.5",
+						typescript: "^5.9.2",
+						typia: "^12.0.1",
+					},
+				},
+				null,
+				2,
+			),
+		);
+
+		const plan = getInitPlan(projectDir);
+
+		expect(plan.status).toBe("already-initialized");
+		expect(plan.detectedLayout.kind).toBe("generated-project");
+		expect(plan.packageChanges.addDevDependencies).toEqual([]);
+		expect(plan.packageChanges.scripts).toEqual([]);
+		expect(plan.plannedFiles).toEqual([]);
+	});
+});

--- a/packages/wp-typia-project-tools/tests/template-source.test.ts
+++ b/packages/wp-typia-project-tools/tests/template-source.test.ts
@@ -1,12 +1,13 @@
 import { afterAll, describe, expect, test } from "bun:test";
 import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
+import * as http from "node:http";
 import * as path from "node:path";
 import { blockTypesPackageVersion, cleanupScaffoldTempRoot, createBlockExternalFixturePath, createBlockSubsetFixturePath, createScaffoldTempRoot, normalizedBlockRuntimePackageVersion, packageRoot, templateLayerFixturePath, workspaceTemplatePackageManifest } from "./helpers/scaffold-test-harness.js";
 import { getTemplateVariables, scaffoldProject } from "../src/runtime/index.js";
 import { resolveTemplateId } from "../src/runtime/scaffold.js";
 import { copyRenderedDirectory } from "../src/runtime/template-render.js";
-import { parseGitHubTemplateLocator, parseNpmTemplateLocator, parseTemplateLocator } from "../src/runtime/template-source.js";
+import { parseGitHubTemplateLocator, parseNpmTemplateLocator, parseTemplateLocator, resolveTemplateSeed } from "../src/runtime/template-source.js";
 import { EXTERNAL_TEMPLATE_TRUST_WARNING } from "../src/runtime/template-source-external.js";
 
 describe("@wp-typia/project-tools template sources", () => {
@@ -15,6 +16,36 @@ describe("@wp-typia/project-tools template sources", () => {
   afterAll(() => {
     cleanupScaffoldTempRoot(tempRoot);
   });
+
+  async function startStubServer(
+    handler: (
+      request: http.IncomingMessage,
+      response: http.ServerResponse<http.IncomingMessage>
+    ) => void
+  ): Promise<{ close: () => Promise<void>; url: string }> {
+    const server = http.createServer(handler);
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Expected an ephemeral stub server port.");
+    }
+
+    return {
+      close: () =>
+        new Promise<void>((resolve, reject) => {
+          server.close((error) => {
+            if (error) {
+              reject(error);
+              return;
+            }
+            resolve();
+          });
+        }),
+      url: `http://127.0.0.1:${address.port}`,
+    };
+  }
 
 test("getTemplateVariables rejects slugs that normalize to an empty identifier", () => {
   expect(() =>
@@ -182,6 +213,117 @@ test("local official external template configs scaffold with the default variant
   expect(generatedEdit).toContain("standard-transformed");
   expect(generatedBlockJson.editorStyle).toBeUndefined();
   expect(generatedBlockJson.supports.multiple).toBe(false);
+});
+
+test("external template config imports time out with a direct diagnostic", async () => {
+  const fixtureDir = path.join(tempRoot, "create-block-external-timeout");
+  const targetDir = path.join(tempRoot, "demo-external-timeout");
+  fs.cpSync(createBlockExternalFixturePath, fixtureDir, { recursive: true });
+  fs.rmSync(path.join(fixtureDir, "index.cjs"));
+  fs.writeFileSync(
+    path.join(fixtureDir, "index.mjs"),
+    [
+      "await new Promise((resolve) => setTimeout(resolve, 200));",
+      "export default {",
+      '  blockTemplatesPath: "block-templates",',
+      '  assetsPath: "assets",',
+      "};",
+      "",
+    ].join("\n"),
+    "utf8"
+  );
+
+  const previousTimeout = process.env.WP_TYPIA_EXTERNAL_TEMPLATE_TIMEOUT_MS;
+  process.env.WP_TYPIA_EXTERNAL_TEMPLATE_TIMEOUT_MS = "25";
+
+  try {
+    await expect(
+      scaffoldProject({
+        projectDir: targetDir,
+        templateId: fixtureDir,
+        packageManager: "npm",
+        noInstall: true,
+        answers: {
+          author: "Test Runner",
+          description: "Timed out external block",
+          namespace: "create-block",
+          slug: "demo-external-timeout",
+          title: "Demo External Timeout",
+        },
+      })
+    ).rejects.toThrow(/Timed out while loading external template config/);
+  } finally {
+    if (previousTimeout === undefined) {
+      delete process.env.WP_TYPIA_EXTERNAL_TEMPLATE_TIMEOUT_MS;
+    } else {
+      process.env.WP_TYPIA_EXTERNAL_TEMPLATE_TIMEOUT_MS = previousTimeout;
+    }
+  }
+});
+
+test("npm template tarballs that exceed the configured size limit fail early", async () => {
+  let serverUrl = "";
+  const server = await startStubServer((request, response) => {
+    if ((request.url ?? "") === "/%40scope%2Ftemplate") {
+      response.writeHead(200, {
+        "content-type": "application/json; charset=utf-8",
+      });
+      response.end(
+        JSON.stringify({
+          "dist-tags": {
+            latest: "1.0.0",
+          },
+          versions: {
+            "1.0.0": {
+              dist: {
+                tarball: `${serverUrl}/template.tgz`,
+              },
+            },
+          },
+        })
+      );
+      return;
+    }
+
+    if ((request.url ?? "") === "/template.tgz") {
+      const payload = Buffer.alloc(128, 65);
+      response.writeHead(200, {
+        "content-length": String(payload.length),
+        "content-type": "application/octet-stream",
+      });
+      response.end(payload);
+      return;
+    }
+
+    response.writeHead(404);
+    response.end("not found");
+  });
+  serverUrl = server.url;
+
+  const previousRegistry = process.env.NPM_CONFIG_REGISTRY;
+  const previousTarballLimit =
+    process.env.WP_TYPIA_EXTERNAL_TEMPLATE_TARBALL_MAX_BYTES;
+  process.env.NPM_CONFIG_REGISTRY = server.url;
+  process.env.WP_TYPIA_EXTERNAL_TEMPLATE_TARBALL_MAX_BYTES = "64";
+
+  try {
+    await expect(
+      resolveTemplateSeed(parseTemplateLocator("@scope/template"), tempRoot)
+    ).rejects.toThrow(/external template size limit/);
+  } finally {
+    if (previousRegistry === undefined) {
+      delete process.env.NPM_CONFIG_REGISTRY;
+    } else {
+      process.env.NPM_CONFIG_REGISTRY = previousRegistry;
+    }
+    if (previousTarballLimit === undefined) {
+      delete process.env.WP_TYPIA_EXTERNAL_TEMPLATE_TARBALL_MAX_BYTES;
+    } else {
+      process.env.WP_TYPIA_EXTERNAL_TEMPLATE_TARBALL_MAX_BYTES =
+        previousTarballLimit;
+    }
+    await server.close();
+  }
 });
 
 test("local official external template configs honor --variant overrides", async () => {

--- a/packages/wp-typia/.bunli/commands.gen.ts
+++ b/packages/wp-typia/.bunli/commands.gen.ts
@@ -7,19 +7,21 @@ import { createGeneratedHelpers, registerGeneratedStore } from '@bunli/core'
 import Add from '../src/commands/add.js'
 import Create from '../src/commands/create.js'
 import Doctor from '../src/commands/doctor.js'
+import Init from '../src/commands/init.js'
 import Mcp from '../src/commands/mcp.js'
 import Migrate from '../src/commands/migrate.js'
 import Sync from '../src/commands/sync.js'
 import Templates from '../src/commands/templates.js'
 
 // Narrow list of command names to avoid typeof-cycles in types
-const names = ['add', 'create', 'doctor', 'mcp', 'migrate', 'sync', 'templates'] as const
+const names = ['add', 'create', 'doctor', 'init', 'mcp', 'migrate', 'sync', 'templates'] as const
 type GeneratedNames = typeof names[number]
 
 const modules: Record<GeneratedNames, Command<any>> = {
   'add': Add,
   'create': Create,
   'doctor': Doctor,
+  'init': Init,
   'mcp': Mcp,
   'migrate': Migrate,
   'sync': Sync,
@@ -41,6 +43,11 @@ const metadata: Record<GeneratedNames, GeneratedCommandMeta> = {
       name: 'doctor',
       description: 'Run repository and project diagnostics.',
       path: './src/commands/doctor'
+    },
+  'init': {
+      name: 'init',
+      description: 'Preview the minimum wp-typia retrofit plan for an existing project.',
+      path: './src/commands/init'
     },
   'mcp': {
       name: 'mcp',

--- a/packages/wp-typia/src/command-contract.ts
+++ b/packages/wp-typia/src/command-contract.ts
@@ -19,6 +19,7 @@ export const WP_TYPIA_BUNLI_MIGRATION_DOC =
 
 export const WP_TYPIA_RESERVED_TOP_LEVEL_COMMAND_NAMES = [
   'create',
+  'init',
   'sync',
   'add',
   'migrate',
@@ -34,6 +35,7 @@ export const WP_TYPIA_RESERVED_TOP_LEVEL_COMMAND_NAMES = [
 
 export const WP_TYPIA_NODE_FALLBACK_TOP_LEVEL_COMMAND_NAMES = [
   'create',
+  'init',
   'sync',
   'add',
   'migrate',
@@ -45,6 +47,7 @@ export const WP_TYPIA_NODE_FALLBACK_TOP_LEVEL_COMMAND_NAMES = [
 
 export const WP_TYPIA_TOP_LEVEL_COMMAND_NAMES = [
   'create',
+  'init',
   'sync',
   'add',
   'migrate',
@@ -140,6 +143,10 @@ export const WP_TYPIA_FUTURE_COMMAND_TREE = [
   {
     description: 'Scaffold a new wp-typia project.',
     name: 'create',
+  },
+  {
+    description: 'Preview the minimum retrofit plan for an existing project.',
+    name: 'init',
   },
   {
     description: 'Run the common generated-project sync workflow.',

--- a/packages/wp-typia/src/command-list.ts
+++ b/packages/wp-typia/src/command-list.ts
@@ -3,6 +3,7 @@ import type { Command } from "@bunli/core";
 import { addCommand } from "./commands/add";
 import { createCommand } from "./commands/create";
 import { doctorCommand } from "./commands/doctor";
+import { initCommand } from "./commands/init";
 import { mcpCommand } from "./commands/mcp";
 import { migrateCommand } from "./commands/migrate";
 import { syncCommand } from "./commands/sync";
@@ -10,6 +11,7 @@ import { templatesCommand } from "./commands/templates";
 
 export const wpTypiaCommands: Command<any, any>[] = [
 	createCommand,
+	initCommand,
 	syncCommand,
 	addCommand,
 	migrateCommand,

--- a/packages/wp-typia/src/commands/init.ts
+++ b/packages/wp-typia/src/commands/init.ts
@@ -1,0 +1,38 @@
+import { defineCommand } from "@bunli/core";
+
+import {
+	emitCliDiagnosticFailure,
+	prefersStructuredCliOutput,
+} from "../cli-diagnostic-output";
+import { executeInitCommand } from "../runtime-bridge";
+
+export const initCommand = defineCommand({
+	defaultFormat: "toon",
+	description:
+		"Preview the minimum wp-typia retrofit plan for an existing project.",
+	handler: async (args) => {
+		const prefersStructuredOutput = prefersStructuredCliOutput(args);
+
+		try {
+			const plan = await executeInitCommand(
+				{
+					cwd: args.cwd,
+					projectDir: args.positional[0] as string | undefined,
+				},
+				{ emitOutput: !prefersStructuredOutput },
+			);
+			if (prefersStructuredOutput) {
+				args.output({ init: plan });
+			}
+		} catch (error) {
+			emitCliDiagnosticFailure(args, {
+				command: "init",
+				error,
+			});
+		}
+	},
+	name: "init",
+	options: {},
+});
+
+export default initCommand;

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -34,6 +34,7 @@ import {
   executeAddCommand,
   executeCreateCommand,
   executeDoctorCommand,
+  executeInitCommand,
   executeMigrateCommand,
   executeSyncCommand,
   executeTemplatesCommand,
@@ -70,7 +71,7 @@ const STANDALONE_GUIDANCE_LINE =
 
 const NODE_FALLBACK_RUNTIME_SUMMARY_LINES = [
   'Runtime: Node fallback',
-  'Human-readable fallback for common non-interactive create/add/migrate flows, doctor, sync, templates, --help, and --version when Bun is unavailable.',
+  'Human-readable fallback for common non-interactive create/init/add/migrate flows, doctor, sync, templates, --help, and --version when Bun is unavailable.',
   `Install Bun 1.3.11+ or use \`bunx wp-typia ...\` for the full Bunli/OpenTUI runtime and Bun-only command surfaces such as \`skills\`, \`completions\`, and \`mcp\`. ${STANDALONE_GUIDANCE_LINE}`,
 ];
 
@@ -209,6 +210,7 @@ function renderGeneralHelp() {
     '',
     'Canonical usage:',
     `- ${WP_TYPIA_CANONICAL_CREATE_USAGE}`,
+    '- wp-typia init [project-dir]',
     `- ${WP_TYPIA_CANONICAL_MIGRATE_USAGE}`,
     `- ${WP_TYPIA_POSITIONAL_ALIAS_USAGE}`,
   ]);
@@ -233,6 +235,16 @@ function renderCreateHelp() {
     '',
     'Supported flags:',
     ...formatNodeFallbackOptionHelp(CREATE_OPTION_METADATA),
+  ]);
+}
+
+function renderInitHelp() {
+  printBlock([
+    'Usage: wp-typia init [project-dir]',
+    '',
+    ...NODE_FALLBACK_RUNTIME_SUMMARY_LINES,
+    '',
+    'Preview-only retrofit planner for existing WordPress block or plugin projects. No files are written yet.',
   ]);
 }
 
@@ -343,7 +355,7 @@ function renderUnsupportedCommand(command: string) {
     detailLines: [
       [
         `The Bun-free fallback runtime does not support \`${command}\` yet.`,
-        'Supported without Bun: `--version`, `--help`, non-interactive `create`/`add`/`migrate`, `doctor`, `sync`, `templates list`, and `templates inspect`.',
+        'Supported without Bun: `--version`, `--help`, non-interactive `create`/`init`/`add`/`migrate`, `doctor`, `sync`, `templates list`, and `templates inspect`.',
         `Install Bun 1.3.11+ or use \`bunx wp-typia ...\` for the full Bunli-powered runtime. ${STANDALONE_GUIDANCE_LINE}`,
       ].join(' '),
     ],
@@ -403,6 +415,10 @@ export async function runNodeCli(argv = process.argv.slice(2)): Promise<void> {
     }
     if (command === 'create') {
       renderCreateHelp();
+      return;
+    }
+    if (command === 'init') {
+      renderInitHelp();
       return;
     }
     if (command === 'add') {
@@ -486,6 +502,30 @@ export async function runNodeCli(argv = process.argv.slice(2)): Promise<void> {
       interactive: false,
       projectDir,
     });
+    return;
+  }
+
+  if (command === 'init') {
+    const plan = await executeInitCommand(
+      {
+        cwd: process.cwd(),
+        projectDir: positionals[1],
+      },
+      {
+        emitOutput: mergedFlags.format !== 'json',
+      },
+    );
+    if (mergedFlags.format === 'json') {
+      printLine(
+        JSON.stringify(
+          {
+            init: plan,
+          },
+          null,
+          2,
+        ),
+      );
+    }
     return;
   }
 

--- a/packages/wp-typia/src/runtime-bridge-output.ts
+++ b/packages/wp-typia/src/runtime-bridge-output.ts
@@ -217,6 +217,102 @@ export function buildCreateDryRunPayload(
   };
 }
 
+/**
+ * Builds the completion payload shown after an init preview succeeds.
+ *
+ * @param plan Preview-only retrofit init plan for one project directory.
+ * @returns A structured alternate-buffer completion payload.
+ */
+export function buildInitCompletionPayload(
+  plan: {
+    detectedLayout: {
+      blockNames: string[];
+      description: string;
+      kind: string;
+    };
+    generatedArtifacts: string[];
+    nextSteps: string[];
+    notes: string[];
+    packageChanges: {
+      addDevDependencies: Array<{
+        action: 'add' | 'update';
+        name: string;
+        requiredValue: string;
+      }>;
+      packageManagerField?: {
+        action: 'add' | 'update';
+        requiredValue: string;
+      };
+      scripts: Array<{
+        action: 'add' | 'update';
+        name: string;
+        requiredValue: string;
+      }>;
+    };
+    plannedFiles: Array<{
+      path: string;
+      purpose: string;
+    }>;
+    packageManager: PackageManagerId;
+    projectDir: string;
+    projectName: string;
+    status: 'already-initialized' | 'preview';
+    summary: string;
+  },
+  markerOptions?: OutputMarkerOptions,
+): AlternateBufferCompletionPayload {
+  const plannedChanges = [
+    ...plan.packageChanges.addDevDependencies.map(
+      (dependency) =>
+        `devDependency ${dependency.action} ${dependency.name} -> ${dependency.requiredValue}`,
+    ),
+    ...(plan.packageChanges.packageManagerField
+      ? [
+          `packageManager ${plan.packageChanges.packageManagerField.action} -> ${plan.packageChanges.packageManagerField.requiredValue}`,
+        ]
+      : []),
+    ...plan.packageChanges.scripts.map(
+      (script) =>
+        `script ${script.action} ${script.name} -> ${script.requiredValue}`,
+    ),
+    ...plan.plannedFiles.map(
+      (filePlan) => `file add ${filePlan.path} (${filePlan.purpose})`,
+    ),
+    ...plan.generatedArtifacts.map(
+      (artifactPath) => `generated artifact ${artifactPath}`,
+    ),
+  ];
+
+  return {
+    nextSteps: plan.nextSteps,
+    optionalLines: plannedChanges,
+    optionalNote: plan.summary,
+    optionalTitle: `Planned adoption changes (${plannedChanges.length}):`,
+    summaryLines: [
+      `Project directory: ${plan.projectDir}`,
+      `Detected layout: ${plan.detectedLayout.description}`,
+      ...(plan.detectedLayout.blockNames.length > 0
+        ? [`Block targets: ${plan.detectedLayout.blockNames.join(', ')}`]
+        : []),
+      `Package manager: ${plan.packageManager}`,
+      'Mode: preview only; no files were written.',
+    ],
+    title:
+      plan.status === 'already-initialized'
+        ? formatOutputMarker(
+            'success',
+            `wp-typia init: ${plan.projectName} is already initialized`,
+            markerOptions,
+          )
+        : formatOutputMarker(
+            'dryRun',
+            `Retrofit init plan for ${plan.projectName}`,
+            markerOptions,
+          ),
+    warningLines: plan.notes,
+  };
+}
+
 function inferProjectPackageManager(projectDir: string): PackageManagerId {
   try {
     const packageJsonPath = path.join(projectDir, 'package.json');

--- a/packages/wp-typia/src/runtime-bridge.ts
+++ b/packages/wp-typia/src/runtime-bridge.ts
@@ -12,6 +12,7 @@ import {
   buildAddDryRunPayload,
   buildCreateCompletionPayload,
   buildCreateDryRunPayload,
+  buildInitCompletionPayload,
   buildMigrationCompletionPayload,
   formatCreateProgressLine,
   printBlock,
@@ -22,6 +23,7 @@ import { isInteractiveTerminal } from './runtime-capabilities';
 export {
   buildCreateCompletionPayload,
   buildCreateDryRunPayload,
+  buildInitCompletionPayload,
   buildMigrationCompletionPayload,
   formatCreateProgressLine,
   printCompletionPayload,
@@ -64,6 +66,11 @@ type TemplatesExecutionInput = {
   };
 };
 
+type InitExecutionInput = {
+  cwd: string;
+  projectDir?: string;
+};
+
 type MigrateExecutionInput = {
   command?: string;
   cwd: string;
@@ -73,12 +80,13 @@ type MigrateExecutionInput = {
 };
 
 type PrintLine = (line: string) => void;
-type CliCommandId = 'add' | 'create' | 'doctor' | 'migrate';
+type CliCommandId = 'add' | 'create' | 'doctor' | 'init' | 'migrate';
 
 const loadCliAddRuntime = () => import('@wp-typia/project-tools/cli-add');
 const loadCliDiagnosticsRuntime = () =>
   import('@wp-typia/project-tools/cli-diagnostics');
 const loadCliDoctorRuntime = () => import('@wp-typia/project-tools/cli-doctor');
+const loadCliInitRuntime = () => import('@wp-typia/project-tools/cli-init');
 const loadCliPromptRuntime = () => import('@wp-typia/project-tools/cli-prompt');
 const loadCliScaffoldRuntime = () =>
   import('@wp-typia/project-tools/cli-scaffold');
@@ -831,6 +839,35 @@ export async function executeTemplatesCommand(
   throw new Error(
     `Unknown templates subcommand "${subcommand}". Expected list or inspect.`,
   );
+}
+
+export async function executeInitCommand(
+  { cwd, projectDir }: InitExecutionInput,
+  options: {
+    emitOutput?: boolean;
+    printLine?: PrintLine;
+    warnLine?: PrintLine;
+  } = {},
+) {
+  try {
+    const { getInitPlan } = await loadCliInitRuntime();
+    const resolvedProjectDir = projectDir
+      ? (await import('node:path')).resolve(cwd, projectDir)
+      : cwd;
+    const plan = getInitPlan(resolvedProjectDir);
+    const completion = buildInitCompletionPayload(plan);
+
+    if (options.emitOutput ?? true) {
+      printCompletionPayload(completion, {
+        printLine: options.printLine,
+        warnLine: options.warnLine,
+      });
+    }
+
+    return plan;
+  } catch (error) {
+    throw await wrapCliCommandError('init', error);
+  }
 }
 
 export async function executeDoctorCommand(cwd: string): Promise<void> {

--- a/packages/wp-typia/tests/bunli-prep.test.ts
+++ b/packages/wp-typia/tests/bunli-prep.test.ts
@@ -71,6 +71,9 @@ describe('wp-typia Bunli preparation', () => {
       fs.existsSync(path.join(packageRoot, 'src', 'commands', 'create.ts')),
     ).toBe(true);
     expect(
+      fs.existsSync(path.join(packageRoot, 'src', 'commands', 'init.ts')),
+    ).toBe(true);
+    expect(
       fs.existsSync(path.join(packageRoot, 'src', 'commands', 'sync.ts')),
     ).toBe(true);
     expect(

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -13,6 +13,7 @@ import {
 
 import { runUtf8Command } from '../../../tests/helpers/process-utils';
 import {
+  createBlockExternalFixturePath,
   linkWorkspaceNodeModules,
   scaffoldOfficialWorkspace,
 } from '../../wp-typia-project-tools/tests/helpers/scaffold-test-harness.js';
@@ -169,6 +170,47 @@ fs.appendFileSync(logPath, \`\${JSON.stringify({ args, label })}\n\`);
   return { fixtureRoot, logPath };
 }
 
+function createRetrofitInitFixture(): string {
+  const fixtureRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'wp-typia-init-fixture-'),
+  );
+  fs.mkdirSync(path.join(fixtureRoot, 'src'), { recursive: true });
+  fs.writeFileSync(
+    path.join(fixtureRoot, 'package.json'),
+    `${JSON.stringify(
+      {
+        name: path.basename(fixtureRoot),
+        private: true,
+      },
+      null,
+      2,
+    )}\n`,
+    'utf8',
+  );
+  fs.writeFileSync(
+    path.join(fixtureRoot, 'src', 'block.json'),
+    `${JSON.stringify(
+      {
+        name: 'create-block/retrofit-init',
+      },
+      null,
+      2,
+    )}\n`,
+    'utf8',
+  );
+  fs.writeFileSync(
+    path.join(fixtureRoot, 'src', 'types.ts'),
+    'export interface RetrofitInitAttributes {}\n',
+    'utf8',
+  );
+  fs.writeFileSync(
+    path.join(fixtureRoot, 'src', 'save.tsx'),
+    'export default function Save() { return null; }\n',
+    'utf8',
+  );
+  return fixtureRoot;
+}
+
 function readSyncLog(
   logPath: string,
 ): Array<{ args: string[]; label: string }> {
@@ -299,6 +341,7 @@ describe('wp-typia package', () => {
       'create',
       '--help',
     ]);
+    const initHelpOutput = runUtf8Command('node', [entryPath, 'init', '--help']);
     const addHelpOutput = runUtf8Command('node', [entryPath, 'add', '--help']);
 
     for (const commandName of WP_TYPIA_TOP_LEVEL_COMMAND_NAMES) {
@@ -310,10 +353,48 @@ describe('wp-typia package', () => {
     expect(createHelpOutput).toContain('--external-layer-id');
     expect(createHelpOutput).toContain('--alternate-render-targets');
     expect(createHelpOutput).toContain('Query Loop');
+    expect(initHelpOutput).toContain('Preview-only retrofit planner');
     expect(addHelpOutput).toContain('--external-layer-source');
     expect(addHelpOutput).toContain('--external-layer-id');
     expect(addHelpOutput).toContain('--alternate-render-targets');
     expect(addHelpOutput).toContain('editor-plugin');
+  });
+
+  test('prints structured init plans through the canonical bin', () => {
+    const fixtureRoot = createRetrofitInitFixture();
+
+    try {
+      const output = runUtf8Command(
+        'node',
+        [entryPath, 'init', '--format', 'json'],
+        {
+          cwd: fixtureRoot,
+        },
+      );
+      const parsed = parseJsonObjectFromOutput<{
+        init?: {
+          detectedLayout?: { kind?: string; blockNames?: string[] };
+          nextSteps?: string[];
+          packageChanges?: {
+            scripts?: Array<{ name?: string }>;
+          };
+          status?: string;
+        };
+      }>(output);
+
+      expect(parsed.init?.status).toBe('preview');
+      expect(parsed.init?.detectedLayout?.kind).toBe('single-block');
+      expect(parsed.init?.detectedLayout?.blockNames).toEqual([
+        'create-block/retrofit-init',
+      ]);
+      expect(parsed.init?.packageChanges?.scripts?.map((script) => script.name))
+        .toEqual(['sync', 'sync-types', 'typecheck']);
+      expect(parsed.init?.nextSteps).toContain(
+        `npx --yes wp-typia@${packageManifest.version} doctor`,
+      );
+    } finally {
+      fs.rmSync(fixtureRoot, { force: true, recursive: true });
+    }
   });
 
   test('renders a human-readable version line through the canonical bin', () => {
@@ -816,6 +897,80 @@ describe('wp-typia package', () => {
     expect(() =>
       runUtf8Command('node', [entryPath, 'create', '--dry-run']),
     ).toThrow(/`--dry-run` still needs a logical project directory name/);
+  });
+
+  test('surfaces external template timeout codes in structured create failures', () => {
+    const fixtureRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'wp-typia-create-timeout-template-'),
+    );
+    const targetDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'wp-typia-create-timeout-output-'),
+    );
+    fs.rmSync(targetDir, { force: true, recursive: true });
+    fs.cpSync(createBlockExternalFixturePath, fixtureRoot, { recursive: true });
+    fs.rmSync(path.join(fixtureRoot, 'index.cjs'));
+    fs.writeFileSync(
+      path.join(fixtureRoot, 'index.mjs'),
+      [
+        "await new Promise((resolve) => setTimeout(resolve, 200));",
+        "export default {",
+        '  blockTemplatesPath: "block-templates",',
+        '  assetsPath: "assets",',
+        "};",
+        "",
+      ].join('\n'),
+      'utf8',
+    );
+
+    const previousTimeout = process.env.WP_TYPIA_EXTERNAL_TEMPLATE_TIMEOUT_MS;
+    process.env.WP_TYPIA_EXTERNAL_TEMPLATE_TIMEOUT_MS = '25';
+
+    try {
+      const result = runCapturedCommand(
+        process.execPath,
+        [
+          entryPath,
+          'create',
+          targetDir,
+          '--template',
+          fixtureRoot,
+          '--package-manager',
+          'npm',
+          '--yes',
+          '--no-install',
+          '--format',
+          'json',
+        ],
+        {
+          env: {
+            ...withoutLocalBunEnv(),
+            WP_TYPIA_EXTERNAL_TEMPLATE_TIMEOUT_MS: '25',
+          },
+        },
+      );
+      const diagnosticOutput = result.stderr.includes('{')
+        ? result.stderr
+        : result.stdout;
+      const parsed = parseJsonObjectFromOutput<{
+        error?: { code?: string; message?: string };
+        ok?: boolean;
+      }>(diagnosticOutput);
+
+      expect(result.status).toBe(1);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error?.code).toBe('template-source-timeout');
+      expect(parsed.error?.message).toContain(
+        'Timed out while loading external template config',
+      );
+    } finally {
+      if (previousTimeout === undefined) {
+        delete process.env.WP_TYPIA_EXTERNAL_TEMPLATE_TIMEOUT_MS;
+      } else {
+        process.env.WP_TYPIA_EXTERNAL_TEMPLATE_TIMEOUT_MS = previousTimeout;
+      }
+      fs.rmSync(fixtureRoot, { force: true, recursive: true });
+      fs.rmSync(targetDir, { force: true, recursive: true });
+    }
   });
 
   test('rejects typo-like positional alias invocations with extra arguments', () => {


### PR DESCRIPTION
## Summary
- add a preview-only `wp-typia init [project-dir]` command that detects retrofit candidates and prints the minimum sync/doctor/migration adoption plan for existing projects
- harden external template loading with bounded timeout and size guards across local executable configs, GitHub clones, npm metadata fetches, and npm tarball downloads
- document the new init preview path and extend the CLI error-code vocabulary with template timeout/size-limit failures

## Verification
- `bun run typecheck`
- `bun run --filter @wp-typia/project-tools test:scaffold-core`
- `bun run --filter wp-typia test`

Closes #449
Closes #515