### PR TITLE
Introduce AbilitySpec and AI capability foundations

### DIFF
--- a/apps/docs/src/content/docs/reference/wordpress-ai-projections.md
+++ b/apps/docs/src/content/docs/reference/wordpress-ai-projections.md
@@ -11,6 +11,8 @@ existing persistence counter example.
   `projectJsonSchemaDocument( ..., { profile: "ai-structured-output" } )`
 - Abilities API: the endpoint manifest is a strong typed source, but it is not
   sufficient on its own
+- the repo now names that additive WordPress-only layer `AbilitySpec` instead
+  of treating it as ad hoc per-example projection wiring
 - typia.llm: see [`docs/typia-llm-evaluation.md`](./typia-llm-evaluation.md)
   for the separate build-time tool/function consumer evaluation
 
@@ -44,10 +46,45 @@ The Abilities API proof still needed a WordPress-only extension layer for:
 - execute callback name
 - permission callback name
 - semantic annotations such as `readonly`, `destructive`, and `idempotent`
+- optional MCP exposure metadata such as `meta.mcp.public`
 
 That result is the key design takeaway from `#48`: the manifest is a strong
 typed source, but WordPress-native ability registration still needs a small
-projection layer for execution semantics and capability metadata.
+additive `AbilitySpec` layer for execution semantics and capability metadata.
+
+## Current merge boundary
+
+The current internal split is:
+
+- endpoint manifest owns `operationId`, method/path, summary, request and
+  response contract selection, and auth intent / `wordpressAuth`
+- `AbilitySpec` owns category metadata, WordPress callback names, semantic
+  annotations, optional `meta.mcp.public`, and `showInRest`
+
+That keeps WordPress-only execution semantics out of the backend-neutral REST
+manifest while still letting the two sources compose at build time.
+
+## Compatibility draft for future scaffolds
+
+The repo also now carries a draft AI feature capability model that lets future
+scaffolds describe feature surfaces as either:
+
+- `required`
+- `optional`
+
+That draft is intentionally only a foundation for now. It records the minimum
+WordPress floor and runtime gate expectations for surfaces such as:
+
+- server-side Abilities registration
+- `@wordpress/core-abilities`
+- the WordPress AI Client
+- optional MCP public metadata
+
+Scaffolds do not apply those rules yet. The current state is still:
+
+- no plugin header changes
+- no generated runtime guards
+- no AI-capable scaffold rollout in the supported templates yet
 
 ## What this does not change
 

--- a/examples/persistence-examples/scripts/wordpress-ai-projections.ts
+++ b/examples/persistence-examples/scripts/wordpress-ai-projections.ts
@@ -3,322 +3,336 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import type {
-  EndpointManifestDefinition,
-  EndpointManifestEndpointDefinition,
+	EndpointManifestDefinition,
+	EndpointManifestEndpointDefinition,
 } from '@wp-typia/block-runtime/metadata-core';
 import type { JsonSchemaDocument } from '../../../packages/wp-typia-block-runtime/src/schema-core';
 import {
-  buildWordPressAiArtifacts,
-  type ProjectedWordPressAbilitiesDocument,
-  type AbilityCategorySpec,
-  type AbilitySpec,
-  type AbilitySpecCatalog,
-  type WordPressAiInputSchemaTransformContext,
+	buildWordPressAiArtifacts,
+	type ProjectedWordPressAbilitiesDocument,
+	type AbilityCategorySpec,
+	type AbilitySpec,
+	type AbilitySpecCatalog,
+	type WordPressAiInputSchemaTransformContext,
 } from '../../../packages/wp-typia-project-tools/src/internal/wordpress-ai';
 
 import { BLOCKS } from './block-config';
 export type {
-  AbilityCategorySpec,
-  AbilitySpec,
-  AbilitySpecCatalog,
-  ProjectedWordPressAbilitiesDocument,
-  ProjectedWordPressAbilityDefinition,
+	AbilityCategorySpec,
+	AbilitySpec,
+	AbilitySpecCatalog,
+	ProjectedWordPressAbilitiesDocument,
+	ProjectedWordPressAbilityDefinition,
 } from '../../../packages/wp-typia-project-tools/src/internal/wordpress-ai';
 
 const WORDPRESS_AI_ROOT = 'wordpress-ai';
 
 export const COUNTER_AI_RESPONSE_SCHEMA_RELATIVE_PATH = path.join(
-  WORDPRESS_AI_ROOT,
-  'counter-response.ai.schema.json',
+	WORDPRESS_AI_ROOT,
+	'counter-response.ai.schema.json'
 );
 
 export const COUNTER_ABILITIES_RELATIVE_PATH = path.join(
-  WORDPRESS_AI_ROOT,
-  'counter.abilities.json',
+	WORDPRESS_AI_ROOT,
+	'counter.abilities.json'
 );
 
 export const COUNTER_ABILITY_CATEGORY = {
-  id: 'persistence-examples',
-  label: 'Persistence Examples',
+	id: 'persistence-examples',
+	label: 'Persistence Examples',
 } as const satisfies AbilityCategorySpec;
 
-export const COUNTER_WORDPRESS_ABILITY_SPECS: Record<string, AbilitySpec> = {
-  getPersistenceCounterState: {
-    annotations: {
-      idempotent: true,
-      readonly: true,
-    },
-    categoryId: COUNTER_ABILITY_CATEGORY.id,
-    executeCallback: 'persistence_examples_execute_get_counter_ability',
-    label: 'Get Counter State',
-    permissionCallback: 'persistence_examples_can_read_counter_ability',
-    showInRest: true,
-  },
-  incrementPersistenceCounterState: {
-    annotations: {
-      destructive: false,
-      idempotent: false,
-      readonly: false,
-    },
-    categoryId: COUNTER_ABILITY_CATEGORY.id,
-    executeCallback: 'persistence_examples_execute_increment_counter_ability',
-    label: 'Increment Counter State',
-    permissionCallback:
-      'persistence_examples_can_execute_increment_counter_ability',
-    showInRest: true,
-  },
-} as const satisfies Record<string, AbilitySpec>;
+export const COUNTER_WORDPRESS_ABILITY_SPECS = {
+	getPersistenceCounterState: {
+		annotations: {
+			idempotent: true,
+			readonly: true,
+		},
+		categoryId: COUNTER_ABILITY_CATEGORY.id,
+		executeCallback: 'persistence_examples_execute_get_counter_ability',
+		label: 'Get Counter State',
+		permissionCallback: 'persistence_examples_can_read_counter_ability',
+		showInRest: true,
+	},
+	incrementPersistenceCounterState: {
+		annotations: {
+			destructive: false,
+			idempotent: false,
+			readonly: false,
+		},
+		categoryId: COUNTER_ABILITY_CATEGORY.id,
+		executeCallback:
+			'persistence_examples_execute_increment_counter_ability',
+		label: 'Increment Counter State',
+		permissionCallback:
+			'persistence_examples_can_execute_increment_counter_ability',
+		showInRest: true,
+	},
+} as const satisfies Record< string, AbilitySpec >;
 
 export const COUNTER_WORDPRESS_ABILITY_CATALOG = {
-  abilities: COUNTER_WORDPRESS_ABILITY_SPECS,
-  categories: {
-    [COUNTER_ABILITY_CATEGORY.id]: COUNTER_ABILITY_CATEGORY,
-  },
+	abilities: COUNTER_WORDPRESS_ABILITY_SPECS,
+	categories: {
+		[ COUNTER_ABILITY_CATEGORY.id ]: COUNTER_ABILITY_CATEGORY,
+	},
 } as const satisfies AbilitySpecCatalog;
 
-const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
-const EXAMPLE_ROOT = path.resolve(SCRIPT_DIR, '..');
-const COUNTER_BLOCK = (() => {
-  const block = BLOCKS.find((candidate) => candidate.slug === 'counter');
-  if (!block) {
-    throw new Error(
-      'Could not find the persistence counter block configuration.',
-    );
-  }
+const SCRIPT_DIR = path.dirname( fileURLToPath( import.meta.url ) );
+const EXAMPLE_ROOT = path.resolve( SCRIPT_DIR, '..' );
+const COUNTER_BLOCK = ( () => {
+	const block = BLOCKS.find( ( candidate ) => candidate.slug === 'counter' );
+	if ( ! block ) {
+		throw new Error(
+			'Could not find the persistence counter block configuration.'
+		);
+	}
 
-  return block;
-})();
-
-const COUNTER_WORDPRESS_AI_MANIFEST: EndpointManifestDefinition = {
-  ...COUNTER_BLOCK.restManifest,
-  endpoints: COUNTER_BLOCK.restManifest.endpoints.filter(
-    (endpoint) => endpoint.operationId !== 'getPersistenceCounterBootstrap',
-  ),
-};
+	return block;
+} )();
 
 function filterCounterWordPressAiManifest(
-  manifest: EndpointManifestDefinition,
+	manifest: EndpointManifestDefinition
 ): EndpointManifestDefinition {
-  return {
-    ...manifest,
-    endpoints: manifest.endpoints.filter(
-      (endpoint) => endpoint.operationId !== 'getPersistenceCounterBootstrap',
-    ),
-  };
+	return {
+		...manifest,
+		endpoints: manifest.endpoints.filter(
+			( endpoint ) =>
+				endpoint.operationId !== 'getPersistenceCounterBootstrap'
+		),
+	};
 }
 
 interface GeneratedArtifactFile {
-  content: string;
-  path: string;
+	content: string;
+	path: string;
 }
 
 interface ArtifactSyncOptions {
-  check?: boolean;
+	check?: boolean;
 }
 
 function normalizeGeneratedArtifactContentForComparison(
-  content: string,
+	content: string
 ): string {
-  return content.replace(/\r\n?/g, '\n');
+	return content.replace( /\r\n?/g, '\n' );
 }
 
 async function reconcileGeneratedArtifacts(
-  artifacts: readonly GeneratedArtifactFile[],
-  options: ArtifactSyncOptions = {},
+	artifacts: readonly GeneratedArtifactFile[],
+	options: ArtifactSyncOptions = {}
 ) {
-  if (options.check !== true) {
-    for (const artifact of artifacts) {
-      await mkdir(path.dirname(artifact.path), {
-        recursive: true,
-      });
-      await writeFile(artifact.path, artifact.content, 'utf8');
-    }
+	if ( options.check !== true ) {
+		for ( const artifact of artifacts ) {
+			await mkdir( path.dirname( artifact.path ), {
+				recursive: true,
+			} );
+			await writeFile( artifact.path, artifact.content, 'utf8' );
+		}
 
-    return;
-  }
+		return;
+	}
 
-  const issues: string[] = [];
+	const issues: string[] = [];
 
-  for (const artifact of artifacts) {
-    try {
-      const current = normalizeGeneratedArtifactContentForComparison(
-        await readFile(artifact.path, 'utf8'),
-      );
-      const expected = normalizeGeneratedArtifactContentForComparison(
-        artifact.content,
-      );
-      if (current !== expected) {
-        issues.push(`- ${artifact.path} (stale)`);
-      }
-    } catch (error) {
-      if (
-        error &&
-        typeof error === 'object' &&
-        'code' in error &&
-        error.code === 'ENOENT'
-      ) {
-        issues.push(`- ${artifact.path} (missing)`);
-        continue;
-      }
+	for ( const artifact of artifacts ) {
+		try {
+			const current = normalizeGeneratedArtifactContentForComparison(
+				await readFile( artifact.path, 'utf8' )
+			);
+			const expected = normalizeGeneratedArtifactContentForComparison(
+				artifact.content
+			);
+			if ( current !== expected ) {
+				issues.push( `- ${ artifact.path } (stale)` );
+			}
+		} catch ( error ) {
+			if (
+				error &&
+				typeof error === 'object' &&
+				'code' in error &&
+				error.code === 'ENOENT'
+			) {
+				issues.push( `- ${ artifact.path } (missing)` );
+				continue;
+			}
 
-      throw error;
-    }
-  }
+			throw error;
+		}
+	}
 
-  if (issues.length > 0) {
-    throw new Error(
-      `Generated artifacts are missing or stale:\n${issues.join('\n')}`,
-    );
-  }
+	if ( issues.length > 0 ) {
+		throw new Error(
+			`Generated artifacts are missing or stale:\n${ issues.join(
+				'\n'
+			) }`
+		);
+	}
 }
 
-function toAbilityId(operationId: string): string {
-  return `persistence-examples/${operationId
-    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
-    .toLowerCase()}`;
+function toAbilityId( operationId: string ): string {
+	return `persistence-examples/${ operationId
+		.replace( /([a-z0-9])([A-Z])/g, '$1-$2' )
+		.toLowerCase() }`;
 }
 
-function getBlockArtifactPath(blockSlug: string, relativePath: string): string {
-  return path.join(EXAMPLE_ROOT, 'src', 'blocks', blockSlug, relativePath);
+function getBlockArtifactPath(
+	blockSlug: string,
+	relativePath: string
+): string {
+	return path.join( EXAMPLE_ROOT, 'src', 'blocks', blockSlug, relativePath );
 }
 
 async function loadJsonDocument(
-  blockSlug: string,
-  relativePath: string,
-): Promise<JsonSchemaDocument & Record<string, unknown>> {
-  const decoded = JSON.parse(
-    await readFile(getBlockArtifactPath(blockSlug, relativePath), 'utf8'),
-  ) as unknown;
+	blockSlug: string,
+	relativePath: string
+): Promise< JsonSchemaDocument & Record< string, unknown > > {
+	const decoded = JSON.parse(
+		await readFile(
+			getBlockArtifactPath( blockSlug, relativePath ),
+			'utf8'
+		)
+	) as unknown;
 
-  if (!decoded || typeof decoded !== 'object' || Array.isArray(decoded)) {
-    throw new Error(`Expected ${relativePath} to decode to a JSON object.`);
-  }
+	if (
+		! decoded ||
+		typeof decoded !== 'object' ||
+		Array.isArray( decoded )
+	) {
+		throw new Error(
+			`Expected ${ relativePath } to decode to a JSON object.`
+		);
+	}
 
-  return decoded as JsonSchemaDocument & Record<string, unknown>;
+	return decoded as JsonSchemaDocument & Record< string, unknown >;
 }
 
-function applyCounterAbilityInputSchemaPolicy({
-  endpoint,
-  schema,
-}: WordPressAiInputSchemaTransformContext): JsonSchemaDocument &
-  Record<string, unknown> {
-  if (endpoint.method !== 'POST') {
-    return schema;
-  }
+function applyCounterAbilityInputSchemaPolicy( {
+	endpoint,
+	schema,
+}: WordPressAiInputSchemaTransformContext ): JsonSchemaDocument &
+	Record< string, unknown > {
+	if ( endpoint.method !== 'POST' ) {
+		return schema;
+	}
 
-  const properties =
-    schema.properties &&
-    typeof schema.properties === 'object' &&
-    !Array.isArray(schema.properties)
-      ? { ...(schema.properties as Record<string, unknown>) }
-      : {};
-  const required = Array.isArray(schema.required) ? [...schema.required] : [];
-  const postIdSchema =
-    properties.postId &&
-    typeof properties.postId === 'object' &&
-    !Array.isArray(properties.postId)
-      ? { ...(properties.postId as Record<string, unknown>) }
-      : null;
-  const tokenSchema =
-    properties.publicWriteToken &&
-    typeof properties.publicWriteToken === 'object' &&
-    !Array.isArray(properties.publicWriteToken)
-      ? {
-          ...(properties.publicWriteToken as Record<string, unknown>),
-        }
-      : null;
+	const properties =
+		schema.properties &&
+		typeof schema.properties === 'object' &&
+		! Array.isArray( schema.properties )
+			? { ...( schema.properties as Record< string, unknown > ) }
+			: {};
+	const required = Array.isArray( schema.required )
+		? [ ...schema.required ]
+		: [];
+	const postIdSchema =
+		properties.postId &&
+		typeof properties.postId === 'object' &&
+		! Array.isArray( properties.postId )
+			? { ...( properties.postId as Record< string, unknown > ) }
+			: null;
+	const tokenSchema =
+		properties.publicWriteToken &&
+		typeof properties.publicWriteToken === 'object' &&
+		! Array.isArray( properties.publicWriteToken )
+			? {
+					...( properties.publicWriteToken as Record<
+						string,
+						unknown
+					> ),
+			  }
+			: null;
 
-  if (!postIdSchema || !tokenSchema) {
-    throw new Error(
-      'The increment request schema must define both "postId" and "publicWriteToken" for the WordPress AI overlay.',
-    );
-  }
+	if ( ! postIdSchema || ! tokenSchema ) {
+		throw new Error(
+			'The increment request schema must define both "postId" and "publicWriteToken" for the WordPress AI overlay.'
+		);
+	}
 
-  postIdSchema.minimum = 1;
-  properties.postId = postIdSchema;
-  properties.publicWriteToken = tokenSchema;
+	postIdSchema.minimum = 1;
+	properties.postId = postIdSchema;
+	properties.publicWriteToken = tokenSchema;
 
-  if (!required.includes('publicWriteToken')) {
-    required.push('publicWriteToken');
-  }
+	if ( ! required.includes( 'publicWriteToken' ) ) {
+		required.push( 'publicWriteToken' );
+	}
 
-  return {
-    ...schema,
-    properties,
-    required,
-  } as JsonSchemaDocument & Record<string, unknown>;
+	return {
+		...schema,
+		properties,
+		required,
+	} as JsonSchemaDocument & Record< string, unknown >;
 }
 
-export async function buildCounterWordPressAiArtifacts(options?: {
-  abilityCatalog?: AbilitySpecCatalog;
-  manifest?: EndpointManifestDefinition;
-}): Promise<{
-  abilitiesDocument: ProjectedWordPressAbilitiesDocument;
-  aiResponseSchema: Record<string, unknown>;
-}> {
-  const manifest = filterCounterWordPressAiManifest(
-    options?.manifest ?? COUNTER_WORDPRESS_AI_MANIFEST,
-  );
-  const abilityCatalog =
-    options?.abilityCatalog ?? COUNTER_WORDPRESS_ABILITY_CATALOG;
+export async function buildCounterWordPressAiArtifacts( options?: {
+	abilityCatalog?: AbilitySpecCatalog;
+	manifest?: EndpointManifestDefinition;
+} ): Promise< {
+	abilitiesDocument: ProjectedWordPressAbilitiesDocument;
+	aiResponseSchema: Record< string, unknown >;
+} > {
+	const manifest = filterCounterWordPressAiManifest(
+		options?.manifest ?? COUNTER_BLOCK.restManifest
+	);
+	const abilityCatalog =
+		options?.abilityCatalog ?? COUNTER_WORDPRESS_ABILITY_CATALOG;
 
-  const responseContractName = manifest.endpoints[0]?.responseContract;
-  if (!responseContractName) {
-    throw new Error(
-      'The counter manifest is missing its shared response contract.',
-    );
-  }
+	const responseContractName = manifest.endpoints[ 0 ]?.responseContract;
+	if ( ! responseContractName ) {
+		throw new Error(
+			'The counter manifest is missing its shared response contract.'
+		);
+	}
 
-  const responseSchema = await loadJsonDocument(
-    COUNTER_BLOCK.slug,
-    path.join('api-schemas', `${responseContractName}.schema.json`),
-  );
+	const responseSchema = await loadJsonDocument(
+		COUNTER_BLOCK.slug,
+		path.join( 'api-schemas', `${ responseContractName }.schema.json` )
+	);
 
-  return buildWordPressAiArtifacts({
-    abilityCatalog,
-    buildAbilityId: toAbilityId,
-    generatedFrom: {
-      blockSlug: COUNTER_BLOCK.slug,
-      responseSchemaPath: COUNTER_AI_RESPONSE_SCHEMA_RELATIVE_PATH,
-      schemaProfile: 'ai-structured-output',
-    },
-    loadInputSchema: async (
-      _endpoint: EndpointManifestEndpointDefinition,
-      contractName: string,
-    ) =>
-      loadJsonDocument(
-        COUNTER_BLOCK.slug,
-        path.join('api-schemas', `${contractName}.schema.json`),
-      ),
-    manifest,
-    responseSchema,
-    transformInputSchema: applyCounterAbilityInputSchemaPolicy,
-  });
+	return buildWordPressAiArtifacts( {
+		abilityCatalog,
+		buildAbilityId: toAbilityId,
+		generatedFrom: {
+			blockSlug: COUNTER_BLOCK.slug,
+			responseSchemaPath: COUNTER_AI_RESPONSE_SCHEMA_RELATIVE_PATH,
+			schemaProfile: 'ai-structured-output',
+		},
+		loadInputSchema: async (
+			_endpoint: EndpointManifestEndpointDefinition,
+			contractName: string
+		) =>
+			loadJsonDocument(
+				COUNTER_BLOCK.slug,
+				path.join( 'api-schemas', `${ contractName }.schema.json` )
+			),
+		manifest,
+		responseSchema,
+		transformInputSchema: applyCounterAbilityInputSchemaPolicy,
+	} );
 }
 
 export async function syncCounterWordPressAiArtifacts(
-  options: ArtifactSyncOptions = {},
+	options: ArtifactSyncOptions = {}
 ) {
-  const { abilitiesDocument, aiResponseSchema } =
-    await buildCounterWordPressAiArtifacts();
+	const { abilitiesDocument, aiResponseSchema } =
+		await buildCounterWordPressAiArtifacts();
 
-  await reconcileGeneratedArtifacts(
-    [
-      {
-        content: JSON.stringify(aiResponseSchema, null, 2) + '\n',
-        path: getBlockArtifactPath(
-          COUNTER_BLOCK.slug,
-          COUNTER_AI_RESPONSE_SCHEMA_RELATIVE_PATH,
-        ),
-      },
-      {
-        content: JSON.stringify(abilitiesDocument, null, 2) + '\n',
-        path: getBlockArtifactPath(
-          COUNTER_BLOCK.slug,
-          COUNTER_ABILITIES_RELATIVE_PATH,
-        ),
-      },
-    ],
-    options,
-  );
+	await reconcileGeneratedArtifacts(
+		[
+			{
+				content: JSON.stringify( aiResponseSchema, null, 2 ) + '\n',
+				path: getBlockArtifactPath(
+					COUNTER_BLOCK.slug,
+					COUNTER_AI_RESPONSE_SCHEMA_RELATIVE_PATH
+				),
+			},
+			{
+				content: JSON.stringify( abilitiesDocument, null, 2 ) + '\n',
+				path: getBlockArtifactPath(
+					COUNTER_BLOCK.slug,
+					COUNTER_ABILITIES_RELATIVE_PATH
+				),
+			},
+		],
+		options
+	);
 }

--- a/examples/persistence-examples/scripts/wordpress-ai-projections.ts
+++ b/examples/persistence-examples/scripts/wordpress-ai-projections.ts
@@ -3,345 +3,322 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import type {
-	EndpointManifestDefinition,
-	EndpointManifestEndpointDefinition,
+  EndpointManifestDefinition,
+  EndpointManifestEndpointDefinition,
 } from '@wp-typia/block-runtime/metadata-core';
 import type { JsonSchemaDocument } from '../../../packages/wp-typia-block-runtime/src/schema-core';
 import {
-	buildWordPressAiArtifacts,
-	type ProjectedWordPressAbilitiesDocument,
-	type WordPressAbilityProjectionConfig,
-	type WordPressAiInputSchemaTransformContext,
+  buildWordPressAiArtifacts,
+  type ProjectedWordPressAbilitiesDocument,
+  type AbilityCategorySpec,
+  type AbilitySpec,
+  type AbilitySpecCatalog,
+  type WordPressAiInputSchemaTransformContext,
 } from '../../../packages/wp-typia-project-tools/src/internal/wordpress-ai';
 
 import { BLOCKS } from './block-config';
 export type {
-	ProjectedWordPressAbilitiesDocument,
-	ProjectedWordPressAbilityDefinition,
-	WordPressAbilityProjectionConfig,
+  AbilityCategorySpec,
+  AbilitySpec,
+  AbilitySpecCatalog,
+  ProjectedWordPressAbilitiesDocument,
+  ProjectedWordPressAbilityDefinition,
 } from '../../../packages/wp-typia-project-tools/src/internal/wordpress-ai';
 
 const WORDPRESS_AI_ROOT = 'wordpress-ai';
 
 export const COUNTER_AI_RESPONSE_SCHEMA_RELATIVE_PATH = path.join(
-	WORDPRESS_AI_ROOT,
-	'counter-response.ai.schema.json'
+  WORDPRESS_AI_ROOT,
+  'counter-response.ai.schema.json',
 );
 
 export const COUNTER_ABILITIES_RELATIVE_PATH = path.join(
-	WORDPRESS_AI_ROOT,
-	'counter.abilities.json'
+  WORDPRESS_AI_ROOT,
+  'counter.abilities.json',
 );
 
 export const COUNTER_ABILITY_CATEGORY = {
-	id: 'persistence-examples',
-	label: 'Persistence Examples',
-} as const;
+  id: 'persistence-examples',
+  label: 'Persistence Examples',
+} as const satisfies AbilityCategorySpec;
 
-export const COUNTER_WORDPRESS_ABILITY_CONFIG: Record<
-	string,
-	WordPressAbilityProjectionConfig
-> = {
-	getPersistenceCounterState: {
-		annotations: {
-			idempotent: true,
-			readonly: true,
-		},
-		categoryId: COUNTER_ABILITY_CATEGORY.id,
-		executeCallback: 'persistence_examples_execute_get_counter_ability',
-		label: 'Get Counter State',
-		permissionCallback: 'persistence_examples_can_read_counter_ability',
-		showInRest: true,
-	},
-	incrementPersistenceCounterState: {
-		annotations: {
-			destructive: false,
-			idempotent: false,
-			readonly: false,
-		},
-		categoryId: COUNTER_ABILITY_CATEGORY.id,
-		executeCallback:
-			'persistence_examples_execute_increment_counter_ability',
-		label: 'Increment Counter State',
-		permissionCallback:
-			'persistence_examples_can_execute_increment_counter_ability',
-		showInRest: true,
-	},
-} as const satisfies Record< string, WordPressAbilityProjectionConfig >;
+export const COUNTER_WORDPRESS_ABILITY_SPECS: Record<string, AbilitySpec> = {
+  getPersistenceCounterState: {
+    annotations: {
+      idempotent: true,
+      readonly: true,
+    },
+    categoryId: COUNTER_ABILITY_CATEGORY.id,
+    executeCallback: 'persistence_examples_execute_get_counter_ability',
+    label: 'Get Counter State',
+    permissionCallback: 'persistence_examples_can_read_counter_ability',
+    showInRest: true,
+  },
+  incrementPersistenceCounterState: {
+    annotations: {
+      destructive: false,
+      idempotent: false,
+      readonly: false,
+    },
+    categoryId: COUNTER_ABILITY_CATEGORY.id,
+    executeCallback: 'persistence_examples_execute_increment_counter_ability',
+    label: 'Increment Counter State',
+    permissionCallback:
+      'persistence_examples_can_execute_increment_counter_ability',
+    showInRest: true,
+  },
+} as const satisfies Record<string, AbilitySpec>;
 
-const SCRIPT_DIR = path.dirname( fileURLToPath( import.meta.url ) );
-const EXAMPLE_ROOT = path.resolve( SCRIPT_DIR, '..' );
-const COUNTER_BLOCK = ( () => {
-	const block = BLOCKS.find( ( candidate ) => candidate.slug === 'counter' );
-	if ( ! block ) {
-		throw new Error(
-			'Could not find the persistence counter block configuration.'
-		);
-	}
+export const COUNTER_WORDPRESS_ABILITY_CATALOG = {
+  abilities: COUNTER_WORDPRESS_ABILITY_SPECS,
+  categories: {
+    [COUNTER_ABILITY_CATEGORY.id]: COUNTER_ABILITY_CATEGORY,
+  },
+} as const satisfies AbilitySpecCatalog;
 
-	return block;
-} )();
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const EXAMPLE_ROOT = path.resolve(SCRIPT_DIR, '..');
+const COUNTER_BLOCK = (() => {
+  const block = BLOCKS.find((candidate) => candidate.slug === 'counter');
+  if (!block) {
+    throw new Error(
+      'Could not find the persistence counter block configuration.',
+    );
+  }
+
+  return block;
+})();
 
 const COUNTER_WORDPRESS_AI_MANIFEST: EndpointManifestDefinition = {
-	...COUNTER_BLOCK.restManifest,
-	endpoints: COUNTER_BLOCK.restManifest.endpoints.filter(
-		( endpoint ) =>
-			endpoint.operationId !== 'getPersistenceCounterBootstrap'
-	),
+  ...COUNTER_BLOCK.restManifest,
+  endpoints: COUNTER_BLOCK.restManifest.endpoints.filter(
+    (endpoint) => endpoint.operationId !== 'getPersistenceCounterBootstrap',
+  ),
 };
 
 function filterCounterWordPressAiManifest(
-	manifest: EndpointManifestDefinition
+  manifest: EndpointManifestDefinition,
 ): EndpointManifestDefinition {
-	return {
-		...manifest,
-		endpoints: manifest.endpoints.filter(
-			( endpoint ) =>
-				endpoint.operationId !== 'getPersistenceCounterBootstrap'
-		),
-	};
+  return {
+    ...manifest,
+    endpoints: manifest.endpoints.filter(
+      (endpoint) => endpoint.operationId !== 'getPersistenceCounterBootstrap',
+    ),
+  };
 }
 
 interface GeneratedArtifactFile {
-	content: string;
-	path: string;
+  content: string;
+  path: string;
 }
 
 interface ArtifactSyncOptions {
-	check?: boolean;
+  check?: boolean;
 }
 
 function normalizeGeneratedArtifactContentForComparison(
-	content: string
+  content: string,
 ): string {
-	return content.replace( /\r\n?/g, '\n' );
+  return content.replace(/\r\n?/g, '\n');
 }
 
 async function reconcileGeneratedArtifacts(
-	artifacts: readonly GeneratedArtifactFile[],
-	options: ArtifactSyncOptions = {}
+  artifacts: readonly GeneratedArtifactFile[],
+  options: ArtifactSyncOptions = {},
 ) {
-	if ( options.check !== true ) {
-		for ( const artifact of artifacts ) {
-			await mkdir( path.dirname( artifact.path ), {
-				recursive: true,
-			} );
-			await writeFile( artifact.path, artifact.content, 'utf8' );
-		}
+  if (options.check !== true) {
+    for (const artifact of artifacts) {
+      await mkdir(path.dirname(artifact.path), {
+        recursive: true,
+      });
+      await writeFile(artifact.path, artifact.content, 'utf8');
+    }
 
-		return;
-	}
+    return;
+  }
 
-	const issues: string[] = [];
+  const issues: string[] = [];
 
-	for ( const artifact of artifacts ) {
-		try {
-			const current = normalizeGeneratedArtifactContentForComparison(
-				await readFile( artifact.path, 'utf8' )
-			);
-			const expected = normalizeGeneratedArtifactContentForComparison(
-				artifact.content
-			);
-			if ( current !== expected ) {
-				issues.push( `- ${ artifact.path } (stale)` );
-			}
-		} catch ( error ) {
-			if (
-				error &&
-				typeof error === 'object' &&
-				'code' in error &&
-				error.code === 'ENOENT'
-			) {
-				issues.push( `- ${ artifact.path } (missing)` );
-				continue;
-			}
+  for (const artifact of artifacts) {
+    try {
+      const current = normalizeGeneratedArtifactContentForComparison(
+        await readFile(artifact.path, 'utf8'),
+      );
+      const expected = normalizeGeneratedArtifactContentForComparison(
+        artifact.content,
+      );
+      if (current !== expected) {
+        issues.push(`- ${artifact.path} (stale)`);
+      }
+    } catch (error) {
+      if (
+        error &&
+        typeof error === 'object' &&
+        'code' in error &&
+        error.code === 'ENOENT'
+      ) {
+        issues.push(`- ${artifact.path} (missing)`);
+        continue;
+      }
 
-			throw error;
-		}
-	}
+      throw error;
+    }
+  }
 
-	if ( issues.length > 0 ) {
-		throw new Error(
-			`Generated artifacts are missing or stale:\n${ issues.join(
-				'\n'
-			) }`
-		);
-	}
+  if (issues.length > 0) {
+    throw new Error(
+      `Generated artifacts are missing or stale:\n${issues.join('\n')}`,
+    );
+  }
 }
 
-function toAbilityId( operationId: string ): string {
-	return `persistence-examples/${ operationId
-		.replace( /([a-z0-9])([A-Z])/g, '$1-$2' )
-		.toLowerCase() }`;
+function toAbilityId(operationId: string): string {
+  return `persistence-examples/${operationId
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .toLowerCase()}`;
 }
 
-function getBlockArtifactPath(
-	blockSlug: string,
-	relativePath: string
-): string {
-	return path.join( EXAMPLE_ROOT, 'src', 'blocks', blockSlug, relativePath );
+function getBlockArtifactPath(blockSlug: string, relativePath: string): string {
+  return path.join(EXAMPLE_ROOT, 'src', 'blocks', blockSlug, relativePath);
 }
 
 async function loadJsonDocument(
-	blockSlug: string,
-	relativePath: string
-): Promise< JsonSchemaDocument & Record< string, unknown > > {
-	const decoded = JSON.parse(
-		await readFile(
-			getBlockArtifactPath( blockSlug, relativePath ),
-			'utf8'
-		)
-	) as unknown;
+  blockSlug: string,
+  relativePath: string,
+): Promise<JsonSchemaDocument & Record<string, unknown>> {
+  const decoded = JSON.parse(
+    await readFile(getBlockArtifactPath(blockSlug, relativePath), 'utf8'),
+  ) as unknown;
 
-	if (
-		! decoded ||
-		typeof decoded !== 'object' ||
-		Array.isArray( decoded )
-	) {
-		throw new Error(
-			`Expected ${ relativePath } to decode to a JSON object.`
-		);
-	}
+  if (!decoded || typeof decoded !== 'object' || Array.isArray(decoded)) {
+    throw new Error(`Expected ${relativePath} to decode to a JSON object.`);
+  }
 
-	return decoded as JsonSchemaDocument & Record< string, unknown >;
+  return decoded as JsonSchemaDocument & Record<string, unknown>;
 }
 
-function applyCounterAbilityInputSchemaPolicy( {
-	endpoint,
-	schema,
-}: WordPressAiInputSchemaTransformContext ): JsonSchemaDocument &
-	Record< string, unknown > {
-	if ( endpoint.method !== 'POST' ) {
-		return schema;
-	}
+function applyCounterAbilityInputSchemaPolicy({
+  endpoint,
+  schema,
+}: WordPressAiInputSchemaTransformContext): JsonSchemaDocument &
+  Record<string, unknown> {
+  if (endpoint.method !== 'POST') {
+    return schema;
+  }
 
-	const properties =
-		schema.properties &&
-		typeof schema.properties === 'object' &&
-		! Array.isArray( schema.properties )
-			? { ...( schema.properties as Record< string, unknown > ) }
-			: {};
-	const required = Array.isArray( schema.required )
-		? [ ...schema.required ]
-		: [];
-	const postIdSchema =
-		properties.postId &&
-		typeof properties.postId === 'object' &&
-		! Array.isArray( properties.postId )
-			? { ...( properties.postId as Record< string, unknown > ) }
-			: null;
-	const tokenSchema =
-		properties.publicWriteToken &&
-		typeof properties.publicWriteToken === 'object' &&
-		! Array.isArray( properties.publicWriteToken )
-			? {
-					...( properties.publicWriteToken as Record<
-						string,
-						unknown
-					> ),
-			  }
-			: null;
+  const properties =
+    schema.properties &&
+    typeof schema.properties === 'object' &&
+    !Array.isArray(schema.properties)
+      ? { ...(schema.properties as Record<string, unknown>) }
+      : {};
+  const required = Array.isArray(schema.required) ? [...schema.required] : [];
+  const postIdSchema =
+    properties.postId &&
+    typeof properties.postId === 'object' &&
+    !Array.isArray(properties.postId)
+      ? { ...(properties.postId as Record<string, unknown>) }
+      : null;
+  const tokenSchema =
+    properties.publicWriteToken &&
+    typeof properties.publicWriteToken === 'object' &&
+    !Array.isArray(properties.publicWriteToken)
+      ? {
+          ...(properties.publicWriteToken as Record<string, unknown>),
+        }
+      : null;
 
-	if ( ! postIdSchema || ! tokenSchema ) {
-		throw new Error(
-			'The increment request schema must define both "postId" and "publicWriteToken" for the WordPress AI overlay.'
-		);
-	}
+  if (!postIdSchema || !tokenSchema) {
+    throw new Error(
+      'The increment request schema must define both "postId" and "publicWriteToken" for the WordPress AI overlay.',
+    );
+  }
 
-	postIdSchema.minimum = 1;
-	properties.postId = postIdSchema;
-	properties.publicWriteToken = tokenSchema;
+  postIdSchema.minimum = 1;
+  properties.postId = postIdSchema;
+  properties.publicWriteToken = tokenSchema;
 
-	if ( ! required.includes( 'publicWriteToken' ) ) {
-		required.push( 'publicWriteToken' );
-	}
+  if (!required.includes('publicWriteToken')) {
+    required.push('publicWriteToken');
+  }
 
-	return {
-		...schema,
-		properties,
-		required,
-	} as JsonSchemaDocument & Record< string, unknown >;
+  return {
+    ...schema,
+    properties,
+    required,
+  } as JsonSchemaDocument & Record<string, unknown>;
 }
 
-export async function buildCounterWordPressAiArtifacts( options?: {
-	abilityConfig?: Record< string, WordPressAbilityProjectionConfig >;
-	category?: {
-		id: string;
-		label: string;
-	};
-	manifest?: EndpointManifestDefinition;
-} ): Promise< {
-	abilitiesDocument: ProjectedWordPressAbilitiesDocument;
-	aiResponseSchema: Record< string, unknown >;
-} > {
-	const manifest = filterCounterWordPressAiManifest(
-		options?.manifest ?? COUNTER_WORDPRESS_AI_MANIFEST
-	);
-	const abilityConfig = ( options?.abilityConfig ??
-		COUNTER_WORDPRESS_ABILITY_CONFIG ) as Record<
-		string,
-		WordPressAbilityProjectionConfig
-	>;
-	const category = options?.category ?? COUNTER_ABILITY_CATEGORY;
+export async function buildCounterWordPressAiArtifacts(options?: {
+  abilityCatalog?: AbilitySpecCatalog;
+  manifest?: EndpointManifestDefinition;
+}): Promise<{
+  abilitiesDocument: ProjectedWordPressAbilitiesDocument;
+  aiResponseSchema: Record<string, unknown>;
+}> {
+  const manifest = filterCounterWordPressAiManifest(
+    options?.manifest ?? COUNTER_WORDPRESS_AI_MANIFEST,
+  );
+  const abilityCatalog =
+    options?.abilityCatalog ?? COUNTER_WORDPRESS_ABILITY_CATALOG;
 
-	const responseContractName = manifest.endpoints[ 0 ]?.responseContract;
-	if ( ! responseContractName ) {
-		throw new Error(
-			'The counter manifest is missing its shared response contract.'
-		);
-	}
+  const responseContractName = manifest.endpoints[0]?.responseContract;
+  if (!responseContractName) {
+    throw new Error(
+      'The counter manifest is missing its shared response contract.',
+    );
+  }
 
-	const responseSchema = await loadJsonDocument(
-		COUNTER_BLOCK.slug,
-		path.join( 'api-schemas', `${ responseContractName }.schema.json` )
-	);
+  const responseSchema = await loadJsonDocument(
+    COUNTER_BLOCK.slug,
+    path.join('api-schemas', `${responseContractName}.schema.json`),
+  );
 
-	return buildWordPressAiArtifacts( {
-		abilityConfig,
-		buildAbilityId: toAbilityId,
-		category,
-		generatedFrom: {
-			blockSlug: COUNTER_BLOCK.slug,
-			responseSchemaPath: COUNTER_AI_RESPONSE_SCHEMA_RELATIVE_PATH,
-			schemaProfile: 'ai-structured-output',
-		},
-		loadInputSchema: async (
-			_endpoint: EndpointManifestEndpointDefinition,
-			contractName: string
-		) =>
-			loadJsonDocument(
-				COUNTER_BLOCK.slug,
-				path.join( 'api-schemas', `${ contractName }.schema.json` )
-			),
-		manifest,
-		responseSchema,
-		transformInputSchema: applyCounterAbilityInputSchemaPolicy,
-	} );
+  return buildWordPressAiArtifacts({
+    abilityCatalog,
+    buildAbilityId: toAbilityId,
+    generatedFrom: {
+      blockSlug: COUNTER_BLOCK.slug,
+      responseSchemaPath: COUNTER_AI_RESPONSE_SCHEMA_RELATIVE_PATH,
+      schemaProfile: 'ai-structured-output',
+    },
+    loadInputSchema: async (
+      _endpoint: EndpointManifestEndpointDefinition,
+      contractName: string,
+    ) =>
+      loadJsonDocument(
+        COUNTER_BLOCK.slug,
+        path.join('api-schemas', `${contractName}.schema.json`),
+      ),
+    manifest,
+    responseSchema,
+    transformInputSchema: applyCounterAbilityInputSchemaPolicy,
+  });
 }
 
 export async function syncCounterWordPressAiArtifacts(
-	options: ArtifactSyncOptions = {}
+  options: ArtifactSyncOptions = {},
 ) {
-	const { abilitiesDocument, aiResponseSchema } =
-		await buildCounterWordPressAiArtifacts();
+  const { abilitiesDocument, aiResponseSchema } =
+    await buildCounterWordPressAiArtifacts();
 
-	await reconcileGeneratedArtifacts(
-		[
-			{
-				content: JSON.stringify( aiResponseSchema, null, 2 ) + '\n',
-				path: getBlockArtifactPath(
-					COUNTER_BLOCK.slug,
-					COUNTER_AI_RESPONSE_SCHEMA_RELATIVE_PATH
-				),
-			},
-			{
-				content: JSON.stringify( abilitiesDocument, null, 2 ) + '\n',
-				path: getBlockArtifactPath(
-					COUNTER_BLOCK.slug,
-					COUNTER_ABILITIES_RELATIVE_PATH
-				),
-			},
-		],
-		options
-	);
+  await reconcileGeneratedArtifacts(
+    [
+      {
+        content: JSON.stringify(aiResponseSchema, null, 2) + '\n',
+        path: getBlockArtifactPath(
+          COUNTER_BLOCK.slug,
+          COUNTER_AI_RESPONSE_SCHEMA_RELATIVE_PATH,
+        ),
+      },
+      {
+        content: JSON.stringify(abilitiesDocument, null, 2) + '\n',
+        path: getBlockArtifactPath(
+          COUNTER_BLOCK.slug,
+          COUNTER_ABILITIES_RELATIVE_PATH,
+        ),
+      },
+    ],
+    options,
+  );
 }

--- a/examples/persistence-examples/src/blocks/counter/wordpress-ai/counter.abilities.json
+++ b/examples/persistence-examples/src/blocks/counter/wordpress-ai/counter.abilities.json
@@ -32,8 +32,10 @@
       },
       "label": "Get Counter State",
       "meta": {
-        "idempotent": true,
-        "readonly": true,
+        "annotations": {
+          "idempotent": true,
+          "readonly": true
+        },
         "show_in_rest": true
       },
       "method": "GET",
@@ -129,9 +131,11 @@
       },
       "label": "Increment Counter State",
       "meta": {
-        "destructive": false,
-        "idempotent": false,
-        "readonly": false,
+        "annotations": {
+          "destructive": false,
+          "idempotent": false,
+          "readonly": false
+        },
         "show_in_rest": true
       },
       "method": "POST",

--- a/packages/wp-typia-project-tools/package.json
+++ b/packages/wp-typia-project-tools/package.json
@@ -95,7 +95,7 @@
     "prepack": "bun run build && node ./scripts/publish-manifest.mjs prepare",
     "postpack": "node ./scripts/publish-manifest.mjs restore",
     "test": "bun run build && bun test tests/*.test.ts",
-    "test:scaffold-core": "bun run build && bun test tests/block-generator-service.test.ts tests/built-in-block-artifacts.test.ts tests/scaffold-basic.test.ts tests/scaffold-persistence.test.ts tests/template-source.test.ts tests/init-command.test.ts tests/cli-entry.test.ts tests/cli-prompt.test.ts tests/import-policy.test.ts",
+    "test:scaffold-core": "bun run build && bun test tests/block-generator-service.test.ts tests/built-in-block-artifacts.test.ts tests/scaffold-basic.test.ts tests/scaffold-persistence.test.ts tests/template-source.test.ts tests/init-command.test.ts tests/cli-entry.test.ts tests/cli-prompt.test.ts tests/import-policy.test.ts tests/wordpress-ai-spec.test.ts",
     "test:workspace": "bun run build && bun test tests/workspace-add.test.ts tests/workspace-doctor.test.ts",
     "test:compound": "bun run build && bun test tests/scaffold-compound.test.ts",
     "test:migration-planning": "bun run build && bun test tests/migration-init.test.ts tests/migration-config.test.ts tests/migration-plan-wizard.test.ts",

--- a/packages/wp-typia-project-tools/src/internal/ability-spec.ts
+++ b/packages/wp-typia-project-tools/src/internal/ability-spec.ts
@@ -1,0 +1,82 @@
+export interface AbilityAnnotationSpec {
+  destructive?: boolean;
+  idempotent?: boolean;
+  readonly?: boolean;
+}
+
+export interface AbilityCategorySpec {
+  id: string;
+  label: string;
+}
+
+export interface AbilityMcpProjectionSpec {
+  public?: boolean;
+}
+
+export interface AbilityMetaSpec {
+  [key: string]: unknown;
+  mcp?: AbilityMcpProjectionSpec;
+}
+
+export interface AbilitySpec {
+  annotations?: AbilityAnnotationSpec;
+  categoryId: string;
+  executeCallback: string;
+  label: string;
+  meta?: AbilityMetaSpec;
+  permissionCallback: string;
+  showInRest?: boolean;
+}
+
+export interface AbilitySpecCatalog {
+  abilities: Record<string, AbilitySpec>;
+  categories: Record<string, AbilityCategorySpec>;
+}
+
+export const ABILITY_SPEC_MERGE_BOUNDARY = {
+  abilitySpecOwns: [
+    'categoryId',
+    'category.label',
+    'label',
+    'executeCallback',
+    'permissionCallback',
+    'annotations.readonly',
+    'annotations.destructive',
+    'annotations.idempotent',
+    'meta.mcp.public',
+    'showInRest',
+  ],
+  endpointManifestOwns: [
+    'operationId',
+    'method',
+    'path',
+    'summary',
+    'queryContract',
+    'bodyContract',
+    'responseContract',
+    'auth',
+    'authMode',
+    'wordpressAuth',
+  ],
+} as const;
+
+export function resolveAbilityCategorySpec(
+  abilitySpec: AbilitySpec,
+  categories: Record<string, AbilityCategorySpec>,
+  operationId: string,
+): AbilityCategorySpec {
+  const category = categories[abilitySpec.categoryId];
+  if (!category) {
+    throw new Error(
+      `Operation "${operationId}" references unknown AbilitySpec category "${abilitySpec.categoryId}".`,
+    );
+  }
+
+  if (category.id !== abilitySpec.categoryId) {
+    throw new Error(
+      `AbilitySpec category "${abilitySpec.categoryId}" resolves to category id "${category.id}".`,
+    );
+  }
+
+  return category;
+}

--- a/packages/wp-typia-project-tools/src/internal/ai-feature-capability.ts
+++ b/packages/wp-typia-project-tools/src/internal/ai-feature-capability.ts
@@ -1,0 +1,202 @@
+export type AiFeatureCapabilityMode = 'optional' | 'required';
+
+export interface AiFeatureCompatibilityFloor {
+  php?: string;
+  wordpress?: string;
+}
+
+export interface AiFeatureRuntimeGate {
+  kind:
+    | 'adapter'
+    | 'php-function'
+    | 'script-package'
+    | 'wordpress-core-feature';
+  value: string;
+}
+
+export interface AiFeatureDefinition {
+  description: string;
+  id: string;
+  label: string;
+  minimumVersions?: AiFeatureCompatibilityFloor;
+  runtimeGates?: readonly AiFeatureRuntimeGate[];
+}
+
+export interface AiFeatureCapabilitySelection {
+  featureId: string;
+  mode: AiFeatureCapabilityMode;
+}
+
+export interface ResolvedAiFeatureCapability extends AiFeatureDefinition {
+  mode: AiFeatureCapabilityMode;
+}
+
+export interface ResolvedAiFeatureCapabilityPlan {
+  hardMinimums: AiFeatureCompatibilityFloor;
+  optionalFeatures: ResolvedAiFeatureCapability[];
+  requiredFeatures: ResolvedAiFeatureCapability[];
+}
+
+export const AI_FEATURE_DEFINITIONS = {
+  wordpressAiClient: {
+    description:
+      'WordPress 7.0 AI Client surface used by AI-capable feature endpoints.',
+    id: 'wordpress-ai-client',
+    label: 'WordPress AI Client',
+    minimumVersions: {
+      wordpress: '7.0',
+    },
+    runtimeGates: [
+      {
+        kind: 'wordpress-core-feature',
+        value: 'WordPress AI Client',
+      },
+    ],
+  },
+  wordpressCoreAbilities: {
+    description:
+      'Client-side ability discovery surface for editor and admin flows.',
+    id: 'wordpress-core-abilities',
+    label: '@wordpress/core-abilities',
+    minimumVersions: {
+      wordpress: '7.0',
+    },
+    runtimeGates: [
+      {
+        kind: 'script-package',
+        value: '@wordpress/core-abilities',
+      },
+    ],
+  },
+  wordpressMcpPublicMetadata: {
+    description:
+      'Optional MCP exposure metadata consumed by a separate adapter path rather than core alone.',
+    id: 'wordpress-mcp-public-metadata',
+    label: 'MCP public metadata',
+    runtimeGates: [
+      {
+        kind: 'adapter',
+        value: 'MCP adapter',
+      },
+    ],
+  },
+  wordpressServerAbilities: {
+    description:
+      'Server-side ability registration and execution surface for WordPress-native abilities.',
+    id: 'wordpress-server-abilities',
+    label: 'WordPress Abilities API',
+    minimumVersions: {
+      wordpress: '6.9',
+    },
+    runtimeGates: [
+      {
+        kind: 'php-function',
+        value: 'wp_register_ability',
+      },
+      {
+        kind: 'php-function',
+        value: 'wp_register_ability_category',
+      },
+    ],
+  },
+} as const satisfies Record<string, AiFeatureDefinition>;
+
+function compareVersionFloors(left: string, right: string): number {
+  const leftParts = left.split('.').map((value) => Number.parseInt(value, 10));
+  const rightParts = right
+    .split('.')
+    .map((value) => Number.parseInt(value, 10));
+  const length = Math.max(leftParts.length, rightParts.length);
+
+  for (let index = 0; index < length; index += 1) {
+    const leftValue = leftParts[index] ?? 0;
+    const rightValue = rightParts[index] ?? 0;
+    if (leftValue > rightValue) {
+      return 1;
+    }
+    if (leftValue < rightValue) {
+      return -1;
+    }
+  }
+
+  return 0;
+}
+
+function pickHigherVersionFloor(
+  current: string | undefined,
+  candidate: string | undefined,
+): string | undefined {
+  if (!candidate) {
+    return current;
+  }
+  if (!current) {
+    return candidate;
+  }
+
+  return compareVersionFloors(current, candidate) >= 0 ? current : candidate;
+}
+
+function normalizeSelections(
+  selections: readonly AiFeatureCapabilitySelection[],
+): AiFeatureCapabilitySelection[] {
+  const normalized = new Map<string, AiFeatureCapabilitySelection>();
+
+  for (const selection of selections) {
+    const current = normalized.get(selection.featureId);
+    if (!current || selection.mode === 'required') {
+      normalized.set(selection.featureId, selection);
+    }
+  }
+
+  return [...normalized.values()];
+}
+
+export function resolveAiFeatureCapabilityPlan(
+  selections: readonly AiFeatureCapabilitySelection[],
+  registry: Readonly<Record<string, AiFeatureDefinition>> = Object.values(
+    AI_FEATURE_DEFINITIONS,
+  ).reduce<Record<string, AiFeatureDefinition>>((accumulator, definition) => {
+    accumulator[definition.id] = definition;
+    return accumulator;
+  }, {}),
+): ResolvedAiFeatureCapabilityPlan {
+  const requiredFeatures: ResolvedAiFeatureCapability[] = [];
+  const optionalFeatures: ResolvedAiFeatureCapability[] = [];
+  let wordpress: string | undefined;
+  let php: string | undefined;
+
+  for (const selection of normalizeSelections(selections)) {
+    const definition = registry[selection.featureId];
+    if (!definition) {
+      throw new Error(
+        `Unknown AI feature capability "${selection.featureId}".`,
+      );
+    }
+
+    const resolvedDefinition = {
+      ...definition,
+      mode: selection.mode,
+    } satisfies ResolvedAiFeatureCapability;
+
+    if (selection.mode === 'required') {
+      requiredFeatures.push(resolvedDefinition);
+      wordpress = pickHigherVersionFloor(
+        wordpress,
+        definition.minimumVersions?.wordpress,
+      );
+      php = pickHigherVersionFloor(php, definition.minimumVersions?.php);
+      continue;
+    }
+
+    optionalFeatures.push(resolvedDefinition);
+  }
+
+  return {
+    hardMinimums: {
+      ...(php ? { php } : {}),
+      ...(wordpress ? { wordpress } : {}),
+    },
+    optionalFeatures,
+    requiredFeatures,
+  };
+}

--- a/packages/wp-typia-project-tools/src/internal/ai-feature-capability.ts
+++ b/packages/wp-typia-project-tools/src/internal/ai-feature-capability.ts
@@ -101,11 +101,32 @@ export const AI_FEATURE_DEFINITIONS = {
   },
 } as const satisfies Record<string, AiFeatureDefinition>;
 
+const DEFAULT_AI_FEATURE_REGISTRY: Readonly<
+  Record<string, AiFeatureDefinition>
+> = Object.values(AI_FEATURE_DEFINITIONS).reduce<
+  Record<string, AiFeatureDefinition>
+>((accumulator, definition) => {
+  accumulator[definition.id] = definition;
+  return accumulator;
+}, {});
+
+function parseVersionFloorParts(value: string): number[] {
+  const parts = value.split('.').map((part) => Number.parseInt(part, 10));
+
+  for (const [index, part] of parts.entries()) {
+    if (!Number.isFinite(part)) {
+      throw new Error(
+        `compareVersionFloors received an invalid version floor "${value}" at segment ${index + 1}.`,
+      );
+    }
+  }
+
+  return parts;
+}
+
 function compareVersionFloors(left: string, right: string): number {
-  const leftParts = left.split('.').map((value) => Number.parseInt(value, 10));
-  const rightParts = right
-    .split('.')
-    .map((value) => Number.parseInt(value, 10));
+  const leftParts = parseVersionFloorParts(left);
+  const rightParts = parseVersionFloorParts(right);
   const length = Math.max(leftParts.length, rightParts.length);
 
   for (let index = 0; index < length; index += 1) {
@@ -153,12 +174,9 @@ function normalizeSelections(
 
 export function resolveAiFeatureCapabilityPlan(
   selections: readonly AiFeatureCapabilitySelection[],
-  registry: Readonly<Record<string, AiFeatureDefinition>> = Object.values(
-    AI_FEATURE_DEFINITIONS,
-  ).reduce<Record<string, AiFeatureDefinition>>((accumulator, definition) => {
-    accumulator[definition.id] = definition;
-    return accumulator;
-  }, {}),
+  registry: Readonly<
+    Record<string, AiFeatureDefinition>
+  > = DEFAULT_AI_FEATURE_REGISTRY,
 ): ResolvedAiFeatureCapabilityPlan {
   const requiredFeatures: ResolvedAiFeatureCapability[] = [];
   const optionalFeatures: ResolvedAiFeatureCapability[] = [];

--- a/packages/wp-typia-project-tools/src/internal/wordpress-ai.ts
+++ b/packages/wp-typia-project-tools/src/internal/wordpress-ai.ts
@@ -118,6 +118,27 @@ export function projectWordPressAiSchema(
   }) as JsonSchemaDocument & Record<string, unknown>;
 }
 
+function assertAbilityMetaKeys(
+  abilitySpec: AbilitySpec,
+  operationId: string,
+): void {
+  if (!abilitySpec.meta) {
+    return;
+  }
+
+  if ('annotations' in abilitySpec.meta) {
+    throw new Error(
+      `Operation "${operationId}" cannot set AbilitySpec.meta.annotations directly; use AbilitySpec.annotations instead.`,
+    );
+  }
+
+  if ('show_in_rest' in abilitySpec.meta) {
+    throw new Error(
+      `Operation "${operationId}" cannot set AbilitySpec.meta.show_in_rest directly; use AbilitySpec.showInRest instead.`,
+    );
+  }
+}
+
 export async function buildWordPressAbilitiesDocument({
   abilityCatalog,
   buildAbilityId,
@@ -127,29 +148,45 @@ export async function buildWordPressAbilitiesDocument({
   outputSchema,
   transformInputSchema,
 }: BuildWordPressAbilitiesDocumentOptions): Promise<ProjectedWordPressAbilitiesDocument> {
-  let documentCategory: AbilityCategorySpec | null = null;
-  const abilities = await Promise.all(
-    manifest.endpoints.map(async (endpoint) => {
-      const abilitySpec = abilityCatalog.abilities[endpoint.operationId];
-      if (!abilitySpec) {
-        throw new Error(
-          `Missing AbilitySpec for operationId "${endpoint.operationId}".`,
-        );
-      }
+  const resolvedEndpoints = manifest.endpoints.map((endpoint) => {
+    const abilitySpec = abilityCatalog.abilities[endpoint.operationId];
+    if (!abilitySpec) {
+      throw new Error(
+        `Missing AbilitySpec for operationId "${endpoint.operationId}".`,
+      );
+    }
 
-      const category = resolveAbilityCategorySpec(
+    assertAbilityMetaKeys(abilitySpec, endpoint.operationId);
+
+    return {
+      abilitySpec,
+      category: resolveAbilityCategorySpec(
         abilitySpec,
         abilityCatalog.categories,
         endpoint.operationId,
-      );
-      if (!documentCategory) {
-        documentCategory = category;
-      } else if (documentCategory.id !== category.id) {
-        throw new Error(
-          `Operation "${endpoint.operationId}" uses AbilitySpec category "${category.id}" but WordPress AI projections currently support one shared category per document.`,
-        );
-      }
+      ),
+      endpoint,
+    };
+  });
 
+  const documentCategory: AbilityCategorySpec | null =
+    resolvedEndpoints[0]?.category ?? null;
+  if (!documentCategory) {
+    throw new Error(
+      'WordPress AI projection requires at least one endpoint before it can resolve an AbilitySpec category.',
+    );
+  }
+
+  for (const resolvedEndpoint of resolvedEndpoints) {
+    if (resolvedEndpoint.category.id !== documentCategory.id) {
+      throw new Error(
+        `Operation "${resolvedEndpoint.endpoint.operationId}" uses AbilitySpec category "${resolvedEndpoint.category.id}" but WordPress AI projections currently support one shared category per document.`,
+      );
+    }
+  }
+
+  const abilities = await Promise.all(
+    resolvedEndpoints.map(async ({ abilitySpec, category, endpoint }) => {
       const inputContractName = getEndpointInputContractName(endpoint);
       let inputSchema: (JsonSchemaDocument & Record<string, unknown>) | null =
         null;
@@ -194,8 +231,12 @@ export async function buildWordPressAbilitiesDocument({
         inputSchema,
         label: abilitySpec.label,
         meta: {
-          ...(abilitySpec.annotations ?? {}),
           ...(abilitySpec.meta ?? {}),
+          ...(abilitySpec.annotations
+            ? {
+                annotations: abilitySpec.annotations,
+              }
+            : {}),
           show_in_rest: abilitySpec.showInRest ?? true,
         },
         method: endpoint.method,
@@ -209,12 +250,6 @@ export async function buildWordPressAbilitiesDocument({
       } satisfies ProjectedWordPressAbilityDefinition;
     }),
   );
-
-  if (!documentCategory) {
-    throw new Error(
-      'WordPress AI projection requires at least one endpoint before it can resolve an AbilitySpec category.',
-    );
-  }
 
   return {
     abilities,

--- a/packages/wp-typia-project-tools/src/internal/wordpress-ai.ts
+++ b/packages/wp-typia-project-tools/src/internal/wordpress-ai.ts
@@ -1,251 +1,270 @@
 import type {
-	EndpointManifestDefinition,
-	EndpointManifestEndpointDefinition,
-} from "@wp-typia/block-runtime/metadata-core";
+  EndpointManifestDefinition,
+  EndpointManifestEndpointDefinition,
+} from '@wp-typia/block-runtime/metadata-core';
 import {
-	normalizeEndpointAuthDefinition,
-	projectJsonSchemaDocument,
-	type EndpointAuthIntent,
-	type EndpointWordPressAuthDefinition,
-	type JsonSchemaDocument,
-} from "../runtime/schema-core.js";
+  normalizeEndpointAuthDefinition,
+  projectJsonSchemaDocument,
+  type EndpointAuthIntent,
+  type EndpointWordPressAuthDefinition,
+  type JsonSchemaDocument,
+} from '../runtime/schema-core.js';
+import {
+  resolveAbilityCategorySpec,
+  type AbilityCategorySpec,
+  type AbilitySpec,
+  type AbilitySpecCatalog,
+} from './ability-spec.js';
 
-export interface WordPressAbilityProjectionConfig {
-	annotations: {
-		destructive?: boolean;
-		idempotent?: boolean;
-		readonly?: boolean;
-	};
-	categoryId: string;
-	executeCallback: string;
-	label: string;
-	permissionCallback: string;
-	showInRest?: boolean;
-}
+export type {
+  AbilityAnnotationSpec,
+  AbilityCategorySpec,
+  AbilityMcpProjectionSpec,
+  AbilityMetaSpec,
+  AbilitySpec,
+  AbilitySpecCatalog,
+} from './ability-spec.js';
 
 export interface ProjectedWordPressAbilityDefinition {
-	authIntent: EndpointAuthIntent;
-	authMode?: EndpointManifestEndpointDefinition["authMode"];
-	category: string;
-	description: string;
-	executeCallback: string;
-	id: string;
-	inputSchema: Record<string, unknown> | null;
-	label: string;
-	meta: Record<string, unknown>;
-	method: EndpointManifestEndpointDefinition["method"];
-	operationId: string;
-	outputSchema: Record<string, unknown>;
-	path: string;
-	permissionCallback: string;
-	wordpressAuth?: EndpointWordPressAuthDefinition;
+  authIntent: EndpointAuthIntent;
+  authMode?: EndpointManifestEndpointDefinition['authMode'];
+  category: string;
+  description: string;
+  executeCallback: string;
+  id: string;
+  inputSchema: Record<string, unknown> | null;
+  label: string;
+  meta: Record<string, unknown>;
+  method: EndpointManifestEndpointDefinition['method'];
+  operationId: string;
+  outputSchema: Record<string, unknown>;
+  path: string;
+  permissionCallback: string;
+  wordpressAuth?: EndpointWordPressAuthDefinition;
 }
 
 export interface ProjectedWordPressAbilitiesDocument {
-	abilities: ProjectedWordPressAbilityDefinition[];
-	category: {
-		id: string;
-		label: string;
-	};
-	generatedFrom: {
-		blockSlug: string;
-		responseSchemaPath: string;
-		schemaProfile: "ai-structured-output";
-	};
+  abilities: ProjectedWordPressAbilityDefinition[];
+  category: {
+    id: string;
+    label: string;
+  };
+  generatedFrom: {
+    blockSlug: string;
+    responseSchemaPath: string;
+    schemaProfile: 'ai-structured-output';
+  };
 }
 
 export interface WordPressAiInputSchemaTransformContext {
-	contractName: string;
-	endpoint: EndpointManifestEndpointDefinition;
-	schema: JsonSchemaDocument & Record<string, unknown>;
+  contractName: string;
+  endpoint: EndpointManifestEndpointDefinition;
+  schema: JsonSchemaDocument & Record<string, unknown>;
 }
 
 interface BuildWordPressAbilitiesDocumentOptions {
-	abilityConfig: Record<string, WordPressAbilityProjectionConfig>;
-	buildAbilityId?: (operationId: string) => string;
-	category: ProjectedWordPressAbilitiesDocument["category"];
-	generatedFrom: ProjectedWordPressAbilitiesDocument["generatedFrom"];
-	loadInputSchema?: (
-		endpoint: EndpointManifestEndpointDefinition,
-		contractName: string,
-	) => Promise<JsonSchemaDocument & Record<string, unknown>>;
-	manifest: EndpointManifestDefinition;
-	outputSchema: Record<string, unknown>;
-	transformInputSchema?: (
-		context: WordPressAiInputSchemaTransformContext,
-	) => JsonSchemaDocument & Record<string, unknown>;
+  abilityCatalog: AbilitySpecCatalog;
+  buildAbilityId?: (operationId: string) => string;
+  generatedFrom: ProjectedWordPressAbilitiesDocument['generatedFrom'];
+  loadInputSchema?: (
+    endpoint: EndpointManifestEndpointDefinition,
+    contractName: string,
+  ) => Promise<JsonSchemaDocument & Record<string, unknown>>;
+  manifest: EndpointManifestDefinition;
+  outputSchema: Record<string, unknown>;
+  transformInputSchema?: (
+    context: WordPressAiInputSchemaTransformContext,
+  ) => JsonSchemaDocument & Record<string, unknown>;
 }
 
-interface BuildWordPressAiArtifactsOptions
-	extends Omit<
-		BuildWordPressAbilitiesDocumentOptions,
-		"outputSchema"
-	> {
-	responseSchema: JsonSchemaDocument & Record<string, unknown>;
+interface BuildWordPressAiArtifactsOptions extends Omit<
+  BuildWordPressAbilitiesDocumentOptions,
+  'outputSchema'
+> {
+  responseSchema: JsonSchemaDocument & Record<string, unknown>;
 }
 
 function getEndpointInputContractName(
-	endpoint: EndpointManifestEndpointDefinition,
+  endpoint: EndpointManifestEndpointDefinition,
 ): string | null {
-	if (endpoint.method !== "GET" && endpoint.bodyContract && endpoint.queryContract) {
-		throw new Error(
-			`Endpoint "${endpoint.operationId}" defines both bodyContract and queryContract; WordPress AI input projection is ambiguous.`,
-		);
-	}
+  if (
+    endpoint.method !== 'GET' &&
+    endpoint.bodyContract &&
+    endpoint.queryContract
+  ) {
+    throw new Error(
+      `Endpoint "${endpoint.operationId}" defines both bodyContract and queryContract; WordPress AI input projection is ambiguous.`,
+    );
+  }
 
-	if (endpoint.method === "GET") {
-		return endpoint.queryContract ?? null;
-	}
+  if (endpoint.method === 'GET') {
+    return endpoint.queryContract ?? null;
+  }
 
-	return endpoint.bodyContract ?? endpoint.queryContract ?? null;
+  return endpoint.bodyContract ?? endpoint.queryContract ?? null;
 }
 
 function toAbilityId(categoryId: string, operationId: string): string {
-	return `${categoryId}/${operationId
-		.replace(/([a-z0-9])([A-Z])/g, "$1-$2")
-		.toLowerCase()}`;
+  return `${categoryId}/${operationId
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .toLowerCase()}`;
 }
 
 export function projectWordPressAiSchema(
-	schema: JsonSchemaDocument & Record<string, unknown>,
+  schema: JsonSchemaDocument & Record<string, unknown>,
 ): JsonSchemaDocument & Record<string, unknown> {
-	return projectJsonSchemaDocument(schema, {
-		profile: "ai-structured-output",
-	}) as JsonSchemaDocument & Record<string, unknown>;
+  return projectJsonSchemaDocument(schema, {
+    profile: 'ai-structured-output',
+  }) as JsonSchemaDocument & Record<string, unknown>;
 }
 
 export async function buildWordPressAbilitiesDocument({
-	abilityConfig,
-	buildAbilityId,
-	category,
-	generatedFrom,
-	loadInputSchema,
-	manifest,
-	outputSchema,
-	transformInputSchema,
+  abilityCatalog,
+  buildAbilityId,
+  generatedFrom,
+  loadInputSchema,
+  manifest,
+  outputSchema,
+  transformInputSchema,
 }: BuildWordPressAbilitiesDocumentOptions): Promise<ProjectedWordPressAbilitiesDocument> {
-	const abilities = await Promise.all(
-		manifest.endpoints.map(async (endpoint) => {
-			const config = abilityConfig[endpoint.operationId];
-			if (!config) {
-				throw new Error(
-					`Missing WordPress ability projection config for operationId "${endpoint.operationId}".`,
-				);
-			}
-			if (config.categoryId !== category.id) {
-				throw new Error(
-					`Operation "${endpoint.operationId}" uses categoryId "${config.categoryId}" but document category is "${category.id}".`,
-				);
-			}
+  let documentCategory: AbilityCategorySpec | null = null;
+  const abilities = await Promise.all(
+    manifest.endpoints.map(async (endpoint) => {
+      const abilitySpec = abilityCatalog.abilities[endpoint.operationId];
+      if (!abilitySpec) {
+        throw new Error(
+          `Missing AbilitySpec for operationId "${endpoint.operationId}".`,
+        );
+      }
 
-			const inputContractName = getEndpointInputContractName(endpoint);
-			let inputSchema: JsonSchemaDocument & Record<string, unknown> | null = null;
+      const category = resolveAbilityCategorySpec(
+        abilitySpec,
+        abilityCatalog.categories,
+        endpoint.operationId,
+      );
+      if (!documentCategory) {
+        documentCategory = category;
+      } else if (documentCategory.id !== category.id) {
+        throw new Error(
+          `Operation "${endpoint.operationId}" uses AbilitySpec category "${category.id}" but WordPress AI projections currently support one shared category per document.`,
+        );
+      }
 
-			if (inputContractName) {
-				if (!manifest.contracts[inputContractName]) {
-					throw new Error(
-						`Endpoint "${endpoint.operationId}" references missing input contract "${inputContractName}".`,
-					);
-				}
-				if (!loadInputSchema) {
-					throw new Error(
-						`Missing input schema loader for operationId "${endpoint.operationId}".`,
-					);
-				}
+      const inputContractName = getEndpointInputContractName(endpoint);
+      let inputSchema: (JsonSchemaDocument & Record<string, unknown>) | null =
+        null;
 
-				const projectedInputSchema = projectWordPressAiSchema(
-					await loadInputSchema(endpoint, inputContractName),
-				);
-				inputSchema = transformInputSchema
-					? transformInputSchema({
-							contractName: inputContractName,
-							endpoint,
-							schema: projectedInputSchema,
-						})
-					: projectedInputSchema;
-			}
+      if (inputContractName) {
+        if (!manifest.contracts[inputContractName]) {
+          throw new Error(
+            `Endpoint "${endpoint.operationId}" references missing input contract "${inputContractName}".`,
+          );
+        }
+        if (!loadInputSchema) {
+          throw new Error(
+            `Missing input schema loader for operationId "${endpoint.operationId}".`,
+          );
+        }
 
-			const normalizedAuth = normalizeEndpointAuthDefinition(endpoint);
-			return {
-				authIntent: normalizedAuth.auth,
-				...(normalizedAuth.authMode
-					? { authMode: normalizedAuth.authMode }
-					: {}),
-				category: category.id,
-				description: endpoint.summary ?? config.label,
-				executeCallback: config.executeCallback,
-				id: (buildAbilityId ?? ((operationId) => toAbilityId(category.id, operationId)))(
-					endpoint.operationId,
-				),
-				inputSchema,
-				label: config.label,
-				meta: {
-					...config.annotations,
-					show_in_rest: config.showInRest ?? true,
-				},
-				method: endpoint.method,
-				operationId: endpoint.operationId,
-				outputSchema,
-				path: endpoint.path,
-				permissionCallback: config.permissionCallback,
-				...(normalizedAuth.wordpressAuth
-					? { wordpressAuth: normalizedAuth.wordpressAuth }
-					: {}),
-			} satisfies ProjectedWordPressAbilityDefinition;
-		}),
-	);
+        const projectedInputSchema = projectWordPressAiSchema(
+          await loadInputSchema(endpoint, inputContractName),
+        );
+        inputSchema = transformInputSchema
+          ? transformInputSchema({
+              contractName: inputContractName,
+              endpoint,
+              schema: projectedInputSchema,
+            })
+          : projectedInputSchema;
+      }
 
-	return {
-		abilities,
-		category,
-		generatedFrom,
-	};
+      const normalizedAuth = normalizeEndpointAuthDefinition(endpoint);
+      return {
+        authIntent: normalizedAuth.auth,
+        ...(normalizedAuth.authMode
+          ? { authMode: normalizedAuth.authMode }
+          : {}),
+        category: category.id,
+        description: endpoint.summary ?? abilitySpec.label,
+        executeCallback: abilitySpec.executeCallback,
+        id: (
+          buildAbilityId ??
+          ((operationId) => toAbilityId(category.id, operationId))
+        )(endpoint.operationId),
+        inputSchema,
+        label: abilitySpec.label,
+        meta: {
+          ...(abilitySpec.annotations ?? {}),
+          ...(abilitySpec.meta ?? {}),
+          show_in_rest: abilitySpec.showInRest ?? true,
+        },
+        method: endpoint.method,
+        operationId: endpoint.operationId,
+        outputSchema,
+        path: endpoint.path,
+        permissionCallback: abilitySpec.permissionCallback,
+        ...(normalizedAuth.wordpressAuth
+          ? { wordpressAuth: normalizedAuth.wordpressAuth }
+          : {}),
+      } satisfies ProjectedWordPressAbilityDefinition;
+    }),
+  );
+
+  if (!documentCategory) {
+    throw new Error(
+      'WordPress AI projection requires at least one endpoint before it can resolve an AbilitySpec category.',
+    );
+  }
+
+  return {
+    abilities,
+    category: documentCategory,
+    generatedFrom,
+  };
 }
 
 export async function buildWordPressAiArtifacts({
-	abilityConfig,
-	buildAbilityId,
-	category,
-	generatedFrom,
-	loadInputSchema,
-	manifest,
-	responseSchema,
-	transformInputSchema,
+  abilityCatalog,
+  buildAbilityId,
+  generatedFrom,
+  loadInputSchema,
+  manifest,
+  responseSchema,
+  transformInputSchema,
 }: BuildWordPressAiArtifactsOptions): Promise<{
-	abilitiesDocument: ProjectedWordPressAbilitiesDocument;
-	aiResponseSchema: Record<string, unknown>;
+  abilitiesDocument: ProjectedWordPressAbilitiesDocument;
+  aiResponseSchema: Record<string, unknown>;
 }> {
-	const responseContractName = manifest.endpoints[0]?.responseContract;
-	if (!responseContractName) {
-		throw new Error("The manifest is missing its shared response contract.");
-	}
-	for (const endpoint of manifest.endpoints) {
-		if (endpoint.responseContract !== responseContractName) {
-			throw new Error(
-				`Endpoint "${endpoint.operationId}" uses response contract "${endpoint.responseContract}" but expected shared response contract "${responseContractName}".`,
-			);
-		}
-	}
-	if (!manifest.contracts[responseContractName]) {
-		throw new Error(
-			`The manifest references missing response contract "${responseContractName}".`,
-		);
-	}
+  const responseContractName = manifest.endpoints[0]?.responseContract;
+  if (!responseContractName) {
+    throw new Error('The manifest is missing its shared response contract.');
+  }
+  for (const endpoint of manifest.endpoints) {
+    if (endpoint.responseContract !== responseContractName) {
+      throw new Error(
+        `Endpoint "${endpoint.operationId}" uses response contract "${endpoint.responseContract}" but expected shared response contract "${responseContractName}".`,
+      );
+    }
+  }
+  if (!manifest.contracts[responseContractName]) {
+    throw new Error(
+      `The manifest references missing response contract "${responseContractName}".`,
+    );
+  }
 
-	const aiResponseSchema = projectWordPressAiSchema(responseSchema);
-	const abilitiesDocument = await buildWordPressAbilitiesDocument({
-		abilityConfig,
-		buildAbilityId,
-		category,
-		generatedFrom,
-		loadInputSchema,
-		manifest,
-		outputSchema: aiResponseSchema,
-		transformInputSchema,
-	});
+  const aiResponseSchema = projectWordPressAiSchema(responseSchema);
+  const abilitiesDocument = await buildWordPressAbilitiesDocument({
+    abilityCatalog,
+    buildAbilityId,
+    generatedFrom,
+    loadInputSchema,
+    manifest,
+    outputSchema: aiResponseSchema,
+    transformInputSchema,
+  });
 
-	return {
-		abilitiesDocument,
-		aiResponseSchema,
-	};
+  return {
+    abilitiesDocument,
+    aiResponseSchema,
+  };
 }

--- a/packages/wp-typia-project-tools/tests/wordpress-ai-spec.test.ts
+++ b/packages/wp-typia-project-tools/tests/wordpress-ai-spec.test.ts
@@ -151,20 +151,24 @@ describe('WordPress AI AbilitySpec foundation', () => {
       executeCallback: 'demo_execute_get_counter',
       label: 'Get Counter',
       meta: {
-        idempotent: true,
+        annotations: {
+          idempotent: true,
+          readonly: true,
+        },
         mcp: {
           public: true,
         },
-        readonly: true,
         show_in_rest: true,
       },
       operationId: 'getCounter',
       permissionCallback: 'demo_can_get_counter',
     });
     expect(document.abilities[1]?.meta).toEqual({
-      destructive: true,
-      idempotent: false,
-      readonly: false,
+      annotations: {
+        destructive: true,
+        idempotent: false,
+        readonly: false,
+      },
       show_in_rest: false,
     });
   });
@@ -242,5 +246,40 @@ describe('WordPress AI AbilitySpec foundation', () => {
     expect(plan.optionalFeatures.map((feature) => feature.id)).toEqual([
       AI_FEATURE_DEFINITIONS.wordpressAiClient.id,
     ]);
+  });
+
+  test('rejects invalid version floor segments instead of silently comparing them', () => {
+    expect(() =>
+      resolveAiFeatureCapabilityPlan(
+        [
+          {
+            featureId: 'valid-feature',
+            mode: 'required',
+          },
+          {
+            featureId: 'invalid-feature',
+            mode: 'required',
+          },
+        ],
+        {
+          'invalid-feature': {
+            description: 'Invalid floor',
+            id: 'invalid-feature',
+            label: 'Invalid floor',
+            minimumVersions: {
+              wordpress: '7.x',
+            },
+          },
+          'valid-feature': {
+            description: 'Valid floor',
+            id: 'valid-feature',
+            label: 'Valid floor',
+            minimumVersions: {
+              wordpress: '7.0',
+            },
+          },
+        },
+      ),
+    ).toThrow(/compareVersionFloors received an invalid version floor "7\.x"/);
   });
 });

--- a/packages/wp-typia-project-tools/tests/wordpress-ai-spec.test.ts
+++ b/packages/wp-typia-project-tools/tests/wordpress-ai-spec.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, test } from 'bun:test';
+import type { EndpointManifestDefinition } from '@wp-typia/block-runtime/metadata-core';
+import type { JsonSchemaDocument } from '../src/runtime/schema-core.js';
+import {
+  ABILITY_SPEC_MERGE_BOUNDARY,
+  type AbilitySpecCatalog,
+} from '../src/internal/ability-spec.js';
+import {
+  AI_FEATURE_DEFINITIONS,
+  resolveAiFeatureCapabilityPlan,
+} from '../src/internal/ai-feature-capability.js';
+import { buildWordPressAbilitiesDocument } from '../src/internal/wordpress-ai.js';
+
+const RESPONSE_SCHEMA = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  additionalProperties: false,
+  properties: {
+    count: {
+      type: 'integer',
+    },
+  },
+  required: ['count'],
+  title: 'CounterResponse',
+  type: 'object',
+} as const satisfies JsonSchemaDocument & Record<string, unknown>;
+
+const INPUT_SCHEMA = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  additionalProperties: false,
+  properties: {
+    id: {
+      type: 'integer',
+    },
+  },
+  required: ['id'],
+  title: 'CounterInput',
+  type: 'object',
+} as const satisfies JsonSchemaDocument & Record<string, unknown>;
+
+const MANIFEST = {
+  contracts: {
+    CounterQuery: {
+      sourceTypeName: 'CounterQuery',
+    },
+    CounterResponse: {
+      sourceTypeName: 'CounterResponse',
+    },
+    ResetCounterRequest: {
+      sourceTypeName: 'ResetCounterRequest',
+    },
+  },
+  endpoints: [
+    {
+      auth: 'public',
+      method: 'GET',
+      operationId: 'getCounter',
+      path: '/demo/v1/counter',
+      queryContract: 'CounterQuery',
+      responseContract: 'CounterResponse',
+      summary: 'Read the current counter value.',
+      tags: ['counter'],
+    },
+    {
+      auth: 'authenticated',
+      bodyContract: 'ResetCounterRequest',
+      method: 'POST',
+      operationId: 'resetCounter',
+      path: '/demo/v1/counter/reset',
+      responseContract: 'CounterResponse',
+      summary: 'Reset the current counter value.',
+      tags: ['counter'],
+    },
+  ],
+} as const satisfies EndpointManifestDefinition;
+
+describe('WordPress AI AbilitySpec foundation', () => {
+  test('documents the merge boundary between endpoint manifests and AbilitySpec metadata', () => {
+    expect(ABILITY_SPEC_MERGE_BOUNDARY.endpointManifestOwns).toContain(
+      'responseContract',
+    );
+    expect(ABILITY_SPEC_MERGE_BOUNDARY.endpointManifestOwns).toContain(
+      'wordpressAuth',
+    );
+    expect(ABILITY_SPEC_MERGE_BOUNDARY.abilitySpecOwns).toContain(
+      'executeCallback',
+    );
+    expect(ABILITY_SPEC_MERGE_BOUNDARY.abilitySpecOwns).toContain(
+      'meta.mcp.public',
+    );
+  });
+
+  test('composes endpoint manifests with AbilitySpec catalogs and preserves optional MCP metadata', async () => {
+    const abilityCatalog = {
+      abilities: {
+        getCounter: {
+          annotations: {
+            idempotent: true,
+            readonly: true,
+          },
+          categoryId: 'counter',
+          executeCallback: 'demo_execute_get_counter',
+          label: 'Get Counter',
+          meta: {
+            mcp: {
+              public: true,
+            },
+          },
+          permissionCallback: 'demo_can_get_counter',
+        },
+        resetCounter: {
+          annotations: {
+            destructive: true,
+            idempotent: false,
+            readonly: false,
+          },
+          categoryId: 'counter',
+          executeCallback: 'demo_execute_reset_counter',
+          label: 'Reset Counter',
+          permissionCallback: 'demo_can_reset_counter',
+          showInRest: false,
+        },
+      },
+      categories: {
+        counter: {
+          id: 'counter',
+          label: 'Counter',
+        },
+      },
+    } as const satisfies AbilitySpecCatalog;
+
+    const document = await buildWordPressAbilitiesDocument({
+      abilityCatalog,
+      generatedFrom: {
+        blockSlug: 'counter',
+        responseSchemaPath: 'wordpress-ai/counter-response.ai.schema.json',
+        schemaProfile: 'ai-structured-output',
+      },
+      loadInputSchema: async () => INPUT_SCHEMA,
+      manifest: MANIFEST,
+      outputSchema: RESPONSE_SCHEMA,
+    });
+
+    expect(document.category).toEqual({
+      id: 'counter',
+      label: 'Counter',
+    });
+    expect(document.abilities).toHaveLength(2);
+    expect(document.abilities[0]).toMatchObject({
+      category: 'counter',
+      description: 'Read the current counter value.',
+      executeCallback: 'demo_execute_get_counter',
+      label: 'Get Counter',
+      meta: {
+        idempotent: true,
+        mcp: {
+          public: true,
+        },
+        readonly: true,
+        show_in_rest: true,
+      },
+      operationId: 'getCounter',
+      permissionCallback: 'demo_can_get_counter',
+    });
+    expect(document.abilities[1]?.meta).toEqual({
+      destructive: true,
+      idempotent: false,
+      readonly: false,
+      show_in_rest: false,
+    });
+  });
+
+  test('rejects mixed AbilitySpec categories until multi-category projections are designed', async () => {
+    const mixedCategoryCatalog = {
+      abilities: {
+        getCounter: {
+          categoryId: 'counter',
+          executeCallback: 'demo_execute_get_counter',
+          label: 'Get Counter',
+          permissionCallback: 'demo_can_get_counter',
+        },
+        resetCounter: {
+          categoryId: 'mutations',
+          executeCallback: 'demo_execute_reset_counter',
+          label: 'Reset Counter',
+          permissionCallback: 'demo_can_reset_counter',
+        },
+      },
+      categories: {
+        counter: {
+          id: 'counter',
+          label: 'Counter',
+        },
+        mutations: {
+          id: 'mutations',
+          label: 'Mutations',
+        },
+      },
+    } as const satisfies AbilitySpecCatalog;
+
+    await expect(
+      buildWordPressAbilitiesDocument({
+        abilityCatalog: mixedCategoryCatalog,
+        generatedFrom: {
+          blockSlug: 'counter',
+          responseSchemaPath: 'wordpress-ai/counter-response.ai.schema.json',
+          schemaProfile: 'ai-structured-output',
+        },
+        loadInputSchema: async () => INPUT_SCHEMA,
+        manifest: MANIFEST,
+        outputSchema: RESPONSE_SCHEMA,
+      }),
+    ).rejects.toThrow(/one shared category per document/);
+  });
+
+  test('keeps optional AI features out of hard minimums and lets required features raise the baseline', () => {
+    const plan = resolveAiFeatureCapabilityPlan([
+      {
+        featureId: AI_FEATURE_DEFINITIONS.wordpressAiClient.id,
+        mode: 'optional',
+      },
+      {
+        featureId: AI_FEATURE_DEFINITIONS.wordpressCoreAbilities.id,
+        mode: 'required',
+      },
+      {
+        featureId: AI_FEATURE_DEFINITIONS.wordpressServerAbilities.id,
+        mode: 'required',
+      },
+      {
+        featureId: AI_FEATURE_DEFINITIONS.wordpressCoreAbilities.id,
+        mode: 'optional',
+      },
+    ]);
+
+    expect(plan.hardMinimums).toEqual({
+      wordpress: '7.0',
+    });
+    expect(plan.requiredFeatures.map((feature) => feature.id)).toEqual([
+      AI_FEATURE_DEFINITIONS.wordpressCoreAbilities.id,
+      AI_FEATURE_DEFINITIONS.wordpressServerAbilities.id,
+    ]);
+    expect(plan.optionalFeatures.map((feature) => feature.id)).toEqual([
+      AI_FEATURE_DEFINITIONS.wordpressAiClient.id,
+    ]);
+  });
+});

--- a/tests/unit/wordpress-ai-helper.test.ts
+++ b/tests/unit/wordpress-ai-helper.test.ts
@@ -1,30 +1,30 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, test } from 'bun:test';
 
-import type { JsonSchemaDocument } from "@wp-typia/project-tools";
+import type { JsonSchemaDocument } from '@wp-typia/project-tools';
 
-import counterQuerySchema from "../../examples/persistence-examples/src/blocks/counter/api-schemas/counter-query.schema.json";
-import counterResponseSchema from "../../examples/persistence-examples/src/blocks/counter/api-schemas/counter-response.schema.json";
-import incrementRequestSchema from "../../examples/persistence-examples/src/blocks/counter/api-schemas/increment-request.schema.json";
-import counterResponseAiSchema from "../../examples/persistence-examples/src/blocks/counter/wordpress-ai/counter-response.ai.schema.json";
-import { BLOCKS } from "../../examples/persistence-examples/scripts/block-config";
+import counterQuerySchema from '../../examples/persistence-examples/src/blocks/counter/api-schemas/counter-query.schema.json';
+import counterResponseSchema from '../../examples/persistence-examples/src/blocks/counter/api-schemas/counter-response.schema.json';
+import incrementRequestSchema from '../../examples/persistence-examples/src/blocks/counter/api-schemas/increment-request.schema.json';
+import counterResponseAiSchema from '../../examples/persistence-examples/src/blocks/counter/wordpress-ai/counter-response.ai.schema.json';
+import { BLOCKS } from '../../examples/persistence-examples/scripts/block-config';
 import {
   COUNTER_ABILITY_CATEGORY,
-  COUNTER_WORDPRESS_ABILITY_CONFIG,
-} from "../../examples/persistence-examples/scripts/wordpress-ai-projections";
+  COUNTER_WORDPRESS_ABILITY_CATALOG,
+} from '../../examples/persistence-examples/scripts/wordpress-ai-projections';
 import {
   buildWordPressAiArtifacts,
   buildWordPressAbilitiesDocument,
   projectWordPressAiSchema,
-} from "../../packages/wp-typia-project-tools/src/internal/wordpress-ai";
+} from '../../packages/wp-typia-project-tools/src/internal/wordpress-ai';
 
 const counterManifest = BLOCKS.find(
-  (block) => block.slug === "counter"
+  (block) => block.slug === 'counter',
 )?.restManifest;
 const counterWordPressAiManifest = counterManifest
   ? {
       ...counterManifest,
       endpoints: counterManifest.endpoints.filter(
-        (endpoint) => endpoint.operationId !== "getPersistenceCounterBootstrap"
+        (endpoint) => endpoint.operationId !== 'getPersistenceCounterBootstrap',
       ),
     }
   : undefined;
@@ -39,28 +39,27 @@ const incrementRequestSchemaDocument =
 const counterResponseAiSchemaDocument =
   counterResponseAiSchema as ProjectableSchemaDocument;
 const inputSchemas = {
-  "counter-query": counterQuerySchemaDocument,
-  "increment-request": incrementRequestSchemaDocument,
+  'counter-query': counterQuerySchemaDocument,
+  'increment-request': incrementRequestSchemaDocument,
 } as const;
 
-describe("WordPress AI internal helper", () => {
-  test("projects canonical JSON Schema documents with the ai-structured-output profile", () => {
+describe('WordPress AI internal helper', () => {
+  test('projects canonical JSON Schema documents with the ai-structured-output profile', () => {
     expect(projectWordPressAiSchema(counterResponseSchemaDocument)).toEqual(
-      counterResponseAiSchemaDocument
+      counterResponseAiSchemaDocument,
     );
   });
 
-  test("builds abilities documents from endpoint manifests with projected input and output schemas", async () => {
+  test('builds abilities documents from endpoint manifests with projected input and output schemas', async () => {
     expect(counterManifest).toBeDefined();
     expect(counterWordPressAiManifest).toBeDefined();
 
     const abilitiesDocument = await buildWordPressAbilitiesDocument({
-      abilityConfig: COUNTER_WORDPRESS_ABILITY_CONFIG,
-      category: COUNTER_ABILITY_CATEGORY,
+      abilityCatalog: COUNTER_WORDPRESS_ABILITY_CATALOG,
       generatedFrom: {
-        blockSlug: "counter",
-        responseSchemaPath: "wordpress-ai/counter-response.ai.schema.json",
-        schemaProfile: "ai-structured-output",
+        blockSlug: 'counter',
+        responseSchemaPath: 'wordpress-ai/counter-response.ai.schema.json',
+        schemaProfile: 'ai-structured-output',
       },
       loadInputSchema: async (_endpoint, contractName) => {
         const schema = inputSchemas[contractName as keyof typeof inputSchemas];
@@ -79,25 +78,25 @@ describe("WordPress AI internal helper", () => {
 
     expect(abilitiesDocument.abilities).toEqual([
       expect.objectContaining({
-        authIntent: "public",
-        authMode: "public-read",
+        authIntent: 'public',
+        authMode: 'public-read',
         category: COUNTER_ABILITY_CATEGORY.id,
-        method: "GET",
-        operationId: "getPersistenceCounterState",
+        method: 'GET',
+        operationId: 'getPersistenceCounterState',
         outputSchema: counterResponseAiSchemaDocument,
-        path: "/persistence-examples/v1/counter",
+        path: '/persistence-examples/v1/counter',
       }),
       expect.objectContaining({
-        authIntent: "public-write-protected",
-        authMode: "public-signed-token",
+        authIntent: 'public-write-protected',
+        authMode: 'public-signed-token',
         category: COUNTER_ABILITY_CATEGORY.id,
-        method: "POST",
-        operationId: "incrementPersistenceCounterState",
+        method: 'POST',
+        operationId: 'incrementPersistenceCounterState',
         outputSchema: counterResponseAiSchemaDocument,
-        path: "/persistence-examples/v1/counter",
+        path: '/persistence-examples/v1/counter',
         wordpressAuth: {
-          mechanism: "public-signed-token",
-          publicTokenField: "publicWriteToken",
+          mechanism: 'public-signed-token',
+          publicTokenField: 'publicWriteToken',
         },
       }),
     ]);
@@ -106,67 +105,34 @@ describe("WordPress AI internal helper", () => {
     const postAbility = abilitiesDocument.abilities[1];
 
     expect(getAbility?.inputSchema).toEqual(
-      projectWordPressAiSchema(counterQuerySchemaDocument)
+      projectWordPressAiSchema(counterQuerySchemaDocument),
     );
     expect(postAbility?.inputSchema).toEqual(
-      projectWordPressAiSchema(incrementRequestSchemaDocument)
+      projectWordPressAiSchema(incrementRequestSchemaDocument),
     );
     expect(
-      (postAbility?.inputSchema as { required?: string[] } | null)?.required
-    ).not.toContain("publicWriteToken");
+      (postAbility?.inputSchema as { required?: string[] } | null)?.required,
+    ).not.toContain('publicWriteToken');
   });
 
-  test("fails clearly when an endpoint is missing WordPress-only ability metadata", async () => {
+  test('fails clearly when an endpoint is missing WordPress-only ability metadata', async () => {
     expect(counterManifest).toBeDefined();
     expect(counterWordPressAiManifest).toBeDefined();
 
     await expect(
       buildWordPressAbilitiesDocument({
-        abilityConfig: {
-          getPersistenceCounterState:
-            COUNTER_WORDPRESS_ABILITY_CONFIG.getPersistenceCounterState,
-        },
-        category: COUNTER_ABILITY_CATEGORY,
-        generatedFrom: {
-          blockSlug: "counter",
-          responseSchemaPath: "wordpress-ai/counter-response.ai.schema.json",
-          schemaProfile: "ai-structured-output",
-        },
-        loadInputSchema: async (_endpoint, contractName) => {
-          const schema =
-            inputSchemas[contractName as keyof typeof inputSchemas];
-          if (!schema) {
-            throw new Error(`Unexpected contract "${contractName}".`);
-          }
-
-          return schema;
-        },
-        manifest: counterWordPressAiManifest!,
-        outputSchema: counterResponseAiSchemaDocument,
-      })
-    ).rejects.toThrow(
-      'Missing WordPress ability projection config for operationId "incrementPersistenceCounterState".'
-    );
-  });
-
-  test("fails clearly when ability config category ids drift from the document category", async () => {
-    expect(counterManifest).toBeDefined();
-    expect(counterWordPressAiManifest).toBeDefined();
-
-    await expect(
-      buildWordPressAbilitiesDocument({
-        abilityConfig: {
-          ...COUNTER_WORDPRESS_ABILITY_CONFIG,
-          getPersistenceCounterState: {
-            ...COUNTER_WORDPRESS_ABILITY_CONFIG.getPersistenceCounterState,
-            categoryId: "mismatched-category",
+        abilityCatalog: {
+          ...COUNTER_WORDPRESS_ABILITY_CATALOG,
+          abilities: {
+            getPersistenceCounterState:
+              COUNTER_WORDPRESS_ABILITY_CATALOG.abilities
+                .getPersistenceCounterState,
           },
         },
-        category: COUNTER_ABILITY_CATEGORY,
         generatedFrom: {
-          blockSlug: "counter",
-          responseSchemaPath: "wordpress-ai/counter-response.ai.schema.json",
-          schemaProfile: "ai-structured-output",
+          blockSlug: 'counter',
+          responseSchemaPath: 'wordpress-ai/counter-response.ai.schema.json',
+          schemaProfile: 'ai-structured-output',
         },
         loadInputSchema: async (_endpoint, contractName) => {
           const schema =
@@ -179,23 +145,61 @@ describe("WordPress AI internal helper", () => {
         },
         manifest: counterWordPressAiManifest!,
         outputSchema: counterResponseAiSchemaDocument,
-      })
+      }),
     ).rejects.toThrow(
-      'Operation "getPersistenceCounterState" uses categoryId "mismatched-category" but document category is "persistence-examples".'
+      'Missing AbilitySpec for operationId "incrementPersistenceCounterState".',
     );
   });
 
-  test("fails clearly when endpoints do not share the same response contract", async () => {
+  test('fails clearly when an AbilitySpec category is missing from the catalog', async () => {
+    expect(counterManifest).toBeDefined();
+    expect(counterWordPressAiManifest).toBeDefined();
+
+    await expect(
+      buildWordPressAbilitiesDocument({
+        abilityCatalog: {
+          ...COUNTER_WORDPRESS_ABILITY_CATALOG,
+          abilities: {
+            ...COUNTER_WORDPRESS_ABILITY_CATALOG.abilities,
+            getPersistenceCounterState: {
+              ...COUNTER_WORDPRESS_ABILITY_CATALOG.abilities
+                .getPersistenceCounterState,
+              categoryId: 'mismatched-category',
+            },
+          },
+        },
+        generatedFrom: {
+          blockSlug: 'counter',
+          responseSchemaPath: 'wordpress-ai/counter-response.ai.schema.json',
+          schemaProfile: 'ai-structured-output',
+        },
+        loadInputSchema: async (_endpoint, contractName) => {
+          const schema =
+            inputSchemas[contractName as keyof typeof inputSchemas];
+          if (!schema) {
+            throw new Error(`Unexpected contract "${contractName}".`);
+          }
+
+          return schema;
+        },
+        manifest: counterWordPressAiManifest!,
+        outputSchema: counterResponseAiSchemaDocument,
+      }),
+    ).rejects.toThrow(
+      'Operation "getPersistenceCounterState" references unknown AbilitySpec category "mismatched-category".',
+    );
+  });
+
+  test('fails clearly when endpoints do not share the same response contract', async () => {
     expect(counterManifest).toBeDefined();
 
     await expect(
       buildWordPressAiArtifacts({
-        abilityConfig: COUNTER_WORDPRESS_ABILITY_CONFIG,
-        category: COUNTER_ABILITY_CATEGORY,
+        abilityCatalog: COUNTER_WORDPRESS_ABILITY_CATALOG,
         generatedFrom: {
-          blockSlug: "counter",
-          responseSchemaPath: "wordpress-ai/counter-response.ai.schema.json",
-          schemaProfile: "ai-structured-output",
+          blockSlug: 'counter',
+          responseSchemaPath: 'wordpress-ai/counter-response.ai.schema.json',
+          schemaProfile: 'ai-structured-output',
         },
         loadInputSchema: async (_endpoint, contractName) => {
           const schema =
@@ -210,8 +214,8 @@ describe("WordPress AI internal helper", () => {
           ...counterWordPressAiManifest!,
           contracts: {
             ...counterWordPressAiManifest!.contracts,
-            "alt-counter-response": {
-              sourceTypeName: "PersistenceCounterResponse",
+            'alt-counter-response': {
+              sourceTypeName: 'PersistenceCounterResponse',
             },
           },
           endpoints: counterWordPressAiManifest!.endpoints.map(
@@ -220,14 +224,14 @@ describe("WordPress AI internal helper", () => {
                 ? endpoint
                 : {
                     ...endpoint,
-                    responseContract: "alt-counter-response",
-                  }
+                    responseContract: 'alt-counter-response',
+                  },
           ),
         },
         responseSchema: counterResponseSchemaDocument,
-      })
+      }),
     ).rejects.toThrow(
-      'Endpoint "incrementPersistenceCounterState" uses response contract "alt-counter-response" but expected shared response contract "counter-response".'
+      'Endpoint "incrementPersistenceCounterState" uses response contract "alt-counter-response" but expected shared response contract "counter-response".',
     );
   });
 });

--- a/tests/unit/wordpress-ai-projections.test.ts
+++ b/tests/unit/wordpress-ai-projections.test.ts
@@ -1,27 +1,28 @@
-import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
-import path from "node:path";
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
 
-import Ajv2020 from "ajv/dist/2020.js";
+import Ajv2020 from 'ajv/dist/2020.js';
 
-import counterResponseAiSchema from "../../examples/persistence-examples/src/blocks/counter/wordpress-ai/counter-response.ai.schema.json";
-import counterAbilitiesProjection from "../../examples/persistence-examples/src/blocks/counter/wordpress-ai/counter.abilities.json";
-import { BLOCKS } from "../../examples/persistence-examples/scripts/block-config";
+import counterResponseAiSchema from '../../examples/persistence-examples/src/blocks/counter/wordpress-ai/counter-response.ai.schema.json';
+import counterAbilitiesProjection from '../../examples/persistence-examples/src/blocks/counter/wordpress-ai/counter.abilities.json';
+import { BLOCKS } from '../../examples/persistence-examples/scripts/block-config';
 import {
   buildCounterWordPressAiArtifacts,
   COUNTER_ABILITY_CATEGORY,
   COUNTER_AI_RESPONSE_SCHEMA_RELATIVE_PATH,
-  COUNTER_WORDPRESS_ABILITY_CONFIG,
-} from "../../examples/persistence-examples/scripts/wordpress-ai-projections";
+  COUNTER_WORDPRESS_ABILITY_CATALOG,
+  COUNTER_WORDPRESS_ABILITY_SPECS,
+} from '../../examples/persistence-examples/scripts/wordpress-ai-projections';
 
-describe("WordPress AI projections", () => {
+describe('WordPress AI projections', () => {
   const counterWordPressAiManifest = BLOCKS.find(
-    (block) => block.slug === "counter"
+    (block) => block.slug === 'counter',
   )?.restManifest.endpoints.filter(
-    (endpoint) => endpoint.operationId !== "getPersistenceCounterBootstrap"
+    (endpoint) => endpoint.operationId !== 'getPersistenceCounterBootstrap',
   );
 
-  test("emits an AI-safe counter response schema that compiles under strict AJV without custom keywords", () => {
+  test('emits an AI-safe counter response schema that compiles under strict AJV without custom keywords', () => {
     const ajv = new Ajv2020({
       allErrors: true,
       strict: true,
@@ -32,44 +33,44 @@ describe("WordPress AI projections", () => {
       validate({
         count: 3,
         postId: 7,
-        resourceKey: "demo",
-        storage: "custom-table",
-      })
+        resourceKey: 'demo',
+        storage: 'custom-table',
+      }),
     ).toBe(true);
     expect(
       validate({
         count: -1,
         postId: 7.5,
-        resourceKey: "",
-        storage: "custom-table",
-      })
+        resourceKey: '',
+        storage: 'custom-table',
+      }),
     ).toBe(false);
     expect(
-      validate.errors?.some((error) => error.instancePath === "/postId")
+      validate.errors?.some((error) => error.instancePath === '/postId'),
     ).toBe(true);
   });
 
-  test("projects exactly two counter abilities with manifest-aligned route metadata and schema wiring", async () => {
+  test('projects exactly two counter abilities with manifest-aligned route metadata and schema wiring', async () => {
     const liveProjected = await buildCounterWordPressAiArtifacts();
     const counterManifest = BLOCKS.find(
-      (block) => block.slug === "counter"
+      (block) => block.slug === 'counter',
     )?.restManifest;
 
     expect(counterManifest).toBeDefined();
     expect(counterWordPressAiManifest).toBeDefined();
     expect(counterAbilitiesProjection.category).toEqual(
-      COUNTER_ABILITY_CATEGORY
+      COUNTER_ABILITY_CATEGORY,
     );
     expect(counterAbilitiesProjection.generatedFrom.responseSchemaPath).toBe(
-      COUNTER_AI_RESPONSE_SCHEMA_RELATIVE_PATH
+      COUNTER_AI_RESPONSE_SCHEMA_RELATIVE_PATH,
     );
     expect(counterAbilitiesProjection.abilities).toHaveLength(2);
 
     const routeSignatures = counterAbilitiesProjection.abilities.map(
-      (ability) => `${ability.method} ${ability.path}`
+      (ability) => `${ability.method} ${ability.path}`,
     );
     const manifestSignatures = counterWordPressAiManifest!.map(
-      (endpoint) => `${endpoint.method} ${endpoint.path}`
+      (endpoint) => `${endpoint.method} ${endpoint.path}`,
     );
 
     expect(routeSignatures).toEqual(manifestSignatures);
@@ -79,24 +80,24 @@ describe("WordPress AI projections", () => {
       expect(ability.category).toBe(COUNTER_ABILITY_CATEGORY.id);
       expect(ability.permissionCallback).toBe(
         (
-          COUNTER_WORDPRESS_ABILITY_CONFIG as Record<
+          COUNTER_WORDPRESS_ABILITY_SPECS as Record<
             string,
             { permissionCallback: string }
           >
-        )[ability.operationId]?.permissionCallback
+        )[ability.operationId]?.permissionCallback,
       );
       expect(ability.executeCallback).toBe(
         (
-          COUNTER_WORDPRESS_ABILITY_CONFIG as Record<
+          COUNTER_WORDPRESS_ABILITY_SPECS as Record<
             string,
             { executeCallback: string }
           >
-        )[ability.operationId]?.executeCallback
+        )[ability.operationId]?.executeCallback,
       );
     }
 
     const postAbility = liveProjected.abilitiesDocument.abilities.find(
-      (ability) => ability.method === "POST"
+      (ability) => ability.method === 'POST',
     );
     const postAbilityInputSchema = postAbility?.inputSchema as
       | {
@@ -111,118 +112,126 @@ describe("WordPress AI projections", () => {
 
     expect(postAbility).toBeDefined();
     expect(postAbilityInputSchema).toBeDefined();
-    expect(postAbilityInputSchema?.required).toContain("publicWriteToken");
+    expect(postAbilityInputSchema?.required).toContain('publicWriteToken');
     expect(postAbilityInputSchema?.properties?.postId?.minimum).toBe(1);
   });
 
-  test("fails clearly when an endpoint is missing WordPress-only ability metadata", async () => {
+  test('fails clearly when an endpoint is missing WordPress-only ability metadata', async () => {
     await expect(
       buildCounterWordPressAiArtifacts({
-        abilityConfig: {
-          getPersistenceCounterState:
-            COUNTER_WORDPRESS_ABILITY_CONFIG.getPersistenceCounterState,
+        abilityCatalog: {
+          ...COUNTER_WORDPRESS_ABILITY_CATALOG,
+          abilities: {
+            getPersistenceCounterState:
+              COUNTER_WORDPRESS_ABILITY_CATALOG.abilities
+                .getPersistenceCounterState,
+          },
         },
-      })
+      }),
     ).rejects.toThrow(
-      'Missing WordPress ability projection config for operationId "incrementPersistenceCounterState".'
+      'Missing AbilitySpec for operationId "incrementPersistenceCounterState".',
     );
   });
 
-  test("fails clearly when the counter overlay fields disappear from the increment schema", async () => {
+  test('fails clearly when the counter overlay fields disappear from the increment schema', async () => {
     await expect(
       buildCounterWordPressAiArtifacts({
         manifest: {
-          ...BLOCKS.find((block) => block.slug === "counter")!.restManifest,
+          ...BLOCKS.find((block) => block.slug === 'counter')!.restManifest,
           endpoints: BLOCKS.find(
-            (block) => block.slug === "counter"
+            (block) => block.slug === 'counter',
           )!.restManifest.endpoints.map((endpoint) =>
-            endpoint.method === "POST"
+            endpoint.method === 'POST'
               ? {
                   ...endpoint,
-                  bodyContract: "counter-query",
+                  bodyContract: 'counter-query',
                 }
-              : endpoint
+              : endpoint,
           ),
         },
-      })
+      }),
     ).rejects.toThrow(
-      'The increment request schema must define both "postId" and "publicWriteToken" for the WordPress AI overlay.'
+      'The increment request schema must define both "postId" and "publicWriteToken" for the WordPress AI overlay.',
     );
   });
 
-  test("uses the provided category id consistently for the document and every ability", async () => {
+  test('uses the provided category id consistently for the document and every ability', async () => {
     const projected = await buildCounterWordPressAiArtifacts({
-      abilityConfig: Object.fromEntries(
-        Object.entries(COUNTER_WORDPRESS_ABILITY_CONFIG).map(
-          ([operationId, config]) => [
-            operationId,
-            {
-              ...config,
-              categoryId: "custom-counter-category",
-            },
-          ]
-        )
-      ),
-      category: {
-        id: "custom-counter-category",
-        label: "Custom Counter Category",
+      abilityCatalog: {
+        abilities: Object.fromEntries(
+          Object.entries(COUNTER_WORDPRESS_ABILITY_SPECS).map(
+            ([operationId, config]) => [
+              operationId,
+              {
+                ...config,
+                categoryId: 'custom-counter-category',
+              },
+            ],
+          ),
+        ),
+        categories: {
+          'custom-counter-category': {
+            id: 'custom-counter-category',
+            label: 'Custom Counter Category',
+          },
+        },
       },
     });
 
     expect(projected.abilitiesDocument.category.id).toBe(
-      "custom-counter-category"
+      'custom-counter-category',
     );
     expect(
       projected.abilitiesDocument.abilities.every(
-        (ability) => ability.category === "custom-counter-category"
-      )
+        (ability) => ability.category === 'custom-counter-category',
+      ),
     ).toBe(true);
   });
 
-  test("keeps the example plugin integration explicitly guarded behind WordPress AI and abilities feature detection", () => {
+  test('keeps the example plugin integration explicitly guarded behind WordPress AI and abilities feature detection', () => {
     const phpSource = readFileSync(
       path.join(
         import.meta.dir,
-        "..",
-        "..",
-        "examples",
-        "persistence-examples",
-        "inc",
-        "wordpress-ai.php"
+        '..',
+        '..',
+        'examples',
+        'persistence-examples',
+        'inc',
+        'wordpress-ai.php',
       ),
-      "utf8"
+      'utf8',
     );
 
     expect(phpSource).toContain("function_exists( 'wp_ai_client_prompt' )");
     expect(phpSource).toContain(
-      "function_exists( 'wp_register_ability_category' )"
+      "function_exists( 'wp_register_ability_category' )",
     );
     expect(phpSource).toContain("function_exists( 'wp_register_ability' )");
   });
 
-  test("marks bootstrap example handlers as no-store to avoid caching viewer state", () => {
+  test('marks bootstrap example handlers as no-store to avoid caching viewer state', () => {
     const pluginSource = readFileSync(
       path.join(
         import.meta.dir,
-        "..",
-        "..",
-        "examples",
-        "persistence-examples",
-        "persistence-examples.php"
+        '..',
+        '..',
+        'examples',
+        'persistence-examples',
+        'persistence-examples.php',
       ),
-      "utf8"
+      'utf8',
     );
 
     expect(pluginSource).toContain(
-      "function persistence_examples_handle_get_counter_bootstrap"
+      'function persistence_examples_handle_get_counter_bootstrap',
     );
     expect(pluginSource).toContain(
-      "function persistence_examples_handle_get_like_bootstrap"
+      'function persistence_examples_handle_get_like_bootstrap',
     );
     expect(
       pluginSource.match(
-        /Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0, s-maxage=0'/g
-      ) ?? []
+        /Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0, s-maxage=0'/g,
+      ) ?? [],
     ).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Summary
- introduce internal `AbilitySpec` and `AbilitySpecCatalog` contracts for WordPress-only ability metadata
- add a draft AI feature capability model for `required` vs `optional` scaffold surfaces
- refactor the WordPress AI proof, docs, and tests to consume the new boundary

## Why
- Closes #557 by giving WordPress-native ability semantics a dedicated additive layer
- Refs #561 by defining the compatibility metadata model before scaffold/header policy work lands
- keeps endpoint manifests backend-neutral while still allowing WordPress-only projection metadata such as `meta.mcp.public`

## Validation
- `bun run typecheck`
- `bun run --filter @wp-typia/project-tools test:scaffold-core`
- `bun test tests/unit/wordpress-ai-helper.test.ts tests/unit/wordpress-ai-projections.test.ts packages/wp-typia-project-tools/tests/wordpress-ai-spec.test.ts`
- `bun run --filter persistence-examples sync-wordpress-ai --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Formalized WordPress AI projection configuration documentation with detailed merge boundaries and metadata handling requirements.

* **New Features**
  * Added draft AI feature capability model for future scaffolds with required/optional feature selection support.

* **Tests**
  * Expanded test coverage for WordPress AI specifications and capability resolution planning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->