### PR TITLE
feat(scaffold): add server-only WordPress AI feature scaffolds

### DIFF
--- a/apps/docs/src/content/docs/reference/api.md
+++ b/apps/docs/src/content/docs/reference/api.md
@@ -693,12 +693,13 @@ without changing the parent block's default seeded template for hidden child
 extensions, and it also supports visible container children plus nested ancestor
 chains for richer document-style layouts.
 
-Official workspaces also support first-class variation, pattern, binding-source, and hooked-block expansion:
+Official workspaces also support first-class variation, pattern, binding-source, AI-feature, and hooked-block expansion:
 
 ```bash
 wp-typia add variation hero-card --block counter-card
 wp-typia add pattern hero-layout
 wp-typia add binding-source hero-data
+wp-typia add ai-feature brief-suggestions --namespace my-plugin/v1
 wp-typia add hooked-block counter-card --anchor core/post-content --position after
 ```
 
@@ -711,6 +712,9 @@ starter contract keeps one field-keyed data map in each file, so the common
 follow-up is to edit `src/bindings/<name>/server.php` and
 `src/bindings/<name>/editor.ts` in parallel by replacing the default starter
 values for the fields you want to expose.
+AI features are generated under `src/ai-features/*/` plus `inc/ai-features/*.php`
+and scaffold a server-owned REST endpoint, AI-safe response schema projection,
+typed endpoint client wrapper, and WordPress AI Client feature-detection seam.
 Hooked blocks patch `src/blocks/<block>/block.json` with `blockHooks` metadata
 so the target block is inserted relative to the chosen anchor block.
 

--- a/apps/docs/src/content/docs/reference/wordpress-ai-projections.md
+++ b/apps/docs/src/content/docs/reference/wordpress-ai-projections.md
@@ -9,6 +9,11 @@ The projection path is no longer internal-only: the supported helper surface now
 lives on `@wp-typia/project-tools/ai-artifacts`, and generated projects can opt
 into a dedicated `sync-ai` script that `wp-typia sync ai` understands.
 
+That supported sync path now also underpins scaffolded server-only AI feature
+endpoints. Official workspaces can generate a starter feature with
+`wp-typia add ai-feature <name>`, which wires a typed REST endpoint plus an
+AI-safe response schema under `src/ai-features/<slug>/ai-schemas/`.
+
 ## Outcome
 
 - WordPress AI Client: the generated counter response schema can be reused after
@@ -84,15 +89,16 @@ WordPress floor and runtime gate expectations for surfaces such as:
 - the WordPress AI Client
 - optional MCP public metadata
 
-Scaffolds do not apply those rules yet. The current state is still:
+Scaffolds do not apply the compatibility policy yet. The current state is:
 
 - no plugin header changes
 - no generated runtime guards
-- no AI-capable scaffold rollout in the supported templates yet
+- a server-only `add ai-feature` workflow for WordPress AI Client endpoints
+- no typed Abilities scaffold rollout yet
 
 ## What this does not change
 
-- No scaffold imports or templates change
+- No typed Abilities scaffold is included here yet
 - No MCP integration is included here
 - No frontend or default AI behavior is added to generated projects
 - `typia.llm` remains a separate evaluation path rather than part of the

--- a/packages/create-workspace-template/package.json.mustache
+++ b/packages/create-workspace-template/package.json.mustache
@@ -29,6 +29,7 @@
     "@wp-typia/api-client": "{{apiClientPackageVersion}}",
     "@wp-typia/block-runtime": "{{blockRuntimePackageVersion}}",
     "@wp-typia/block-types": "{{blockTypesPackageVersion}}",
+    "@wp-typia/project-tools": "{{projectToolsPackageVersion}}",
     "@wp-typia/rest": "{{restPackageVersion}}",
     "@typia/unplugin": "^12.0.1",
     "@types/node": "^24.5.2",

--- a/packages/wp-typia-project-tools/src/runtime/ai-feature-artifacts.ts
+++ b/packages/wp-typia-project-tools/src/runtime/ai-feature-artifacts.ts
@@ -1,0 +1,234 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import {
+	defineEndpointManifest,
+	syncEndpointClient,
+	syncRestOpenApi,
+	syncTypeSchemas,
+	type ArtifactSyncExecutionOptions,
+} from "@wp-typia/block-runtime/metadata-core";
+
+import { projectWordPressAiSchema } from "./ai-artifacts.js";
+import type { JsonSchemaDocument } from "./schema-core.js";
+
+interface AiFeatureTemplateVariablesLike {
+	namespace: string;
+	pascalCase: string;
+	slugKebabCase: string;
+	title: string;
+}
+
+interface SyncAiFeatureRestArtifactsOptions {
+	clientFile: string;
+	outputDir: string;
+	projectDir: string;
+	typesFile: string;
+	validatorsFile: string;
+	variables: AiFeatureTemplateVariablesLike;
+}
+
+/**
+ * Configures the AI-safe schema projection for one scaffolded AI feature.
+ */
+export interface SyncAiFeatureSchemaArtifactOptions
+	extends ArtifactSyncExecutionOptions {
+	aiSchemaFile: string;
+	outputDir: string;
+	projectDir: string;
+}
+
+/**
+ * Carries the generated AI schema document and the file paths touched on disk.
+ */
+export interface SyncAiFeatureSchemaArtifactResult {
+	aiSchema: JsonSchemaDocument & Record<string, unknown>;
+	aiSchemaPath: string;
+	check: boolean;
+	sourceSchemaPath: string;
+}
+
+function normalizeGeneratedArtifactContent(content: string): string {
+	return content.replace(/\r\n?/g, "\n");
+}
+
+async function reconcileGeneratedArtifact(options: {
+	check: boolean;
+	content: string;
+	filePath: string;
+	label: string;
+}): Promise<void> {
+	if (!options.check) {
+		await mkdir(path.dirname(options.filePath), {
+			recursive: true,
+		});
+		await writeFile(options.filePath, options.content, "utf8");
+		return;
+	}
+
+	try {
+		const current = normalizeGeneratedArtifactContent(
+			await readFile(options.filePath, "utf8"),
+		);
+		const expected = normalizeGeneratedArtifactContent(options.content);
+		if (current !== expected) {
+			throw new Error(
+				`Generated AI feature artifact is stale: ${options.label} (${options.filePath}).`,
+			);
+		}
+	} catch (error) {
+		const code =
+			error && typeof error === "object" && "code" in error
+				? (error as { code?: string }).code
+				: undefined;
+		if (code === "ENOENT") {
+			throw new Error(
+				`Generated AI feature artifact is missing: ${options.label} (${options.filePath}).`,
+			);
+		}
+		throw error;
+	}
+}
+
+function assertJsonObject(
+	value: unknown,
+	label: string,
+): JsonSchemaDocument & Record<string, unknown> {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		throw new Error(`Expected ${label} to decode to a JSON object.`);
+	}
+
+	return value as JsonSchemaDocument & Record<string, unknown>;
+}
+
+/**
+ * Build the endpoint manifest for a workspace-level AI feature scaffold.
+ *
+ * The endpoint response wraps a typed AI result payload together with provider,
+ * model, and token-usage telemetry. The nested `feature-result` contract is
+ * also kept in the manifest so `sync-rest` can emit the canonical JSON Schema
+ * that `sync-ai` later projects into the AI structured-output profile.
+ *
+ * @param variables Template naming data used for type names, routes, and docs.
+ * @returns Endpoint manifest consumed by schema, OpenAPI, and client generators.
+ */
+export function buildAiFeatureEndpointManifest(
+	variables: AiFeatureTemplateVariablesLike,
+) {
+	return defineEndpointManifest({
+		contracts: {
+			"feature-request": {
+				sourceTypeName: `${variables.pascalCase}AiFeatureRequest`,
+			},
+			"feature-response": {
+				sourceTypeName: `${variables.pascalCase}AiFeatureResponse`,
+			},
+			"feature-result": {
+				sourceTypeName: `${variables.pascalCase}AiFeatureResult`,
+			},
+		},
+		endpoints: [
+			{
+				auth: "authenticated",
+				bodyContract: "feature-request",
+				method: "POST",
+				operationId: `run${variables.pascalCase}AiFeature`,
+				path: `/${variables.namespace}/ai/${variables.slugKebabCase}`,
+				responseContract: "feature-response",
+				summary: `Run the ${variables.title} AI feature endpoint.`,
+				tags: [`${variables.title} AI`],
+				wordpressAuth: {
+					mechanism: "rest-nonce",
+				},
+			},
+		],
+		info: {
+			title: `${variables.title} AI Feature API`,
+			version: "1.0.0",
+		},
+	});
+}
+
+/**
+ * Synchronize generated schemas, OpenAPI output, and endpoint client code for
+ * a workspace-level AI feature scaffold.
+ *
+ * @param options Feature file paths and naming variables.
+ * @returns A promise that resolves after every generated REST artifact has been refreshed.
+ */
+export async function syncAiFeatureRestArtifacts({
+	clientFile,
+	outputDir,
+	projectDir,
+	typesFile,
+	validatorsFile,
+	variables,
+}: SyncAiFeatureRestArtifactsOptions): Promise<void> {
+	const manifest = buildAiFeatureEndpointManifest(variables);
+
+	for (const [baseName, contract] of Object.entries(manifest.contracts) as Array<
+		[string, { sourceTypeName: string }]
+	>) {
+		await syncTypeSchemas({
+			jsonSchemaFile: path.join(outputDir, "api-schemas", `${baseName}.schema.json`),
+			openApiFile: path.join(outputDir, "api-schemas", `${baseName}.openapi.json`),
+			projectRoot: projectDir,
+			sourceTypeName: contract.sourceTypeName,
+			typesFile,
+		});
+	}
+
+	await syncRestOpenApi({
+		manifest,
+		openApiFile: path.join(outputDir, "api.openapi.json"),
+		projectRoot: projectDir,
+		typesFile,
+	});
+
+	await syncEndpointClient({
+		clientFile,
+		manifest,
+		projectRoot: projectDir,
+		typesFile,
+		validatorsFile,
+	});
+}
+
+/**
+ * Project the canonical AI result contract for one scaffolded feature into the
+ * AI structured-output schema profile consumed by `wp_ai_client_prompt()`.
+ *
+ * @param options Artifact destination plus the feature output directory.
+ * @returns The projected AI schema and the source schema path it derived from.
+ */
+export async function syncAiFeatureSchemaArtifact({
+	aiSchemaFile,
+	check = false,
+	outputDir,
+	projectDir,
+}: SyncAiFeatureSchemaArtifactOptions): Promise<SyncAiFeatureSchemaArtifactResult> {
+	const sourceSchemaPath = path.join(
+		projectDir,
+		outputDir,
+		"api-schemas",
+		"feature-result.schema.json",
+	);
+	const responseSchema = assertJsonObject(
+		JSON.parse(await readFile(sourceSchemaPath, "utf8")) as unknown,
+		sourceSchemaPath,
+	);
+	const aiSchema = projectWordPressAiSchema(responseSchema);
+	await reconcileGeneratedArtifact({
+		check,
+		content: `${JSON.stringify(aiSchema, null, 2)}\n`,
+		filePath: path.join(projectDir, aiSchemaFile),
+		label: "AI feature schema",
+	});
+
+	return {
+		aiSchema,
+		aiSchemaPath: path.join(projectDir, aiSchemaFile),
+		check,
+		sourceSchemaPath,
+	};
+}

--- a/packages/wp-typia-project-tools/src/runtime/ai-feature-artifacts.ts
+++ b/packages/wp-typia-project-tools/src/runtime/ai-feature-artifacts.ts
@@ -21,6 +21,7 @@ interface AiFeatureTemplateVariablesLike {
 
 interface SyncAiFeatureRestArtifactsOptions {
 	clientFile: string;
+	executionOptions?: ArtifactSyncExecutionOptions;
 	outputDir: string;
 	projectDir: string;
 	typesFile: string;
@@ -158,6 +159,7 @@ export function buildAiFeatureEndpointManifest(
  */
 export async function syncAiFeatureRestArtifacts({
 	clientFile,
+	executionOptions,
 	outputDir,
 	projectDir,
 	typesFile,
@@ -169,29 +171,38 @@ export async function syncAiFeatureRestArtifacts({
 	for (const [baseName, contract] of Object.entries(manifest.contracts) as Array<
 		[string, { sourceTypeName: string }]
 	>) {
-		await syncTypeSchemas({
-			jsonSchemaFile: path.join(outputDir, "api-schemas", `${baseName}.schema.json`),
-			openApiFile: path.join(outputDir, "api-schemas", `${baseName}.openapi.json`),
-			projectRoot: projectDir,
-			sourceTypeName: contract.sourceTypeName,
-			typesFile,
-		});
+		await syncTypeSchemas(
+			{
+				jsonSchemaFile: path.join(outputDir, "api-schemas", `${baseName}.schema.json`),
+				openApiFile: path.join(outputDir, "api-schemas", `${baseName}.openapi.json`),
+				projectRoot: projectDir,
+				sourceTypeName: contract.sourceTypeName,
+				typesFile,
+			},
+			executionOptions,
+		);
 	}
 
-	await syncRestOpenApi({
-		manifest,
-		openApiFile: path.join(outputDir, "api.openapi.json"),
-		projectRoot: projectDir,
-		typesFile,
-	});
+	await syncRestOpenApi(
+		{
+			manifest,
+			openApiFile: path.join(outputDir, "api.openapi.json"),
+			projectRoot: projectDir,
+			typesFile,
+		},
+		executionOptions,
+	);
 
-	await syncEndpointClient({
-		clientFile,
-		manifest,
-		projectRoot: projectDir,
-		typesFile,
-		validatorsFile,
-	});
+	await syncEndpointClient(
+		{
+			clientFile,
+			manifest,
+			projectRoot: projectDir,
+			typesFile,
+			validatorsFile,
+		},
+		executionOptions,
+	);
 }
 
 /**

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-shared.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-shared.ts
@@ -31,6 +31,7 @@ export const ADD_KIND_IDS = [
 	"pattern",
 	"binding-source",
 	"rest-resource",
+	"ai-feature",
 	"hooked-block",
 	"editor-plugin",
 ] as const;
@@ -90,6 +91,12 @@ export interface RunAddRestResourceCommandOptions {
 	methods?: string;
 	namespace?: string;
 	restResourceName: string;
+}
+
+export interface RunAddAiFeatureCommandOptions {
+	aiFeatureName: string;
+	cwd?: string;
+	namespace?: string;
 }
 
 export interface RunAddHookedBlockCommandOptions {
@@ -491,6 +498,35 @@ export function assertRestResourceDoesNotExist(
 	}
 }
 
+export function assertAiFeatureDoesNotExist(
+	projectDir: string,
+	aiFeatureSlug: string,
+	inventory: WorkspaceInventory,
+): void {
+	const aiFeatureDir = path.join(projectDir, "src", "ai-features", aiFeatureSlug);
+	const aiFeaturePhpPath = path.join(
+		projectDir,
+		"inc",
+		"ai-features",
+		`${aiFeatureSlug}.php`,
+	);
+	if (fs.existsSync(aiFeatureDir)) {
+		throw new Error(
+			`An AI feature already exists at ${path.relative(projectDir, aiFeatureDir)}. Choose a different name.`,
+		);
+	}
+	if (fs.existsSync(aiFeaturePhpPath)) {
+		throw new Error(
+			`An AI feature bootstrap already exists at ${path.relative(projectDir, aiFeaturePhpPath)}. Choose a different name.`,
+		);
+	}
+	if (inventory.aiFeatures.some((entry) => entry.slug === aiFeatureSlug)) {
+		throw new Error(
+			`An AI feature inventory entry already exists for ${aiFeatureSlug}. Choose a different name.`,
+		);
+	}
+}
+
 /**
  * Ensure an editor plugin scaffold does not already exist on disk or in the
  * workspace inventory.
@@ -524,6 +560,7 @@ export function formatAddHelpText(): string {
   wp-typia add pattern <name> [--dry-run]
   wp-typia add binding-source <name> [--dry-run]
   wp-typia add rest-resource <name> [--namespace <vendor/v1>] [--methods <list,read,create,update,delete>] [--dry-run]
+  wp-typia add ai-feature <name> [--namespace <vendor/v1>] [--dry-run]
   wp-typia add hooked-block <block-slug> --anchor <anchor-block-name> --position <${HOOKED_BLOCK_POSITION_IDS.join("|")}> [--dry-run]
   wp-typia add editor-plugin <name> [--slot <${EDITOR_PLUGIN_SLOT_IDS.join("|")}>] [--dry-run]
 
@@ -535,6 +572,7 @@ Notes:
   \`add pattern\` scaffolds a namespaced PHP pattern shell under \`src/patterns/\`.
   \`add binding-source\` scaffolds shared PHP and editor registration under \`src/bindings/\`.
   \`add rest-resource\` scaffolds plugin-level TypeScript REST contracts under \`src/rest/\` and PHP route glue under \`inc/rest/\`.
+  \`add ai-feature\` scaffolds server-owned AI feature endpoints under \`src/ai-features/\` and PHP route glue under \`inc/ai-features/\`.
   \`add hooked-block\` patches an existing workspace block's \`block.json\` \`blockHooks\` metadata.
   \`add editor-plugin\` scaffolds a document-level editor extension under \`src/editor-plugins/\`.`;
 }

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai-anchors.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai-anchors.ts
@@ -1,0 +1,413 @@
+import { promises as fsp } from "node:fs";
+import path from "node:path";
+
+import { getPackageVersions } from "./package-versions.js";
+import {
+	getWorkspaceBootstrapPath,
+	patchFile,
+} from "./cli-add-shared.js";
+import type { WorkspaceProject } from "./workspace-project.js";
+
+const AI_FEATURE_SERVER_GLOB = "/inc/ai-features/*.php";
+
+function escapeRegex(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+export async function ensureAiFeatureBootstrapAnchors(
+	workspace: WorkspaceProject,
+): Promise<void> {
+	const bootstrapPath = getWorkspaceBootstrapPath(workspace);
+
+	await patchFile(bootstrapPath, (source) => {
+		let nextSource = source;
+		const registerFunctionName = `${workspace.workspace.phpPrefix}_register_ai_features`;
+		const registerHook = `add_action( 'init', '${registerFunctionName}', 20 );`;
+		const registerFunction = `
+
+function ${registerFunctionName}() {
+\tforeach ( glob( __DIR__ . '${AI_FEATURE_SERVER_GLOB}' ) ?: array() as $ai_feature_module ) {
+\t\trequire_once $ai_feature_module;
+\t}
+}
+`;
+		const insertionAnchors = [
+			/add_action\(\s*["']init["']\s*,\s*["'][^"']+_load_textdomain["']\s*\);\s*\n/u,
+			/\?>\s*$/u,
+		];
+		const hasPhpFunctionDefinition = (functionName: string): boolean =>
+			new RegExp(`function\\s+${escapeRegex(functionName)}\\s*\\(`, "u").test(nextSource);
+		const insertPhpSnippet = (snippet: string): void => {
+			for (const anchor of insertionAnchors) {
+				const candidate = nextSource.replace(anchor, (match) => `${snippet}\n${match}`);
+				if (candidate !== nextSource) {
+					nextSource = candidate;
+					return;
+				}
+			}
+			nextSource = `${nextSource.trimEnd()}\n${snippet}\n`;
+		};
+		const appendPhpSnippet = (snippet: string): void => {
+			const closingTagPattern = /\?>\s*$/u;
+			if (closingTagPattern.test(nextSource)) {
+				nextSource = nextSource.replace(closingTagPattern, `${snippet}\n?>`);
+				return;
+			}
+			nextSource = `${nextSource.trimEnd()}\n${snippet}\n`;
+		};
+
+		if (!hasPhpFunctionDefinition(registerFunctionName)) {
+			insertPhpSnippet(registerFunction);
+		} else if (!nextSource.includes(AI_FEATURE_SERVER_GLOB)) {
+			throw new Error(
+				[
+					`Unable to patch ${path.basename(bootstrapPath)} in ensureAiFeatureBootstrapAnchors.`,
+					`The existing ${registerFunctionName}() definition does not include ${AI_FEATURE_SERVER_GLOB}.`,
+					"Restore the generated bootstrap shape or wire the AI feature loader manually before retrying.",
+				].join(" "),
+			);
+		}
+
+		if (!nextSource.includes(registerHook)) {
+			appendPhpSnippet(registerHook);
+		}
+
+		return nextSource;
+	});
+}
+
+export async function ensureAiFeaturePackageScripts(
+	workspace: WorkspaceProject,
+): Promise<{
+	addedProjectToolsDependency: boolean;
+	addedSyncAiScript: boolean;
+}> {
+	const packageJsonPath = path.join(workspace.projectDir, "package.json");
+	const packageJson = JSON.parse(
+		await fsp.readFile(packageJsonPath, "utf8"),
+	) as {
+		devDependencies?: Record<string, string>;
+		scripts?: Record<string, string>;
+	};
+
+	const nextScripts = {
+		...(packageJson.scripts ?? {}),
+		"sync-ai":
+			packageJson.scripts?.["sync-ai"] ?? "tsx scripts/sync-ai-features.ts",
+	};
+	const nextDevDependencies = {
+		...(packageJson.devDependencies ?? {}),
+		"@wp-typia/project-tools":
+			packageJson.devDependencies?.["@wp-typia/project-tools"] ??
+			getPackageVersions().projectToolsPackageVersion,
+	};
+	const addedSyncAiScript = packageJson.scripts?.["sync-ai"] === undefined;
+	const addedProjectToolsDependency =
+		packageJson.devDependencies?.["@wp-typia/project-tools"] === undefined;
+
+	if (
+		JSON.stringify(nextScripts) === JSON.stringify(packageJson.scripts ?? {}) &&
+		JSON.stringify(nextDevDependencies) ===
+			JSON.stringify(packageJson.devDependencies ?? {})
+	) {
+		return {
+			addedProjectToolsDependency: false,
+			addedSyncAiScript: false,
+		};
+	}
+
+	packageJson.scripts = nextScripts;
+	packageJson.devDependencies = nextDevDependencies;
+	await fsp.writeFile(
+		packageJsonPath,
+		`${JSON.stringify(packageJson, null, "\t")}\n`,
+		"utf8",
+	);
+
+	return {
+		addedProjectToolsDependency,
+		addedSyncAiScript,
+	};
+}
+
+export async function ensureAiFeatureSyncProjectAnchors(
+	workspace: WorkspaceProject,
+): Promise<void> {
+	const syncProjectScriptPath = path.join(
+		workspace.projectDir,
+		"scripts",
+		"sync-project.ts",
+	);
+
+	await patchFile(syncProjectScriptPath, (source) => {
+		let nextSource = source;
+		const syncRestConst = "const syncRestScriptPath = path.join( 'scripts', 'sync-rest-contracts.ts' );";
+		const syncAiConst = "const syncAiScriptPath = path.join( 'scripts', 'sync-ai-features.ts' );";
+		const syncRestBlockPattern =
+			/if \( fs\.existsSync\( path\.resolve\( process\.cwd\(\), syncRestScriptPath \) \) \) \{\n\s*runSyncScript\( syncRestScriptPath, options \);\n\s*\}/u;
+		const syncAiBlock = [
+			"if ( fs.existsSync( path.resolve( process.cwd(), syncAiScriptPath ) ) ) {",
+			"\trunSyncScript( syncAiScriptPath, options );",
+			"}",
+		].join("\n");
+
+		if (!nextSource.includes(syncAiConst)) {
+			if (!nextSource.includes(syncRestConst)) {
+				throw new Error(
+					[
+						`ensureAiFeatureSyncProjectAnchors could not patch ${path.basename(syncProjectScriptPath)}.`,
+						"Missing the expected sync-rest script constant in scripts/sync-project.ts.",
+						"Restore the generated template or wire sync-ai manually before retrying.",
+					].join(" "),
+				);
+			}
+			nextSource = nextSource.replace(
+				syncRestConst,
+				`${syncRestConst}\nconst syncAiScriptPath = path.join( 'scripts', 'sync-ai-features.ts' );`,
+			);
+		}
+
+		if (!nextSource.includes("runSyncScript( syncAiScriptPath, options );")) {
+			if (!syncRestBlockPattern.test(nextSource)) {
+				throw new Error(
+					[
+						`ensureAiFeatureSyncProjectAnchors could not patch ${path.basename(syncProjectScriptPath)}.`,
+						"Missing the expected sync-rest invocation block in scripts/sync-project.ts.",
+						"Restore the generated template or wire sync-ai manually before retrying.",
+					].join(" "),
+				);
+			}
+
+			nextSource = nextSource.replace(
+				syncRestBlockPattern,
+				(match) => `${match}\n\n${syncAiBlock}`,
+			);
+		}
+
+		return nextSource;
+	});
+}
+
+function assertSyncRestAnchor(
+	nextSource: string,
+	target: string,
+	anchorDescription: string,
+	hasAnchor: boolean,
+	syncRestScriptPath: string,
+): void {
+	if (!nextSource.includes(target) && !hasAnchor) {
+		throw new Error(
+			[
+				`ensureAiFeatureSyncRestAnchors could not patch ${path.basename(syncRestScriptPath)}.`,
+				`Missing expected ${anchorDescription} anchor in scripts/sync-rest-contracts.ts.`,
+				"Restore the generated template or add the AI feature wiring manually before retrying.",
+			].join(" "),
+		);
+	}
+}
+
+function replaceRequiredSyncRestSource(
+	nextSource: string,
+	target: string,
+	anchor: string | RegExp,
+	replacement: string,
+	anchorDescription: string,
+	syncRestScriptPath: string,
+): string {
+	if (nextSource.includes(target)) {
+		return nextSource;
+	}
+
+	const hasAnchor =
+		typeof anchor === "string" ? nextSource.includes(anchor) : anchor.test(nextSource);
+	assertSyncRestAnchor(
+		nextSource,
+		target,
+		anchorDescription,
+		hasAnchor,
+		syncRestScriptPath,
+	);
+
+	return nextSource.replace(anchor, replacement);
+}
+
+export async function ensureAiFeatureSyncRestAnchors(
+	workspace: WorkspaceProject,
+): Promise<void> {
+	const syncRestScriptPath = path.join(
+		workspace.projectDir,
+		"scripts",
+		"sync-rest-contracts.ts",
+	);
+
+	await patchFile(syncRestScriptPath, (source) => {
+		let nextSource = source;
+		const importAnchor = [
+			"import {",
+			"\tBLOCKS,",
+			"\tREST_RESOURCES,",
+			"\ttype WorkspaceBlockConfig,",
+			"\ttype WorkspaceRestResourceConfig,",
+			"} from './block-config';",
+		].join("\n");
+		const helperInsertionAnchor = "async function assertTypeArtifactsCurrent";
+		const restResourcesAnchor =
+			"const restResources = REST_RESOURCES.filter( isWorkspaceRestResource );";
+		const noResourcesPattern =
+			/if \( restBlocks.length === 0 && restResources.length === 0 \) \{[\s\S]*?\n\t\treturn;\n\t\}/u;
+		const consoleLogPattern = /\n\tconsole\.log\(\n\t\toptions\.check/u;
+
+		nextSource = replaceRequiredSyncRestSource(
+			nextSource,
+			"AI_FEATURES",
+			importAnchor,
+			[
+				"import {",
+				"\tAI_FEATURES,",
+				"\tBLOCKS,",
+				"\tREST_RESOURCES,",
+				"\ttype WorkspaceAiFeatureConfig,",
+				"\ttype WorkspaceBlockConfig,",
+				"\ttype WorkspaceRestResourceConfig,",
+				"} from './block-config';",
+			].join("\n"),
+			"workspace inventory import",
+			syncRestScriptPath,
+		);
+
+		nextSource = replaceRequiredSyncRestSource(
+			nextSource,
+			"function isWorkspaceAiFeature(",
+			helperInsertionAnchor,
+			[
+				"function isWorkspaceAiFeature(",
+				"\tfeature: WorkspaceAiFeatureConfig",
+				"): feature is WorkspaceAiFeatureConfig & {",
+				"\taiSchemaFile: string;",
+				"\tclientFile: string;",
+				"\topenApiFile: string;",
+				"\trestManifest: NonNullable< WorkspaceAiFeatureConfig[ 'restManifest' ] >;",
+				"\ttypesFile: string;",
+				"\tvalidatorsFile: string;",
+				"} {",
+				"\treturn (",
+				"\t\ttypeof feature.aiSchemaFile === 'string' &&",
+				"\t\ttypeof feature.clientFile === 'string' &&",
+				"\t\ttypeof feature.openApiFile === 'string' &&",
+				"\t\ttypeof feature.typesFile === 'string' &&",
+				"\t\ttypeof feature.validatorsFile === 'string' &&",
+				"\t\ttypeof feature.restManifest === 'object' &&",
+				"\t\tfeature.restManifest !== null",
+				"\t);",
+				"}",
+				"",
+				"async function assertTypeArtifactsCurrent",
+			].join("\n"),
+			"type artifact assertion helper",
+			syncRestScriptPath,
+		);
+
+		nextSource = replaceRequiredSyncRestSource(
+			nextSource,
+			"const aiFeatures = AI_FEATURES.filter( isWorkspaceAiFeature );",
+			restResourcesAnchor,
+			[
+				"const restResources = REST_RESOURCES.filter( isWorkspaceRestResource );",
+				"const aiFeatures = AI_FEATURES.filter( isWorkspaceAiFeature );",
+			].join("\n"),
+			"rest resource filter",
+			syncRestScriptPath,
+		);
+
+		nextSource = replaceRequiredSyncRestSource(
+			nextSource,
+			"restBlocks.length === 0 && restResources.length === 0 && aiFeatures.length === 0",
+			noResourcesPattern,
+			[
+				"if ( restBlocks.length === 0 && restResources.length === 0 && aiFeatures.length === 0 ) {",
+				"\t\tconsole.log(",
+				"\t\t\toptions.check",
+				"\t\t\t\t? 'ℹ️ No REST-enabled workspace blocks, plugin-level REST resources, or AI features are registered yet. `sync-rest --check` is already clean.'",
+				"\t\t\t\t: 'ℹ️ No REST-enabled workspace blocks, plugin-level REST resources, or AI features are registered yet.'",
+				"\t\t);",
+				"\t\treturn;",
+				"\t}",
+			].join("\n"),
+			"no-resources guard",
+			syncRestScriptPath,
+		);
+
+		nextSource = replaceRequiredSyncRestSource(
+			nextSource,
+			"for ( const feature of aiFeatures ) {",
+			consoleLogPattern,
+			[
+				"",
+				"\tfor ( const feature of aiFeatures ) {",
+				"\t\tconst contracts = feature.restManifest.contracts;",
+				"",
+				"\t\tfor ( const [ baseName, contract ] of Object.entries( contracts ) ) {",
+				"\t\t\tawait syncTypeSchemas(",
+				"\t\t\t\t{",
+				"\t\t\t\t\tjsonSchemaFile: path.join(",
+				"\t\t\t\t\t\tpath.dirname( feature.typesFile ),",
+				"\t\t\t\t\t\t'api-schemas',",
+				"\t\t\t\t\t\t`${ baseName }.schema.json`",
+				"\t\t\t\t\t),",
+				"\t\t\t\t\topenApiFile: path.join(",
+				"\t\t\t\t\t\tpath.dirname( feature.typesFile ),",
+				"\t\t\t\t\t\t'api-schemas',",
+				"\t\t\t\t\t\t`${ baseName }.openapi.json`",
+				"\t\t\t\t\t),",
+				"\t\t\t\t\tsourceTypeName: contract.sourceTypeName,",
+				"\t\t\t\t\ttypesFile: feature.typesFile,",
+				"\t\t\t\t},",
+				"\t\t\t\t{",
+				"\t\t\t\t\tcheck: options.check,",
+				"\t\t\t\t}",
+				"\t\t\t);",
+				"\t\t}",
+				"",
+				"\t\tawait syncRestOpenApi(",
+				"\t\t\t{",
+				"\t\t\t\tmanifest: feature.restManifest,",
+				"\t\t\t\topenApiFile: feature.openApiFile,",
+				"\t\t\t\ttypesFile: feature.typesFile,",
+				"\t\t\t},",
+				"\t\t\t{",
+				"\t\t\t\tcheck: options.check,",
+				"\t\t\t}",
+				"\t\t);",
+				"",
+				"\t\tawait syncEndpointClient(",
+				"\t\t\t{",
+				"\t\t\t\tclientFile: feature.clientFile,",
+				"\t\t\t\tmanifest: feature.restManifest,",
+				"\t\t\t\ttypesFile: feature.typesFile,",
+				"\t\t\t\tvalidatorsFile: feature.validatorsFile,",
+				"\t\t\t},",
+				"\t\t\t{",
+				"\t\t\t\tcheck: options.check,",
+				"\t\t\t}",
+				"\t\t);",
+				"\t}",
+				"",
+				"\tconsole.log(",
+				"\t\toptions.check",
+			].join("\n"),
+			"final sync summary",
+			syncRestScriptPath,
+		);
+
+		nextSource = replaceRequiredSyncRestSource(
+			nextSource,
+			"workspace blocks, plugin-level resources, and AI features",
+			"workspace blocks and plugin-level resources",
+			"workspace blocks, plugin-level resources, and AI features",
+			"sync summary copy",
+			syncRestScriptPath,
+		);
+
+		return nextSource;
+	});
+}

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai-anchors.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai-anchors.ts
@@ -14,6 +14,9 @@ function escapeRegex(value: string): string {
 	return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
 }
 
+/**
+ * Patch the workspace bootstrap file so it loads generated AI feature PHP modules.
+ */
 export async function ensureAiFeatureBootstrapAnchors(
 	workspace: WorkspaceProject,
 ): Promise<void> {
@@ -76,10 +79,15 @@ function ${registerFunctionName}() {
 	});
 }
 
+/**
+ * Patch `package.json` with `sync-ai` plus the project-tools dependency used by generated AI sync scripts.
+ */
 export async function ensureAiFeaturePackageScripts(
 	workspace: WorkspaceProject,
 ): Promise<{
+	/** True when `@wp-typia/project-tools` was newly added to `devDependencies`. */
 	addedProjectToolsDependency: boolean;
+	/** True when the workspace did not already define a `sync-ai` script. */
 	addedSyncAiScript: boolean;
 }> {
 	const packageJsonPath = path.join(workspace.projectDir, "package.json");
@@ -130,6 +138,9 @@ export async function ensureAiFeaturePackageScripts(
 	};
 }
 
+/**
+ * Patch `scripts/sync-project.ts` after package scripts so generated workspaces invoke `sync-ai` when present.
+ */
 export async function ensureAiFeatureSyncProjectAnchors(
 	workspace: WorkspaceProject,
 ): Promise<void> {
@@ -163,7 +174,7 @@ export async function ensureAiFeatureSyncProjectAnchors(
 			}
 			nextSource = nextSource.replace(
 				syncRestConst,
-				`${syncRestConst}\nconst syncAiScriptPath = path.join( 'scripts', 'sync-ai-features.ts' );`,
+				`${syncRestConst}\n${syncAiConst}`,
 			);
 		}
 
@@ -231,6 +242,9 @@ function replaceRequiredSyncRestSource(
 	return nextSource.replace(anchor, replacement);
 }
 
+/**
+ * Patch `scripts/sync-rest-contracts.ts` after sync-project wiring so AI feature REST artifacts join the split sync flow.
+ */
 export async function ensureAiFeatureSyncRestAnchors(
 	workspace: WorkspaceProject,
 ): Promise<void> {

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai-source-emitters.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai-source-emitters.ts
@@ -1,0 +1,348 @@
+import {
+	normalizeBlockSlug,
+	quoteTsString,
+} from "./cli-add-shared.js";
+import { buildAiFeatureEndpointManifest } from "./ai-feature-artifacts.js";
+import { toTitleCase } from "./string-case.js";
+
+export function toPascalCaseFromAiFeatureSlug(slug: string): string {
+	return normalizeBlockSlug(slug)
+		.split("-")
+		.filter(Boolean)
+		.map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+		.join("");
+}
+
+function indentMultiline(source: string, prefix: string): string {
+	return source
+		.split("\n")
+		.map((line) => `${prefix}${line}`)
+		.join("\n");
+}
+
+export function buildAiFeatureConfigEntry(
+	aiFeatureSlug: string,
+	namespace: string,
+): string {
+	const pascalCase = toPascalCaseFromAiFeatureSlug(aiFeatureSlug);
+	const title = toTitleCase(aiFeatureSlug);
+	const manifest = buildAiFeatureEndpointManifest({
+		namespace,
+		pascalCase,
+		slugKebabCase: aiFeatureSlug,
+		title,
+	});
+
+	return [
+		"\t{",
+		`\t\taiSchemaFile: ${quoteTsString(
+			`src/ai-features/${aiFeatureSlug}/ai-schemas/feature-result.ai.schema.json`,
+		)},`,
+		`\t\tapiFile: ${quoteTsString(`src/ai-features/${aiFeatureSlug}/api.ts`)},`,
+		`\t\tclientFile: ${quoteTsString(
+			`src/ai-features/${aiFeatureSlug}/api-client.ts`,
+		)},`,
+		`\t\tdataFile: ${quoteTsString(`src/ai-features/${aiFeatureSlug}/data.ts`)},`,
+		`\t\tnamespace: ${quoteTsString(namespace)},`,
+		`\t\topenApiFile: ${quoteTsString(
+			`src/ai-features/${aiFeatureSlug}/api.openapi.json`,
+		)},`,
+		`\t\tphpFile: ${quoteTsString(`inc/ai-features/${aiFeatureSlug}.php`)},`,
+		"\t\trestManifest: defineEndpointManifest(",
+		indentMultiline(JSON.stringify(manifest, null, "\t"), "\t\t\t"),
+		"\t\t),",
+		`\t\tslug: ${quoteTsString(aiFeatureSlug)},`,
+		`\t\ttypesFile: ${quoteTsString(
+			`src/ai-features/${aiFeatureSlug}/api-types.ts`,
+		)},`,
+		`\t\tvalidatorsFile: ${quoteTsString(
+			`src/ai-features/${aiFeatureSlug}/api-validators.ts`,
+		)},`,
+		"\t},",
+	].join("\n");
+}
+
+export function buildAiFeatureTypesSource(aiFeatureSlug: string): string {
+	const pascalCase = toPascalCaseFromAiFeatureSlug(aiFeatureSlug);
+
+	return `import { tags } from 'typia';
+
+export interface ${pascalCase}AiFeatureRequest {
+\tbrief: string & tags.MinLength< 1 > & tags.MaxLength< 4000 >;
+\tcontext?: string & tags.MaxLength< 4000 >;
+}
+
+export interface ${pascalCase}AiFeatureResult {
+\ttitle: string & tags.MinLength< 1 > & tags.MaxLength< 160 >;
+\tsummary: string & tags.MinLength< 1 > & tags.MaxLength< 2000 >;
+\tconfidence?: number & tags.Minimum< 0 > & tags.Maximum< 1 >;
+}
+
+export interface ${pascalCase}AiFeatureTokenUsage {
+\tcompletionTokens: number & tags.Type< 'uint32' >;
+\tpromptTokens: number & tags.Type< 'uint32' >;
+\ttotalTokens: number & tags.Type< 'uint32' >;
+\tthoughtTokens?: number & tags.Type< 'uint32' >;
+}
+
+export interface ${pascalCase}AiFeatureTelemetry {
+\tmodelId: string & tags.MinLength< 1 > & tags.MaxLength< 160 >;
+\tmodelName: string & tags.MinLength< 1 > & tags.MaxLength< 160 >;
+\tproviderId: string & tags.MinLength< 1 > & tags.MaxLength< 80 >;
+\tproviderName: string & tags.MinLength< 1 > & tags.MaxLength< 160 >;
+\tproviderType: 'client' | 'cloud' | 'server';
+\tresultId: string & tags.MinLength< 1 > & tags.MaxLength< 160 >;
+\ttokenUsage: ${pascalCase}AiFeatureTokenUsage;
+}
+
+export interface ${pascalCase}AiFeatureResponse {
+\tresult: ${pascalCase}AiFeatureResult;
+\ttelemetry: ${pascalCase}AiFeatureTelemetry;
+}
+`;
+}
+
+export function buildAiFeatureValidatorsSource(
+	aiFeatureSlug: string,
+): string {
+	const pascalCase = toPascalCaseFromAiFeatureSlug(aiFeatureSlug);
+
+	return `import typia from 'typia';
+
+import { toValidationResult } from '@wp-typia/rest';
+import type {
+\t${pascalCase}AiFeatureRequest,
+\t${pascalCase}AiFeatureResponse,
+\t${pascalCase}AiFeatureResult,
+} from './api-types';
+
+const validateFeatureRequest = typia.createValidate< ${pascalCase}AiFeatureRequest >();
+const validateFeatureResult = typia.createValidate< ${pascalCase}AiFeatureResult >();
+const validateFeatureResponse = typia.createValidate< ${pascalCase}AiFeatureResponse >();
+
+export const apiValidators = {
+\tfeatureRequest: ( input: unknown ) =>
+\t\ttoValidationResult< ${pascalCase}AiFeatureRequest >(
+\t\t\tvalidateFeatureRequest( input )
+\t\t),
+\tfeatureResult: ( input: unknown ) =>
+\t\ttoValidationResult< ${pascalCase}AiFeatureResult >(
+\t\t\tvalidateFeatureResult( input )
+\t\t),
+\tfeatureResponse: ( input: unknown ) =>
+\t\ttoValidationResult< ${pascalCase}AiFeatureResponse >(
+\t\t\tvalidateFeatureResponse( input )
+\t\t),
+};
+`;
+}
+
+export function buildAiFeatureApiSource(aiFeatureSlug: string): string {
+	const pascalCase = toPascalCaseFromAiFeatureSlug(aiFeatureSlug);
+
+	return `import {
+\tcallEndpoint,
+\tresolveRestRouteUrl,
+} from '@wp-typia/rest';
+
+import type {
+\t${pascalCase}AiFeatureRequest,
+} from './api-types';
+import {
+\trun${pascalCase}AiFeatureEndpoint,
+} from './api-client';
+
+function resolveRestNonce( fallback?: string ): string | undefined {
+\tif ( typeof fallback === 'string' && fallback.length > 0 ) {
+\t\treturn fallback;
+\t}
+
+\tif ( typeof window === 'undefined' ) {
+\t\treturn undefined;
+\t}
+
+\tconst wpApiSettings = (
+\t\twindow as typeof window & {
+\t\t\twpApiSettings?: { nonce?: string };
+\t\t}
+\t).wpApiSettings;
+
+\treturn typeof wpApiSettings?.nonce === 'string' &&
+\t\twpApiSettings.nonce.length > 0
+\t\t? wpApiSettings.nonce
+\t\t: undefined;
+}
+
+export const aiFeatureRunEndpoint = {
+\t...run${pascalCase}AiFeatureEndpoint,
+\tbuildRequestOptions: () => {
+\t\tconst nonce = resolveRestNonce();
+\t\treturn {
+\t\t\theaders: nonce
+\t\t\t\t? {
+\t\t\t\t\t'X-WP-Nonce': nonce,
+\t\t\t\t}
+\t\t\t\t: undefined,
+\t\t\turl: resolveRestRouteUrl( run${pascalCase}AiFeatureEndpoint.path ),
+\t\t};
+\t},
+};
+
+export function runAiFeature( request: ${pascalCase}AiFeatureRequest ) {
+\treturn callEndpoint( aiFeatureRunEndpoint, request );
+}
+`;
+}
+
+export function buildAiFeatureDataSource(aiFeatureSlug: string): string {
+	const pascalCase = toPascalCaseFromAiFeatureSlug(aiFeatureSlug);
+
+	return `import {
+\tuseEndpointMutation,
+\ttype UseEndpointMutationOptions,
+} from '@wp-typia/rest/react';
+
+import type {
+\t${pascalCase}AiFeatureRequest,
+\t${pascalCase}AiFeatureResponse,
+} from './api-types';
+import {
+\taiFeatureRunEndpoint,
+} from './api';
+
+export type UseRun${pascalCase}AiFeatureMutationOptions =
+\tUseEndpointMutationOptions<
+\t\t${pascalCase}AiFeatureRequest,
+\t\t${pascalCase}AiFeatureResponse,
+\t\tunknown
+\t>;
+
+export function useRun${pascalCase}AiFeatureMutation(
+\toptions: UseRun${pascalCase}AiFeatureMutationOptions = {}
+) {
+\treturn useEndpointMutation( aiFeatureRunEndpoint, options );
+}
+`;
+}
+
+export function buildAiFeatureSyncScriptSource(): string {
+	return `/* eslint-disable no-console */
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { projectWordPressAiSchema } from '@wp-typia/project-tools/ai-artifacts';
+
+import {
+\tAI_FEATURES,
+\ttype WorkspaceAiFeatureConfig,
+} from './block-config';
+
+function parseCliOptions( argv: string[] ) {
+\tconst options = {
+\t\tcheck: false,
+\t};
+
+\tfor ( const argument of argv ) {
+\t\tif ( argument === '--check' ) {
+\t\t\toptions.check = true;
+\t\t\tcontinue;
+\t\t}
+
+\t\tthrow new Error( \`Unknown sync-ai flag: \${ argument }\` );
+\t}
+
+\treturn options;
+}
+
+function isWorkspaceAiFeature(
+\tfeature: WorkspaceAiFeatureConfig
+): feature is WorkspaceAiFeatureConfig & {
+\taiSchemaFile: string;
+\ttypesFile: string;
+} {
+\treturn (
+\t\ttypeof feature.aiSchemaFile === 'string' &&
+\t\ttypeof feature.typesFile === 'string'
+\t);
+}
+
+function normalizeGeneratedArtifactContent( content: string ) {
+\treturn content.replace( /\\r\\n?/g, '\\n' );
+}
+
+async function reconcileGeneratedArtifact( options: {
+\tcheck: boolean;
+\tcontent: string;
+\tfilePath: string;
+\tlabel: string;
+} ) {
+\tif ( ! options.check ) {
+\t\tawait mkdir( path.dirname( options.filePath ), {
+\t\t\trecursive: true,
+\t\t} );
+\t\tawait writeFile( options.filePath, options.content, 'utf8' );
+\t\treturn;
+\t}
+
+\tconst current = normalizeGeneratedArtifactContent(
+\t\tawait readFile( options.filePath, 'utf8' )
+\t);
+\tconst expected = normalizeGeneratedArtifactContent( options.content );
+\tif ( current !== expected ) {
+\t\tthrow new Error(
+\t\t\t\`Generated AI feature artifact is stale: \${ options.label } (\${ options.filePath }).\`
+\t\t);
+\t}
+}
+
+async function loadJsonDocument( filePath: string ) {
+\tconst decoded = JSON.parse( await readFile( filePath, 'utf8' ) ) as unknown;
+\tif ( ! decoded || typeof decoded !== 'object' || Array.isArray( decoded ) ) {
+\t\tthrow new Error( \`Expected \${ filePath } to decode to a JSON object.\` );
+\t}
+
+\treturn decoded as Parameters< typeof projectWordPressAiSchema >[ 0 ];
+}
+
+async function main() {
+\tconst options = parseCliOptions( process.argv.slice( 2 ) );
+\tconst aiFeatures = AI_FEATURES.filter( isWorkspaceAiFeature );
+
+\tif ( aiFeatures.length === 0 ) {
+\t\tconsole.log(
+\t\t\toptions.check
+\t\t\t\t? 'ℹ️ No workspace AI features are registered yet. \`sync-ai --check\` is already clean.'
+\t\t\t\t: 'ℹ️ No workspace AI features are registered yet.'
+\t\t);
+\t\treturn;
+\t}
+
+\tfor ( const feature of aiFeatures ) {
+\t\tconst sourceSchemaPath = path.join(
+\t\t\tpath.dirname( feature.typesFile ),
+\t\t\t'api-schemas',
+\t\t\t'feature-result.schema.json'
+\t\t);
+\t\tconst sourceSchema = await loadJsonDocument( sourceSchemaPath );
+\t\tconst aiSchema = projectWordPressAiSchema( sourceSchema );
+\t\tawait reconcileGeneratedArtifact( {
+\t\t\tcheck: options.check,
+\t\t\tcontent: \`\${ JSON.stringify( aiSchema, null, 2 ) }\\n\`,
+\t\t\tfilePath: feature.aiSchemaFile,
+\t\t\tlabel: feature.slug,
+\t\t} );
+\t}
+
+\tconsole.log(
+\t\toptions.check
+\t\t\t? '✅ AI feature structured-output schemas are already synchronized.'
+\t\t\t: '✅ AI feature structured-output schemas were synchronized.'
+\t);
+}
+
+main().catch( ( error ) => {
+\tconsole.error( '❌ AI feature sync failed:', error );
+\tprocess.exit( 1 );
+} );
+`;
+}

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai-source-emitters.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai-source-emitters.ts
@@ -5,6 +5,9 @@ import {
 import { buildAiFeatureEndpointManifest } from "./ai-feature-artifacts.js";
 import { toTitleCase } from "./string-case.js";
 
+/**
+ * Convert an AI feature slug into the PascalCase identifier used by generated types.
+ */
 export function toPascalCaseFromAiFeatureSlug(slug: string): string {
 	return normalizeBlockSlug(slug)
 		.split("-")
@@ -17,9 +20,12 @@ function indentMultiline(source: string, prefix: string): string {
 	return source
 		.split("\n")
 		.map((line) => `${prefix}${line}`)
-		.join("\n");
+	.join("\n");
 }
 
+/**
+ * Build the workspace inventory entry written into `scripts/block-config.ts` for one AI feature.
+ */
 export function buildAiFeatureConfigEntry(
 	aiFeatureSlug: string,
 	namespace: string,
@@ -62,6 +68,9 @@ export function buildAiFeatureConfigEntry(
 	].join("\n");
 }
 
+/**
+ * Generate TypeScript request, response, and telemetry contracts for an AI feature scaffold.
+ */
 export function buildAiFeatureTypesSource(aiFeatureSlug: string): string {
 	const pascalCase = toPascalCaseFromAiFeatureSlug(aiFeatureSlug);
 
@@ -102,6 +111,9 @@ export interface ${pascalCase}AiFeatureResponse {
 `;
 }
 
+/**
+ * Generate runtime validators for the AI feature request/result/response contracts.
+ */
 export function buildAiFeatureValidatorsSource(
 	aiFeatureSlug: string,
 ): string {
@@ -137,6 +149,9 @@ export const apiValidators = {
 `;
 }
 
+/**
+ * Generate the typed client wrapper that calls the scaffolded AI feature endpoint.
+ */
 export function buildAiFeatureApiSource(aiFeatureSlug: string): string {
 	const pascalCase = toPascalCaseFromAiFeatureSlug(aiFeatureSlug);
 
@@ -194,6 +209,9 @@ export function runAiFeature( request: ${pascalCase}AiFeatureRequest ) {
 `;
 }
 
+/**
+ * Generate React endpoint-mutation hooks for the scaffolded AI feature client wrapper.
+ */
 export function buildAiFeatureDataSource(aiFeatureSlug: string): string {
 	const pascalCase = toPascalCaseFromAiFeatureSlug(aiFeatureSlug);
 
@@ -225,6 +243,9 @@ export function useRun${pascalCase}AiFeatureMutation(
 `;
 }
 
+/**
+ * Generate the `scripts/sync-ai-features.ts` source that projects AI-safe schemas for workspace features.
+ */
 export function buildAiFeatureSyncScriptSource(): string {
 	return `/* eslint-disable no-console */
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
@@ -307,6 +328,11 @@ async function loadJsonDocument( filePath: string ) {
 async function main() {
 \tconst options = parseCliOptions( process.argv.slice( 2 ) );
 \tconst aiFeatures = AI_FEATURES.filter( isWorkspaceAiFeature );
+\tif ( AI_FEATURES.length > 0 && aiFeatures.length === 0 ) {
+\t\tconsole.warn(
+\t\t\t'⚠️ AI_FEATURES entries exist, but none satisfied the generated sync-ai guard. Check for missing aiSchemaFile/typesFile fields in scripts/block-config.ts.'
+\t\t);
+\t}
 
 \tif ( aiFeatures.length === 0 ) {
 \t\tconsole.log(

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai.ts
@@ -1,0 +1,547 @@
+import { promises as fsp } from "node:fs";
+import path from "node:path";
+
+import {
+	assertAiFeatureDoesNotExist,
+	assertValidGeneratedSlug,
+	getWorkspaceBootstrapPath,
+	normalizeBlockSlug,
+	resolveRestResourceNamespace,
+	rollbackWorkspaceMutation,
+	snapshotWorkspaceFiles,
+	type RunAddAiFeatureCommandOptions,
+	type WorkspaceMutationSnapshot,
+} from "./cli-add-shared.js";
+import { ensureBlockConfigCanAddRestManifests } from "./cli-add-block-legacy-validator.js";
+import {
+	buildAiFeatureConfigEntry,
+	buildAiFeatureDataSource,
+	buildAiFeatureSyncScriptSource,
+	buildAiFeatureTypesSource,
+	buildAiFeatureValidatorsSource,
+	buildAiFeatureApiSource,
+	toPascalCaseFromAiFeatureSlug,
+} from "./cli-add-workspace-ai-source-emitters.js";
+import {
+	ensureAiFeatureBootstrapAnchors,
+	ensureAiFeaturePackageScripts,
+	ensureAiFeatureSyncProjectAnchors,
+	ensureAiFeatureSyncRestAnchors,
+} from "./cli-add-workspace-ai-anchors.js";
+import {
+	syncAiFeatureRestArtifacts,
+	syncAiFeatureSchemaArtifact,
+} from "./ai-feature-artifacts.js";
+import { appendWorkspaceInventoryEntries, readWorkspaceInventory } from "./workspace-inventory.js";
+import { resolveWorkspaceProject } from "./workspace-project.js";
+import { toTitleCase } from "./string-case.js";
+
+function quotePhpString(value: string): string {
+	return `'${value.replace(/\\/gu, "\\\\").replace(/'/gu, "\\'")}'`;
+}
+
+function buildAiFeaturePhpSource(
+	aiFeatureSlug: string,
+	namespace: string,
+	phpPrefix: string,
+): string {
+	const aiFeatureTitle = toTitleCase(aiFeatureSlug);
+	const aiFeaturePhpId = aiFeatureSlug.replace(/-/g, "_");
+	const loadSchemaFunctionName = `${phpPrefix}_${aiFeaturePhpId}_load_ai_feature_schema`;
+	const loadAiSchemaFunctionName = `${phpPrefix}_${aiFeaturePhpId}_load_ai_response_schema`;
+	const normalizeSchemaFunctionName = `${phpPrefix}_${aiFeaturePhpId}_sanitize_ai_feature_schema`;
+	const validatePayloadFunctionName = `${phpPrefix}_${aiFeaturePhpId}_validate_ai_feature_payload`;
+	const canManageFunctionName = `${phpPrefix}_${aiFeaturePhpId}_can_manage_ai_feature`;
+	const buildPromptFunctionName = `${phpPrefix}_${aiFeaturePhpId}_build_ai_feature_prompt`;
+	const normalizeProviderTypeFunctionName = `${phpPrefix}_${aiFeaturePhpId}_normalize_provider_type`;
+	const buildTelemetryFunctionName = `${phpPrefix}_${aiFeaturePhpId}_build_ai_feature_telemetry`;
+	const isSupportedFunctionName = `${phpPrefix}_${aiFeaturePhpId}_is_ai_feature_supported`;
+	const handlerFunctionName = `${phpPrefix}_${aiFeaturePhpId}_handle_run_ai_feature`;
+	const registerRoutesFunctionName = `${phpPrefix}_${aiFeaturePhpId}_register_ai_feature_routes`;
+
+	return `<?php
+if ( ! defined( 'ABSPATH' ) ) {
+\treturn;
+}
+
+if ( ! function_exists( '${loadSchemaFunctionName}' ) ) {
+\tfunction ${loadSchemaFunctionName}( $schema_name ) {
+\t\t$project_root = dirname( __DIR__, 2 );
+\t\t$schema_path  = $project_root . '/src/ai-features/${aiFeatureSlug}/api-schemas/' . $schema_name . '.schema.json';
+\t\tif ( ! file_exists( $schema_path ) ) {
+\t\t\treturn null;
+\t\t}
+
+\t\t$decoded = json_decode( file_get_contents( $schema_path ), true );
+\t\treturn is_array( $decoded ) ? $decoded : null;
+\t}
+}
+
+if ( ! function_exists( '${loadAiSchemaFunctionName}' ) ) {
+\tfunction ${loadAiSchemaFunctionName}() {
+\t\t$project_root = dirname( __DIR__, 2 );
+\t\t$schema_path  = $project_root . '/src/ai-features/${aiFeatureSlug}/ai-schemas/feature-result.ai.schema.json';
+\t\tif ( ! file_exists( $schema_path ) ) {
+\t\t\treturn null;
+\t\t}
+
+\t\t$decoded = json_decode( file_get_contents( $schema_path ), true );
+\t\treturn is_array( $decoded ) ? $decoded : null;
+\t}
+}
+
+if ( ! function_exists( '${normalizeSchemaFunctionName}' ) ) {
+\tfunction ${normalizeSchemaFunctionName}( $schema ) {
+\t\tif ( ! is_array( $schema ) ) {
+\t\t\treturn $schema;
+\t\t}
+
+\t\tunset( $schema['$schema'], $schema['title'] );
+
+\t\tif ( isset( $schema['properties'] ) && is_array( $schema['properties'] ) ) {
+\t\t\tforeach ( $schema['properties'] as $key => $property_schema ) {
+\t\t\t\t$schema['properties'][ $key ] = ${normalizeSchemaFunctionName}( $property_schema );
+\t\t\t}
+\t\t}
+
+\t\tif ( isset( $schema['items'] ) && is_array( $schema['items'] ) ) {
+\t\t\t$schema['items'] = ${normalizeSchemaFunctionName}( $schema['items'] );
+\t\t}
+
+\t\treturn $schema;
+\t}
+}
+
+if ( ! function_exists( '${validatePayloadFunctionName}' ) ) {
+\tfunction ${validatePayloadFunctionName}( $value, $schema_name, $param_name ) {
+\t\t$schema = ${loadSchemaFunctionName}( $schema_name );
+\t\tif ( ! is_array( $schema ) ) {
+\t\t\treturn new WP_Error( 'missing_schema', 'Missing AI feature schema.', array( 'status' => 500 ) );
+\t\t}
+
+\t\t$rest_schema = ${normalizeSchemaFunctionName}( $schema );
+\t\t$validation  = rest_validate_value_from_schema( $value, $rest_schema, $param_name );
+\t\tif ( is_wp_error( $validation ) ) {
+\t\t\treturn $validation;
+\t\t}
+
+\t\treturn rest_sanitize_value_from_schema( $value, $rest_schema, $param_name );
+\t}
+}
+
+if ( ! function_exists( '${canManageFunctionName}' ) ) {
+\tfunction ${canManageFunctionName}() {
+\t\treturn current_user_can( 'edit_posts' );
+\t}
+}
+
+if ( ! function_exists( '${buildPromptFunctionName}' ) ) {
+\tfunction ${buildPromptFunctionName}( array $payload ) {
+\t\treturn sprintf(
+\t\t\t'You are helping with the %1$s AI workflow. Read the JSON request payload and return JSON that matches the provided schema. Request payload: %2$s',
+\t\t\t${quotePhpString(aiFeatureTitle)},
+\t\t\twp_json_encode( $payload )
+\t\t);
+\t}
+}
+
+if ( ! function_exists( '${normalizeProviderTypeFunctionName}' ) ) {
+\tfunction ${normalizeProviderTypeFunctionName}( $provider_type ) {
+\t\tif ( is_object( $provider_type ) && isset( $provider_type->value ) && is_string( $provider_type->value ) ) {
+\t\t\treturn $provider_type->value;
+\t\t}
+
+\t\treturn is_string( $provider_type ) && '' !== $provider_type ? $provider_type : 'cloud';
+\t}
+}
+
+if ( ! function_exists( '${buildTelemetryFunctionName}' ) ) {
+\tfunction ${buildTelemetryFunctionName}( $result ) {
+\t\tif (
+\t\t\t! is_object( $result ) ||
+\t\t\t! method_exists( $result, 'getId' ) ||
+\t\t\t! method_exists( $result, 'getModelMetadata' ) ||
+\t\t\t! method_exists( $result, 'getProviderMetadata' ) ||
+\t\t\t! method_exists( $result, 'getTokenUsage' )
+\t\t) {
+\t\t\treturn new WP_Error(
+\t\t\t\t'ai_client_result_shape',
+\t\t\t\t'The current WordPress AI Client result object is missing telemetry helpers.',
+\t\t\t\tarray( 'status' => 502 )
+\t\t\t);
+\t\t}
+
+\t\t$model_metadata    = $result->getModelMetadata();
+\t\t$provider_metadata = $result->getProviderMetadata();
+\t\t$token_usage       = $result->getTokenUsage();
+
+\t\tif (
+\t\t\t! is_object( $model_metadata ) ||
+\t\t\t! method_exists( $model_metadata, 'getId' ) ||
+\t\t\t! method_exists( $model_metadata, 'getName' ) ||
+\t\t\t! is_object( $provider_metadata ) ||
+\t\t\t! method_exists( $provider_metadata, 'getId' ) ||
+\t\t\t! method_exists( $provider_metadata, 'getName' ) ||
+\t\t\t! method_exists( $provider_metadata, 'getType' ) ||
+\t\t\t! is_object( $token_usage ) ||
+\t\t\t! method_exists( $token_usage, 'getCompletionTokens' ) ||
+\t\t\t! method_exists( $token_usage, 'getPromptTokens' ) ||
+\t\t\t! method_exists( $token_usage, 'getTotalTokens' )
+\t\t) {
+\t\t\treturn new WP_Error(
+\t\t\t\t'ai_client_result_shape',
+\t\t\t\t'The current WordPress AI Client telemetry objects are missing expected getters.',
+\t\t\t\tarray( 'status' => 502 )
+\t\t\t);
+\t\t}
+
+\t\t$telemetry = array(
+\t\t\t'modelId'      => (string) $model_metadata->getId(),
+\t\t\t'modelName'    => (string) $model_metadata->getName(),
+\t\t\t'providerId'   => (string) $provider_metadata->getId(),
+\t\t\t'providerName' => (string) $provider_metadata->getName(),
+\t\t\t'providerType' => ${normalizeProviderTypeFunctionName}( $provider_metadata->getType() ),
+\t\t\t'resultId'     => (string) $result->getId(),
+\t\t\t'tokenUsage'   => array(
+\t\t\t\t'completionTokens' => (int) $token_usage->getCompletionTokens(),
+\t\t\t\t'promptTokens'     => (int) $token_usage->getPromptTokens(),
+\t\t\t\t'totalTokens'      => (int) $token_usage->getTotalTokens(),
+\t\t\t),
+\t\t);
+
+\t\tif ( method_exists( $token_usage, 'getThoughtTokens' ) ) {
+\t\t\t$thought_tokens = $token_usage->getThoughtTokens();
+\t\t\tif ( null !== $thought_tokens ) {
+\t\t\t\t$telemetry['tokenUsage']['thoughtTokens'] = (int) $thought_tokens;
+\t\t\t}
+\t\t}
+
+\t\treturn $telemetry;
+\t}
+}
+
+if ( ! function_exists( '${isSupportedFunctionName}' ) ) {
+\tfunction ${isSupportedFunctionName}() {
+\t\tif ( ! function_exists( 'wp_ai_client_prompt' ) ) {
+\t\t\treturn false;
+\t\t}
+
+\t\t$schema = ${loadAiSchemaFunctionName}();
+\t\tif ( ! is_array( $schema ) ) {
+\t\t\treturn false;
+\t\t}
+
+\t\t$prompt = wp_ai_client_prompt( 'AI feature support probe.' );
+\t\tif ( ! is_object( $prompt ) || ! method_exists( $prompt, 'as_json_response' ) ) {
+\t\t\treturn false;
+\t\t}
+
+\t\t$structured_prompt = $prompt->as_json_response( $schema );
+\t\tif ( ! is_object( $structured_prompt ) ) {
+\t\t\treturn false;
+\t\t}
+
+\t\tif ( method_exists( $structured_prompt, 'is_supported_for_text_generation' ) ) {
+\t\t\treturn (bool) $structured_prompt->is_supported_for_text_generation();
+\t\t}
+
+\t\treturn method_exists( $structured_prompt, 'generate_text_result' );
+\t}
+}
+
+if ( ! function_exists( '${handlerFunctionName}' ) ) {
+\tfunction ${handlerFunctionName}( WP_REST_Request $request ) {
+\t\t$payload = ${validatePayloadFunctionName}( $request->get_json_params(), 'feature-request', 'body' );
+\t\tif ( is_wp_error( $payload ) ) {
+\t\t\treturn $payload;
+\t\t}
+
+\t\tif ( ! ${isSupportedFunctionName}() ) {
+\t\t\treturn new WP_Error(
+\t\t\t\t'ai_client_unavailable',
+\t\t\t\t'The WordPress AI Client is unavailable or does not support this feature endpoint.',
+\t\t\t\tarray( 'status' => 501 )
+\t\t\t);
+\t\t}
+
+\t\t$ai_schema = ${loadAiSchemaFunctionName}();
+\t\tif ( ! is_array( $ai_schema ) ) {
+\t\t\treturn new WP_Error(
+\t\t\t\t'ai_client_schema_missing',
+\t\t\t\t'The generated AI response schema is missing for this feature endpoint.',
+\t\t\t\tarray( 'status' => 500 )
+\t\t\t);
+\t\t}
+
+\t\t$prompt = wp_ai_client_prompt( ${buildPromptFunctionName}( $payload ) );
+\t\tif ( ! is_object( $prompt ) ) {
+\t\t\treturn new WP_Error(
+\t\t\t\t'ai_client_unavailable',
+\t\t\t\t'The WordPress AI Client prompt builder is unavailable on this site.',
+\t\t\t\tarray( 'status' => 501 )
+\t\t\t);
+\t\t}
+
+\t\tif ( method_exists( $prompt, 'using_temperature' ) ) {
+\t\t\t$prompt = $prompt->using_temperature( 0.2 );
+\t\t}
+\t\tif ( ! method_exists( $prompt, 'as_json_response' ) ) {
+\t\t\treturn new WP_Error(
+\t\t\t\t'ai_client_unavailable',
+\t\t\t\t'The current WordPress AI Client does not expose as_json_response().',
+\t\t\t\tarray( 'status' => 501 )
+\t\t\t);
+\t\t}
+
+\t\t$structured_prompt = $prompt->as_json_response( $ai_schema );
+\t\tif ( ! is_object( $structured_prompt ) ) {
+\t\t\treturn new WP_Error(
+\t\t\t\t'ai_client_unavailable',
+\t\t\t\t'The current WordPress AI Client could not prepare a structured-output prompt.',
+\t\t\t\tarray( 'status' => 501 )
+\t\t\t);
+\t\t}
+
+\t\tif (
+\t\t\tmethod_exists( $structured_prompt, 'is_supported_for_text_generation' ) &&
+\t\t\t! $structured_prompt->is_supported_for_text_generation()
+\t\t) {
+\t\t\treturn new WP_Error(
+\t\t\t\t'ai_client_unavailable',
+\t\t\t\t'The current WordPress AI Client provider or model does not support this structured-output feature.',
+\t\t\t\tarray( 'status' => 501 )
+\t\t\t);
+\t\t}
+\t\tif ( ! method_exists( $structured_prompt, 'generate_text_result' ) ) {
+\t\t\treturn new WP_Error(
+\t\t\t\t'ai_client_unavailable',
+\t\t\t\t'The current WordPress AI Client does not expose generate_text_result() after as_json_response().',
+\t\t\t\tarray( 'status' => 501 )
+\t\t\t);
+\t\t}
+
+\t\t$result = $structured_prompt->generate_text_result();
+\t\tif ( is_wp_error( $result ) ) {
+\t\t\treturn $result;
+\t\t}
+\t\tif ( ! is_object( $result ) || ! method_exists( $result, 'toText' ) ) {
+\t\t\treturn new WP_Error(
+\t\t\t\t'ai_client_result_shape',
+\t\t\t\t'The current WordPress AI Client result does not expose toText().',
+\t\t\t\tarray( 'status' => 502 )
+\t\t\t);
+\t\t}
+
+\t\t$decoded_result = json_decode( $result->toText(), true );
+\t\tif ( ! is_array( $decoded_result ) ) {
+\t\t\treturn new WP_Error(
+\t\t\t\t'ai_client_invalid_json',
+\t\t\t\t'The AI feature response did not decode to a JSON object.',
+\t\t\t\tarray( 'status' => 502 )
+\t\t\t);
+\t\t}
+
+\t\t$normalized_result = ${validatePayloadFunctionName}( $decoded_result, 'feature-result', 'result' );
+\t\tif ( is_wp_error( $normalized_result ) ) {
+\t\t\treturn new WP_Error(
+\t\t\t\t'ai_client_invalid_response',
+\t\t\t\t$normalized_result->get_error_message(),
+\t\t\t\tarray( 'status' => 502 )
+\t\t\t);
+\t\t}
+
+\t\t$telemetry = ${buildTelemetryFunctionName}( $result );
+\t\tif ( is_wp_error( $telemetry ) ) {
+\t\t\treturn $telemetry;
+\t\t}
+
+\t\t$response = ${validatePayloadFunctionName}(
+\t\t\tarray(
+\t\t\t\t'result'    => $normalized_result,
+\t\t\t\t'telemetry' => $telemetry,
+\t\t\t),
+\t\t\t'feature-response',
+\t\t\t'response'
+\t\t);
+\t\tif ( is_wp_error( $response ) ) {
+\t\t\treturn new WP_Error(
+\t\t\t\t'ai_client_invalid_response',
+\t\t\t\t$response->get_error_message(),
+\t\t\t\tarray( 'status' => 502 )
+\t\t\t);
+\t\t}
+
+\t\treturn rest_ensure_response( $response );
+\t}
+}
+
+if ( ! function_exists( '${registerRoutesFunctionName}' ) ) {
+\tfunction ${registerRoutesFunctionName}() {
+\t\tregister_rest_route(
+\t\t\t${quotePhpString(namespace)},
+\t\t\t'/ai/${aiFeatureSlug}',
+\t\t\tarray(
+\t\t\t\tarray(
+\t\t\t\t\t'methods'             => WP_REST_Server::CREATABLE,
+\t\t\t\t\t'callback'            => '${handlerFunctionName}',
+\t\t\t\t\t'permission_callback' => '${canManageFunctionName}',
+\t\t\t\t)
+\t\t\t)
+\t\t);
+\t}
+}
+
+add_action( 'rest_api_init', '${registerRoutesFunctionName}' );
+`;
+}
+
+/**
+ * Scaffold a workspace-level server-only AI feature endpoint and synchronize
+ * its typed REST plus AI-schema artifacts.
+ *
+ * @param options Command options for the AI feature scaffold workflow.
+ * @returns Resolved scaffold metadata for the created AI feature.
+ */
+export async function runAddAiFeatureCommand({
+	aiFeatureName,
+	cwd = process.cwd(),
+	namespace,
+}: RunAddAiFeatureCommandOptions): Promise<{
+	aiFeatureSlug: string;
+	namespace: string;
+	projectDir: string;
+	warnings: string[];
+}> {
+	const workspace = resolveWorkspaceProject(cwd);
+	const aiFeatureSlug = assertValidGeneratedSlug(
+		"AI feature name",
+		normalizeBlockSlug(aiFeatureName),
+		"wp-typia add ai-feature <name> [--namespace <vendor/v1>]",
+	);
+	const resolvedNamespace = resolveRestResourceNamespace(
+		workspace.workspace.namespace,
+		namespace,
+	);
+
+	const inventory = readWorkspaceInventory(workspace.projectDir);
+	assertAiFeatureDoesNotExist(workspace.projectDir, aiFeatureSlug, inventory);
+
+	const blockConfigPath = path.join(workspace.projectDir, "scripts", "block-config.ts");
+	const bootstrapPath = getWorkspaceBootstrapPath(workspace);
+	const packageJsonPath = path.join(workspace.projectDir, "package.json");
+	const syncAiScriptPath = path.join(workspace.projectDir, "scripts", "sync-ai-features.ts");
+	const syncProjectScriptPath = path.join(workspace.projectDir, "scripts", "sync-project.ts");
+	const syncRestScriptPath = path.join(workspace.projectDir, "scripts", "sync-rest-contracts.ts");
+	const aiFeatureDir = path.join(
+		workspace.projectDir,
+		"src",
+		"ai-features",
+		aiFeatureSlug,
+	);
+	const typesFilePath = path.join(aiFeatureDir, "api-types.ts");
+	const validatorsFilePath = path.join(aiFeatureDir, "api-validators.ts");
+	const apiFilePath = path.join(aiFeatureDir, "api.ts");
+	const dataFilePath = path.join(aiFeatureDir, "data.ts");
+	const clientFilePath = path.join(aiFeatureDir, "api-client.ts");
+	const phpFilePath = path.join(
+		workspace.projectDir,
+		"inc",
+		"ai-features",
+		`${aiFeatureSlug}.php`,
+	);
+	const mutationSnapshot: WorkspaceMutationSnapshot = {
+		fileSources: await snapshotWorkspaceFiles([
+			blockConfigPath,
+			bootstrapPath,
+			packageJsonPath,
+			syncAiScriptPath,
+			syncProjectScriptPath,
+			syncRestScriptPath,
+		]),
+		snapshotDirs: [],
+		targetPaths: [aiFeatureDir, phpFilePath, syncAiScriptPath],
+	};
+
+	try {
+		await fsp.mkdir(aiFeatureDir, { recursive: true });
+		await fsp.mkdir(path.dirname(phpFilePath), { recursive: true });
+		await ensureAiFeatureBootstrapAnchors(workspace);
+		const packageScriptChanges = await ensureAiFeaturePackageScripts(workspace);
+		await ensureAiFeatureSyncProjectAnchors(workspace);
+		await ensureAiFeatureSyncRestAnchors(workspace);
+		await fsp.writeFile(
+			syncAiScriptPath,
+			buildAiFeatureSyncScriptSource(),
+			"utf8",
+		);
+		await fsp.writeFile(
+			typesFilePath,
+			buildAiFeatureTypesSource(aiFeatureSlug),
+			"utf8",
+		);
+		await fsp.writeFile(
+			validatorsFilePath,
+			buildAiFeatureValidatorsSource(aiFeatureSlug),
+			"utf8",
+		);
+		await fsp.writeFile(
+			apiFilePath,
+			buildAiFeatureApiSource(aiFeatureSlug),
+			"utf8",
+		);
+		await fsp.writeFile(
+			dataFilePath,
+			buildAiFeatureDataSource(aiFeatureSlug),
+			"utf8",
+		);
+		await fsp.writeFile(
+			phpFilePath,
+			buildAiFeaturePhpSource(
+				aiFeatureSlug,
+				resolvedNamespace,
+				workspace.workspace.phpPrefix,
+			),
+			"utf8",
+		);
+
+		const pascalCase = toPascalCaseFromAiFeatureSlug(aiFeatureSlug);
+		await syncAiFeatureRestArtifacts({
+			clientFile: `src/ai-features/${aiFeatureSlug}/api-client.ts`,
+			outputDir: path.join("src", "ai-features", aiFeatureSlug),
+			projectDir: workspace.projectDir,
+			typesFile: `src/ai-features/${aiFeatureSlug}/api-types.ts`,
+			validatorsFile: `src/ai-features/${aiFeatureSlug}/api-validators.ts`,
+			variables: {
+				namespace: resolvedNamespace,
+				pascalCase,
+				slugKebabCase: aiFeatureSlug,
+				title: toTitleCase(aiFeatureSlug),
+			},
+		});
+		await syncAiFeatureSchemaArtifact({
+			aiSchemaFile: `src/ai-features/${aiFeatureSlug}/ai-schemas/feature-result.ai.schema.json`,
+			outputDir: path.join("src", "ai-features", aiFeatureSlug),
+			projectDir: workspace.projectDir,
+		});
+		await appendWorkspaceInventoryEntries(workspace.projectDir, {
+			aiFeatureEntries: [
+				buildAiFeatureConfigEntry(aiFeatureSlug, resolvedNamespace),
+			],
+			transformSource: ensureBlockConfigCanAddRestManifests,
+		});
+
+		return {
+			aiFeatureSlug,
+			namespace: resolvedNamespace,
+			projectDir: workspace.projectDir,
+			warnings: packageScriptChanges.addedProjectToolsDependency
+				? [
+						"Added `@wp-typia/project-tools` to devDependencies for `sync-ai`. If this workspace was already installed, rerun your package manager install command before the first `wp-typia sync ai`.",
+					]
+				: [],
+		};
+	} catch (error) {
+		await rollbackWorkspaceMutation(mutationSnapshot);
+		throw error;
+	}
+}

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace.ts
@@ -190,6 +190,11 @@ export {
  * rest-resource runtime helper module.
  */
 export { runAddRestResourceCommand } from "./cli-add-workspace-rest.js";
+/**
+ * Re-export the server-only AI feature scaffold workflow from the focused
+ * AI-feature runtime helper module.
+ */
+export { runAddAiFeatureCommand } from "./cli-add-workspace-ai.js";
 
 /**
  * Add one variation entry to an existing workspace block.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add.ts
@@ -24,6 +24,7 @@ export {
 } from "./cli-add-block.js";
 export {
 	runAddBindingSourceCommand,
+	runAddAiFeatureCommand,
 	runAddEditorPluginCommand,
 	runAddHookedBlockCommand,
 	runAddPatternCommand,

--- a/packages/wp-typia-project-tools/src/runtime/cli-core.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-core.ts
@@ -11,6 +11,7 @@
  * and `HOOKED_BLOCK_POSITION_IDS`,
  * `getWorkspaceBlockSelectOptions`, and `seedWorkspaceMigrationProject` for
  * explicit `wp-typia add` flows,
+ * `runAddAiFeatureCommand` for server-owned WordPress AI feature scaffolds,
  * `runAddRestResourceCommand` for plugin-level REST resource scaffolds,
  * `getDoctorChecks`, `runDoctor`, and `DoctorCheck` for diagnostics,
  * `createCliCommandError` and `formatCliDiagnosticError` for shared

--- a/packages/wp-typia-project-tools/src/runtime/cli-core.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-core.ts
@@ -40,6 +40,7 @@ export {
 	formatAddHelpText,
 	getWorkspaceBlockSelectOptions,
 	runAddBindingSourceCommand,
+	runAddAiFeatureCommand,
 	runAddBlockCommand,
 	runAddEditorPluginCommand,
 	runAddHookedBlockCommand,

--- a/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace.ts
@@ -30,6 +30,7 @@ const WORKSPACE_BINDING_SERVER_GLOB = "/src/bindings/*/server.php";
 const WORKSPACE_BINDING_EDITOR_SCRIPT = "build/bindings/index.js";
 const WORKSPACE_BINDING_EDITOR_ASSET = "build/bindings/index.asset.php";
 const WORKSPACE_REST_RESOURCE_GLOB = "/inc/rest/*.php";
+const WORKSPACE_AI_FEATURE_GLOB = "/inc/ai-features/*.php";
 const WORKSPACE_EDITOR_PLUGIN_EDITOR_SCRIPT = "build/editor-plugins/index.js";
 const WORKSPACE_EDITOR_PLUGIN_EDITOR_ASSET = "build/editor-plugins/index.asset.php";
 const WORKSPACE_EDITOR_PLUGIN_EDITOR_STYLE = "build/editor-plugins/style-index.css";
@@ -452,6 +453,82 @@ function checkWorkspaceRestResourceBootstrap(
 	);
 }
 
+function getWorkspaceAiFeatureRequiredFiles(
+	aiFeature: WorkspaceInventory["aiFeatures"][number],
+): string[] {
+	return Array.from(
+		new Set([
+			aiFeature.aiSchemaFile,
+			aiFeature.apiFile,
+			path.join(
+				path.dirname(aiFeature.typesFile),
+				"api-schemas",
+				"feature-request.schema.json",
+			),
+			path.join(
+				path.dirname(aiFeature.typesFile),
+				"api-schemas",
+				"feature-response.schema.json",
+			),
+			path.join(
+				path.dirname(aiFeature.typesFile),
+				"api-schemas",
+				"feature-result.schema.json",
+			),
+			aiFeature.clientFile,
+			aiFeature.dataFile,
+			aiFeature.openApiFile,
+			aiFeature.phpFile,
+			aiFeature.typesFile,
+			aiFeature.validatorsFile,
+		]),
+	);
+}
+
+function checkWorkspaceAiFeatureConfig(
+	aiFeature: WorkspaceInventory["aiFeatures"][number],
+): DoctorCheck {
+	const hasNamespace = REST_RESOURCE_NAMESPACE_PATTERN.test(aiFeature.namespace);
+
+	return createDoctorCheck(
+		`AI feature config ${aiFeature.slug}`,
+		hasNamespace ? "pass" : "fail",
+		hasNamespace
+			? `AI feature namespace ${aiFeature.namespace} is valid`
+			: "AI feature namespace is invalid",
+	);
+}
+
+function checkWorkspaceAiFeatureBootstrap(
+	projectDir: string,
+	packageName: string,
+	phpPrefix: string,
+): DoctorCheck {
+	const packageBaseName = packageName.split("/").pop() ?? packageName;
+	const bootstrapPath = path.join(projectDir, `${packageBaseName}.php`);
+	if (!fs.existsSync(bootstrapPath)) {
+		return createDoctorCheck(
+			"AI feature bootstrap",
+			"fail",
+			`Missing ${path.basename(bootstrapPath)}`,
+		);
+	}
+
+	const source = fs.readFileSync(bootstrapPath, "utf8");
+	const registerFunctionName = `${phpPrefix}_register_ai_features`;
+	const registerHook = `add_action( 'init', '${registerFunctionName}', 20 );`;
+	const hasServerGlob = source.includes(WORKSPACE_AI_FEATURE_GLOB);
+	const hasRegisterHook = source.includes(registerHook);
+
+	return createDoctorCheck(
+		"AI feature bootstrap",
+		hasServerGlob && hasRegisterHook ? "pass" : "fail",
+		hasServerGlob && hasRegisterHook
+			? "AI feature PHP loader hook is present"
+			: "Missing AI feature PHP require glob or init hook",
+	);
+}
+
 function getWorkspaceEditorPluginRequiredFiles(
 	editorPlugin: WorkspaceInventory["editorPlugins"][number],
 ): string[] {
@@ -692,7 +769,7 @@ export function getWorkspaceDoctorChecks(cwd: string): DoctorCheck[] {
 			createDoctorCheck(
 				"Workspace inventory",
 				"pass",
-				`${inventory.blocks.length} block(s), ${inventory.variations.length} variation(s), ${inventory.patterns.length} pattern(s), ${inventory.bindingSources.length} binding source(s), ${inventory.restResources.length} REST resource(s), ${inventory.editorPlugins.length} editor plugin(s)`,
+				`${inventory.blocks.length} block(s), ${inventory.variations.length} variation(s), ${inventory.patterns.length} pattern(s), ${inventory.bindingSources.length} binding source(s), ${inventory.restResources.length} REST resource(s), ${inventory.aiFeatures.length} AI feature(s), ${inventory.editorPlugins.length} editor plugin(s)`,
 			),
 		);
 
@@ -779,6 +856,26 @@ export function getWorkspaceDoctorChecks(cwd: string): DoctorCheck[] {
 					workspace.projectDir,
 					`REST resource ${restResource.slug}`,
 					getWorkspaceRestResourceRequiredFiles(restResource),
+				),
+			);
+		}
+
+		if (inventory.aiFeatures.length > 0) {
+			checks.push(
+				checkWorkspaceAiFeatureBootstrap(
+					workspace.projectDir,
+					workspace.packageName,
+					workspace.workspace.phpPrefix,
+				),
+			);
+		}
+		for (const aiFeature of inventory.aiFeatures) {
+			checks.push(checkWorkspaceAiFeatureConfig(aiFeature));
+			checks.push(
+				checkExistingFiles(
+					workspace.projectDir,
+					`AI feature ${aiFeature.slug}`,
+					getWorkspaceAiFeatureRequiredFiles(aiFeature),
 				),
 			);
 		}

--- a/packages/wp-typia-project-tools/src/runtime/cli-help.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-help.ts
@@ -24,6 +24,7 @@ export function formatHelpText(): string {
   wp-typia add pattern <name>
   wp-typia add binding-source <name>
   wp-typia add rest-resource <name> [--namespace <vendor/v1>] [--methods <method[,method...]>]
+  wp-typia add ai-feature <name> [--namespace <vendor/v1>]
   wp-typia add editor-plugin <name> [--slot <PluginSidebar>]
   wp-typia add hooked-block <block-slug> --anchor <anchor-block-name> --position <before|after|firstChild|lastChild>
   wp-typia migrate <init|snapshot|diff|scaffold|verify|doctor|fixtures|fuzz> [...]
@@ -46,6 +47,7 @@ Notes:
   \`add pattern\` scaffolds a namespaced PHP pattern shell under \`src/patterns/\`.
   \`add binding-source\` scaffolds shared PHP and editor registration under \`src/bindings/\`.
   \`add rest-resource\` scaffolds plugin-level TypeScript REST contracts under \`src/rest/\` and PHP route glue under \`inc/rest/\`.
+  \`add ai-feature\` scaffolds server-owned AI feature endpoints under \`src/ai-features/\` and PHP route glue under \`inc/ai-features/\`.
   \`add editor-plugin\` scaffolds a document-level editor extension under \`src/editor-plugins/\`.
   \`add hooked-block\` patches an existing workspace block's \`block.json\` \`blockHooks\` metadata.
   \`wp-typia doctor\` always checks environment readiness and reports when it only ran environment-level diagnostics; official workspace roots also get inventory and source-tree drift checks.

--- a/packages/wp-typia-project-tools/src/runtime/index.ts
+++ b/packages/wp-typia-project-tools/src/runtime/index.ts
@@ -159,6 +159,7 @@ export {
 	HOOKED_BLOCK_POSITION_IDS,
 	EDITOR_PLUGIN_SLOT_IDS,
 	isCliDiagnosticError,
+	runAddAiFeatureCommand,
 	runAddBindingSourceCommand,
 	runAddBlockCommand,
 	runAddEditorPluginCommand,

--- a/packages/wp-typia-project-tools/src/runtime/workspace-inventory.ts
+++ b/packages/wp-typia-project-tools/src/runtime/workspace-inventory.ts
@@ -738,7 +738,8 @@ function appendEntriesAtMarker(source: string, marker: string, entries: string[]
 /**
  * Update `scripts/block-config.ts` source text with additional inventory entries.
  *
- * Missing `VARIATIONS` and `PATTERNS` sections are created automatically before
+ * Missing inventory sections for variations, patterns, binding sources, REST
+ * resources, AI features, and editor plugins are created automatically before
  * new entries are appended at their marker comments. When provided,
  * `transformSource` runs before any entries are inserted.
  *

--- a/packages/wp-typia-project-tools/src/runtime/workspace-inventory.ts
+++ b/packages/wp-typia-project-tools/src/runtime/workspace-inventory.ts
@@ -52,6 +52,26 @@ export interface WorkspaceRestResourceInventoryEntry {
 }
 
 /**
+ * AI-feature entry parsed from `scripts/block-config.ts`.
+ *
+ * Each file path stays relative to the workspace root so doctor checks, add
+ * workflows, and split sync scripts can reason about the REST and AI-safe
+ * artifacts without guessing their locations.
+ */
+export interface WorkspaceAiFeatureInventoryEntry {
+	aiSchemaFile: string;
+	apiFile: string;
+	clientFile: string;
+	dataFile: string;
+	namespace: string;
+	openApiFile: string;
+	phpFile: string;
+	slug: string;
+	typesFile: string;
+	validatorsFile: string;
+}
+
+/**
  * Editor-plugin entry parsed from `scripts/block-config.ts`.
  *
  * @property file Relative path to the generated editor plugin entry file.
@@ -68,7 +88,9 @@ export interface WorkspaceInventory {
 	bindingSources: WorkspaceBindingSourceInventoryEntry[];
 	blockConfigPath: string;
 	blocks: WorkspaceBlockInventoryEntry[];
+	aiFeatures: WorkspaceAiFeatureInventoryEntry[];
 	hasBindingSourcesSection: boolean;
+	hasAiFeaturesSection: boolean;
 	hasEditorPluginsSection: boolean;
 	hasPatternsSection: boolean;
 	hasRestResourcesSection: boolean;
@@ -85,6 +107,7 @@ export const VARIATION_CONFIG_ENTRY_MARKER = "\t// wp-typia add variation entrie
 export const PATTERN_CONFIG_ENTRY_MARKER = "\t// wp-typia add pattern entries";
 export const BINDING_SOURCE_CONFIG_ENTRY_MARKER = "\t// wp-typia add binding-source entries";
 export const REST_RESOURCE_CONFIG_ENTRY_MARKER = "\t// wp-typia add rest-resource entries";
+export const AI_FEATURE_CONFIG_ENTRY_MARKER = "\t// wp-typia add ai-feature entries";
 /**
  * Marker used to append generated editor-plugin entries into `EDITOR_PLUGINS`.
  */
@@ -160,6 +183,32 @@ const REST_RESOURCES_CONST_SECTION = `
 
 export const REST_RESOURCES: WorkspaceRestResourceConfig[] = [
 \t// wp-typia add rest-resource entries
+];
+`;
+
+const AI_FEATURES_INTERFACE_SECTION = `
+
+export interface WorkspaceAiFeatureConfig {
+\taiSchemaFile: string;
+\tapiFile: string;
+\tclientFile: string;
+\tdataFile: string;
+\tnamespace: string;
+\topenApiFile: string;
+\tphpFile: string;
+\trestManifest?: ReturnType<
+\t\ttypeof import( '@wp-typia/block-runtime/metadata-core' ).defineEndpointManifest
+\t>;
+\tslug: string;
+\ttypesFile: string;
+\tvalidatorsFile: string;
+}
+`;
+
+const AI_FEATURES_CONST_SECTION = `
+
+export const AI_FEATURES: WorkspaceAiFeatureConfig[] = [
+\t// wp-typia add ai-feature entries
 ];
 `;
 
@@ -441,6 +490,56 @@ function parseRestResourceEntries(
 	});
 }
 
+function parseAiFeatureEntries(
+	arrayLiteral: ts.ArrayLiteralExpression,
+): WorkspaceAiFeatureInventoryEntry[] {
+	return arrayLiteral.elements.map((element, elementIndex) => {
+		if (!ts.isObjectLiteralExpression(element)) {
+			throw new Error(
+				`AI_FEATURES[${elementIndex}] must be an object literal in scripts/block-config.ts.`,
+			);
+		}
+
+		return {
+			aiSchemaFile: getRequiredStringProperty(
+				"AI_FEATURES",
+				elementIndex,
+				element,
+				"aiSchemaFile",
+			),
+			apiFile: getRequiredStringProperty("AI_FEATURES", elementIndex, element, "apiFile"),
+			clientFile: getRequiredStringProperty(
+				"AI_FEATURES",
+				elementIndex,
+				element,
+				"clientFile",
+			),
+			dataFile: getRequiredStringProperty("AI_FEATURES", elementIndex, element, "dataFile"),
+			namespace: getRequiredStringProperty(
+				"AI_FEATURES",
+				elementIndex,
+				element,
+				"namespace",
+			),
+			openApiFile: getRequiredStringProperty(
+				"AI_FEATURES",
+				elementIndex,
+				element,
+				"openApiFile",
+			),
+			phpFile: getRequiredStringProperty("AI_FEATURES", elementIndex, element, "phpFile"),
+			slug: getRequiredStringProperty("AI_FEATURES", elementIndex, element, "slug"),
+			typesFile: getRequiredStringProperty("AI_FEATURES", elementIndex, element, "typesFile"),
+			validatorsFile: getRequiredStringProperty(
+				"AI_FEATURES",
+				elementIndex,
+				element,
+				"validatorsFile",
+			),
+		};
+	});
+}
+
 function parseEditorPluginEntries(
 	arrayLiteral: ts.ArrayLiteralExpression,
 ): WorkspaceEditorPluginInventoryEntry[] {
@@ -482,6 +581,7 @@ export function parseWorkspaceInventorySource(source: string): Omit<WorkspaceInv
 	const patternArray = findExportedArrayLiteral(sourceFile, "PATTERNS");
 	const bindingSourceArray = findExportedArrayLiteral(sourceFile, "BINDING_SOURCES");
 	const restResourceArray = findExportedArrayLiteral(sourceFile, "REST_RESOURCES");
+	const aiFeatureArray = findExportedArrayLiteral(sourceFile, "AI_FEATURES");
 	const editorPluginArray = findExportedArrayLiteral(sourceFile, "EDITOR_PLUGINS");
 	if (variationArray.found && !variationArray.array) {
 		throw new Error("scripts/block-config.ts must export VARIATIONS as an array literal.");
@@ -495,15 +595,20 @@ export function parseWorkspaceInventorySource(source: string): Omit<WorkspaceInv
 	if (restResourceArray.found && !restResourceArray.array) {
 		throw new Error("scripts/block-config.ts must export REST_RESOURCES as an array literal.");
 	}
+	if (aiFeatureArray.found && !aiFeatureArray.array) {
+		throw new Error("scripts/block-config.ts must export AI_FEATURES as an array literal.");
+	}
 	if (editorPluginArray.found && !editorPluginArray.array) {
 		throw new Error("scripts/block-config.ts must export EDITOR_PLUGINS as an array literal.");
 	}
 
 	return {
+		aiFeatures: aiFeatureArray.array ? parseAiFeatureEntries(aiFeatureArray.array) : [],
 		bindingSources: bindingSourceArray.array
 			? parseBindingSourceEntries(bindingSourceArray.array)
 			: [],
 		blocks: parseBlockEntries(blockArray.array),
+		hasAiFeaturesSection: aiFeatureArray.found,
 		hasBindingSourcesSection: bindingSourceArray.found,
 		hasEditorPluginsSection: editorPluginArray.found,
 		hasPatternsSection: patternArray.found,
@@ -603,6 +708,12 @@ function ensureWorkspaceInventorySections(source: string): string {
 	if (!/export\s+const\s+REST_RESOURCES\b/u.test(nextSource)) {
 		nextSource += REST_RESOURCES_CONST_SECTION;
 	}
+	if (!/export\s+interface\s+WorkspaceAiFeatureConfig\b/u.test(nextSource)) {
+		nextSource += AI_FEATURES_INTERFACE_SECTION;
+	}
+	if (!/export\s+const\s+AI_FEATURES\b/u.test(nextSource)) {
+		nextSource += AI_FEATURES_CONST_SECTION;
+	}
 	if (!/export\s+interface\s+WorkspaceEditorPluginConfig\b/u.test(nextSource)) {
 		nextSource += EDITOR_PLUGINS_INTERFACE_SECTION;
 	}
@@ -640,12 +751,14 @@ export function updateWorkspaceInventorySource(
 	{
 		blockEntries = [],
 		bindingSourceEntries = [],
+		aiFeatureEntries = [],
 		editorPluginEntries = [],
 		patternEntries = [],
 		restResourceEntries = [],
 		variationEntries = [],
 		transformSource,
 	}: {
+		aiFeatureEntries?: string[];
 		blockEntries?: string[];
 		bindingSourceEntries?: string[];
 		editorPluginEntries?: string[];
@@ -671,6 +784,11 @@ export function updateWorkspaceInventorySource(
 		nextSource,
 		REST_RESOURCE_CONFIG_ENTRY_MARKER,
 		restResourceEntries,
+	);
+	nextSource = appendEntriesAtMarker(
+		nextSource,
+		AI_FEATURE_CONFIG_ENTRY_MARKER,
+		aiFeatureEntries,
 	);
 	nextSource = appendEntriesAtMarker(
 		nextSource,

--- a/packages/wp-typia-project-tools/tests/cli-add-workspace-boundaries.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-add-workspace-boundaries.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 
 const runtimeRoot = path.join(import.meta.dir, "..", "src", "runtime");
 
-test("cli-add-workspace delegates asset and rest-resource workflows to focused helpers", () => {
+test("cli-add-workspace delegates asset, rest-resource, and ai-feature workflows to focused helpers", () => {
 	const addWorkspaceSource = fs.readFileSync(
 		path.join(runtimeRoot, "cli-add-workspace.ts"),
 		"utf8",
@@ -25,19 +25,36 @@ test("cli-add-workspace delegates asset and rest-resource workflows to focused h
 		path.join(runtimeRoot, "cli-add-workspace-rest-source-emitters.ts"),
 		"utf8",
 	);
+	const aiSource = fs.readFileSync(
+		path.join(runtimeRoot, "cli-add-workspace-ai.ts"),
+		"utf8",
+	);
+	const aiAnchorsSource = fs.readFileSync(
+		path.join(runtimeRoot, "cli-add-workspace-ai-anchors.ts"),
+		"utf8",
+	);
+	const aiSourceEmittersSource = fs.readFileSync(
+		path.join(runtimeRoot, "cli-add-workspace-ai-source-emitters.ts"),
+		"utf8",
+	);
 
 	expect(addWorkspaceSource).toContain('from "./cli-add-workspace-assets.js"');
 	expect(addWorkspaceSource).toContain('from "./cli-add-workspace-rest.js"');
+	expect(addWorkspaceSource).toContain('from "./cli-add-workspace-ai.js"');
+	expect(addWorkspaceSource).toContain("runAddAiFeatureCommand");
 	expect(addWorkspaceSource).toContain("runAddBindingSourceCommand");
 	expect(addWorkspaceSource).toContain("runAddEditorPluginCommand");
 	expect(addWorkspaceSource).toContain("runAddPatternCommand");
 	expect(addWorkspaceSource).toContain("runAddRestResourceCommand");
 	expect(addWorkspaceSource).not.toContain("function buildPatternSource(");
+	expect(addWorkspaceSource).not.toContain("function buildAiFeatureTypesSource(");
 	expect(addWorkspaceSource).not.toContain("function buildBindingSourceServerSource(");
+	expect(addWorkspaceSource).not.toContain("async function ensureAiFeatureBootstrapAnchors(");
 	expect(addWorkspaceSource).not.toContain("async function ensureBindingSourceBootstrapAnchors(");
 	expect(addWorkspaceSource).not.toContain("async function ensureEditorPluginBootstrapAnchors(");
 	expect(addWorkspaceSource).not.toContain("function buildRestResourceTypesSource(");
 	expect(addWorkspaceSource).not.toContain("async function ensureRestResourceBootstrapAnchors(");
+	expect(addWorkspaceSource).not.toContain("export async function runAddAiFeatureCommand(");
 	expect(addWorkspaceSource).not.toContain("export async function runAddPatternCommand(");
 	expect(addWorkspaceSource).not.toContain("export async function runAddBindingSourceCommand(");
 	expect(addWorkspaceSource).not.toContain("export async function runAddEditorPluginCommand(");
@@ -59,4 +76,15 @@ test("cli-add-workspace delegates asset and rest-resource workflows to focused h
 	expect(restSourceEmittersSource).toContain("function buildRestResourceDataSource(");
 	expect(restAnchorsSource).toContain("async function ensureRestResourceBootstrapAnchors(");
 	expect(restAnchorsSource).toContain("async function ensureRestResourceSyncScriptAnchors(");
+	expect(aiSource).toContain('from "./cli-add-workspace-ai-anchors.js"');
+	expect(aiSource).toContain('from "./cli-add-workspace-ai-source-emitters.js"');
+	expect(aiSource).not.toContain("function buildAiFeatureTypesSource(");
+	expect(aiSource).not.toContain("async function ensureAiFeatureBootstrapAnchors(");
+	expect(aiSource).toContain("function buildAiFeaturePhpSource(");
+	expect(aiSource).toContain("export async function runAddAiFeatureCommand(");
+	expect(aiSourceEmittersSource).toContain("function buildAiFeatureTypesSource(");
+	expect(aiSourceEmittersSource).toContain("function buildAiFeatureApiSource(");
+	expect(aiSourceEmittersSource).toContain("function buildAiFeatureDataSource(");
+	expect(aiAnchorsSource).toContain("async function ensureAiFeatureBootstrapAnchors(");
+	expect(aiAnchorsSource).toContain("async function ensureAiFeatureSyncRestAnchors(");
 });

--- a/packages/wp-typia-project-tools/tests/cli-entry.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-entry.test.ts
@@ -689,12 +689,18 @@ test("formatHelpText keeps migration UI flags out of external template usage", (
   expect(helpText).toContain("--external-layer-id");
   expect(helpText).toContain("@wp-typia/create-workspace-template");
   expect(helpText).toContain("`query-loop` is create-only.");
+  expect(helpText).toContain("wp-typia add ai-feature <name>");
+  expect(helpText).toContain(
+    "wp-typia add ai-feature <name> [--namespace <vendor/v1>]"
+  );
   expect(helpText).toContain("wp-typia add editor-plugin <name>");
   expect(helpText).toContain(
     "wp-typia add editor-plugin <name> [--slot <PluginSidebar>]"
   );
   expect(helpText).toContain("wp-typia add rest-resource <name>");
   expect(helpText).toContain("--methods <method[,method...]>");
+  expect(helpText).toContain("src/ai-features/");
+  expect(helpText).toContain("inc/ai-features/");
   expect(helpText).toContain("src/rest/");
   expect(helpText).toContain("inc/rest/");
   expect(helpText).toContain("src/editor-plugins/");

--- a/packages/wp-typia-project-tools/tests/workspace-add.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-add.test.ts
@@ -2901,6 +2901,209 @@ test("rest resource workflow rejects invalid namespace and methods and preserves
   ).toBe(originalPhpSource);
 }, 20_000);
 
+test("canonical CLI can add a server-only AI feature to an official workspace template", async () => {
+  const targetDir = path.join(tempRoot, "demo-workspace-add-ai-feature");
+
+  await scaffoldProject({
+    projectDir: targetDir,
+    templateId: workspaceTemplatePackageManifest.name,
+    packageManager: "npm",
+    noInstall: true,
+    answers: {
+      author: "Test Runner",
+      description: "Demo workspace add ai feature",
+      namespace: "demo-space",
+      phpPrefix: "demo_space",
+      slug: "demo-workspace-add-ai-feature",
+      textDomain: "demo-space",
+      title: "Demo Workspace Add AI Feature",
+    },
+  });
+
+  linkWorkspaceNodeModules(targetDir);
+
+  runCli(
+    "node",
+    [
+      entryPath,
+      "add",
+      "ai-feature",
+      "brief-suggestions",
+      "--namespace",
+      "demo-space/v1",
+    ],
+    {
+      cwd: targetDir,
+    }
+  );
+
+  const blockConfigSource = fs.readFileSync(
+    path.join(targetDir, "scripts", "block-config.ts"),
+    "utf8"
+  );
+  const bootstrapSource = fs.readFileSync(
+    path.join(targetDir, "demo-workspace-add-ai-feature.php"),
+    "utf8"
+  );
+  const packageJson = JSON.parse(
+    fs.readFileSync(path.join(targetDir, "package.json"), "utf8")
+  ) as {
+    devDependencies?: Record<string, string>;
+    scripts?: Record<string, string>;
+  };
+  const syncProjectSource = fs.readFileSync(
+    path.join(targetDir, "scripts", "sync-project.ts"),
+    "utf8"
+  );
+  const syncRestSource = fs.readFileSync(
+    path.join(targetDir, "scripts", "sync-rest-contracts.ts"),
+    "utf8"
+  );
+  const syncAiSource = fs.readFileSync(
+    path.join(targetDir, "scripts", "sync-ai-features.ts"),
+    "utf8"
+  );
+  const typesSource = fs.readFileSync(
+    path.join(targetDir, "src", "ai-features", "brief-suggestions", "api-types.ts"),
+    "utf8"
+  );
+  const validatorsSource = fs.readFileSync(
+    path.join(
+      targetDir,
+      "src",
+      "ai-features",
+      "brief-suggestions",
+      "api-validators.ts"
+    ),
+    "utf8"
+  );
+  const apiSource = fs.readFileSync(
+    path.join(targetDir, "src", "ai-features", "brief-suggestions", "api.ts"),
+    "utf8"
+  );
+  const dataSource = fs.readFileSync(
+    path.join(targetDir, "src", "ai-features", "brief-suggestions", "data.ts"),
+    "utf8"
+  );
+  const phpSource = fs.readFileSync(
+    path.join(targetDir, "inc", "ai-features", "brief-suggestions.php"),
+    "utf8"
+  );
+
+  expect(blockConfigSource).toContain('slug: "brief-suggestions"');
+  expect(blockConfigSource).toContain('namespace: "demo-space/v1"');
+  expect(blockConfigSource).toContain(
+    'aiSchemaFile: "src/ai-features/brief-suggestions/ai-schemas/feature-result.ai.schema.json"'
+  );
+  expect(blockConfigSource).toContain(
+    'apiFile: "src/ai-features/brief-suggestions/api.ts"'
+  );
+  expect(blockConfigSource).toContain(
+    'phpFile: "inc/ai-features/brief-suggestions.php"'
+  );
+  expect(blockConfigSource).toContain("defineEndpointManifest");
+  expect(bootstrapSource).toContain("function demo_space_register_ai_features()");
+  expect(bootstrapSource).toContain("inc/ai-features/*.php");
+  expect(packageJson.scripts?.["sync-ai"]).toBe("tsx scripts/sync-ai-features.ts");
+  expect(packageJson.devDependencies?.["@wp-typia/project-tools"]).toBeDefined();
+  expect(syncProjectSource).toContain("const syncAiScriptPath");
+  expect(syncProjectSource).toContain("runSyncScript( syncAiScriptPath, options );");
+  expect(syncRestSource).toContain("AI_FEATURES");
+  expect(syncRestSource).toContain("isWorkspaceAiFeature");
+  expect(syncRestSource).toContain("const aiFeatures = AI_FEATURES.filter");
+  expect(syncAiSource).toContain("@wp-typia/project-tools/ai-artifacts");
+  expect(syncAiSource).toContain("projectWordPressAiSchema");
+  expect(typesSource).toContain(
+    "export interface BriefSuggestionsAiFeatureRequest"
+  );
+  expect(typesSource).toContain(
+    "export interface BriefSuggestionsAiFeatureResponse"
+  );
+  expect(typesSource).toContain("providerType: 'client' | 'cloud' | 'server'");
+  expect(validatorsSource).toContain("featureRequest");
+  expect(validatorsSource).toContain("featureResponse");
+  expect(apiSource).toContain("aiFeatureRunEndpoint");
+  expect(apiSource).toContain("resolveRestNonce");
+  expect(dataSource).toContain("useRunBriefSuggestionsAiFeatureMutation");
+  expect(phpSource).toContain("wp_ai_client_prompt");
+  expect(phpSource).toContain("is_supported_for_text_generation");
+  expect(phpSource).toContain("generate_text_result");
+  expect(phpSource).toContain("register_rest_route");
+  expect(phpSource).toContain("'demo-space/v1'");
+
+  expect(
+    fs.existsSync(
+      path.join(
+        targetDir,
+        "src",
+        "ai-features",
+        "brief-suggestions",
+        "api-client.ts"
+      )
+    )
+  ).toBe(true);
+  expect(
+    fs.existsSync(
+      path.join(
+        targetDir,
+        "src",
+        "ai-features",
+        "brief-suggestions",
+        "api.openapi.json"
+      )
+    )
+  ).toBe(true);
+  expect(
+    fs.existsSync(
+      path.join(
+        targetDir,
+        "src",
+        "ai-features",
+        "brief-suggestions",
+        "api-schemas",
+        "feature-request.schema.json"
+      )
+    )
+  ).toBe(true);
+  expect(
+    fs.existsSync(
+      path.join(
+        targetDir,
+        "src",
+        "ai-features",
+        "brief-suggestions",
+        "ai-schemas",
+        "feature-result.ai.schema.json"
+      )
+    )
+  ).toBe(true);
+
+  const doctorOutput = runCli("node", [entryPath, "doctor", "--format", "json"], {
+    cwd: targetDir,
+  });
+  const doctorChecks = JSON.parse(doctorOutput) as {
+    checks: Array<{ detail: string; label: string; status: string }>;
+  };
+  expect(
+    doctorChecks.checks.find((check) => check.label === "AI feature bootstrap")
+      ?.status
+  ).toBe("pass");
+  expect(
+    doctorChecks.checks.find(
+      (check) => check.label === "AI feature config brief-suggestions"
+    )?.status
+  ).toBe("pass");
+  expect(
+    doctorChecks.checks.find(
+      (check) => check.label === "AI feature brief-suggestions"
+    )?.status
+  ).toBe("pass");
+
+  runCli("npm", ["run", "sync-rest", "--", "--check"], { cwd: targetDir });
+  runCli("npm", ["run", "sync-ai", "--", "--check"], { cwd: targetDir });
+  typecheckGeneratedProject(targetDir);
+}, 30_000);
+
 test("canonical CLI can add an editor plugin to an official workspace template", async () => {
   const targetDir = path.join(tempRoot, "demo-workspace-add-editor-plugin");
 

--- a/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
@@ -349,6 +349,23 @@ export const REST_RESOURCES: WorkspaceRestResourceConfig[] = [
 \t// wp-typia add rest-resource entries
 ];
 
+export interface WorkspaceAiFeatureConfig {
+\taiSchemaFile: string;
+\tapiFile: string;
+\tclientFile: string;
+\tdataFile: string;
+\tnamespace: string;
+\topenApiFile: string;
+\tphpFile: string;
+\tslug: string;
+\ttypesFile: string;
+\tvalidatorsFile: string;
+}
+
+export const AI_FEATURES: WorkspaceAiFeatureConfig[] = [
+\t// wp-typia add ai-feature entries
+];
+
 export interface WorkspaceEditorPluginConfig {
 \tfile: string;
 \tslug: string;
@@ -370,6 +387,9 @@ export const EDITOR_PLUGINS: WorkspaceEditorPluginConfig[] = [
       restResourceEntries: [
         '\t{ apiFile: "src/rest/hero/api.ts", clientFile: "src/rest/hero/api-client.ts", dataFile: "src/rest/hero/data.ts", methods: [ "list", "read" ], namespace: "demo-space/v1", openApiFile: "src/rest/hero/api.openapi.json", phpFile: "inc/rest/hero.php", slug: "hero", typesFile: "src/rest/hero/api-types.ts", validatorsFile: "src/rest/hero/api-validators.ts" },',
       ],
+      aiFeatureEntries: [
+        '\t{ aiSchemaFile: "src/ai-features/hero/ai-schemas/feature-result.ai.schema.json", apiFile: "src/ai-features/hero/api.ts", clientFile: "src/ai-features/hero/api-client.ts", dataFile: "src/ai-features/hero/data.ts", namespace: "demo-space/v1", openApiFile: "src/ai-features/hero/api.openapi.json", phpFile: "inc/ai-features/hero.php", slug: "hero", typesFile: "src/ai-features/hero/api-types.ts", validatorsFile: "src/ai-features/hero/api-validators.ts" },',
+      ],
       editorPluginEntries: [
         '\t{ file: "src/editor-plugins/document-tools/index.tsx", slug: "document-tools", slot: "PluginSidebar" },',
       ],
@@ -384,6 +404,7 @@ export const EDITOR_PLUGINS: WorkspaceEditorPluginConfig[] = [
   expect(
     repairedSource.match(/export const REST_RESOURCES\b/gu)?.length
   ).toBe(1);
+  expect(repairedSource.match(/export const AI_FEATURES\b/gu)?.length).toBe(1);
   expect(
     repairedSource.match(/export const EDITOR_PLUGINS\b/gu)?.length
   ).toBe(1);
@@ -396,6 +417,9 @@ export const EDITOR_PLUGINS: WorkspaceEditorPluginConfig[] = [
   );
   expect(repairedSource).toContain(
     "export interface WorkspaceRestResourceConfig"
+  );
+  expect(repairedSource).toContain(
+    "export interface WorkspaceAiFeatureConfig"
   );
   expect(repairedSource).toContain(
     "export interface WorkspaceEditorPluginConfig"

--- a/packages/wp-typia/.bunli/commands.gen.ts
+++ b/packages/wp-typia/.bunli/commands.gen.ts
@@ -31,7 +31,7 @@ const modules: Record<GeneratedNames, Command<any>> = {
 const metadata: Record<GeneratedNames, GeneratedCommandMeta> = {
   'add': {
       name: 'add',
-      description: 'Extend an official wp-typia workspace with blocks, variations, patterns, binding sources, plugin-level REST resources, editor plugins, or hooked blocks.',
+      description: 'Extend an official wp-typia workspace with blocks, variations, patterns, binding sources, plugin-level REST resources, server-only AI features, editor plugins, or hooked blocks.',
       path: './src/commands/add'
     },
   'create': {

--- a/packages/wp-typia/README.md
+++ b/packages/wp-typia/README.md
@@ -15,6 +15,7 @@ Extend an existing workspace with:
 - `wp-typia add block counter-card --template basic`
 - `wp-typia add binding-source hero-data`
 - `wp-typia add rest-resource snapshots --namespace my-plugin/v1 --methods list,read,create`
+- `wp-typia add ai-feature brief-suggestions --namespace my-plugin/v1`
 - `wp-typia add hooked-block counter-card --anchor core/post-content --position after`
 
 `wp-typia <project-dir>` remains available as a backward-compatible alias to

--- a/packages/wp-typia/src/add-kind-registry.ts
+++ b/packages/wp-typia/src/add-kind-registry.ts
@@ -4,6 +4,7 @@ export const ADD_KIND_IDS = [
   'pattern',
   'binding-source',
   'rest-resource',
+  'ai-feature',
   'editor-plugin',
   'hooked-block',
 ] as const;
@@ -179,6 +180,23 @@ export const ADD_KIND_REGISTRY = {
     description: 'Add a plugin-level typed REST resource',
     nameLabel: 'REST resource name',
     visibleFieldNames: () => ['kind', 'name', 'namespace', 'methods'],
+  },
+  'ai-feature': {
+    completion: {
+      nextSteps: (values) => [
+        `Review src/ai-features/${values.aiFeatureSlug}/ and inc/ai-features/${values.aiFeatureSlug}.php.`,
+        'Run `wp-typia sync ai` or your workspace build/dev command to verify the generated AI schema and endpoint client.',
+      ],
+      summaryLines: (values, projectDir) => [
+        `AI feature: ${values.aiFeatureSlug}`,
+        `Namespace: ${values.namespace}`,
+        `Project directory: ${projectDir}`,
+      ],
+      title: 'Added server-only AI feature',
+    },
+    description: 'Add a server-owned WordPress AI feature endpoint',
+    nameLabel: 'AI feature name',
+    visibleFieldNames: () => ['kind', 'name', 'namespace'],
   },
   variation: {
     completion: {

--- a/packages/wp-typia/src/add-kind-registry.ts
+++ b/packages/wp-typia/src/add-kind-registry.ts
@@ -185,7 +185,7 @@ export const ADD_KIND_REGISTRY = {
     completion: {
       nextSteps: (values) => [
         `Review src/ai-features/${values.aiFeatureSlug}/ and inc/ai-features/${values.aiFeatureSlug}.php.`,
-        'Run `wp-typia sync ai` or your workspace build/dev command to verify the generated AI schema and endpoint client.',
+        'Run `wp-typia sync-rest` and `wp-typia sync ai` or your workspace build/dev command to verify the generated REST artifacts and AI schema.',
       ],
       summaryLines: (values, projectDir) => [
         `AI feature: ${values.aiFeatureSlug}`,

--- a/packages/wp-typia/src/command-option-metadata.ts
+++ b/packages/wp-typia/src/command-option-metadata.ts
@@ -162,7 +162,7 @@ export const ADD_OPTION_METADATA = {
 		type: "string",
 	},
 	namespace: {
-		description: "REST namespace for rest-resource workflows.",
+		description: "REST namespace for rest-resource and ai-feature workflows.",
 		type: "string",
 	},
 	"persistence-policy": {

--- a/packages/wp-typia/src/commands/add.ts
+++ b/packages/wp-typia/src/commands/add.ts
@@ -36,7 +36,7 @@ const addOptions = buildCommandOptions(ADD_OPTION_METADATA);
 export const addCommand = defineCommand({
   defaultFormat: 'toon',
   description:
-    'Extend an official wp-typia workspace with blocks, variations, patterns, binding sources, plugin-level REST resources, editor plugins, or hooked blocks.',
+    'Extend an official wp-typia workspace with blocks, variations, patterns, binding sources, plugin-level REST resources, server-only AI features, editor plugins, or hooked blocks.',
   handler: async (args) => {
     const prefersStructuredOutput = prefersStructuredCliOutput(args);
 

--- a/packages/wp-typia/src/runtime-bridge.ts
+++ b/packages/wp-typia/src/runtime-bridge.ts
@@ -105,6 +105,9 @@ type AddBlockResult = Awaited<ReturnType<AddRuntime['runAddBlockCommand']>>;
 type AddEditorPluginResult = Awaited<
   ReturnType<AddRuntime['runAddEditorPluginCommand']>
 >;
+type AddAiFeatureResult = Awaited<
+  ReturnType<AddRuntime['runAddAiFeatureCommand']>
+>;
 type AddHookedBlockResult = Awaited<
   ReturnType<AddRuntime['runAddHookedBlockCommand']>
 >;
@@ -356,6 +359,32 @@ const ADD_KIND_EXECUTION_REGISTRY: Record<
           cwd: targetCwd,
           editorPluginName: name,
           slot,
+        }),
+    });
+  },
+  'ai-feature': async (context) => {
+    const name = requireAddKindName(
+      context,
+      '`wp-typia add ai-feature` requires <name>. Usage: wp-typia add ai-feature <name> [--namespace <vendor/v1>].',
+    );
+    const namespace = readOptionalStringFlag(context.flags, 'namespace');
+
+    return runRegisteredAddKind<AddAiFeatureResult>(context, {
+      buildCompletion: (result) =>
+        buildAddCompletionPayload({
+          kind: 'ai-feature',
+          projectDir: result.projectDir,
+          values: {
+            aiFeatureSlug: result.aiFeatureSlug,
+            namespace: result.namespace,
+          },
+          warnings: result.warnings,
+        }),
+      execute: (targetCwd) =>
+        context.addRuntime.runAddAiFeatureCommand({
+          aiFeatureName: name,
+          cwd: targetCwd,
+          namespace,
         }),
     });
   },

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -1253,7 +1253,7 @@ describe('wp-typia package', () => {
     expect(result.stdout).toContain('Usage:');
     expect(result.stdout).toContain('wp-typia add block <name>');
     expect(result.stderr).toContain(
-      '`wp-typia add` requires <kind>. Usage: wp-typia add <block|variation|pattern|binding-source|rest-resource|editor-plugin|hooked-block> ...',
+      '`wp-typia add` requires <kind>. Usage: wp-typia add <block|variation|pattern|binding-source|rest-resource|ai-feature|editor-plugin|hooked-block> ...',
     );
   });
 
@@ -1268,6 +1268,9 @@ describe('wp-typia package', () => {
       await expect(runNodeCli(['add'])).rejects.toThrow('wp-typia add failed');
       expect(capturedStdout.join('\n')).toContain('Usage:');
       expect(capturedStdout.join('\n')).toContain('wp-typia add block <name>');
+      expect(capturedStdout.join('\n')).toContain(
+        'wp-typia add ai-feature <name>',
+      );
       expect(capturedStdout.join('\n')).toContain(
         'wp-typia add editor-plugin <name>',
       );

--- a/packages/wp-typia/tests/tui-interaction-models.test.ts
+++ b/packages/wp-typia/tests/tui-interaction-models.test.ts
@@ -47,6 +47,11 @@ describe("first-party TUI interaction models", () => {
 			"namespace",
 			"methods",
 		]);
+		expect(getVisibleAddFieldNames({ kind: "ai-feature" })).toEqual([
+			"kind",
+			"name",
+			"namespace",
+		]);
 		expect(getVisibleAddFieldNames({ kind: "hooked-block" })).toEqual([
 			"kind",
 			"name",
@@ -118,6 +123,22 @@ describe("first-party TUI interaction models", () => {
 			block: "counter-card",
 			kind: "variation",
 			name: "hero-card",
+		});
+
+		expect(
+			sanitizeAddSubmitValues({
+				anchor: "",
+				block: "",
+				kind: "ai-feature",
+				name: "brief-suggestions",
+				namespace: " demo-space/v1 ",
+				position: "",
+				template: "persistence",
+			}),
+		).toEqual({
+			kind: "ai-feature",
+			name: "brief-suggestions",
+			namespace: "demo-space/v1",
 		});
 
 		expect(


### PR DESCRIPTION
## Summary
- add a first-class `wp-typia add ai-feature <name>` workspace flow for server-owned WordPress AI feature endpoints
- scaffold typed AI feature REST contracts, AI-safe `sync-ai` schema projection, PHP feature-detection/telemetry seams, and workspace doctor coverage
- document the new AI feature workflow and wire the CLI/TUI/help surfaces plus tests around it

## Testing
- `bun run typecheck`
- `bun test packages/wp-typia-project-tools/tests/cli-add-workspace-boundaries.test.ts packages/wp-typia-project-tools/tests/cli-entry.test.ts packages/wp-typia-project-tools/tests/workspace-add.test.ts packages/wp-typia-project-tools/tests/workspace-doctor.test.ts packages/wp-typia-project-tools/tests/wordpress-ai-spec.test.ts`
- `bun test packages/wp-typia/tests/cli-package.test.ts packages/wp-typia/tests/tui-interaction-models.test.ts`
- `bun run docs:build:site`

Closes #558.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * New `wp-typia add ai-feature <name>` command enables you to scaffold AI-powered features with automated type-safe request/response schemas, structured output validation, typed client libraries, and full workspace synchronization integration.

* **Documentation**
  * Updated API reference and workspace documentation explaining the complete AI feature scaffolding workflow, endpoint configuration, schema validation requirements, and integration with existing tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->