### PR TITLE
feat(scaffold): add typed workflow ability scaffolds

### DIFF
--- a/apps/docs/src/content/docs/reference/api.md
+++ b/apps/docs/src/content/docs/reference/api.md
@@ -699,6 +699,7 @@ Official workspaces also support first-class variation, pattern, binding-source,
 wp-typia add variation hero-card --block counter-card
 wp-typia add pattern hero-layout
 wp-typia add binding-source hero-data
+wp-typia add ability review-workflow
 wp-typia add ai-feature brief-suggestions --namespace my-plugin/v1
 wp-typia add hooked-block counter-card --anchor core/post-content --position after
 ```
@@ -712,6 +713,10 @@ starter contract keeps one field-keyed data map in each file, so the common
 follow-up is to edit `src/bindings/<name>/server.php` and
 `src/bindings/<name>/editor.ts` in parallel by replacing the default starter
 values for the fields you want to expose.
+Workflow abilities are generated under `src/abilities/*/` plus
+`inc/abilities/*.php` and scaffold typed input/output contracts, JSON Schema
+sync, server-side Abilities API registration, and a lightweight admin/editor
+client helper that expects the WordPress abilities client to be available.
 AI features are generated under `src/ai-features/*/` plus `inc/ai-features/*.php`
 and scaffold a server-owned REST endpoint, AI-safe response schema projection,
 typed endpoint client wrapper, and WordPress AI Client feature-detection seam.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-shared.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-shared.ts
@@ -31,6 +31,7 @@ export const ADD_KIND_IDS = [
 	"pattern",
 	"binding-source",
 	"rest-resource",
+	"ability",
 	"ai-feature",
 	"hooked-block",
 	"editor-plugin",
@@ -91,6 +92,11 @@ export interface RunAddRestResourceCommandOptions {
 	methods?: string;
 	namespace?: string;
 	restResourceName: string;
+}
+
+export interface RunAddAbilityCommandOptions {
+	abilityName: string;
+	cwd?: string;
 }
 
 export interface RunAddAiFeatureCommandOptions {
@@ -498,6 +504,30 @@ export function assertRestResourceDoesNotExist(
 	}
 }
 
+export function assertAbilityDoesNotExist(
+	projectDir: string,
+	abilitySlug: string,
+	inventory: WorkspaceInventory,
+): void {
+	const abilityDir = path.join(projectDir, "src", "abilities", abilitySlug);
+	const abilityPhpPath = path.join(projectDir, "inc", "abilities", `${abilitySlug}.php`);
+	if (fs.existsSync(abilityDir)) {
+		throw new Error(
+			`An ability scaffold already exists at ${path.relative(projectDir, abilityDir)}. Choose a different name.`,
+		);
+	}
+	if (fs.existsSync(abilityPhpPath)) {
+		throw new Error(
+			`An ability bootstrap already exists at ${path.relative(projectDir, abilityPhpPath)}. Choose a different name.`,
+		);
+	}
+	if (inventory.abilities.some((entry) => entry.slug === abilitySlug)) {
+		throw new Error(
+			`An ability inventory entry already exists for ${abilitySlug}. Choose a different name.`,
+		);
+	}
+}
+
 export function assertAiFeatureDoesNotExist(
 	projectDir: string,
 	aiFeatureSlug: string,
@@ -560,6 +590,7 @@ export function formatAddHelpText(): string {
   wp-typia add pattern <name> [--dry-run]
   wp-typia add binding-source <name> [--dry-run]
   wp-typia add rest-resource <name> [--namespace <vendor/v1>] [--methods <list,read,create,update,delete>] [--dry-run]
+  wp-typia add ability <name> [--dry-run]
   wp-typia add ai-feature <name> [--namespace <vendor/v1>] [--dry-run]
   wp-typia add hooked-block <block-slug> --anchor <anchor-block-name> --position <${HOOKED_BLOCK_POSITION_IDS.join("|")}> [--dry-run]
   wp-typia add editor-plugin <name> [--slot <${EDITOR_PLUGIN_SLOT_IDS.join("|")}>] [--dry-run]
@@ -572,6 +603,7 @@ Notes:
   \`add pattern\` scaffolds a namespaced PHP pattern shell under \`src/patterns/\`.
   \`add binding-source\` scaffolds shared PHP and editor registration under \`src/bindings/\`.
   \`add rest-resource\` scaffolds plugin-level TypeScript REST contracts under \`src/rest/\` and PHP route glue under \`inc/rest/\`.
+  \`add ability\` scaffolds typed workflow abilities under \`src/abilities/\` and server registration under \`inc/abilities/\`.
   \`add ai-feature\` scaffolds server-owned AI feature endpoints under \`src/ai-features/\` and PHP route glue under \`inc/ai-features/\`.
   \`add hooked-block\` patches an existing workspace block's \`block.json\` \`blockHooks\` metadata.
   \`add editor-plugin\` scaffolds a document-level editor extension under \`src/editor-plugins/\`.`;

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-shared.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-shared.ts
@@ -94,6 +94,14 @@ export interface RunAddRestResourceCommandOptions {
 	restResourceName: string;
 }
 
+/**
+ * Options for `wp-typia add ability`.
+ *
+ * @property cwd Working directory used to resolve the nearest official workspace.
+ * Defaults to `process.cwd()`.
+ * @property abilityName Human-entered workflow ability name that will be
+ * normalized into the generated slug.
+ */
 export interface RunAddAbilityCommandOptions {
 	abilityName: string;
 	cwd?: string;
@@ -504,6 +512,18 @@ export function assertRestResourceDoesNotExist(
 	}
 }
 
+/**
+ * Ensure a workflow ability scaffold does not already exist on disk or in the
+ * workspace inventory.
+ *
+ * The check covers the generated `src/abilities/<slug>` directory,
+ * `inc/abilities/<slug>.php`, and any matching `inventory.abilities` entry.
+ *
+ * @param projectDir Workspace root directory.
+ * @param abilitySlug Normalized workflow ability slug.
+ * @param inventory Parsed workspace inventory.
+ * @throws {Error} When the ability directory, PHP bootstrap, or inventory entry already exists.
+ */
 export function assertAbilityDoesNotExist(
 	projectDir: string,
 	abilitySlug: string,

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ability.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ability.ts
@@ -26,7 +26,8 @@ import {
 const ABILITY_SERVER_GLOB = "/inc/abilities/*.php";
 const ABILITY_EDITOR_SCRIPT = "build/abilities/index.js";
 const ABILITY_EDITOR_ASSET = "build/abilities/index.asset.php";
-const ABILITY_REGISTRY_MARKER = "// wp-typia add ability entries";
+const ABILITY_REGISTRY_END_MARKER = "// wp-typia add ability entries end";
+const ABILITY_REGISTRY_START_MARKER = "// wp-typia add ability entries start";
 const WP_ABILITIES_SCRIPT_HANDLE = "wp-abilities";
 const WP_CORE_ABILITIES_SCRIPT_HANDLE = "wp-core-abilities";
 
@@ -423,10 +424,8 @@ if ( ! function_exists( '${executeFunctionName}' ) ) {
 \t\t$note = isset( $payload['note'] ) && is_string( $payload['note'] )
 \t\t\t? trim( $payload['note'] )
 \t\t\t: '';
-
-\t\treturn array(
+\t\t$result = array(
 \t\t\t'processedContextId' => $context_id,
-\t\t\t'receivedNote'       => '' !== $note ? $note : null,
 \t\t\t'status'             => 'ready',
 \t\t\t'summary'            => sprintf(
 \t\t\t\t/* translators: 1: workflow title, 2: context id */
@@ -437,6 +436,12 @@ if ( ! function_exists( '${executeFunctionName}' ) ) {
 \t\t\t\t$context_id
 \t\t\t),
 \t\t);
+
+\t\tif ( '' !== $note ) {
+\t\t\t$result['receivedNote'] = $note;
+\t\t}
+
+\t\treturn $result;
 \t}
 }
 
@@ -521,7 +526,14 @@ function buildAbilityRegistrySource(abilitySlugs: string[]): string {
 		.map((abilitySlug) => `export * from './${abilitySlug}/client';`)
 		.join("\n");
 
-	return `${exportLines}${exportLines ? "\n\n" : ""}${ABILITY_REGISTRY_MARKER}\n`;
+	return [
+		ABILITY_REGISTRY_START_MARKER,
+		exportLines,
+		ABILITY_REGISTRY_END_MARKER,
+	]
+		.filter((line) => line.length > 0)
+		.join("\n")
+		.concat("\n");
 }
 
 function resolveAbilityRegistryPath(projectDir: string): string {
@@ -557,9 +569,22 @@ async function writeAbilityRegistry(
 	const nextAbilitySlugs = Array.from(
 		new Set([...existingAbilitySlugs, ...existingRegistrySlugs, abilitySlug]),
 	).sort();
+	const generatedSection = buildAbilityRegistrySource(nextAbilitySlugs);
+	const existingSource = fs.existsSync(registryPath)
+		? fs.readFileSync(registryPath, "utf8")
+		: "";
+	const generatedSectionPattern = new RegExp(
+		`${escapeRegex(ABILITY_REGISTRY_START_MARKER)}[\\s\\S]*?${escapeRegex(ABILITY_REGISTRY_END_MARKER)}\\n?`,
+		"u",
+	);
+	const nextSource = existingSource
+		? generatedSectionPattern.test(existingSource)
+			? existingSource.replace(generatedSectionPattern, generatedSection)
+			: `${existingSource.trimEnd()}\n\n${generatedSection}`
+		: generatedSection;
 	await fsp.writeFile(
 		registryPath,
-		buildAbilityRegistrySource(nextAbilitySlugs),
+		nextSource,
 		"utf8",
 	);
 }
@@ -765,22 +790,6 @@ async function ensureAbilitySyncProjectAnchors(
 	});
 }
 
-function replaceOrThrow(
-	source: string,
-	patterns: RegExp[],
-	replacement: string,
-	errorMessage: string,
-): string {
-	for (const pattern of patterns) {
-		if (!pattern.test(source)) {
-			continue;
-		}
-		return source.replace(pattern, replacement);
-	}
-
-	throw new Error(errorMessage);
-}
-
 async function ensureAbilityBuildScriptAnchors(
 	workspace: WorkspaceProject,
 ): Promise<void> {
@@ -792,25 +801,33 @@ async function ensureAbilityBuildScriptAnchors(
 			return nextSource;
 		}
 
-		nextSource = replaceOrThrow(
-			nextSource,
-			[
-				/\[\n\t\t'src\/bindings\/index\.ts',\n\t\t'src\/bindings\/index\.js',\n\t\t'src\/editor-plugins\/index\.ts',\n\t\t'src\/editor-plugins\/index\.js',\n\t\]/u,
-				/\[\n\t\t'src\/bindings\/index\.ts',\n\t\t'src\/bindings\/index\.js',\n\t\]/u,
-			],
-			`[
+		const sharedEntriesPattern =
+			/(for\s*\(\s*const\s+relativePath\s+of\s+\[)([\s\S]*?)(\]\s*\)\s*\{)/u;
+		const match = nextSource.match(sharedEntriesPattern);
+		if (
+			!match ||
+			!match[2].includes("src/bindings/index.ts") ||
+			!match[2].includes("src/editor-plugins/index.ts")
+		) {
+			throw new Error(
+				[
+					`ensureAbilityBuildScriptAnchors could not patch ${path.basename(buildScriptPath)}.`,
+					"Missing the expected shared editor entries array in scripts/build-workspace.mjs.",
+					"Restore the generated template or wire abilities/index manually before retrying.",
+				].join(" "),
+			);
+		}
+
+		nextSource = nextSource.replace(
+			sharedEntriesPattern,
+			`$1
 \t\t'src/bindings/index.ts',
 \t\t'src/bindings/index.js',
 \t\t'src/editor-plugins/index.ts',
 \t\t'src/editor-plugins/index.js',
 \t\t'src/abilities/index.ts',
 \t\t'src/abilities/index.js',
-\t]`,
-			[
-				`ensureAbilityBuildScriptAnchors could not patch ${path.basename(buildScriptPath)}.`,
-				"Missing the expected shared editor entries array in scripts/build-workspace.mjs.",
-				"Restore the generated template or wire abilities/index manually before retrying.",
-			].join(" "),
+\t$3`,
 		);
 
 		return nextSource;
@@ -827,12 +844,25 @@ async function ensureAbilityWebpackAnchors(
 			return source;
 		}
 
-		return replaceOrThrow(
-			source,
-			[
-				/for\s*\(\s*const\s+\[\s*entryName\s*,\s*candidates\s*\]\s+of\s+\[\n\t\t\[\n\t\t\t'bindings\/index',\n\t\t\t\[\s*'src\/bindings\/index\.ts',\s*'src\/bindings\/index\.js'\s*\],\n\t\t\],\n\t\t\[\n\t\t\t'editor-plugins\/index',\n\t\t\t\[\s*'src\/editor-plugins\/index\.ts',\s*'src\/editor-plugins\/index\.js'\s*\],\n\t\t\],\n\t\]\s*\)\s*\{/u,
-				/for\s*\(\s*const\s+\[\s*entryName\s*,\s*candidates\s*\]\s+of\s+\[\n\t\t\[\n\t\t\t'bindings\/index',\n\t\t\t\[\s*'src\/bindings\/index\.ts',\s*'src\/bindings\/index\.js'\s*\],\n\t\t\],\n\t\]\s*\)\s*\{/u,
-			],
+		const sharedEntriesPattern =
+			/for\s*\(\s*const\s+\[\s*entryName\s*,\s*candidates\s*\]\s+of\s+\[([\s\S]*?)\]\s*\)\s*\{/u;
+		const match = source.match(sharedEntriesPattern);
+		if (
+			!match ||
+			!match[1].includes("bindings/index") ||
+			!match[1].includes("editor-plugins/index")
+		) {
+			throw new Error(
+				[
+					`ensureAbilityWebpackAnchors could not patch ${path.basename(webpackConfigPath)}.`,
+					"Missing the expected shared editor entries block in webpack.config.js.",
+					"Restore the generated template or wire abilities/index manually before retrying.",
+				].join(" "),
+			);
+		}
+
+		return source.replace(
+			sharedEntriesPattern,
 			`for ( const [ entryName, candidates ] of [
 \t\t[
 \t\t\t'bindings/index',
@@ -847,11 +877,6 @@ async function ensureAbilityWebpackAnchors(
 \t\t\t[ 'src/abilities/index.ts', 'src/abilities/index.js' ],
 \t\t],
 \t] ) {`,
-			[
-				`ensureAbilityWebpackAnchors could not patch ${path.basename(webpackConfigPath)}.`,
-				"Missing the expected shared editor entries block in webpack.config.js.",
-				"Restore the generated template or wire abilities/index manually before retrying.",
-			].join(" "),
 		);
 	});
 }

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ability.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ability.ts
@@ -1,0 +1,982 @@
+import fs from "node:fs";
+import { promises as fsp } from "node:fs";
+import path from "node:path";
+
+import { syncTypeSchemas } from "@wp-typia/block-runtime/metadata-core";
+
+import {
+	appendWorkspaceInventoryEntries,
+	readWorkspaceInventory,
+} from "./workspace-inventory.js";
+import { resolveWorkspaceProject, type WorkspaceProject } from "./workspace-project.js";
+import { toTitleCase } from "./string-case.js";
+import {
+	assertAbilityDoesNotExist,
+	assertValidGeneratedSlug,
+	getWorkspaceBootstrapPath,
+	normalizeBlockSlug,
+	patchFile,
+	quoteTsString,
+	rollbackWorkspaceMutation,
+	type RunAddAbilityCommandOptions,
+	type WorkspaceMutationSnapshot,
+	snapshotWorkspaceFiles,
+} from "./cli-add-shared.js";
+
+const ABILITY_SERVER_GLOB = "/inc/abilities/*.php";
+const ABILITY_EDITOR_SCRIPT = "build/abilities/index.js";
+const ABILITY_EDITOR_ASSET = "build/abilities/index.asset.php";
+const ABILITY_REGISTRY_MARKER = "// wp-typia add ability entries";
+const WP_ABILITIES_SCRIPT_HANDLE = "wp-abilities";
+const WP_CORE_ABILITIES_SCRIPT_HANDLE = "wp-core-abilities";
+
+function escapeRegex(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+function quotePhpString(value: string): string {
+	return `'${value.replace(/\\/gu, "\\\\").replace(/'/gu, "\\'")}'`;
+}
+
+function toPascalCaseFromAbilitySlug(abilitySlug: string): string {
+	return normalizeBlockSlug(abilitySlug)
+		.split("-")
+		.filter(Boolean)
+		.map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+		.join("");
+}
+
+function toAbilityCategorySlug(workspaceNamespace: string): string {
+	const normalizedNamespace = workspaceNamespace
+		.replace(/[^a-z0-9-]+/gu, "-")
+		.replace(/-{2,}/gu, "-")
+		.replace(/^-|-$/gu, "");
+
+	return `${normalizedNamespace || "workspace"}-workflows`;
+}
+
+function buildAbilityConfigEntry(abilitySlug: string): string {
+	const pascalCase = toPascalCaseFromAbilitySlug(abilitySlug);
+
+	return [
+		"\t{",
+		`\t\tclientFile: ${quoteTsString(`src/abilities/${abilitySlug}/client.ts`)},`,
+		`\t\tconfigFile: ${quoteTsString(`src/abilities/${abilitySlug}/ability.config.json`)},`,
+		`\t\tdataFile: ${quoteTsString(`src/abilities/${abilitySlug}/data.ts`)},`,
+		`\t\tinputSchemaFile: ${quoteTsString(`src/abilities/${abilitySlug}/input.schema.json`)},`,
+		`\t\tinputTypeName: ${quoteTsString(`${pascalCase}AbilityInput`)},`,
+		`\t\toutputSchemaFile: ${quoteTsString(`src/abilities/${abilitySlug}/output.schema.json`)},`,
+		`\t\toutputTypeName: ${quoteTsString(`${pascalCase}AbilityOutput`)},`,
+		`\t\tphpFile: ${quoteTsString(`inc/abilities/${abilitySlug}.php`)},`,
+		`\t\tslug: ${quoteTsString(abilitySlug)},`,
+		`\t\ttypesFile: ${quoteTsString(`src/abilities/${abilitySlug}/types.ts`)},`,
+		"\t},",
+	].join("\n");
+}
+
+function buildAbilityConfigSource(
+	abilitySlug: string,
+	workspaceNamespace: string,
+): string {
+	const abilityTitle = toTitleCase(abilitySlug);
+
+	return `${JSON.stringify(
+		{
+			abilityId: `${workspaceNamespace}/${abilitySlug}`,
+			category: {
+				description: `Typed editor and admin workflows exposed by the ${workspaceNamespace} workspace.`,
+				label: `${toTitleCase(workspaceNamespace)} Workflows`,
+				slug: toAbilityCategorySlug(workspaceNamespace),
+			},
+			description: `Runs the ${abilityTitle} workflow using a typed server callback.`,
+			label: abilityTitle,
+			meta: {
+				annotations: {
+					destructive: false,
+					idempotent: true,
+					readonly: false,
+				},
+				mcp: {
+					public: false,
+				},
+				showInRest: true,
+			},
+		},
+		null,
+		2,
+	)}\n`;
+}
+
+function buildAbilityTypesSource(abilitySlug: string): string {
+	const pascalCase = toPascalCaseFromAbilitySlug(abilitySlug);
+
+	return `export interface ${pascalCase}AbilityInput {
+\tcontextId: number;
+\tnote?: string;
+}
+
+export interface ${pascalCase}AbilityOutput {
+\tprocessedContextId: number;
+\treceivedNote?: string;
+\tstatus: 'ready';
+\tsummary: string;
+}
+`;
+}
+
+function buildAbilityDataSource(abilitySlug: string): string {
+	const pascalCase = toPascalCaseFromAbilitySlug(abilitySlug);
+	const abilityConstBase = abilitySlug
+		.toUpperCase()
+		.replace(/[^A-Z0-9]+/gu, "_")
+		.replace(/_{2,}/gu, "_")
+		.replace(/^_|_$/gu, "");
+
+	return `import abilityConfig from './ability.config.json';
+
+import type { ${pascalCase}AbilityInput, ${pascalCase}AbilityOutput } from './types';
+
+interface WordPressAbilityDefinition {
+\tcategory?: string;
+\tdescription?: string;
+\tlabel?: string;
+\tmeta?: Record<string, unknown>;
+\tname?: string;
+}
+
+interface WordPressAbilitiesClient {
+\texecuteAbility( name: string, input?: unknown ): Promise< unknown >;
+\tgetAbilities( args?: { category?: string } ): WordPressAbilityDefinition[];
+\tgetAbility( name: string ): WordPressAbilityDefinition | undefined;
+}
+
+const ABILITY_CLIENT_UNAVAILABLE_MESSAGE =
+\t'The WordPress abilities client is unavailable on this screen. Ensure the Abilities API and @wordpress/core-abilities integration are loaded before using this scaffold.';
+
+export const ${abilityConstBase}_ABILITY = abilityConfig;
+export const ${abilityConstBase}_ABILITY_CATEGORY = abilityConfig.category;
+export const ${abilityConstBase}_ABILITY_ID = abilityConfig.abilityId;
+export const ${abilityConstBase}_ABILITY_META = abilityConfig.meta;
+
+export type {
+\t${pascalCase}AbilityInput,
+\t${pascalCase}AbilityOutput,
+};
+
+function resolveAbilitiesClient(): WordPressAbilitiesClient {
+\tconst runtime = globalThis as typeof globalThis & {
+\t\twindow?: {
+\t\t\twp?: {
+\t\t\t\tabilities?: WordPressAbilitiesClient;
+\t\t\t};
+\t\t};
+\t};
+\tconst client = runtime.window?.wp?.abilities;
+\tif ( ! client ) {
+\t\tthrow new Error( ABILITY_CLIENT_UNAVAILABLE_MESSAGE );
+\t}
+
+\treturn client;
+}
+
+export function list${pascalCase}CategoryAbilities(): WordPressAbilityDefinition[] {
+\treturn resolveAbilitiesClient().getAbilities( {
+\t\tcategory: ${abilityConstBase}_ABILITY_CATEGORY.slug,
+\t} );
+}
+
+export function get${pascalCase}Ability():
+\t| WordPressAbilityDefinition
+\t| undefined {
+\treturn resolveAbilitiesClient().getAbility( ${abilityConstBase}_ABILITY_ID );
+}
+
+export function require${pascalCase}Ability(): WordPressAbilityDefinition {
+\tconst ability = get${pascalCase}Ability();
+\tif ( ability ) {
+\t\treturn ability;
+\t}
+
+\tthrow new Error(
+\t\t[
+\t\t\t\`Ability "\${ ${abilityConstBase}_ABILITY_ID }" is not available yet.\`,
+\t\t\t'Load the WordPress core abilities integration on this screen and confirm the server-side registration succeeded.',
+\t\t].join( ' ' )
+\t);
+}
+
+export async function run${pascalCase}Ability(
+\tinput: ${pascalCase}AbilityInput
+): Promise< ${pascalCase}AbilityOutput > {
+\treturn ( await resolveAbilitiesClient().executeAbility(
+\t\t${abilityConstBase}_ABILITY_ID,
+\t\tinput
+\t) ) as ${pascalCase}AbilityOutput;
+}
+`;
+}
+
+function buildAbilityClientSource(abilitySlug: string): string {
+	const pascalCase = toPascalCaseFromAbilitySlug(abilitySlug);
+
+	return `/**
+ * Re-export the typed ${pascalCase} ability client helpers.
+ *
+ * The underlying WordPress abilities client is expected to have been hydrated
+ * by the site's admin/editor bootstrap before these helpers execute.
+ */
+export * from './data';
+`;
+}
+
+function buildAbilitySyncScriptSource(): string {
+	return `/* eslint-disable no-console */
+import { syncTypeSchemas } from '@wp-typia/block-runtime/metadata-core';
+
+import {
+\tABILITIES,
+\ttype WorkspaceAbilityConfig,
+} from './block-config';
+
+function parseCliOptions( argv: string[] ) {
+\tconst options = {
+\t\tcheck: false,
+\t};
+
+\tfor ( const argument of argv ) {
+\t\tif ( argument === '--check' ) {
+\t\t\toptions.check = true;
+\t\t\tcontinue;
+\t\t}
+
+\t\tthrow new Error( \`Unknown sync-abilities flag: \${ argument }\` );
+\t}
+
+\treturn options;
+}
+
+function isWorkspaceAbility(
+\tability: WorkspaceAbilityConfig
+): ability is WorkspaceAbilityConfig & {
+\tclientFile: string;
+\tconfigFile: string;
+\tdataFile: string;
+\tinputSchemaFile: string;
+\tinputTypeName: string;
+\toutputSchemaFile: string;
+\toutputTypeName: string;
+\tphpFile: string;
+\ttypesFile: string;
+} {
+\treturn (
+\t\ttypeof ability.clientFile === 'string' &&
+\t\ttypeof ability.configFile === 'string' &&
+\t\ttypeof ability.dataFile === 'string' &&
+\t\ttypeof ability.inputSchemaFile === 'string' &&
+\t\ttypeof ability.inputTypeName === 'string' &&
+\t\ttypeof ability.outputSchemaFile === 'string' &&
+\t\ttypeof ability.outputTypeName === 'string' &&
+\t\ttypeof ability.phpFile === 'string' &&
+\t\ttypeof ability.typesFile === 'string'
+\t);
+}
+
+async function main() {
+\tconst options = parseCliOptions( process.argv.slice( 2 ) );
+\tconst abilities = ABILITIES.filter( isWorkspaceAbility );
+
+\tif ( ABILITIES.length > 0 && abilities.length === 0 ) {
+\t\tconsole.warn(
+\t\t\t'⚠️ Ability inventory entries exist, but none include the required typed schema files. Check scripts/block-config.ts before relying on sync-abilities.'
+\t\t);
+\t}
+
+\tif ( abilities.length === 0 ) {
+\t\tconsole.log(
+\t\t\toptions.check
+\t\t\t\t? 'ℹ️ No typed workflow abilities are registered yet. "sync-abilities --check" is already clean.'
+\t\t\t\t: 'ℹ️ No typed workflow abilities are registered yet.'
+\t\t);
+\t\treturn;
+\t}
+
+\tfor ( const ability of abilities ) {
+\t\tawait syncTypeSchemas(
+\t\t\t{
+\t\t\t\tjsonSchemaFile: ability.inputSchemaFile,
+\t\t\t\tprojectRoot: process.cwd(),
+\t\t\t\tsourceTypeName: ability.inputTypeName,
+\t\t\t\ttypesFile: ability.typesFile,
+\t\t\t},
+\t\t\t{
+\t\t\t\tcheck: options.check,
+\t\t\t}
+\t\t);
+
+\t\tawait syncTypeSchemas(
+\t\t\t{
+\t\t\t\tjsonSchemaFile: ability.outputSchemaFile,
+\t\t\t\tprojectRoot: process.cwd(),
+\t\t\t\tsourceTypeName: ability.outputTypeName,
+\t\t\t\ttypesFile: ability.typesFile,
+\t\t\t},
+\t\t\t{
+\t\t\t\tcheck: options.check,
+\t\t\t}
+\t\t);
+\t}
+
+\tconsole.log(
+\t\toptions.check
+\t\t\t? '✅ Ability input and output schemas are already up to date for all registered workflow abilities!'
+\t\t\t: '✅ Ability input and output schemas generated for all registered workflow abilities!'
+\t);
+}
+
+main().catch( ( error ) => {
+\tconsole.error( '❌ Ability schema sync failed:', error );
+\tprocess.exit( 1 );
+} );
+`;
+}
+
+function buildAbilityPhpSource(
+	abilitySlug: string,
+	workspace: WorkspaceProject,
+): string {
+	const abilityTitle = toTitleCase(abilitySlug);
+	const abilityPhpId = abilitySlug.replace(/-/g, "_");
+	const categoryRegisterFunctionName = `${workspace.workspace.phpPrefix}_${abilityPhpId}_register_ability_category`;
+	const abilityRegisterFunctionName = `${workspace.workspace.phpPrefix}_${abilityPhpId}_register_ability`;
+	const configLoaderFunctionName = `${workspace.workspace.phpPrefix}_${abilityPhpId}_load_ability_config`;
+	const schemaLoaderFunctionName = `${workspace.workspace.phpPrefix}_${abilityPhpId}_load_ability_schema`;
+	const permissionFunctionName = `${workspace.workspace.phpPrefix}_${abilityPhpId}_can_execute_ability`;
+	const executeFunctionName = `${workspace.workspace.phpPrefix}_${abilityPhpId}_execute_ability`;
+	const metaFactoryFunctionName = `${workspace.workspace.phpPrefix}_${abilityPhpId}_build_ability_meta`;
+
+	return `<?php
+if ( ! defined( 'ABSPATH' ) ) {
+\treturn;
+}
+
+if ( ! function_exists( '${configLoaderFunctionName}' ) ) {
+\tfunction ${configLoaderFunctionName}() {
+\t\t$project_root = dirname( __DIR__, 2 );
+\t\t$config_path  = $project_root . '/src/abilities/${abilitySlug}/ability.config.json';
+\t\tif ( ! file_exists( $config_path ) ) {
+\t\t\treturn null;
+\t\t}
+
+\t\t$decoded = json_decode( file_get_contents( $config_path ), true );
+\t\treturn is_array( $decoded ) ? $decoded : null;
+\t}
+}
+
+if ( ! function_exists( '${schemaLoaderFunctionName}' ) ) {
+\tfunction ${schemaLoaderFunctionName}( $schema_name ) {
+\t\t$project_root = dirname( __DIR__, 2 );
+\t\t$schema_path  = $project_root . '/src/abilities/${abilitySlug}/' . $schema_name;
+\t\tif ( ! file_exists( $schema_path ) ) {
+\t\t\treturn null;
+\t\t}
+
+\t\t$decoded = json_decode( file_get_contents( $schema_path ), true );
+\t\treturn is_array( $decoded ) ? $decoded : null;
+\t}
+}
+
+if ( ! function_exists( '${metaFactoryFunctionName}' ) ) {
+\tfunction ${metaFactoryFunctionName}( array $config ) {
+\t\t$meta = array(
+\t\t\t'annotations' => isset( $config['meta']['annotations'] ) && is_array( $config['meta']['annotations'] )
+\t\t\t\t? $config['meta']['annotations']
+\t\t\t\t: array(
+\t\t\t\t\t'destructive' => false,
+\t\t\t\t\t'idempotent'  => true,
+\t\t\t\t\t'readonly'    => false,
+\t\t\t\t),
+\t\t\t'show_in_rest' => ! empty( $config['meta']['showInRest'] ),
+\t\t);
+
+\t\tif ( ! empty( $config['meta']['mcp']['public'] ) ) {
+\t\t\t$meta['mcp'] = array(
+\t\t\t\t'public' => true,
+\t\t\t);
+\t\t}
+
+\t\treturn $meta;
+\t}
+}
+
+if ( ! function_exists( '${permissionFunctionName}' ) ) {
+\tfunction ${permissionFunctionName}( $input = array() ) {
+\t\tunset( $input );
+
+\t\treturn current_user_can( 'edit_posts' );
+\t}
+}
+
+if ( ! function_exists( '${executeFunctionName}' ) ) {
+\tfunction ${executeFunctionName}( $input = array() ) {
+\t\t$payload = is_array( $input ) ? $input : array();
+\t\t$context_id = isset( $payload['contextId'] ) ? (int) $payload['contextId'] : 0;
+\t\t$note = isset( $payload['note'] ) && is_string( $payload['note'] )
+\t\t\t? trim( $payload['note'] )
+\t\t\t: '';
+
+\t\treturn array(
+\t\t\t'processedContextId' => $context_id,
+\t\t\t'receivedNote'       => '' !== $note ? $note : null,
+\t\t\t'status'             => 'ready',
+\t\t\t'summary'            => sprintf(
+\t\t\t\t/* translators: 1: workflow title, 2: context id */
+\t\t\t\t__( '%1$s processed context %2$d.', ${quotePhpString(
+					workspace.workspace.textDomain,
+				)} ),
+\t\t\t\t${quotePhpString(abilityTitle)},
+\t\t\t\t$context_id
+\t\t\t),
+\t\t);
+\t}
+}
+
+if ( ! function_exists( '${categoryRegisterFunctionName}' ) ) {
+\tfunction ${categoryRegisterFunctionName}() {
+\t\tif ( ! function_exists( 'wp_register_ability_category' ) ) {
+\t\t\treturn;
+\t\t}
+
+\t\t$config = ${configLoaderFunctionName}();
+\t\tif (
+\t\t\t! is_array( $config ) ||
+\t\t\tempty( $config['category']['slug'] ) ||
+\t\t\tempty( $config['category']['label'] )
+\t\t) {
+\t\t\treturn;
+\t\t}
+
+\t\twp_register_ability_category(
+\t\t\t(string) $config['category']['slug'],
+\t\t\tarray(
+\t\t\t\t'description' => isset( $config['category']['description'] ) && is_string( $config['category']['description'] )
+\t\t\t\t\t? $config['category']['description']
+\t\t\t\t\t: '',
+\t\t\t\t'label'       => (string) $config['category']['label'],
+\t\t\t)
+\t\t);
+\t}
+}
+
+if ( ! function_exists( '${abilityRegisterFunctionName}' ) ) {
+\tfunction ${abilityRegisterFunctionName}() {
+\t\tif ( ! function_exists( 'wp_register_ability' ) ) {
+\t\t\treturn;
+\t\t}
+
+\t\t$config = ${configLoaderFunctionName}();
+\t\tif (
+\t\t\t! is_array( $config ) ||
+\t\t\tempty( $config['abilityId'] ) ||
+\t\t\tempty( $config['category']['slug'] ) ||
+\t\t\tempty( $config['label'] ) ||
+\t\t\tempty( $config['description'] )
+\t\t) {
+\t\t\treturn;
+\t\t}
+
+\t\t$input_schema  = ${schemaLoaderFunctionName}( 'input.schema.json' );
+\t\t$output_schema = ${schemaLoaderFunctionName}( 'output.schema.json' );
+\t\tif ( ! is_array( $output_schema ) ) {
+\t\t\treturn;
+\t\t}
+
+\t\t$args = array(
+\t\t\t'category'            => (string) $config['category']['slug'],
+\t\t\t'description'         => (string) $config['description'],
+\t\t\t'execute_callback'    => ${quotePhpString(executeFunctionName)},
+\t\t\t'label'               => (string) $config['label'],
+\t\t\t'meta'                => ${metaFactoryFunctionName}( $config ),
+\t\t\t'output_schema'       => $output_schema,
+\t\t\t'permission_callback' => ${quotePhpString(permissionFunctionName)},
+\t\t);
+
+\t\tif ( is_array( $input_schema ) ) {
+\t\t\t$args['input_schema'] = $input_schema;
+\t\t}
+
+\t\twp_register_ability(
+\t\t\t(string) $config['abilityId'],
+\t\t\t$args
+\t\t);
+\t}
+}
+
+add_action( 'wp_abilities_api_categories_init', '${categoryRegisterFunctionName}' );
+add_action( 'wp_abilities_api_init', '${abilityRegisterFunctionName}' );
+`;
+}
+
+function buildAbilityRegistrySource(abilitySlugs: string[]): string {
+	const exportLines = abilitySlugs
+		.map((abilitySlug) => `export * from './${abilitySlug}/client';`)
+		.join("\n");
+
+	return `${exportLines}${exportLines ? "\n\n" : ""}${ABILITY_REGISTRY_MARKER}\n`;
+}
+
+function resolveAbilityRegistryPath(projectDir: string): string {
+	const abilitiesDir = path.join(projectDir, "src", "abilities");
+	return [path.join(abilitiesDir, "index.ts"), path.join(abilitiesDir, "index.js")].find(
+		(candidatePath) => fs.existsSync(candidatePath),
+	) ?? path.join(abilitiesDir, "index.ts");
+}
+
+function readAbilityRegistrySlugs(registryPath: string): string[] {
+	if (!fs.existsSync(registryPath)) {
+		return [];
+	}
+
+	const source = fs.readFileSync(registryPath, "utf8");
+	return Array.from(
+		source.matchAll(/^\s*export\s+\*\s+from\s+['"]\.\/([^/'"]+)\/client['"];?\s*$/gmu),
+	).map((match) => match[1]);
+}
+
+async function writeAbilityRegistry(
+	projectDir: string,
+	abilitySlug: string,
+): Promise<void> {
+	const abilitiesDir = path.join(projectDir, "src", "abilities");
+	const registryPath = resolveAbilityRegistryPath(projectDir);
+	await fsp.mkdir(abilitiesDir, { recursive: true });
+
+	const existingAbilitySlugs = readWorkspaceInventory(projectDir).abilities.map(
+		(entry) => entry.slug,
+	);
+	const existingRegistrySlugs = readAbilityRegistrySlugs(registryPath);
+	const nextAbilitySlugs = Array.from(
+		new Set([...existingAbilitySlugs, ...existingRegistrySlugs, abilitySlug]),
+	).sort();
+	await fsp.writeFile(
+		registryPath,
+		buildAbilityRegistrySource(nextAbilitySlugs),
+		"utf8",
+	);
+}
+
+async function ensureAbilityBootstrapAnchors(
+	workspace: WorkspaceProject,
+): Promise<void> {
+	const bootstrapPath = getWorkspaceBootstrapPath(workspace);
+
+	await patchFile(bootstrapPath, (source) => {
+		let nextSource = source;
+		const workspaceBaseName =
+			workspace.packageName.split("/").pop() ?? workspace.packageName;
+		const loadFunctionName = `${workspace.workspace.phpPrefix}_load_workflow_abilities`;
+		const enqueueFunctionName =
+			`${workspace.workspace.phpPrefix}_enqueue_workflow_abilities`;
+		const loadHook = `add_action( 'plugins_loaded', '${loadFunctionName}' );`;
+		const adminEnqueueHook = `add_action( 'admin_enqueue_scripts', '${enqueueFunctionName}' );`;
+		const editorEnqueueHook = `add_action( 'enqueue_block_editor_assets', '${enqueueFunctionName}' );`;
+		const loadFunction = `
+
+function ${loadFunctionName}() {
+\tforeach ( glob( __DIR__ . '${ABILITY_SERVER_GLOB}' ) ?: array() as $ability_module ) {
+\t\trequire_once $ability_module;
+\t}
+}
+`;
+		const enqueueFunction = `
+
+function ${enqueueFunctionName}() {
+\tif ( ! class_exists( 'WP_Ability' ) ) {
+\t\treturn;
+\t}
+
+\t$script_path = __DIR__ . '/${ABILITY_EDITOR_SCRIPT}';
+\t$asset_path  = __DIR__ . '/${ABILITY_EDITOR_ASSET}';
+
+\tif ( ! file_exists( $script_path ) || ! file_exists( $asset_path ) ) {
+\t\treturn;
+\t}
+
+\t$asset = require $asset_path;
+\tif ( ! is_array( $asset ) ) {
+\t\t$asset = array();
+\t}
+
+\t$dependencies = isset( $asset['dependencies'] ) && is_array( $asset['dependencies'] )
+\t\t? $asset['dependencies']
+\t\t: array();
+
+\tforeach ( array( '${WP_CORE_ABILITIES_SCRIPT_HANDLE}', '${WP_ABILITIES_SCRIPT_HANDLE}' ) as $ability_dependency ) {
+\t\tif (
+\t\t\tfunction_exists( 'wp_script_is' ) &&
+\t\t\twp_script_is( $ability_dependency, 'registered' ) &&
+\t\t\t! in_array( $ability_dependency, $dependencies, true )
+\t\t) {
+\t\t\t$dependencies[] = $ability_dependency;
+\t\t}
+\t}
+
+\twp_enqueue_script(
+\t\t'${workspaceBaseName}-abilities',
+\t\tplugins_url( '${ABILITY_EDITOR_SCRIPT}', __FILE__ ),
+\t\t$dependencies,
+\t\tisset( $asset['version'] ) ? $asset['version'] : filemtime( $script_path ),
+\t\ttrue
+\t);
+}
+`;
+		const insertionAnchors = [
+			/add_action\(\s*["']init["']\s*,\s*["'][^"']+_load_textdomain["']\s*\);\s*\n/u,
+			/\?>\s*$/u,
+		];
+		const hasPhpFunctionDefinition = (functionName: string): boolean =>
+			new RegExp(`function\\s+${escapeRegex(functionName)}\\s*\\(`, "u").test(
+				nextSource,
+			);
+		const insertPhpSnippet = (snippet: string): void => {
+			for (const anchor of insertionAnchors) {
+				const candidate = nextSource.replace(anchor, (match) => `${snippet}\n${match}`);
+				if (candidate !== nextSource) {
+					nextSource = candidate;
+					return;
+				}
+			}
+			nextSource = `${nextSource.trimEnd()}\n${snippet}\n`;
+		};
+		const appendPhpSnippet = (snippet: string): void => {
+			const closingTagPattern = /\?>\s*$/u;
+			if (closingTagPattern.test(nextSource)) {
+				nextSource = nextSource.replace(closingTagPattern, `${snippet}\n?>`);
+				return;
+			}
+			nextSource = `${nextSource.trimEnd()}\n${snippet}\n`;
+		};
+
+		if (!hasPhpFunctionDefinition(loadFunctionName)) {
+			insertPhpSnippet(loadFunction);
+		}
+		if (!hasPhpFunctionDefinition(enqueueFunctionName)) {
+			insertPhpSnippet(enqueueFunction);
+		}
+
+		if (!nextSource.includes(loadHook)) {
+			appendPhpSnippet(loadHook);
+		}
+		if (!nextSource.includes(adminEnqueueHook)) {
+			appendPhpSnippet(adminEnqueueHook);
+		}
+		if (!nextSource.includes(editorEnqueueHook)) {
+			appendPhpSnippet(editorEnqueueHook);
+		}
+
+		return nextSource;
+	});
+}
+
+async function ensureAbilityPackageScripts(
+	workspace: WorkspaceProject,
+): Promise<void> {
+	const packageJsonPath = path.join(workspace.projectDir, "package.json");
+	const packageJson = JSON.parse(
+		await fsp.readFile(packageJsonPath, "utf8"),
+	) as {
+		scripts?: Record<string, string>;
+	};
+
+	const nextScripts = {
+		...(packageJson.scripts ?? {}),
+		"sync-abilities":
+			packageJson.scripts?.["sync-abilities"] ?? "tsx scripts/sync-abilities.ts",
+	};
+
+	if (JSON.stringify(nextScripts) === JSON.stringify(packageJson.scripts ?? {})) {
+		return;
+	}
+
+	packageJson.scripts = nextScripts;
+	await fsp.writeFile(
+		packageJsonPath,
+		`${JSON.stringify(packageJson, null, "\t")}\n`,
+		"utf8",
+	);
+}
+
+async function ensureAbilitySyncProjectAnchors(
+	workspace: WorkspaceProject,
+): Promise<void> {
+	const syncProjectScriptPath = path.join(
+		workspace.projectDir,
+		"scripts",
+		"sync-project.ts",
+	);
+
+	await patchFile(syncProjectScriptPath, (source) => {
+		let nextSource = source;
+		const syncRestConst =
+			"const syncRestScriptPath = path.join( 'scripts', 'sync-rest-contracts.ts' );";
+		const syncAbilitiesConst =
+			"const syncAbilitiesScriptPath = path.join( 'scripts', 'sync-abilities.ts' );";
+		const syncRestBlockPattern =
+			/if \( fs\.existsSync\( path\.resolve\( process\.cwd\(\), syncRestScriptPath \) \) \) \{\n\s*runSyncScript\( syncRestScriptPath, options \);\n\s*\}/u;
+		const syncAbilitiesBlock = [
+			"if ( fs.existsSync( path.resolve( process.cwd(), syncAbilitiesScriptPath ) ) ) {",
+			"\trunSyncScript( syncAbilitiesScriptPath, options );",
+			"}",
+		].join("\n");
+
+		if (!nextSource.includes(syncAbilitiesConst)) {
+			if (!nextSource.includes(syncRestConst)) {
+				throw new Error(
+					[
+						`ensureAbilitySyncProjectAnchors could not patch ${path.basename(syncProjectScriptPath)}.`,
+						"Missing the expected sync-rest script constant in scripts/sync-project.ts.",
+						"Restore the generated template or wire sync-abilities manually before retrying.",
+					].join(" "),
+				);
+			}
+			nextSource = nextSource.replace(
+				syncRestConst,
+				`${syncRestConst}\n${syncAbilitiesConst}`,
+			);
+		}
+
+		if (!nextSource.includes("runSyncScript( syncAbilitiesScriptPath, options );")) {
+			if (!syncRestBlockPattern.test(nextSource)) {
+				throw new Error(
+					[
+						`ensureAbilitySyncProjectAnchors could not patch ${path.basename(syncProjectScriptPath)}.`,
+						"Missing the expected sync-rest invocation block in scripts/sync-project.ts.",
+						"Restore the generated template or wire sync-abilities manually before retrying.",
+					].join(" "),
+				);
+			}
+
+			nextSource = nextSource.replace(
+				syncRestBlockPattern,
+				(match) => `${match}\n\n${syncAbilitiesBlock}`,
+			);
+		}
+
+		return nextSource;
+	});
+}
+
+function replaceOrThrow(
+	source: string,
+	patterns: RegExp[],
+	replacement: string,
+	errorMessage: string,
+): string {
+	for (const pattern of patterns) {
+		if (!pattern.test(source)) {
+			continue;
+		}
+		return source.replace(pattern, replacement);
+	}
+
+	throw new Error(errorMessage);
+}
+
+async function ensureAbilityBuildScriptAnchors(
+	workspace: WorkspaceProject,
+): Promise<void> {
+	const buildScriptPath = path.join(workspace.projectDir, "scripts", "build-workspace.mjs");
+
+	await patchFile(buildScriptPath, (source) => {
+		let nextSource = source;
+		if (/['"]src\/abilities\/index\.(?:ts|js)['"]/u.test(nextSource)) {
+			return nextSource;
+		}
+
+		nextSource = replaceOrThrow(
+			nextSource,
+			[
+				/\[\n\t\t'src\/bindings\/index\.ts',\n\t\t'src\/bindings\/index\.js',\n\t\t'src\/editor-plugins\/index\.ts',\n\t\t'src\/editor-plugins\/index\.js',\n\t\]/u,
+				/\[\n\t\t'src\/bindings\/index\.ts',\n\t\t'src\/bindings\/index\.js',\n\t\]/u,
+			],
+			`[
+\t\t'src/bindings/index.ts',
+\t\t'src/bindings/index.js',
+\t\t'src/editor-plugins/index.ts',
+\t\t'src/editor-plugins/index.js',
+\t\t'src/abilities/index.ts',
+\t\t'src/abilities/index.js',
+\t]`,
+			[
+				`ensureAbilityBuildScriptAnchors could not patch ${path.basename(buildScriptPath)}.`,
+				"Missing the expected shared editor entries array in scripts/build-workspace.mjs.",
+				"Restore the generated template or wire abilities/index manually before retrying.",
+			].join(" "),
+		);
+
+		return nextSource;
+	});
+}
+
+async function ensureAbilityWebpackAnchors(
+	workspace: WorkspaceProject,
+): Promise<void> {
+	const webpackConfigPath = path.join(workspace.projectDir, "webpack.config.js");
+
+	await patchFile(webpackConfigPath, (source) => {
+		if (/['"]abilities\/index['"]/u.test(source)) {
+			return source;
+		}
+
+		return replaceOrThrow(
+			source,
+			[
+				/for\s*\(\s*const\s+\[\s*entryName\s*,\s*candidates\s*\]\s+of\s+\[\n\t\t\[\n\t\t\t'bindings\/index',\n\t\t\t\[\s*'src\/bindings\/index\.ts',\s*'src\/bindings\/index\.js'\s*\],\n\t\t\],\n\t\t\[\n\t\t\t'editor-plugins\/index',\n\t\t\t\[\s*'src\/editor-plugins\/index\.ts',\s*'src\/editor-plugins\/index\.js'\s*\],\n\t\t\],\n\t\]\s*\)\s*\{/u,
+				/for\s*\(\s*const\s+\[\s*entryName\s*,\s*candidates\s*\]\s+of\s+\[\n\t\t\[\n\t\t\t'bindings\/index',\n\t\t\t\[\s*'src\/bindings\/index\.ts',\s*'src\/bindings\/index\.js'\s*\],\n\t\t\],\n\t\]\s*\)\s*\{/u,
+			],
+			`for ( const [ entryName, candidates ] of [
+\t\t[
+\t\t\t'bindings/index',
+\t\t\t[ 'src/bindings/index.ts', 'src/bindings/index.js' ],
+\t\t],
+\t\t[
+\t\t\t'editor-plugins/index',
+\t\t\t[ 'src/editor-plugins/index.ts', 'src/editor-plugins/index.js' ],
+\t\t],
+\t\t[
+\t\t\t'abilities/index',
+\t\t\t[ 'src/abilities/index.ts', 'src/abilities/index.js' ],
+\t\t],
+\t] ) {`,
+			[
+				`ensureAbilityWebpackAnchors could not patch ${path.basename(webpackConfigPath)}.`,
+				"Missing the expected shared editor entries block in webpack.config.js.",
+				"Restore the generated template or wire abilities/index manually before retrying.",
+			].join(" "),
+		);
+	});
+}
+
+/**
+ * Add one typed workflow ability scaffold to an official workspace project.
+ */
+export async function runAddAbilityCommand({
+	abilityName,
+	cwd = process.cwd(),
+}: RunAddAbilityCommandOptions): Promise<{
+	abilitySlug: string;
+	projectDir: string;
+}> {
+	const workspace = resolveWorkspaceProject(cwd);
+	const abilitySlug = assertValidGeneratedSlug(
+		"Ability name",
+		normalizeBlockSlug(abilityName),
+		"wp-typia add ability <name>",
+	);
+
+	const inventory = readWorkspaceInventory(workspace.projectDir);
+	assertAbilityDoesNotExist(workspace.projectDir, abilitySlug, inventory);
+
+	const blockConfigPath = path.join(workspace.projectDir, "scripts", "block-config.ts");
+	const bootstrapPath = getWorkspaceBootstrapPath(workspace);
+	const buildScriptPath = path.join(workspace.projectDir, "scripts", "build-workspace.mjs");
+	const packageJsonPath = path.join(workspace.projectDir, "package.json");
+	const syncAbilitiesScriptPath = path.join(
+		workspace.projectDir,
+		"scripts",
+		"sync-abilities.ts",
+	);
+	const syncProjectScriptPath = path.join(
+		workspace.projectDir,
+		"scripts",
+		"sync-project.ts",
+	);
+	const webpackConfigPath = path.join(workspace.projectDir, "webpack.config.js");
+	const abilitiesIndexPath = resolveAbilityRegistryPath(workspace.projectDir);
+	const abilityDir = path.join(workspace.projectDir, "src", "abilities", abilitySlug);
+	const configFilePath = path.join(abilityDir, "ability.config.json");
+	const typesFilePath = path.join(abilityDir, "types.ts");
+	const dataFilePath = path.join(abilityDir, "data.ts");
+	const clientFilePath = path.join(abilityDir, "client.ts");
+	const phpFilePath = path.join(
+		workspace.projectDir,
+		"inc",
+		"abilities",
+		`${abilitySlug}.php`,
+	);
+	const mutationSnapshot: WorkspaceMutationSnapshot = {
+		fileSources: await snapshotWorkspaceFiles([
+			blockConfigPath,
+			bootstrapPath,
+			buildScriptPath,
+			packageJsonPath,
+			syncAbilitiesScriptPath,
+			syncProjectScriptPath,
+			webpackConfigPath,
+			abilitiesIndexPath,
+		]),
+		snapshotDirs: [],
+		targetPaths: [abilityDir, phpFilePath, syncAbilitiesScriptPath],
+	};
+
+	try {
+		await fsp.mkdir(abilityDir, { recursive: true });
+		await fsp.mkdir(path.dirname(phpFilePath), { recursive: true });
+		await ensureAbilityBootstrapAnchors(workspace);
+		await ensureAbilityPackageScripts(workspace);
+		await ensureAbilitySyncProjectAnchors(workspace);
+		await ensureAbilityBuildScriptAnchors(workspace);
+		await ensureAbilityWebpackAnchors(workspace);
+		await fsp.writeFile(syncAbilitiesScriptPath, buildAbilitySyncScriptSource(), "utf8");
+		await fsp.writeFile(
+			configFilePath,
+			buildAbilityConfigSource(abilitySlug, workspace.workspace.namespace),
+			"utf8",
+		);
+		await fsp.writeFile(
+			typesFilePath,
+			buildAbilityTypesSource(abilitySlug),
+			"utf8",
+		);
+		await fsp.writeFile(
+			dataFilePath,
+			buildAbilityDataSource(abilitySlug),
+			"utf8",
+		);
+		await fsp.writeFile(
+			clientFilePath,
+			buildAbilityClientSource(abilitySlug),
+			"utf8",
+		);
+		await fsp.writeFile(
+			phpFilePath,
+			buildAbilityPhpSource(abilitySlug, workspace),
+			"utf8",
+		);
+
+		const pascalCase = toPascalCaseFromAbilitySlug(abilitySlug);
+		await syncTypeSchemas({
+			jsonSchemaFile: `src/abilities/${abilitySlug}/input.schema.json`,
+			projectRoot: workspace.projectDir,
+			sourceTypeName: `${pascalCase}AbilityInput`,
+			typesFile: `src/abilities/${abilitySlug}/types.ts`,
+		});
+		await syncTypeSchemas({
+			jsonSchemaFile: `src/abilities/${abilitySlug}/output.schema.json`,
+			projectRoot: workspace.projectDir,
+			sourceTypeName: `${pascalCase}AbilityOutput`,
+			typesFile: `src/abilities/${abilitySlug}/types.ts`,
+		});
+		await writeAbilityRegistry(workspace.projectDir, abilitySlug);
+		await appendWorkspaceInventoryEntries(workspace.projectDir, {
+			abilityEntries: [buildAbilityConfigEntry(abilitySlug)],
+		});
+
+		return {
+			abilitySlug,
+			projectDir: workspace.projectDir,
+		};
+	} catch (error) {
+		await rollbackWorkspaceMutation(mutationSnapshot);
+		throw error;
+	}
+}

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace.ts
@@ -191,6 +191,11 @@ export {
  */
 export { runAddRestResourceCommand } from "./cli-add-workspace-rest.js";
 /**
+ * Re-export the typed workflow ability scaffold workflow from the focused
+ * ability runtime helper module.
+ */
+export { runAddAbilityCommand } from "./cli-add-workspace-ability.js";
+/**
  * Re-export the server-only AI feature scaffold workflow from the focused
  * AI-feature runtime helper module.
  */

--- a/packages/wp-typia-project-tools/src/runtime/cli-add.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add.ts
@@ -24,6 +24,7 @@ export {
 } from "./cli-add-block.js";
 export {
 	runAddBindingSourceCommand,
+	runAddAbilityCommand,
 	runAddAiFeatureCommand,
 	runAddEditorPluginCommand,
 	runAddHookedBlockCommand,

--- a/packages/wp-typia-project-tools/src/runtime/cli-core.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-core.ts
@@ -8,6 +8,7 @@
  * Import `formatAddHelpText`, `runAddBlockCommand`,
  * `runAddVariationCommand`, `runAddPatternCommand`,
  * `runAddBindingSourceCommand`, `runAddHookedBlockCommand`,
+ * `runAddAbilityCommand` for typed workflow ability scaffolds,
  * and `HOOKED_BLOCK_POSITION_IDS`,
  * `getWorkspaceBlockSelectOptions`, and `seedWorkspaceMigrationProject` for
  * explicit `wp-typia add` flows,
@@ -40,6 +41,7 @@ export {
 	EDITOR_PLUGIN_SLOT_IDS,
 	formatAddHelpText,
 	getWorkspaceBlockSelectOptions,
+	runAddAbilityCommand,
 	runAddBindingSourceCommand,
 	runAddAiFeatureCommand,
 	runAddBlockCommand,

--- a/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace.ts
@@ -30,6 +30,9 @@ const WORKSPACE_BINDING_SERVER_GLOB = "/src/bindings/*/server.php";
 const WORKSPACE_BINDING_EDITOR_SCRIPT = "build/bindings/index.js";
 const WORKSPACE_BINDING_EDITOR_ASSET = "build/bindings/index.asset.php";
 const WORKSPACE_REST_RESOURCE_GLOB = "/inc/rest/*.php";
+const WORKSPACE_ABILITY_GLOB = "/inc/abilities/*.php";
+const WORKSPACE_ABILITY_EDITOR_SCRIPT = "build/abilities/index.js";
+const WORKSPACE_ABILITY_EDITOR_ASSET = "build/abilities/index.asset.php";
 const WORKSPACE_AI_FEATURE_GLOB = "/inc/ai-features/*.php";
 const WORKSPACE_EDITOR_PLUGIN_EDITOR_SCRIPT = "build/editor-plugins/index.js";
 const WORKSPACE_EDITOR_PLUGIN_EDITOR_ASSET = "build/editor-plugins/index.asset.php";
@@ -453,6 +456,150 @@ function checkWorkspaceRestResourceBootstrap(
 	);
 }
 
+function getWorkspaceAbilityRequiredFiles(
+	ability: WorkspaceInventory["abilities"][number],
+): string[] {
+	return Array.from(
+		new Set([
+			ability.clientFile,
+			ability.configFile,
+			ability.dataFile,
+			ability.inputSchemaFile,
+			ability.outputSchemaFile,
+			ability.phpFile,
+			ability.typesFile,
+		]),
+	);
+}
+
+function checkWorkspaceAbilityConfig(
+	projectDir: string,
+	ability: WorkspaceInventory["abilities"][number],
+): DoctorCheck {
+	const configPath = path.join(projectDir, ability.configFile);
+	if (!fs.existsSync(configPath)) {
+		return createDoctorCheck(
+			`Ability config ${ability.slug}`,
+			"fail",
+			`Missing ${ability.configFile}`,
+		);
+	}
+
+	try {
+		const config = JSON.parse(fs.readFileSync(configPath, "utf8")) as {
+			abilityId?: unknown;
+			category?: { slug?: unknown };
+		};
+		const abilityId =
+			typeof config.abilityId === "string" ? config.abilityId.trim() : "";
+		const categorySlug =
+			typeof config.category?.slug === "string"
+				? config.category.slug.trim()
+				: "";
+		const hasValidAbilityId = /^[a-z0-9-]+\/[a-z0-9-]+$/u.test(abilityId);
+		const hasValidCategorySlug = /^[a-z0-9-]+$/u.test(categorySlug);
+
+		return createDoctorCheck(
+			`Ability config ${ability.slug}`,
+			hasValidAbilityId && hasValidCategorySlug ? "pass" : "fail",
+			hasValidAbilityId && hasValidCategorySlug
+				? `Ability id ${abilityId} in category ${categorySlug} is valid`
+				: "Ability config must define a valid abilityId (`namespace/ability-name`) and category.slug.",
+		);
+	} catch (error) {
+		return createDoctorCheck(
+			`Ability config ${ability.slug}`,
+			"fail",
+			error instanceof Error ? error.message : String(error),
+		);
+	}
+}
+
+function checkWorkspaceAbilityBootstrap(
+	projectDir: string,
+	packageName: string,
+	phpPrefix: string,
+): DoctorCheck {
+	const packageBaseName = packageName.split("/").pop() ?? packageName;
+	const bootstrapPath = path.join(projectDir, `${packageBaseName}.php`);
+	if (!fs.existsSync(bootstrapPath)) {
+		return createDoctorCheck(
+			"Ability bootstrap",
+			"fail",
+			`Missing ${path.basename(bootstrapPath)}`,
+		);
+	}
+
+	const source = fs.readFileSync(bootstrapPath, "utf8");
+	const loadFunctionName = `${phpPrefix}_load_workflow_abilities`;
+	const enqueueFunctionName = `${phpPrefix}_enqueue_workflow_abilities`;
+	const loadHook = `add_action( 'plugins_loaded', '${loadFunctionName}' );`;
+	const adminEnqueueHook = `add_action( 'admin_enqueue_scripts', '${enqueueFunctionName}' );`;
+	const editorEnqueueHook = `add_action( 'enqueue_block_editor_assets', '${enqueueFunctionName}' );`;
+	const hasLoaderHook = source.includes(loadHook);
+	const hasAdminEnqueueHook = source.includes(adminEnqueueHook);
+	const hasEditorEnqueueHook = source.includes(editorEnqueueHook);
+	const hasServerGlob = source.includes(WORKSPACE_ABILITY_GLOB);
+	const hasEditorScript = source.includes(WORKSPACE_ABILITY_EDITOR_SCRIPT);
+	const hasEditorAsset = source.includes(WORKSPACE_ABILITY_EDITOR_ASSET);
+
+	return createDoctorCheck(
+		"Ability bootstrap",
+		hasLoaderHook &&
+			hasAdminEnqueueHook &&
+			hasEditorEnqueueHook &&
+			hasServerGlob &&
+			hasEditorScript &&
+			hasEditorAsset
+			? "pass"
+			: "fail",
+		hasLoaderHook &&
+			hasAdminEnqueueHook &&
+			hasEditorEnqueueHook &&
+			hasServerGlob &&
+			hasEditorScript &&
+			hasEditorAsset
+			? "Ability loader and admin/editor client bootstrap hooks are present"
+			: "Missing ability loader hook or build/abilities script asset references",
+	);
+}
+
+function checkWorkspaceAbilityIndex(
+	projectDir: string,
+	abilities: WorkspaceInventory["abilities"],
+): DoctorCheck {
+	const indexRelativePath = [
+		path.join("src", "abilities", "index.ts"),
+		path.join("src", "abilities", "index.js"),
+	].find((relativePath) => fs.existsSync(path.join(projectDir, relativePath)));
+
+	if (!indexRelativePath) {
+		return createDoctorCheck(
+			"Abilities index",
+			"fail",
+			"Missing src/abilities/index.ts or src/abilities/index.js",
+		);
+	}
+
+	const indexPath = path.join(projectDir, indexRelativePath);
+	const source = fs.readFileSync(indexPath, "utf8");
+	const missingExports = abilities.filter((ability) => {
+		const exportPattern = new RegExp(
+			`['"\`]\\./${escapeRegex(ability.slug)}\\/client['"\`]`,
+			"u",
+		);
+		return !exportPattern.test(source);
+	});
+
+	return createDoctorCheck(
+		"Abilities index",
+		missingExports.length === 0 ? "pass" : "fail",
+		missingExports.length === 0
+			? "Ability client helpers are aggregated"
+			: `Missing ability exports for: ${missingExports.map((entry) => entry.slug).join(", ")}`,
+	);
+}
+
 function getWorkspaceAiFeatureRequiredFiles(
 	aiFeature: WorkspaceInventory["aiFeatures"][number],
 ): string[] {
@@ -769,7 +916,7 @@ export function getWorkspaceDoctorChecks(cwd: string): DoctorCheck[] {
 			createDoctorCheck(
 				"Workspace inventory",
 				"pass",
-				`${inventory.blocks.length} block(s), ${inventory.variations.length} variation(s), ${inventory.patterns.length} pattern(s), ${inventory.bindingSources.length} binding source(s), ${inventory.restResources.length} REST resource(s), ${inventory.aiFeatures.length} AI feature(s), ${inventory.editorPlugins.length} editor plugin(s)`,
+				`${inventory.blocks.length} block(s), ${inventory.variations.length} variation(s), ${inventory.patterns.length} pattern(s), ${inventory.bindingSources.length} binding source(s), ${inventory.restResources.length} REST resource(s), ${inventory.abilities.length} ability scaffold(s), ${inventory.aiFeatures.length} AI feature(s), ${inventory.editorPlugins.length} editor plugin(s)`,
 			),
 		);
 
@@ -856,6 +1003,29 @@ export function getWorkspaceDoctorChecks(cwd: string): DoctorCheck[] {
 					workspace.projectDir,
 					`REST resource ${restResource.slug}`,
 					getWorkspaceRestResourceRequiredFiles(restResource),
+				),
+			);
+		}
+
+		if (inventory.abilities.length > 0) {
+			checks.push(
+				checkWorkspaceAbilityBootstrap(
+					workspace.projectDir,
+					workspace.packageName,
+					workspace.workspace.phpPrefix,
+				),
+			);
+			checks.push(
+				checkWorkspaceAbilityIndex(workspace.projectDir, inventory.abilities),
+			);
+		}
+		for (const ability of inventory.abilities) {
+			checks.push(checkWorkspaceAbilityConfig(workspace.projectDir, ability));
+			checks.push(
+				checkExistingFiles(
+					workspace.projectDir,
+					`Ability ${ability.slug}`,
+					getWorkspaceAbilityRequiredFiles(ability),
 				),
 			);
 		}

--- a/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace.ts
@@ -585,8 +585,10 @@ function checkWorkspaceAbilityIndex(
 	const source = fs.readFileSync(indexPath, "utf8");
 	const missingExports = abilities.filter((ability) => {
 		const exportPattern = new RegExp(
-			`['"\`]\\./${escapeRegex(ability.slug)}\\/client['"\`]`,
-			"u",
+			`^\\s*export\\s+(?:\\*\\s+from|\\{[^}]+\\}\\s+from)\\s+['"\`]\\./${escapeRegex(
+				ability.slug,
+			)}\\/client['"\`]`,
+			"mu",
 		);
 		return !exportPattern.test(source);
 	});

--- a/packages/wp-typia-project-tools/src/runtime/cli-help.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-help.ts
@@ -24,6 +24,7 @@ export function formatHelpText(): string {
   wp-typia add pattern <name>
   wp-typia add binding-source <name>
   wp-typia add rest-resource <name> [--namespace <vendor/v1>] [--methods <method[,method...]>]
+  wp-typia add ability <name>
   wp-typia add ai-feature <name> [--namespace <vendor/v1>]
   wp-typia add editor-plugin <name> [--slot <PluginSidebar>]
   wp-typia add hooked-block <block-slug> --anchor <anchor-block-name> --position <before|after|firstChild|lastChild>
@@ -47,6 +48,7 @@ Notes:
   \`add pattern\` scaffolds a namespaced PHP pattern shell under \`src/patterns/\`.
   \`add binding-source\` scaffolds shared PHP and editor registration under \`src/bindings/\`.
   \`add rest-resource\` scaffolds plugin-level TypeScript REST contracts under \`src/rest/\` and PHP route glue under \`inc/rest/\`.
+  \`add ability\` scaffolds typed workflow abilities under \`src/abilities/\` and server registration under \`inc/abilities/\`.
   \`add ai-feature\` scaffolds server-owned AI feature endpoints under \`src/ai-features/\` and PHP route glue under \`inc/ai-features/\`.
   \`add editor-plugin\` scaffolds a document-level editor extension under \`src/editor-plugins/\`.
   \`add hooked-block\` patches an existing workspace block's \`block.json\` \`blockHooks\` metadata.

--- a/packages/wp-typia-project-tools/src/runtime/index.ts
+++ b/packages/wp-typia-project-tools/src/runtime/index.ts
@@ -159,6 +159,7 @@ export {
 	HOOKED_BLOCK_POSITION_IDS,
 	EDITOR_PLUGIN_SLOT_IDS,
 	isCliDiagnosticError,
+	runAddAbilityCommand,
 	runAddAiFeatureCommand,
 	runAddBindingSourceCommand,
 	runAddBlockCommand,

--- a/packages/wp-typia-project-tools/src/runtime/workspace-inventory.ts
+++ b/packages/wp-typia-project-tools/src/runtime/workspace-inventory.ts
@@ -52,6 +52,26 @@ export interface WorkspaceRestResourceInventoryEntry {
 }
 
 /**
+ * Ability entry parsed from `scripts/block-config.ts`.
+ *
+ * Each file path stays relative to the workspace root so doctor checks, schema
+ * sync scripts, and generated admin/editor helpers can resolve typed workflow
+ * artifacts without guessing their locations.
+ */
+export interface WorkspaceAbilityInventoryEntry {
+	clientFile: string;
+	configFile: string;
+	dataFile: string;
+	inputSchemaFile: string;
+	inputTypeName: string;
+	outputSchemaFile: string;
+	outputTypeName: string;
+	phpFile: string;
+	slug: string;
+	typesFile: string;
+}
+
+/**
  * AI-feature entry parsed from `scripts/block-config.ts`.
  *
  * Each file path stays relative to the workspace root so doctor checks, add
@@ -88,7 +108,9 @@ export interface WorkspaceInventory {
 	bindingSources: WorkspaceBindingSourceInventoryEntry[];
 	blockConfigPath: string;
 	blocks: WorkspaceBlockInventoryEntry[];
+	abilities: WorkspaceAbilityInventoryEntry[];
 	aiFeatures: WorkspaceAiFeatureInventoryEntry[];
+	hasAbilitiesSection: boolean;
 	hasBindingSourcesSection: boolean;
 	hasAiFeaturesSection: boolean;
 	hasEditorPluginsSection: boolean;
@@ -107,6 +129,7 @@ export const VARIATION_CONFIG_ENTRY_MARKER = "\t// wp-typia add variation entrie
 export const PATTERN_CONFIG_ENTRY_MARKER = "\t// wp-typia add pattern entries";
 export const BINDING_SOURCE_CONFIG_ENTRY_MARKER = "\t// wp-typia add binding-source entries";
 export const REST_RESOURCE_CONFIG_ENTRY_MARKER = "\t// wp-typia add rest-resource entries";
+export const ABILITY_CONFIG_ENTRY_MARKER = "\t// wp-typia add ability entries";
 export const AI_FEATURE_CONFIG_ENTRY_MARKER = "\t// wp-typia add ai-feature entries";
 /**
  * Marker used to append generated editor-plugin entries into `EDITOR_PLUGINS`.
@@ -183,6 +206,29 @@ const REST_RESOURCES_CONST_SECTION = `
 
 export const REST_RESOURCES: WorkspaceRestResourceConfig[] = [
 \t// wp-typia add rest-resource entries
+];
+`;
+
+const ABILITIES_INTERFACE_SECTION = `
+
+export interface WorkspaceAbilityConfig {
+\tclientFile: string;
+\tconfigFile: string;
+\tdataFile: string;
+\tinputSchemaFile: string;
+\tinputTypeName: string;
+\toutputSchemaFile: string;
+\toutputTypeName: string;
+\tphpFile: string;
+\tslug: string;
+\ttypesFile: string;
+}
+`;
+
+const ABILITIES_CONST_SECTION = `
+
+export const ABILITIES: WorkspaceAbilityConfig[] = [
+\t// wp-typia add ability entries
 ];
 `;
 
@@ -540,6 +586,51 @@ function parseAiFeatureEntries(
 	});
 }
 
+function parseAbilityEntries(
+	arrayLiteral: ts.ArrayLiteralExpression,
+): WorkspaceAbilityInventoryEntry[] {
+	return arrayLiteral.elements.map((element, elementIndex) => {
+		if (!ts.isObjectLiteralExpression(element)) {
+			throw new Error(
+				`ABILITIES[${elementIndex}] must be an object literal in scripts/block-config.ts.`,
+			);
+		}
+
+		return {
+			clientFile: getRequiredStringProperty("ABILITIES", elementIndex, element, "clientFile"),
+			configFile: getRequiredStringProperty("ABILITIES", elementIndex, element, "configFile"),
+			dataFile: getRequiredStringProperty("ABILITIES", elementIndex, element, "dataFile"),
+			inputSchemaFile: getRequiredStringProperty(
+				"ABILITIES",
+				elementIndex,
+				element,
+				"inputSchemaFile",
+			),
+			inputTypeName: getRequiredStringProperty(
+				"ABILITIES",
+				elementIndex,
+				element,
+				"inputTypeName",
+			),
+			outputSchemaFile: getRequiredStringProperty(
+				"ABILITIES",
+				elementIndex,
+				element,
+				"outputSchemaFile",
+			),
+			outputTypeName: getRequiredStringProperty(
+				"ABILITIES",
+				elementIndex,
+				element,
+				"outputTypeName",
+			),
+			phpFile: getRequiredStringProperty("ABILITIES", elementIndex, element, "phpFile"),
+			slug: getRequiredStringProperty("ABILITIES", elementIndex, element, "slug"),
+			typesFile: getRequiredStringProperty("ABILITIES", elementIndex, element, "typesFile"),
+		};
+	});
+}
+
 function parseEditorPluginEntries(
 	arrayLiteral: ts.ArrayLiteralExpression,
 ): WorkspaceEditorPluginInventoryEntry[] {
@@ -581,6 +672,7 @@ export function parseWorkspaceInventorySource(source: string): Omit<WorkspaceInv
 	const patternArray = findExportedArrayLiteral(sourceFile, "PATTERNS");
 	const bindingSourceArray = findExportedArrayLiteral(sourceFile, "BINDING_SOURCES");
 	const restResourceArray = findExportedArrayLiteral(sourceFile, "REST_RESOURCES");
+	const abilityArray = findExportedArrayLiteral(sourceFile, "ABILITIES");
 	const aiFeatureArray = findExportedArrayLiteral(sourceFile, "AI_FEATURES");
 	const editorPluginArray = findExportedArrayLiteral(sourceFile, "EDITOR_PLUGINS");
 	if (variationArray.found && !variationArray.array) {
@@ -595,6 +687,9 @@ export function parseWorkspaceInventorySource(source: string): Omit<WorkspaceInv
 	if (restResourceArray.found && !restResourceArray.array) {
 		throw new Error("scripts/block-config.ts must export REST_RESOURCES as an array literal.");
 	}
+	if (abilityArray.found && !abilityArray.array) {
+		throw new Error("scripts/block-config.ts must export ABILITIES as an array literal.");
+	}
 	if (aiFeatureArray.found && !aiFeatureArray.array) {
 		throw new Error("scripts/block-config.ts must export AI_FEATURES as an array literal.");
 	}
@@ -603,11 +698,13 @@ export function parseWorkspaceInventorySource(source: string): Omit<WorkspaceInv
 	}
 
 	return {
+		abilities: abilityArray.array ? parseAbilityEntries(abilityArray.array) : [],
 		aiFeatures: aiFeatureArray.array ? parseAiFeatureEntries(aiFeatureArray.array) : [],
 		bindingSources: bindingSourceArray.array
 			? parseBindingSourceEntries(bindingSourceArray.array)
 			: [],
 		blocks: parseBlockEntries(blockArray.array),
+		hasAbilitiesSection: abilityArray.found,
 		hasAiFeaturesSection: aiFeatureArray.found,
 		hasBindingSourcesSection: bindingSourceArray.found,
 		hasEditorPluginsSection: editorPluginArray.found,
@@ -708,6 +805,12 @@ function ensureWorkspaceInventorySections(source: string): string {
 	if (!/export\s+const\s+REST_RESOURCES\b/u.test(nextSource)) {
 		nextSource += REST_RESOURCES_CONST_SECTION;
 	}
+	if (!/export\s+interface\s+WorkspaceAbilityConfig\b/u.test(nextSource)) {
+		nextSource += ABILITIES_INTERFACE_SECTION;
+	}
+	if (!/export\s+const\s+ABILITIES\b/u.test(nextSource)) {
+		nextSource += ABILITIES_CONST_SECTION;
+	}
 	if (!/export\s+interface\s+WorkspaceAiFeatureConfig\b/u.test(nextSource)) {
 		nextSource += AI_FEATURES_INTERFACE_SECTION;
 	}
@@ -739,9 +842,9 @@ function appendEntriesAtMarker(source: string, marker: string, entries: string[]
  * Update `scripts/block-config.ts` source text with additional inventory entries.
  *
  * Missing inventory sections for variations, patterns, binding sources, REST
- * resources, AI features, and editor plugins are created automatically before
- * new entries are appended at their marker comments. When provided,
- * `transformSource` runs before any entries are inserted.
+ * resources, workflow abilities, AI features, and editor plugins are created
+ * automatically before new entries are appended at their marker comments.
+ * When provided, `transformSource` runs before any entries are inserted.
  *
  * @param source Existing `scripts/block-config.ts` source.
  * @param options Entry lists plus an optional source transformer.
@@ -752,6 +855,7 @@ export function updateWorkspaceInventorySource(
 	{
 		blockEntries = [],
 		bindingSourceEntries = [],
+		abilityEntries = [],
 		aiFeatureEntries = [],
 		editorPluginEntries = [],
 		patternEntries = [],
@@ -759,6 +863,7 @@ export function updateWorkspaceInventorySource(
 		variationEntries = [],
 		transformSource,
 	}: {
+		abilityEntries?: string[];
 		aiFeatureEntries?: string[];
 		blockEntries?: string[];
 		bindingSourceEntries?: string[];
@@ -785,6 +890,11 @@ export function updateWorkspaceInventorySource(
 		nextSource,
 		REST_RESOURCE_CONFIG_ENTRY_MARKER,
 		restResourceEntries,
+	);
+	nextSource = appendEntriesAtMarker(
+		nextSource,
+		ABILITY_CONFIG_ENTRY_MARKER,
+		abilityEntries,
 	);
 	nextSource = appendEntriesAtMarker(
 		nextSource,

--- a/packages/wp-typia-project-tools/tests/helpers/scaffold-test-support.ts
+++ b/packages/wp-typia-project-tools/tests/helpers/scaffold-test-support.ts
@@ -58,6 +58,28 @@ export function cleanupScaffoldTempRoot(tempRoot: string) {
 	fs.rmSync(tempRoot, { recursive: true, force: true });
 }
 
+export function parseJsonObjectFromOutput<T>(output: string): T {
+	const trimmed = output.trim();
+	if (trimmed.length === 0) {
+		throw new Error("Expected JSON output but received an empty string.");
+	}
+
+	const objectStart = trimmed.indexOf("{");
+	const arrayStart = trimmed.indexOf("[");
+	const startIndex =
+		objectStart === -1
+			? arrayStart
+			: arrayStart === -1
+				? objectStart
+				: Math.min(objectStart, arrayStart);
+
+	if (startIndex === -1) {
+		throw new Error(`Expected JSON output but received: ${trimmed}`);
+	}
+
+	return JSON.parse(trimmed.slice(startIndex)) as T;
+}
+
 export interface LocalCounterStubServer {
 	close: () => Promise<void>;
 	port: number;

--- a/packages/wp-typia-project-tools/tests/workspace-add.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-add.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, describe, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { cleanupScaffoldTempRoot, createScaffoldTempRoot, entryPath, getCommandErrorMessage, linkWorkspaceNodeModules, runCli, runGeneratedScript, scaffoldOfficialWorkspace, templateLayerFixturePath, templateLayerWorkspaceAmbiguousFixturePath, templateLayerWorkspaceFixturePath, typecheckGeneratedProject, workspaceTemplatePackageManifest } from "./helpers/scaffold-test-harness.js";
+import { cleanupScaffoldTempRoot, createScaffoldTempRoot, entryPath, getCommandErrorMessage, linkWorkspaceNodeModules, parseJsonObjectFromOutput, runCli, runGeneratedScript, scaffoldOfficialWorkspace, templateLayerFixturePath, templateLayerWorkspaceAmbiguousFixturePath, templateLayerWorkspaceFixturePath, typecheckGeneratedProject, workspaceTemplatePackageManifest } from "./helpers/scaffold-test-harness.js";
 import { runAddBlockCommand } from "../src/runtime/cli-core.js";
 import { scaffoldProject } from "../src/runtime/index.js";
 
@@ -493,9 +493,9 @@ test("canonical CLI can add a variation to an official workspace template", asyn
   const doctorOutput = runCli("node", [entryPath, "doctor", "--format", "json"], {
     cwd: targetDir,
   });
-  const doctorChecks = JSON.parse(doctorOutput) as {
+  const doctorChecks = parseJsonObjectFromOutput<{
     checks: Array<{ detail: string; label: string; status: string }>;
-  };
+  }>(doctorOutput);
   expect(
     doctorChecks.checks.find((check) => check.label === "Workspace inventory")
       ?.status
@@ -635,9 +635,9 @@ test("canonical CLI can add hooked-block metadata to an official workspace block
   const doctorOutput = runCli("node", [entryPath, "doctor", "--format", "json"], {
     cwd: targetDir,
   });
-  const doctorChecks = JSON.parse(doctorOutput) as {
+  const doctorChecks = parseJsonObjectFromOutput<{
     checks: Array<{ detail: string; label: string; status: string }>;
-  };
+  }>(doctorOutput);
   expect(
     doctorChecks.checks.find(
       (check) => check.label === "Block hooks counter-card"
@@ -2170,9 +2170,9 @@ test("canonical CLI can add a pattern to an official workspace template", async 
   const doctorOutput = runCli("node", [entryPath, "doctor", "--format", "json"], {
     cwd: targetDir,
   });
-  const doctorChecks = JSON.parse(doctorOutput) as {
+  const doctorChecks = parseJsonObjectFromOutput<{
     checks: Array<{ detail: string; label: string; status: string }>;
-  };
+  }>(doctorOutput);
   expect(
     doctorChecks.checks.find((check) => check.label === "Pattern bootstrap")
       ?.status
@@ -2286,9 +2286,9 @@ test("canonical CLI can add a binding source to an official workspace template",
   const doctorOutput = runCli("node", [entryPath, "doctor", "--format", "json"], {
     cwd: targetDir,
   });
-  const doctorChecks = JSON.parse(doctorOutput) as {
+  const doctorChecks = parseJsonObjectFromOutput<{
     checks: Array<{ detail: string; label: string; status: string }>;
-  };
+  }>(doctorOutput);
   expect(
     doctorChecks.checks.find((check) => check.label === "Binding bootstrap")
       ?.status
@@ -2575,9 +2575,9 @@ test("canonical CLI can add a plugin-level REST resource to an official workspac
   const doctorOutput = runCli("node", [entryPath, "doctor", "--format", "json"], {
     cwd: targetDir,
   });
-  const doctorChecks = JSON.parse(doctorOutput) as {
+  const doctorChecks = parseJsonObjectFromOutput<{
     checks: Array<{ detail: string; label: string; status: string }>;
-  };
+  }>(doctorOutput);
   expect(
     doctorChecks.checks.find((check) => check.label === "REST resource bootstrap")
       ?.status
@@ -3081,9 +3081,9 @@ test("canonical CLI can add a server-only AI feature to an official workspace te
   const doctorOutput = runCli("node", [entryPath, "doctor", "--format", "json"], {
     cwd: targetDir,
   });
-  const doctorChecks = JSON.parse(doctorOutput) as {
+  const doctorChecks = parseJsonObjectFromOutput<{
     checks: Array<{ detail: string; label: string; status: string }>;
-  };
+  }>(doctorOutput);
   expect(
     doctorChecks.checks.find((check) => check.label === "AI feature bootstrap")
       ?.status
@@ -3101,6 +3101,179 @@ test("canonical CLI can add a server-only AI feature to an official workspace te
 
   runCli("npm", ["run", "sync-rest", "--", "--check"], { cwd: targetDir });
   runCli("npm", ["run", "sync-ai", "--", "--check"], { cwd: targetDir });
+  typecheckGeneratedProject(targetDir);
+}, 30_000);
+
+test("canonical CLI can add a typed workflow ability to an official workspace template", async () => {
+  const targetDir = path.join(tempRoot, "demo-workspace-add-ability");
+
+  await scaffoldProject({
+    projectDir: targetDir,
+    templateId: workspaceTemplatePackageManifest.name,
+    packageManager: "npm",
+    noInstall: true,
+    answers: {
+      author: "Test Runner",
+      description: "Demo workspace add ability",
+      namespace: "demo-space",
+      phpPrefix: "demo_space",
+      slug: "demo-workspace-add-ability",
+      textDomain: "demo-space",
+      title: "Demo Workspace Add Ability",
+    },
+  });
+
+  linkWorkspaceNodeModules(targetDir);
+
+  runCli("node", [entryPath, "add", "ability", "review-workflow"], {
+    cwd: targetDir,
+  });
+
+  const blockConfigSource = fs.readFileSync(
+    path.join(targetDir, "scripts", "block-config.ts"),
+    "utf8"
+  );
+  const bootstrapSource = fs.readFileSync(
+    path.join(targetDir, "demo-workspace-add-ability.php"),
+    "utf8"
+  );
+  const packageJson = JSON.parse(
+    fs.readFileSync(path.join(targetDir, "package.json"), "utf8")
+  ) as {
+    scripts?: Record<string, string>;
+  };
+  const syncProjectSource = fs.readFileSync(
+    path.join(targetDir, "scripts", "sync-project.ts"),
+    "utf8"
+  );
+  const syncAbilitiesSource = fs.readFileSync(
+    path.join(targetDir, "scripts", "sync-abilities.ts"),
+    "utf8"
+  );
+  const buildWorkspaceSource = fs.readFileSync(
+    path.join(targetDir, "scripts", "build-workspace.mjs"),
+    "utf8"
+  );
+  const webpackSource = fs.readFileSync(
+    path.join(targetDir, "webpack.config.js"),
+    "utf8"
+  );
+  const abilitiesIndexSource = fs.readFileSync(
+    path.join(targetDir, "src", "abilities", "index.ts"),
+    "utf8"
+  );
+  const typesSource = fs.readFileSync(
+    path.join(targetDir, "src", "abilities", "review-workflow", "types.ts"),
+    "utf8"
+  );
+  const dataSource = fs.readFileSync(
+    path.join(targetDir, "src", "abilities", "review-workflow", "data.ts"),
+    "utf8"
+  );
+  const abilityConfig = JSON.parse(
+    fs.readFileSync(
+      path.join(
+        targetDir,
+        "src",
+        "abilities",
+        "review-workflow",
+        "ability.config.json"
+      ),
+      "utf8"
+    )
+  ) as {
+    abilityId?: string;
+    category?: { slug?: string };
+  };
+  const phpSource = fs.readFileSync(
+    path.join(targetDir, "inc", "abilities", "review-workflow.php"),
+    "utf8"
+  );
+
+  expect(blockConfigSource).toContain('slug: "review-workflow"');
+  expect(blockConfigSource).toContain(
+    'configFile: "src/abilities/review-workflow/ability.config.json"'
+  );
+  expect(blockConfigSource).toContain(
+    'inputTypeName: "ReviewWorkflowAbilityInput"'
+  );
+  expect(blockConfigSource).toContain(
+    'outputTypeName: "ReviewWorkflowAbilityOutput"'
+  );
+  expect(bootstrapSource).toContain("inc/abilities/*.php");
+  expect(bootstrapSource).toContain("build/abilities/index.js");
+  expect(bootstrapSource).toContain("plugins_loaded");
+  expect(bootstrapSource).toContain("admin_enqueue_scripts");
+  expect(packageJson.scripts?.["sync-abilities"]).toBe(
+    "tsx scripts/sync-abilities.ts"
+  );
+  expect(syncProjectSource).toContain("const syncAbilitiesScriptPath");
+  expect(syncProjectSource).toContain(
+    "runSyncScript( syncAbilitiesScriptPath, options );"
+  );
+  expect(syncAbilitiesSource).toContain("ABILITIES");
+  expect(syncAbilitiesSource).toContain("syncTypeSchemas");
+  expect(buildWorkspaceSource).toContain("'src/abilities/index.ts'");
+  expect(webpackSource).toContain("'abilities/index'");
+  expect(abilitiesIndexSource).toContain("./review-workflow/client");
+  expect(typesSource).toContain("export interface ReviewWorkflowAbilityInput");
+  expect(typesSource).toContain("export interface ReviewWorkflowAbilityOutput");
+  expect(dataSource).toContain("@wordpress/core-abilities");
+  expect(abilityConfig.abilityId).toBe("demo-space/review-workflow");
+  expect(abilityConfig.category?.slug).toBe("demo-space-workflows");
+  expect(phpSource).toContain("wp_register_ability_category");
+  expect(phpSource).toContain("wp_register_ability(");
+  expect(phpSource).toContain("input.schema.json");
+  expect(phpSource).toContain("output.schema.json");
+
+  expect(
+    fs.existsSync(
+      path.join(
+        targetDir,
+        "src",
+        "abilities",
+        "review-workflow",
+        "input.schema.json"
+      )
+    )
+  ).toBe(true);
+  expect(
+    fs.existsSync(
+      path.join(
+        targetDir,
+        "src",
+        "abilities",
+        "review-workflow",
+        "output.schema.json"
+      )
+    )
+  ).toBe(true);
+
+  const doctorOutput = runCli("node", [entryPath, "doctor", "--format", "json"], {
+    cwd: targetDir,
+  });
+  const doctorChecks = parseJsonObjectFromOutput<{
+    checks: Array<{ detail: string; label: string; status: string }>;
+  }>(doctorOutput);
+  expect(
+    doctorChecks.checks.find((check) => check.label === "Ability bootstrap")
+      ?.status
+  ).toBe("pass");
+  expect(
+    doctorChecks.checks.find((check) => check.label === "Abilities index")
+      ?.status
+  ).toBe("pass");
+  expect(
+    doctorChecks.checks.find(
+      (check) => check.label === "Ability config review-workflow"
+    )?.status
+  ).toBe("pass");
+  expect(
+    doctorChecks.checks.find((check) => check.label === "Ability review-workflow")
+      ?.status
+  ).toBe("pass");
+
+  runCli("npm", ["run", "sync-abilities", "--", "--check"], { cwd: targetDir });
   typecheckGeneratedProject(targetDir);
 }, 30_000);
 
@@ -3179,9 +3352,9 @@ test("canonical CLI can add an editor plugin to an official workspace template",
   const doctorOutput = runCli("node", [entryPath, "doctor", "--format", "json"], {
     cwd: targetDir,
   });
-  const doctorChecks = JSON.parse(doctorOutput) as {
+  const doctorChecks = parseJsonObjectFromOutput<{
     checks: Array<{ detail: string; label: string; status: string }>;
-  };
+  }>(doctorOutput);
   expect(
     doctorChecks.checks.find(
       (check) => check.label === "Editor plugin bootstrap"

--- a/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, describe, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { cleanupScaffoldTempRoot, createScaffoldTempRoot, entryPath, getCommandErrorMessage, linkWorkspaceNodeModules, runCli, scaffoldOfficialWorkspace, stripPhpFunction, workspaceTemplatePackageManifest } from "./helpers/scaffold-test-harness.js";
+import { cleanupScaffoldTempRoot, createScaffoldTempRoot, entryPath, getCommandErrorMessage, linkWorkspaceNodeModules, parseJsonObjectFromOutput, runCli, scaffoldOfficialWorkspace, stripPhpFunction, workspaceTemplatePackageManifest } from "./helpers/scaffold-test-harness.js";
 import { scaffoldProject } from "../src/runtime/index.js";
 import { getDoctorChecks } from "../src/runtime/cli-core.js";
 import { updateWorkspaceInventorySource } from "../src/runtime/workspace-inventory.js";
@@ -132,9 +132,9 @@ test("doctor accepts workspaces that keep binding registries in src/bindings/ind
   const doctorOutput = runCli("node", [entryPath, "doctor", "--format", "json"], {
     cwd: targetDir,
   });
-  const doctorChecks = JSON.parse(doctorOutput) as {
+  const doctorChecks = parseJsonObjectFromOutput<{
     checks: Array<{ detail: string; label: string; status: string }>;
-  };
+  }>(doctorOutput);
 
   expect(
     doctorChecks.checks.find(
@@ -233,9 +233,9 @@ test("doctor accepts workspaces that keep editor plugin registries in src/editor
   const doctorOutput = runCli("node", [entryPath, "doctor", "--format", "json"], {
     cwd: targetDir,
   });
-  const doctorChecks = JSON.parse(doctorOutput) as {
+  const doctorChecks = parseJsonObjectFromOutput<{
     checks: Array<{ detail: string; label: string; status: string }>;
-  };
+  }>(doctorOutput);
 
   expect(
     doctorChecks.checks.find(
@@ -349,6 +349,23 @@ export const REST_RESOURCES: WorkspaceRestResourceConfig[] = [
 \t// wp-typia add rest-resource entries
 ];
 
+export interface WorkspaceAbilityConfig {
+\tclientFile: string;
+\tconfigFile: string;
+\tdataFile: string;
+\tinputSchemaFile: string;
+\tinputTypeName: string;
+\toutputSchemaFile: string;
+\toutputTypeName: string;
+\tphpFile: string;
+\tslug: string;
+\ttypesFile: string;
+}
+
+export const ABILITIES: WorkspaceAbilityConfig[] = [
+\t// wp-typia add ability entries
+];
+
 export interface WorkspaceAiFeatureConfig {
 \taiSchemaFile: string;
 \tapiFile: string;
@@ -387,6 +404,9 @@ export const EDITOR_PLUGINS: WorkspaceEditorPluginConfig[] = [
       restResourceEntries: [
         '\t{ apiFile: "src/rest/hero/api.ts", clientFile: "src/rest/hero/api-client.ts", dataFile: "src/rest/hero/data.ts", methods: [ "list", "read" ], namespace: "demo-space/v1", openApiFile: "src/rest/hero/api.openapi.json", phpFile: "inc/rest/hero.php", slug: "hero", typesFile: "src/rest/hero/api-types.ts", validatorsFile: "src/rest/hero/api-validators.ts" },',
       ],
+      abilityEntries: [
+        '\t{ clientFile: "src/abilities/review-workflow/client.ts", configFile: "src/abilities/review-workflow/ability.config.json", dataFile: "src/abilities/review-workflow/data.ts", inputSchemaFile: "src/abilities/review-workflow/input.schema.json", inputTypeName: "ReviewWorkflowAbilityInput", outputSchemaFile: "src/abilities/review-workflow/output.schema.json", outputTypeName: "ReviewWorkflowAbilityOutput", phpFile: "inc/abilities/review-workflow.php", slug: "review-workflow", typesFile: "src/abilities/review-workflow/types.ts" },',
+      ],
       aiFeatureEntries: [
         '\t{ aiSchemaFile: "src/ai-features/hero/ai-schemas/feature-result.ai.schema.json", apiFile: "src/ai-features/hero/api.ts", clientFile: "src/ai-features/hero/api-client.ts", dataFile: "src/ai-features/hero/data.ts", namespace: "demo-space/v1", openApiFile: "src/ai-features/hero/api.openapi.json", phpFile: "inc/ai-features/hero.php", slug: "hero", typesFile: "src/ai-features/hero/api-types.ts", validatorsFile: "src/ai-features/hero/api-validators.ts" },',
       ],
@@ -404,6 +424,7 @@ export const EDITOR_PLUGINS: WorkspaceEditorPluginConfig[] = [
   expect(
     repairedSource.match(/export const REST_RESOURCES\b/gu)?.length
   ).toBe(1);
+  expect(repairedSource.match(/export const ABILITIES\b/gu)?.length).toBe(1);
   expect(repairedSource.match(/export const AI_FEATURES\b/gu)?.length).toBe(1);
   expect(
     repairedSource.match(/export const EDITOR_PLUGINS\b/gu)?.length
@@ -418,6 +439,7 @@ export const EDITOR_PLUGINS: WorkspaceEditorPluginConfig[] = [
   expect(repairedSource).toContain(
     "export interface WorkspaceRestResourceConfig"
   );
+  expect(repairedSource).toContain("export interface WorkspaceAbilityConfig");
   expect(repairedSource).toContain(
     "export interface WorkspaceAiFeatureConfig"
   );

--- a/packages/wp-typia/.bunli/commands.gen.ts
+++ b/packages/wp-typia/.bunli/commands.gen.ts
@@ -31,7 +31,7 @@ const modules: Record<GeneratedNames, Command<any>> = {
 const metadata: Record<GeneratedNames, GeneratedCommandMeta> = {
   'add': {
       name: 'add',
-      description: 'Extend an official wp-typia workspace with blocks, variations, patterns, binding sources, plugin-level REST resources, server-only AI features, editor plugins, or hooked blocks.',
+      description: 'Extend an official wp-typia workspace with blocks, variations, patterns, binding sources, plugin-level REST resources, workflow abilities, server-only AI features, editor plugins, or hooked blocks.',
       path: './src/commands/add'
     },
   'create': {

--- a/packages/wp-typia/README.md
+++ b/packages/wp-typia/README.md
@@ -15,6 +15,7 @@ Extend an existing workspace with:
 - `wp-typia add block counter-card --template basic`
 - `wp-typia add binding-source hero-data`
 - `wp-typia add rest-resource snapshots --namespace my-plugin/v1 --methods list,read,create`
+- `wp-typia add ability review-workflow`
 - `wp-typia add ai-feature brief-suggestions --namespace my-plugin/v1`
 - `wp-typia add hooked-block counter-card --anchor core/post-content --position after`
 

--- a/packages/wp-typia/scripts/build-bunli-runtime.ts
+++ b/packages/wp-typia/scripts/build-bunli-runtime.ts
@@ -100,6 +100,7 @@ async function buildNodeFallbackRuntime() {
 await ensureRuntimeBuildDependencies();
 await fs.rm(outdir, { force: true, recursive: true });
 await fs.mkdir(outdir, { recursive: true });
+await fs.mkdir(generatedMetadataOutdir, { recursive: true });
 
 await buildFullBunliRuntime();
 await buildGeneratedMetadataRuntime();

--- a/packages/wp-typia/src/add-kind-registry.ts
+++ b/packages/wp-typia/src/add-kind-registry.ts
@@ -4,6 +4,7 @@ export const ADD_KIND_IDS = [
   'pattern',
   'binding-source',
   'rest-resource',
+  'ability',
   'ai-feature',
   'editor-plugin',
   'hooked-block',
@@ -111,6 +112,22 @@ export const ADD_KIND_REGISTRY = {
         }
         return true;
       }),
+  },
+  ability: {
+    completion: {
+      nextSteps: (values) => [
+        `Review src/abilities/${values.abilitySlug}/ and inc/abilities/${values.abilitySlug}.php.`,
+        'Run `wp-typia sync` or `npm run sync-abilities -- --check` and then your workspace build/dev command to verify the generated workflow ability.',
+      ],
+      summaryLines: (values, projectDir) => [
+        `Ability: ${values.abilitySlug}`,
+        `Project directory: ${projectDir}`,
+      ],
+      title: 'Added workflow ability',
+    },
+    description: 'Add a typed server/client workflow ability scaffold',
+    nameLabel: 'Ability name',
+    visibleFieldNames: () => ['kind', 'name'],
   },
   'editor-plugin': {
     completion: {

--- a/packages/wp-typia/src/commands/add.ts
+++ b/packages/wp-typia/src/commands/add.ts
@@ -36,7 +36,7 @@ const addOptions = buildCommandOptions(ADD_OPTION_METADATA);
 export const addCommand = defineCommand({
   defaultFormat: 'toon',
   description:
-    'Extend an official wp-typia workspace with blocks, variations, patterns, binding sources, plugin-level REST resources, server-only AI features, editor plugins, or hooked blocks.',
+    'Extend an official wp-typia workspace with blocks, variations, patterns, binding sources, plugin-level REST resources, workflow abilities, server-only AI features, editor plugins, or hooked blocks.',
   handler: async (args) => {
     const prefersStructuredOutput = prefersStructuredCliOutput(args);
 

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -21,7 +21,10 @@ import {
   getTemplateById,
   listTemplates,
 } from '@wp-typia/project-tools/cli-templates';
-import { formatAddKindUsagePlaceholder } from './add-kind-registry';
+import {
+  formatAddKindList,
+  formatAddKindUsagePlaceholder,
+} from './add-kind-registry';
 import {
   getAddBlockDefaults,
   getCreateDefaults,
@@ -254,6 +257,8 @@ function renderAddHelp() {
     'Usage: wp-typia add <kind> <name>',
     '',
     ...NODE_FALLBACK_RUNTIME_SUMMARY_LINES,
+    '',
+    `Supported kinds: ${formatAddKindList()}`,
     '',
     'Supported flags:',
     ...formatNodeFallbackOptionHelp(ADD_OPTION_METADATA),

--- a/packages/wp-typia/src/runtime-bridge.ts
+++ b/packages/wp-typia/src/runtime-bridge.ts
@@ -98,6 +98,7 @@ const loadMigrationsRuntime = () =>
   import('@wp-typia/project-tools/migrations');
 
 type AddRuntime = Awaited<ReturnType<typeof loadCliAddRuntime>>;
+type AddAbilityResult = Awaited<ReturnType<AddRuntime['runAddAbilityCommand']>>;
 type AddBindingSourceResult = Awaited<
   ReturnType<AddRuntime['runAddBindingSourceCommand']>
 >;
@@ -230,6 +231,28 @@ const ADD_KIND_EXECUTION_REGISTRY: Record<
     context: AddKindHandlerContext,
   ) => Promise<AlternateBufferCompletionPayload | void>
 > = {
+  ability: async (context) => {
+    const name = requireAddKindName(
+      context,
+      '`wp-typia add ability` requires <name>. Usage: wp-typia add ability <name>.',
+    );
+
+    return runRegisteredAddKind<AddAbilityResult>(context, {
+      buildCompletion: (result) =>
+        buildAddCompletionPayload({
+          kind: 'ability',
+          projectDir: result.projectDir,
+          values: {
+            abilitySlug: result.abilitySlug,
+          },
+        }),
+      execute: (targetCwd) =>
+        context.addRuntime.runAddAbilityCommand({
+          abilityName: name,
+          cwd: targetCwd,
+        }),
+    });
+  },
   'binding-source': async (context) => {
     const name = requireAddKindName(
       context,

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -361,7 +361,7 @@ describe('wp-typia package', () => {
     expect(addHelpOutput).toContain('--external-layer-source');
     expect(addHelpOutput).toContain('--external-layer-id');
     expect(addHelpOutput).toContain('--alternate-render-targets');
-    expect(addHelpOutput).toContain('ability');
+    expect(addHelpOutput).toContain('ability, ai-feature');
     expect(addHelpOutput).toContain('editor-plugin');
   });
 

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -361,6 +361,7 @@ describe('wp-typia package', () => {
     expect(addHelpOutput).toContain('--external-layer-source');
     expect(addHelpOutput).toContain('--external-layer-id');
     expect(addHelpOutput).toContain('--alternate-render-targets');
+    expect(addHelpOutput).toContain('ability');
     expect(addHelpOutput).toContain('editor-plugin');
   });
 
@@ -1253,7 +1254,7 @@ describe('wp-typia package', () => {
     expect(result.stdout).toContain('Usage:');
     expect(result.stdout).toContain('wp-typia add block <name>');
     expect(result.stderr).toContain(
-      '`wp-typia add` requires <kind>. Usage: wp-typia add <block|variation|pattern|binding-source|rest-resource|ai-feature|editor-plugin|hooked-block> ...',
+      '`wp-typia add` requires <kind>. Usage: wp-typia add <block|variation|pattern|binding-source|rest-resource|ability|ai-feature|editor-plugin|hooked-block> ...',
     );
   });
 
@@ -1268,6 +1269,9 @@ describe('wp-typia package', () => {
       await expect(runNodeCli(['add'])).rejects.toThrow('wp-typia add failed');
       expect(capturedStdout.join('\n')).toContain('Usage:');
       expect(capturedStdout.join('\n')).toContain('wp-typia add block <name>');
+      expect(capturedStdout.join('\n')).toContain(
+        'wp-typia add ability <name>',
+      );
       expect(capturedStdout.join('\n')).toContain(
         'wp-typia add ai-feature <name>',
       );

--- a/packages/wp-typia/tests/tui-interaction-models.test.ts
+++ b/packages/wp-typia/tests/tui-interaction-models.test.ts
@@ -47,6 +47,10 @@ describe("first-party TUI interaction models", () => {
 			"namespace",
 			"methods",
 		]);
+		expect(getVisibleAddFieldNames({ kind: "ability" })).toEqual([
+			"kind",
+			"name",
+		]);
 		expect(getVisibleAddFieldNames({ kind: "ai-feature" })).toEqual([
 			"kind",
 			"name",
@@ -123,6 +127,21 @@ describe("first-party TUI interaction models", () => {
 			block: "counter-card",
 			kind: "variation",
 			name: "hero-card",
+		});
+
+		expect(
+			sanitizeAddSubmitValues({
+				anchor: "",
+				block: "",
+				kind: "ability",
+				name: "review-workflow",
+				namespace: " demo-space/v1 ",
+				position: "",
+				template: "persistence",
+			}),
+		).toEqual({
+			kind: "ability",
+			name: "review-workflow",
 		});
 
 		expect(


### PR DESCRIPTION
## Summary
- add `wp-typia add ability <name>` for typed server/client workflow ability scaffolds
- wire workspace inventory, doctor checks, sync-abilities, bootstrap/build hooks, and Node fallback help/completion paths
- document the new add surface in the CLI README and API reference

## Testing
- bun run typecheck
- bun run docs:build:site
- bun test packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
- bun test packages/wp-typia-project-tools/tests/workspace-add.test.ts --test-name-pattern "canonical CLI can add a typed workflow ability to an official workspace template"
- bun test packages/wp-typia/tests/cli-package.test.ts packages/wp-typia/tests/tui-interaction-models.test.ts

Closes #560

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `wp-typia add ability` CLI command to scaffold typed workflow abilities
  * Abilities generate TypeScript sources and PHP registration modules with automatic workspace integration
  * Workspace doctor now validates ability configurations and bootstrapping

* **Documentation**
  * Updated help text and README with new ability command and generated artifact locations

* **Tests**
  * Added integration test coverage for ability scaffolding workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->