### PR TITLE
feat(scaffold): add AI compatibility gating policy

### DIFF
--- a/.sampo/changesets/ai-scaffold-compatibility-policy.md
+++ b/.sampo/changesets/ai-scaffold-compatibility-policy.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/project-tools: minor
+---
+
+Added explicit AI scaffold compatibility policy wiring for generated plugin headers, runtime gates, workspace inventory metadata, and docs.

--- a/apps/docs/src/content/docs/reference/ai-scaffold-compatibility.md
+++ b/apps/docs/src/content/docs/reference/ai-scaffold-compatibility.md
@@ -1,0 +1,64 @@
+---
+title: 'AI Scaffold Compatibility'
+---
+
+AI-capable scaffolds use an explicit compatibility policy instead of changing
+plugin headers ad hoc. The policy keeps the non-AI baseline stable, then lets
+each AI feature declare whether it is a hard requirement or an optional runtime
+capability.
+
+## Baseline
+
+Generated non-AI projects keep the current baseline:
+
+- WordPress `Requires at least: 6.7`
+- WordPress `Tested up to: 6.9`
+- PHP `Requires PHP: 8.0`
+
+The baseline also applies to optional AI features. Optional features must use
+runtime gates and graceful degradation instead of raising the plugin header
+floor.
+
+## Feature Modes
+
+- `required`: raises the generated plugin header to the highest required
+  WordPress/PHP floor across selected features.
+- `optional`: records the feature in workspace compatibility metadata, but
+  keeps the plugin header at the baseline and requires runtime guards.
+- `baseline`: no AI feature selection has been applied.
+
+## Current Matrix
+
+| Feature                     | Mode in generated scaffold             | Version floor               | Runtime gate                                             |
+| --------------------------- | -------------------------------------- | --------------------------- | -------------------------------------------------------- |
+| WordPress AI Client         | Optional for `wp-typia add ai-feature` | WordPress 7.0 when required | WordPress AI Client availability                         |
+| WordPress Abilities API     | Required for `wp-typia add ability`    | WordPress 6.9               | `wp_register_ability` and `wp_register_ability_category` |
+| `@wordpress/core-abilities` | Required for `wp-typia add ability`    | WordPress 7.0               | `@wordpress/core-abilities` script package               |
+| MCP public metadata         | Optional adapter path                  | No core floor by itself     | MCP adapter availability                                 |
+
+Because the typed ability scaffold requires both the server Abilities API and
+the editor/admin discovery client, generated ability projects currently raise
+their plugin headers to WordPress 7.0.
+
+Server-only AI feature endpoints stay optional. They keep the baseline header,
+register their REST endpoint, and return a runtime error when the WordPress AI
+Client or structured text generation support is not available. Generated
+projects also surface an admin notice for site managers so the disabled feature
+does not look like a broken plugin.
+
+## Generated Inventory Metadata
+
+Workspace entries for AI features and typed abilities include a `compatibility`
+object. Tooling can inspect that object to distinguish baseline, optional, and
+required feature surfaces without parsing PHP headers.
+
+The generated object records:
+
+- `mode`
+- `hardMinimums`
+- `optionalFeatures`
+- `requiredFeatures`
+- `runtimeGates`
+
+That metadata is advisory for tooling and docs. The plugin header remains the
+source WordPress uses for installation compatibility.

--- a/apps/docs/src/content/docs/reference/api.md
+++ b/apps/docs/src/content/docs/reference/api.md
@@ -39,6 +39,10 @@ This repository has multiple public surfaces:
 - `@wp-typia/project-tools/ai-artifacts`
   Opt-in WordPress AI artifact sync helpers (`*.ai.schema.json`,
   `*.abilities.json`).
+- `@wp-typia/project-tools` AI scaffold compatibility policy
+  Generated AI-capable scaffold headers, runtime gates, and workspace inventory
+  metadata are described in
+  [`docs/ai-scaffold-compatibility.md`](./ai-scaffold-compatibility.md).
 - `@wp-typia/project-tools/typia-llm`
   Opt-in build-time `typia.llm` adapter emitter for downstream TypeScript-first
   tool/function consumers.

--- a/apps/docs/src/content/docs/reference/api.md
+++ b/apps/docs/src/content/docs/reference/api.md
@@ -34,15 +34,14 @@ This repository has multiple public surfaces:
   Project orchestration package for scaffold, add, migrate, template, doctor,
   package-manager, starter-manifest helpers, and the typed generator
   boundary (`BlockSpec`, `BlockGeneratorService`, `inspectBlockGeneration`).
+  Generated AI-capable scaffold headers, runtime gates, and workspace inventory
+  metadata are described in
+  [`docs/ai-scaffold-compatibility.md`](./ai-scaffold-compatibility.md).
 - `@wp-typia/project-tools/schema-core`
   Project schema/OpenAPI helpers.
 - `@wp-typia/project-tools/ai-artifacts`
   Opt-in WordPress AI artifact sync helpers (`*.ai.schema.json`,
   `*.abilities.json`).
-- `@wp-typia/project-tools` AI scaffold compatibility policy
-  Generated AI-capable scaffold headers, runtime gates, and workspace inventory
-  metadata are described in
-  [`docs/ai-scaffold-compatibility.md`](./ai-scaffold-compatibility.md).
 - `@wp-typia/project-tools/typia-llm`
   Opt-in build-time `typia.llm` adapter emitter for downstream TypeScript-first
   tool/function consumers.

--- a/apps/docs/src/content/docs/reference/wordpress-ai-projections.md
+++ b/apps/docs/src/content/docs/reference/wordpress-ai-projections.md
@@ -73,28 +73,31 @@ The current internal split is:
 That keeps WordPress-only execution semantics out of the backend-neutral REST
 manifest while still letting the two sources compose at build time.
 
-## Compatibility draft for future scaffolds
+## Scaffold compatibility policy
 
-The repo also now carries a draft AI feature capability model that lets future
-scaffolds describe feature surfaces as either:
+AI-capable scaffolds now apply a concrete feature capability model that lets
+generated projects describe feature surfaces as either:
 
 - `required`
 - `optional`
 
-That draft is intentionally only a foundation for now. It records the minimum
-WordPress floor and runtime gate expectations for surfaces such as:
+The policy records the minimum WordPress floor and runtime gate expectations for
+surfaces such as:
 
 - server-side Abilities registration
 - `@wordpress/core-abilities`
 - the WordPress AI Client
 - optional MCP public metadata
 
-Scaffolds do not apply the compatibility policy yet. The current state is:
+See [`docs/ai-scaffold-compatibility.md`](./ai-scaffold-compatibility.md) for
+the current baseline, optional-feature, and required-feature rules. The current
+state is:
 
-- no plugin header changes
-- no generated runtime guards
-- a server-only `add ai-feature` workflow for WordPress AI Client endpoints
-- no typed Abilities scaffold rollout yet
+- non-AI scaffolds keep the WordPress 6.7 / PHP 8.0 baseline
+- server-only `add ai-feature` keeps WordPress AI Client support optional and
+  runtime-gated
+- typed `add ability` raises generated plugin headers to WordPress 7.0 because
+  the generated admin/editor discovery path requires `@wordpress/core-abilities`
 
 ## What this does not change
 

--- a/packages/wp-typia-project-tools/src/internal/scaffold-compatibility.ts
+++ b/packages/wp-typia-project-tools/src/internal/scaffold-compatibility.ts
@@ -1,0 +1,1 @@
+export * from '../runtime/scaffold-compatibility.js';

--- a/packages/wp-typia-project-tools/src/runtime/block-generator-service-spec.ts
+++ b/packages/wp-typia-project-tools/src/runtime/block-generator-service-spec.ts
@@ -29,6 +29,7 @@ import {
 	buildFrontendCssClassName,
 	resolveScaffoldIdentifiers,
 } from "./scaffold-identifiers.js";
+import { resolveScaffoldCompatibilityPolicy } from "./scaffold-compatibility.js";
 import { attachScaffoldTemplateVariableGroups } from "./scaffold-template-variable-groups.js";
 import type {
 	DataStorageMode,
@@ -310,6 +311,7 @@ export function buildTemplateVariablesFromBlockSpec(spec: BlockSpec): ScaffoldTe
 		? spec.persistence.persistencePolicy
 		: "authenticated";
 	const queryVariationNamespace = `${namespace}/${slug}`;
+	const compatibility = resolveScaffoldCompatibilityPolicy([]);
 
 	const flatVariables: FlatScaffoldTemplateVariables = {
 		alternateRenderTargetsCsv: formatAlternateRenderTargets(
@@ -358,6 +360,9 @@ export function buildTemplateVariablesFromBlockSpec(spec: BlockSpec): ScaffoldTe
 		hasAlternateRenderTargets: alternateRenderTargets.length > 0
 			? "true"
 			: "false",
+		requiresAtLeast: compatibility.pluginHeader.requiresAtLeast,
+		requiresPhp: compatibility.pluginHeader.requiresPhp,
+		testedUpTo: compatibility.pluginHeader.testedUpTo,
 		projectToolsPackageVersion,
 		cssClassName,
 		dashCase: slug,
@@ -423,6 +428,7 @@ export function buildTemplateVariablesFromBlockSpec(spec: BlockSpec): ScaffoldTe
 		author: spec.project.author,
 		blockMetadataVersion: BUILTIN_BLOCK_METADATA_VERSION,
 		category: spec.metadata.category,
+		compatibility: compatibility.pluginHeader,
 		cssClassName,
 		description: spec.metadata.description,
 		descriptionJson: flatVariables.descriptionJson,

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ability.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ability.ts
@@ -26,6 +26,7 @@ import {
 	REQUIRED_WORKSPACE_ABILITY_COMPATIBILITY,
 	renderScaffoldCompatibilityConfig,
 	resolveScaffoldCompatibilityPolicy,
+	type ScaffoldCompatibilityPolicy,
 	updatePluginHeaderCompatibility,
 } from "./scaffold-compatibility.js";
 
@@ -62,11 +63,11 @@ function toAbilityCategorySlug(workspaceNamespace: string): string {
 	return `${normalizedNamespace || "workspace"}-workflows`;
 }
 
-function buildAbilityConfigEntry(abilitySlug: string): string {
+function buildAbilityConfigEntry(
+	abilitySlug: string,
+	compatibilityPolicy: ScaffoldCompatibilityPolicy,
+): string {
 	const pascalCase = toPascalCaseFromAbilitySlug(abilitySlug);
-	const compatibilityPolicy = resolveScaffoldCompatibilityPolicy(
-		REQUIRED_WORKSPACE_ABILITY_COMPATIBILITY,
-	);
 
 	return [
 		"\t{",
@@ -1011,7 +1012,7 @@ export async function runAddAbilityCommand({
 		});
 		await writeAbilityRegistry(workspace.projectDir, abilitySlug);
 		await appendWorkspaceInventoryEntries(workspace.projectDir, {
-			abilityEntries: [buildAbilityConfigEntry(abilitySlug)],
+			abilityEntries: [buildAbilityConfigEntry(abilitySlug, compatibilityPolicy)],
 		});
 
 		return {

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ability.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ability.ts
@@ -22,6 +22,12 @@ import {
 	type WorkspaceMutationSnapshot,
 	snapshotWorkspaceFiles,
 } from "./cli-add-shared.js";
+import {
+	REQUIRED_WORKSPACE_ABILITY_COMPATIBILITY,
+	renderScaffoldCompatibilityConfig,
+	resolveScaffoldCompatibilityPolicy,
+	updatePluginHeaderCompatibility,
+} from "./scaffold-compatibility.js";
 
 const ABILITY_SERVER_GLOB = "/inc/abilities/*.php";
 const ABILITY_EDITOR_SCRIPT = "build/abilities/index.js";
@@ -58,10 +64,16 @@ function toAbilityCategorySlug(workspaceNamespace: string): string {
 
 function buildAbilityConfigEntry(abilitySlug: string): string {
 	const pascalCase = toPascalCaseFromAbilitySlug(abilitySlug);
+	const compatibilityPolicy = resolveScaffoldCompatibilityPolicy(
+		REQUIRED_WORKSPACE_ABILITY_COMPATIBILITY,
+	);
 
 	return [
 		"\t{",
 		`\t\tclientFile: ${quoteTsString(`src/abilities/${abilitySlug}/client.ts`)},`,
+		`\t\tcompatibility: ${renderScaffoldCompatibilityConfig(
+			compatibilityPolicy,
+		)},`,
 		`\t\tconfigFile: ${quoteTsString(`src/abilities/${abilitySlug}/ability.config.json`)},`,
 		`\t\tdataFile: ${quoteTsString(`src/abilities/${abilitySlug}/data.ts`)},`,
 		`\t\tinputSchemaFile: ${quoteTsString(`src/abilities/${abilitySlug}/input.schema.json`)},`,
@@ -900,6 +912,9 @@ export async function runAddAbilityCommand({
 
 	const inventory = readWorkspaceInventory(workspace.projectDir);
 	assertAbilityDoesNotExist(workspace.projectDir, abilitySlug, inventory);
+	const compatibilityPolicy = resolveScaffoldCompatibilityPolicy(
+		REQUIRED_WORKSPACE_ABILITY_COMPATIBILITY,
+	);
 
 	const blockConfigPath = path.join(workspace.projectDir, "scripts", "block-config.ts");
 	const bootstrapPath = getWorkspaceBootstrapPath(workspace);
@@ -947,6 +962,9 @@ export async function runAddAbilityCommand({
 		await fsp.mkdir(abilityDir, { recursive: true });
 		await fsp.mkdir(path.dirname(phpFilePath), { recursive: true });
 		await ensureAbilityBootstrapAnchors(workspace);
+		await patchFile(bootstrapPath, (source) =>
+			updatePluginHeaderCompatibility(source, compatibilityPolicy),
+		);
 		await ensureAbilityPackageScripts(workspace);
 		await ensureAbilitySyncProjectAnchors(workspace);
 		await ensureAbilityBuildScriptAnchors(workspace);

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai-source-emitters.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai-source-emitters.ts
@@ -3,6 +3,11 @@ import {
 	quoteTsString,
 } from "./cli-add-shared.js";
 import { buildAiFeatureEndpointManifest } from "./ai-feature-artifacts.js";
+import {
+	OPTIONAL_WORDPRESS_AI_CLIENT_COMPATIBILITY,
+	renderScaffoldCompatibilityConfig,
+	resolveScaffoldCompatibilityPolicy,
+} from "./scaffold-compatibility.js";
 import { toTitleCase } from "./string-case.js";
 
 /**
@@ -32,6 +37,9 @@ export function buildAiFeatureConfigEntry(
 ): string {
 	const pascalCase = toPascalCaseFromAiFeatureSlug(aiFeatureSlug);
 	const title = toTitleCase(aiFeatureSlug);
+	const compatibilityPolicy = resolveScaffoldCompatibilityPolicy(
+		OPTIONAL_WORDPRESS_AI_CLIENT_COMPATIBILITY,
+	);
 	const manifest = buildAiFeatureEndpointManifest({
 		namespace,
 		pascalCase,
@@ -47,6 +55,9 @@ export function buildAiFeatureConfigEntry(
 		`\t\tapiFile: ${quoteTsString(`src/ai-features/${aiFeatureSlug}/api.ts`)},`,
 		`\t\tclientFile: ${quoteTsString(
 			`src/ai-features/${aiFeatureSlug}/api-client.ts`,
+		)},`,
+		`\t\tcompatibility: ${renderScaffoldCompatibilityConfig(
+			compatibilityPolicy,
 		)},`,
 		`\t\tdataFile: ${quoteTsString(`src/ai-features/${aiFeatureSlug}/data.ts`)},`,
 		`\t\tnamespace: ${quoteTsString(namespace)},`,

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai.ts
@@ -270,7 +270,7 @@ if ( ! function_exists( '${isSupportedFunctionName}' ) ) {
 
 if ( ! function_exists( '${adminNoticeFunctionName}' ) ) {
 \tfunction ${adminNoticeFunctionName}() {
-\t\tif ( ${isSupportedFunctionName}() || ! current_user_can( 'manage_options' ) ) {
+\t\tif ( ! current_user_can( 'manage_options' ) || ${isSupportedFunctionName}() ) {
 \t\t\treturn;
 \t\t}
 

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai.ts
@@ -230,30 +230,41 @@ if ( ! function_exists( '${buildTelemetryFunctionName}' ) ) {
 
 if ( ! function_exists( '${isSupportedFunctionName}' ) ) {
 \tfunction ${isSupportedFunctionName}() {
+\t\tstatic $is_supported = null;
+\t\tif ( null !== $is_supported ) {
+\t\t\treturn $is_supported;
+\t\t}
+
 \t\tif ( ! function_exists( 'wp_ai_client_prompt' ) ) {
-\t\t\treturn false;
+\t\t\t$is_supported = false;
+\t\t\treturn $is_supported;
 \t\t}
 
 \t\t$schema = ${loadAiSchemaFunctionName}();
 \t\tif ( ! is_array( $schema ) ) {
-\t\t\treturn false;
+\t\t\t$is_supported = false;
+\t\t\treturn $is_supported;
 \t\t}
 
 \t\t$prompt = wp_ai_client_prompt( 'AI feature support probe.' );
 \t\tif ( ! is_object( $prompt ) || ! method_exists( $prompt, 'as_json_response' ) ) {
-\t\t\treturn false;
+\t\t\t$is_supported = false;
+\t\t\treturn $is_supported;
 \t\t}
 
 \t\t$structured_prompt = $prompt->as_json_response( $schema );
 \t\tif ( ! is_object( $structured_prompt ) ) {
-\t\t\treturn false;
+\t\t\t$is_supported = false;
+\t\t\treturn $is_supported;
 \t\t}
 
 \t\tif ( method_exists( $structured_prompt, 'is_supported_for_text_generation' ) ) {
-\t\t\treturn (bool) $structured_prompt->is_supported_for_text_generation();
+\t\t\t$is_supported = (bool) $structured_prompt->is_supported_for_text_generation();
+\t\t\treturn $is_supported;
 \t\t}
 
-\t\treturn method_exists( $structured_prompt, 'generate_text_result' );
+\t\t$is_supported = method_exists( $structured_prompt, 'generate_text_result' );
+\t\treturn $is_supported;
 \t}
 }
 
@@ -263,9 +274,11 @@ if ( ! function_exists( '${adminNoticeFunctionName}' ) ) {
 \t\t\treturn;
 \t\t}
 
-\t\t$message = __( 'The ${aiFeatureTitle} AI feature is optional and remains disabled until the WordPress AI Client is available with structured text generation support for the generated schema.', ${quotePhpString(
-			textDomain,
-		)} );
+\t\t$message = sprintf(
+\t\t\t/* translators: %s: AI feature name. */
+\t\t\t__( 'The %s AI feature is optional and remains disabled until the WordPress AI Client is available with structured text generation support for the generated schema.', ${quotePhpString(textDomain)} ),
+\t\t\t${quotePhpString(aiFeatureTitle)}
+\t\t);
 \t\tprintf( '<div class="notice notice-warning"><p>%s</p></div>', esc_html( $message ) );
 \t}
 }

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai.ts
@@ -6,6 +6,7 @@ import {
 	assertValidGeneratedSlug,
 	getWorkspaceBootstrapPath,
 	normalizeBlockSlug,
+	patchFile,
 	resolveRestResourceNamespace,
 	rollbackWorkspaceMutation,
 	snapshotWorkspaceFiles,
@@ -34,6 +35,11 @@ import {
 } from "./ai-feature-artifacts.js";
 import { appendWorkspaceInventoryEntries, readWorkspaceInventory } from "./workspace-inventory.js";
 import { resolveWorkspaceProject } from "./workspace-project.js";
+import {
+	OPTIONAL_WORDPRESS_AI_CLIENT_COMPATIBILITY,
+	resolveScaffoldCompatibilityPolicy,
+	updatePluginHeaderCompatibility,
+} from "./scaffold-compatibility.js";
 import { toTitleCase } from "./string-case.js";
 
 function quotePhpString(value: string): string {
@@ -44,6 +50,7 @@ function buildAiFeaturePhpSource(
 	aiFeatureSlug: string,
 	namespace: string,
 	phpPrefix: string,
+	textDomain: string,
 ): string {
 	const aiFeatureTitle = toTitleCase(aiFeatureSlug);
 	const aiFeaturePhpId = aiFeatureSlug.replace(/-/g, "_");
@@ -56,6 +63,7 @@ function buildAiFeaturePhpSource(
 	const normalizeProviderTypeFunctionName = `${phpPrefix}_${aiFeaturePhpId}_normalize_provider_type`;
 	const buildTelemetryFunctionName = `${phpPrefix}_${aiFeaturePhpId}_build_ai_feature_telemetry`;
 	const isSupportedFunctionName = `${phpPrefix}_${aiFeaturePhpId}_is_ai_feature_supported`;
+	const adminNoticeFunctionName = `${phpPrefix}_${aiFeaturePhpId}_ai_feature_admin_notice`;
 	const handlerFunctionName = `${phpPrefix}_${aiFeaturePhpId}_handle_run_ai_feature`;
 	const registerRoutesFunctionName = `${phpPrefix}_${aiFeaturePhpId}_register_ai_feature_routes`;
 
@@ -249,6 +257,19 @@ if ( ! function_exists( '${isSupportedFunctionName}' ) ) {
 \t}
 }
 
+if ( ! function_exists( '${adminNoticeFunctionName}' ) ) {
+\tfunction ${adminNoticeFunctionName}() {
+\t\tif ( ${isSupportedFunctionName}() || ! current_user_can( 'manage_options' ) ) {
+\t\t\treturn;
+\t\t}
+
+\t\t$message = __( 'The ${aiFeatureTitle} AI feature is optional and remains disabled until the WordPress AI Client is available with structured text generation support for the generated schema.', ${quotePhpString(
+			textDomain,
+		)} );
+\t\tprintf( '<div class="notice notice-warning"><p>%s</p></div>', esc_html( $message ) );
+\t}
+}
+
 if ( ! function_exists( '${handlerFunctionName}' ) ) {
 \tfunction ${handlerFunctionName}( WP_REST_Request $request ) {
 \t\t$payload = ${validatePayloadFunctionName}( $request->get_json_params(), 'feature-request', 'body' );
@@ -391,6 +412,7 @@ if ( ! function_exists( '${registerRoutesFunctionName}' ) ) {
 \t}
 }
 
+add_action( 'admin_notices', '${adminNoticeFunctionName}' );
 add_action( 'rest_api_init', '${registerRoutesFunctionName}' );
 `;
 }
@@ -422,6 +444,9 @@ export async function runAddAiFeatureCommand({
 		workspace.workspace.namespace,
 		namespace,
 	);
+	const compatibilityPolicy = resolveScaffoldCompatibilityPolicy(
+		OPTIONAL_WORDPRESS_AI_CLIENT_COMPATIBILITY,
+	);
 
 	const inventory = readWorkspaceInventory(workspace.projectDir);
 	assertAiFeatureDoesNotExist(workspace.projectDir, aiFeatureSlug, inventory);
@@ -442,7 +467,6 @@ export async function runAddAiFeatureCommand({
 	const validatorsFilePath = path.join(aiFeatureDir, "api-validators.ts");
 	const apiFilePath = path.join(aiFeatureDir, "api.ts");
 	const dataFilePath = path.join(aiFeatureDir, "data.ts");
-	const clientFilePath = path.join(aiFeatureDir, "api-client.ts");
 	const phpFilePath = path.join(
 		workspace.projectDir,
 		"inc",
@@ -466,6 +490,9 @@ export async function runAddAiFeatureCommand({
 		await fsp.mkdir(aiFeatureDir, { recursive: true });
 		await fsp.mkdir(path.dirname(phpFilePath), { recursive: true });
 		await ensureAiFeatureBootstrapAnchors(workspace);
+		await patchFile(bootstrapPath, (source) =>
+			updatePluginHeaderCompatibility(source, compatibilityPolicy),
+		);
 		const packageScriptChanges = await ensureAiFeaturePackageScripts(workspace);
 		await ensureAiFeatureSyncProjectAnchors(workspace);
 		await ensureAiFeatureSyncRestAnchors(workspace);
@@ -500,6 +527,7 @@ export async function runAddAiFeatureCommand({
 				aiFeatureSlug,
 				resolvedNamespace,
 				workspace.workspace.phpPrefix,
+				workspace.workspace.textDomain,
 			),
 			"utf8",
 		);

--- a/packages/wp-typia-project-tools/src/runtime/index.ts
+++ b/packages/wp-typia-project-tools/src/runtime/index.ts
@@ -32,6 +32,20 @@ export {
 	resolvePackageManagerId,
 	resolveTemplateId,
 } from "./scaffold.js";
+export {
+	DEFAULT_SCAFFOLD_COMPATIBILITY,
+	OPTIONAL_WORDPRESS_AI_CLIENT_COMPATIBILITY,
+	REQUIRED_WORKSPACE_ABILITY_COMPATIBILITY,
+	createScaffoldCompatibilityConfig,
+	renderScaffoldCompatibilityConfig,
+	resolveScaffoldCompatibilityPolicy,
+	updatePluginHeaderCompatibility,
+} from "./scaffold-compatibility.js";
+export type {
+	ScaffoldCompatibilityConfig,
+	ScaffoldCompatibilityPolicy,
+	ScaffoldPluginHeaderCompatibility,
+} from "./scaffold-compatibility.js";
 export { BlockGeneratorService } from "./block-generator-service.js";
 export type {
 	BasicScaffoldTemplateVariableGroups,

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-compatibility.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-compatibility.ts
@@ -219,8 +219,13 @@ function replacePluginHeaderVersionFloor(
 ): string {
 	return source.replace(
 		pattern,
-		(_match, prefix: string, currentValue: string, lineEnding: string) =>
-			`${prefix}${pickHigherHeaderVersionFloor(policyValue, currentValue)}${lineEnding}`,
+		(_match, prefix: string, currentValue: string, lineEnding: string) => {
+			const versionPrefix = prefix.endsWith(":") ? `${prefix} ` : prefix;
+			return `${versionPrefix}${pickHigherHeaderVersionFloor(
+				policyValue,
+				currentValue,
+			)}${lineEnding}`;
+		},
 	);
 }
 
@@ -238,17 +243,17 @@ export function updatePluginHeaderCompatibility(
 
 	const nextSource = replacePluginHeaderVersionFloor(
 		source,
-		/(\* Requires at least:\s*)([^\r\n]*)(\r?)/u,
+		/(\* Requires at least:[^\S\r\n]*)([^\r\n]*)(\r?)/u,
 		pluginHeader.requiresAtLeast,
 	);
 	const nextSourceWithTestedUpTo = replacePluginHeaderVersionFloor(
 		nextSource,
-		/(\* Tested up to:\s*)([^\r\n]*)(\r?)/u,
+		/(\* Tested up to:[^\S\r\n]*)([^\r\n]*)(\r?)/u,
 		pluginHeader.testedUpTo,
 	);
 	return replacePluginHeaderVersionFloor(
 		nextSourceWithTestedUpTo,
-		/(\* Requires PHP:\s*)([^\r\n]*)(\r?)/u,
+		/(\* Requires PHP:[^\S\r\n]*)([^\r\n]*)(\r?)/u,
 		pluginHeader.requiresPhp,
 	);
 }

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-compatibility.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-compatibility.ts
@@ -1,0 +1,213 @@
+import {
+	AI_FEATURE_DEFINITIONS,
+	type AiFeatureCapabilitySelection,
+	type AiFeatureCompatibilityFloor,
+	type ResolvedAiFeatureCapability,
+	type ResolvedAiFeatureCapabilityPlan,
+	resolveAiFeatureCapabilityPlan,
+} from "./ai-feature-capability.js";
+
+export interface ScaffoldPluginHeaderCompatibility {
+	requiresAtLeast: string;
+	requiresPhp: string;
+	testedUpTo: string;
+}
+
+export interface ScaffoldCompatibilityPolicy {
+	capabilityPlan: ResolvedAiFeatureCapabilityPlan;
+	pluginHeader: ScaffoldPluginHeaderCompatibility;
+}
+
+export interface ScaffoldCompatibilityConfig {
+	hardMinimums: AiFeatureCompatibilityFloor;
+	mode: "baseline" | "optional" | "required";
+	optionalFeatures: string[];
+	requiredFeatures: string[];
+	runtimeGates: string[];
+}
+
+export const DEFAULT_SCAFFOLD_COMPATIBILITY: ScaffoldPluginHeaderCompatibility = {
+	requiresAtLeast: "6.7",
+	requiresPhp: "8.0",
+	testedUpTo: "6.9",
+};
+
+export const OPTIONAL_WORDPRESS_AI_CLIENT_COMPATIBILITY: readonly AiFeatureCapabilitySelection[] =
+	[
+		{
+			featureId: AI_FEATURE_DEFINITIONS.wordpressAiClient.id,
+			mode: "optional",
+		},
+	];
+
+export const REQUIRED_WORKSPACE_ABILITY_COMPATIBILITY: readonly AiFeatureCapabilitySelection[] =
+	[
+		{
+			featureId: AI_FEATURE_DEFINITIONS.wordpressServerAbilities.id,
+			mode: "required",
+		},
+		{
+			featureId: AI_FEATURE_DEFINITIONS.wordpressCoreAbilities.id,
+			mode: "required",
+		},
+	];
+
+function parseVersionFloorParts(value: string): number[] {
+	return value.split(".").map((part, index) => {
+		if (!/^\d+$/u.test(part)) {
+			throw new Error(
+				`parseVersionFloorParts received an invalid version floor "${value}" at segment ${index + 1}.`,
+			);
+		}
+		return Number.parseInt(part, 10);
+	});
+}
+
+function compareVersionFloors(left: string, right: string): number {
+	const leftParts = parseVersionFloorParts(left);
+	const rightParts = parseVersionFloorParts(right);
+	const length = Math.max(leftParts.length, rightParts.length);
+
+	for (let index = 0; index < length; index += 1) {
+		const leftValue = leftParts[index] ?? 0;
+		const rightValue = rightParts[index] ?? 0;
+		if (leftValue > rightValue) {
+			return 1;
+		}
+		if (leftValue < rightValue) {
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
+function pickHigherVersionFloor(current: string, candidate: string | undefined): string {
+	if (!candidate) {
+		return current;
+	}
+
+	return compareVersionFloors(current, candidate) >= 0 ? current : candidate;
+}
+
+function pickHigherHeaderVersionFloor(policyValue: string, currentValue: string): string {
+	const normalizedCurrentValue = currentValue.trim();
+	if (!normalizedCurrentValue) {
+		return policyValue;
+	}
+
+	try {
+		return pickHigherVersionFloor(policyValue, normalizedCurrentValue);
+	} catch {
+		return policyValue;
+	}
+}
+
+function formatRuntimeGate(feature: ResolvedAiFeatureCapability): string[] {
+	return (feature.runtimeGates ?? []).map(
+		(gate) => `${feature.label}: ${gate.kind} ${gate.value}`,
+	);
+}
+
+function getPolicyMode(
+	capabilityPlan: ResolvedAiFeatureCapabilityPlan,
+): ScaffoldCompatibilityConfig["mode"] {
+	if (capabilityPlan.requiredFeatures.length > 0) {
+		return "required";
+	}
+	if (capabilityPlan.optionalFeatures.length > 0) {
+		return "optional";
+	}
+	return "baseline";
+}
+
+export function resolveScaffoldCompatibilityPolicy(
+	selections: readonly AiFeatureCapabilitySelection[],
+	{
+		baseline = DEFAULT_SCAFFOLD_COMPATIBILITY,
+	}: {
+		baseline?: ScaffoldPluginHeaderCompatibility;
+	} = {},
+): ScaffoldCompatibilityPolicy {
+	const capabilityPlan = resolveAiFeatureCapabilityPlan(selections);
+	const requiresAtLeast = pickHigherVersionFloor(
+		baseline.requiresAtLeast,
+		capabilityPlan.hardMinimums.wordpress,
+	);
+	const requiresPhp = pickHigherVersionFloor(
+		baseline.requiresPhp,
+		capabilityPlan.hardMinimums.php,
+	);
+	const testedUpTo = pickHigherVersionFloor(baseline.testedUpTo, requiresAtLeast);
+
+	return {
+		capabilityPlan,
+		pluginHeader: {
+			requiresAtLeast,
+			requiresPhp,
+			testedUpTo,
+		},
+	};
+}
+
+export function createScaffoldCompatibilityConfig(
+	policy: ScaffoldCompatibilityPolicy,
+): ScaffoldCompatibilityConfig {
+	const { capabilityPlan } = policy;
+
+	return {
+		hardMinimums: capabilityPlan.hardMinimums,
+		mode: getPolicyMode(capabilityPlan),
+		optionalFeatures: capabilityPlan.optionalFeatures.map((feature) => feature.label),
+		requiredFeatures: capabilityPlan.requiredFeatures.map((feature) => feature.label),
+		runtimeGates: [
+			...capabilityPlan.requiredFeatures.flatMap(formatRuntimeGate),
+			...capabilityPlan.optionalFeatures.flatMap(formatRuntimeGate),
+		],
+	};
+}
+
+export function renderScaffoldCompatibilityConfig(
+	policy: ScaffoldCompatibilityPolicy,
+	indent = "\t\t",
+): string {
+	const config = createScaffoldCompatibilityConfig(policy);
+
+	return JSON.stringify(config, null, "\t")
+		.split("\n")
+		.map((line, index) => (index === 0 ? line : `${indent}${line}`))
+		.join("\n");
+}
+
+export function updatePluginHeaderCompatibility(
+	source: string,
+	policy: ScaffoldCompatibilityPolicy,
+): string {
+	const { pluginHeader } = policy;
+
+	return source
+		.replace(
+			/(\* Requires at least:\s*)([^\n]+)/u,
+			(_match, prefix: string, currentValue: string) =>
+				`${prefix}${pickHigherHeaderVersionFloor(
+					pluginHeader.requiresAtLeast,
+					currentValue,
+				)}`,
+		)
+		.replace(
+			/(\* Tested up to:\s*)([^\n]+)/u,
+			(_match, prefix: string, currentValue: string) =>
+				`${prefix}${pickHigherHeaderVersionFloor(
+					pluginHeader.testedUpTo,
+					currentValue,
+				)}`,
+		)
+		.replace(
+			/(\* Requires PHP:\s*)([^\n]+)/u,
+			(_match, prefix: string, currentValue: string) =>
+				`${prefix}${pickHigherHeaderVersionFloor(
+					pluginHeader.requiresPhp,
+					currentValue,
+				)}`,
+		);
+}

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-compatibility.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-compatibility.ts
@@ -1,3 +1,9 @@
+/**
+ * Compatibility policy helpers for generated scaffold outputs.
+ *
+ * The policy keeps plugin headers, runtime gates, and workspace inventory
+ * metadata aligned when optional or required AI-capable features are added.
+ */
 import {
 	AI_FEATURE_DEFINITIONS,
 	type AiFeatureCapabilitySelection,
@@ -7,17 +13,26 @@ import {
 	resolveAiFeatureCapabilityPlan,
 } from "./ai-feature-capability.js";
 
+/**
+ * WordPress plugin header version floors emitted by scaffold templates.
+ */
 export interface ScaffoldPluginHeaderCompatibility {
 	requiresAtLeast: string;
 	requiresPhp: string;
 	testedUpTo: string;
 }
 
+/**
+ * Resolved compatibility policy for a set of scaffold feature capabilities.
+ */
 export interface ScaffoldCompatibilityPolicy {
 	capabilityPlan: ResolvedAiFeatureCapabilityPlan;
 	pluginHeader: ScaffoldPluginHeaderCompatibility;
 }
 
+/**
+ * Serializable compatibility metadata stored in generated workspace inventory.
+ */
 export interface ScaffoldCompatibilityConfig {
 	hardMinimums: AiFeatureCompatibilityFloor;
 	mode: "baseline" | "optional" | "required";
@@ -26,12 +41,18 @@ export interface ScaffoldCompatibilityConfig {
 	runtimeGates: string[];
 }
 
+/**
+ * Baseline headers used by scaffold output before optional features are added.
+ */
 export const DEFAULT_SCAFFOLD_COMPATIBILITY: ScaffoldPluginHeaderCompatibility = {
 	requiresAtLeast: "6.7",
 	requiresPhp: "8.0",
 	testedUpTo: "6.9",
 };
 
+/**
+ * Optional WordPress AI Client surface used by server-only AI feature scaffold.
+ */
 export const OPTIONAL_WORDPRESS_AI_CLIENT_COMPATIBILITY: readonly AiFeatureCapabilitySelection[] =
 	[
 		{
@@ -40,6 +61,9 @@ export const OPTIONAL_WORDPRESS_AI_CLIENT_COMPATIBILITY: readonly AiFeatureCapab
 		},
 	];
 
+/**
+ * Required Abilities API surface used by typed workflow ability scaffold.
+ */
 export const REQUIRED_WORKSPACE_ABILITY_COMPATIBILITY: readonly AiFeatureCapabilitySelection[] =
 	[
 		{
@@ -121,6 +145,9 @@ function getPolicyMode(
 	return "baseline";
 }
 
+/**
+ * Resolve plugin header floors and capability gates for scaffold selections.
+ */
 export function resolveScaffoldCompatibilityPolicy(
 	selections: readonly AiFeatureCapabilitySelection[],
 	{
@@ -150,6 +177,9 @@ export function resolveScaffoldCompatibilityPolicy(
 	};
 }
 
+/**
+ * Convert a resolved policy into workspace-inventory-safe JSON metadata.
+ */
 export function createScaffoldCompatibilityConfig(
 	policy: ScaffoldCompatibilityPolicy,
 ): ScaffoldCompatibilityConfig {
@@ -167,6 +197,9 @@ export function createScaffoldCompatibilityConfig(
 	};
 }
 
+/**
+ * Render compatibility metadata as formatted TypeScript object literal JSON.
+ */
 export function renderScaffoldCompatibilityConfig(
 	policy: ScaffoldCompatibilityPolicy,
 	indent = "\t\t",
@@ -179,6 +212,9 @@ export function renderScaffoldCompatibilityConfig(
 		.join("\n");
 }
 
+/**
+ * Patch a generated plugin bootstrap header without lowering custom floors.
+ */
 export function updatePluginHeaderCompatibility(
 	source: string,
 	policy: ScaffoldCompatibilityPolicy,

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-compatibility.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-compatibility.ts
@@ -212,8 +212,23 @@ export function renderScaffoldCompatibilityConfig(
 		.join("\n");
 }
 
+function replacePluginHeaderVersionFloor(
+	source: string,
+	pattern: RegExp,
+	policyValue: string,
+): string {
+	return source.replace(
+		pattern,
+		(_match, prefix: string, currentValue: string, lineEnding: string) =>
+			`${prefix}${pickHigherHeaderVersionFloor(policyValue, currentValue)}${lineEnding}`,
+	);
+}
+
 /**
  * Patch a generated plugin bootstrap header without lowering custom floors.
+ *
+ * Preserves the original header line endings while replacing empty or invalid
+ * version strings with the policy values.
  */
 export function updatePluginHeaderCompatibility(
 	source: string,
@@ -221,29 +236,19 @@ export function updatePluginHeaderCompatibility(
 ): string {
 	const { pluginHeader } = policy;
 
-	return source
-		.replace(
-			/(\* Requires at least:\s*)([^\n]+)/u,
-			(_match, prefix: string, currentValue: string) =>
-				`${prefix}${pickHigherHeaderVersionFloor(
-					pluginHeader.requiresAtLeast,
-					currentValue,
-				)}`,
-		)
-		.replace(
-			/(\* Tested up to:\s*)([^\n]+)/u,
-			(_match, prefix: string, currentValue: string) =>
-				`${prefix}${pickHigherHeaderVersionFloor(
-					pluginHeader.testedUpTo,
-					currentValue,
-				)}`,
-		)
-		.replace(
-			/(\* Requires PHP:\s*)([^\n]+)/u,
-			(_match, prefix: string, currentValue: string) =>
-				`${prefix}${pickHigherHeaderVersionFloor(
-					pluginHeader.requiresPhp,
-					currentValue,
-				)}`,
-		);
+	const nextSource = replacePluginHeaderVersionFloor(
+		source,
+		/(\* Requires at least:\s*)([^\r\n]*)(\r?)/u,
+		pluginHeader.requiresAtLeast,
+	);
+	const nextSourceWithTestedUpTo = replacePluginHeaderVersionFloor(
+		nextSource,
+		/(\* Tested up to:\s*)([^\r\n]*)(\r?)/u,
+		pluginHeader.testedUpTo,
+	);
+	return replacePluginHeaderVersionFloor(
+		nextSourceWithTestedUpTo,
+		/(\* Requires PHP:\s*)([^\r\n]*)(\r?)/u,
+		pluginHeader.requiresPhp,
+	);
 }

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-template-variable-groups.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-template-variable-groups.ts
@@ -1,3 +1,5 @@
+import type { ScaffoldPluginHeaderCompatibility } from "./scaffold-compatibility.js";
+
 export const SCAFFOLD_TEMPLATE_VARIABLE_GROUPS = Symbol(
 	"wp-typia.scaffold-template-variable-groups",
 );
@@ -14,11 +16,7 @@ export interface ScaffoldSharedTemplateVariableGroup {
 	author: string;
 	blockMetadataVersion: string;
 	category: string;
-	compatibility: {
-		requiresAtLeast: string;
-		requiresPhp: string;
-		testedUpTo: string;
-	};
+	compatibility: ScaffoldPluginHeaderCompatibility;
 	cssClassName: string;
 	description: string;
 	descriptionJson: string;

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-template-variable-groups.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-template-variable-groups.ts
@@ -14,6 +14,11 @@ export interface ScaffoldSharedTemplateVariableGroup {
 	author: string;
 	blockMetadataVersion: string;
 	category: string;
+	compatibility: {
+		requiresAtLeast: string;
+		requiresPhp: string;
+		testedUpTo: string;
+	};
 	cssClassName: string;
 	description: string;
 	descriptionJson: string;

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-template-variables.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-template-variables.ts
@@ -31,6 +31,7 @@ import {
   toSnakeCase,
 } from './string-case.js';
 import { attachScaffoldTemplateVariableGroups } from "./scaffold-template-variable-groups.js";
+import { resolveScaffoldCompatibilityPolicy } from "./scaffold-compatibility.js";
 
 /**
  * Build the normalized template variables used by scaffold rendering.
@@ -101,6 +102,7 @@ export function getTemplateVariables(
     templateId === 'persistence' || compoundPersistenceEnabled
       ? answers.persistencePolicy ?? 'authenticated'
       : 'authenticated';
+  const compatibility = resolveScaffoldCompatibilityPolicy([]);
 
   const flatVariables: FlatScaffoldTemplateVariables = {
     alternateRenderTargetsCsv: '',
@@ -140,6 +142,8 @@ export function getTemplateVariables(
     hasAlternatePlainTextRenderTarget: 'false',
     hasAlternateRenderTargets: 'false',
     projectToolsPackageVersion,
+    requiresAtLeast: compatibility.pluginHeader.requiresAtLeast,
+    requiresPhp: compatibility.pluginHeader.requiresPhp,
     cssClassName,
     dataStorageMode,
     dashCase: slug,
@@ -170,6 +174,7 @@ export function getTemplateVariables(
     phpPrefix,
     phpPrefixUpper,
     restPackageVersion,
+    testedUpTo: compatibility.pluginHeader.testedUpTo,
     publicWriteRequestIdDeclaration:
       persistencePolicy === 'public'
         ? "publicWriteRequestId: string & tags.MinLength< 1 > & tags.MaxLength< 128 >;"
@@ -219,6 +224,7 @@ export function getTemplateVariables(
       author: answers.author.trim(),
       blockMetadataVersion: BUILTIN_BLOCK_METADATA_VERSION,
       category: metadataDefaults?.category ?? template?.defaultCategory ?? 'widgets',
+      compatibility: compatibility.pluginHeader,
       cssClassName,
       description,
       descriptionJson: JSON.stringify(description),

--- a/packages/wp-typia-project-tools/src/runtime/scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold.ts
@@ -109,6 +109,8 @@ export interface FlatScaffoldTemplateVariables extends Record<string, string> {
 	hasAlternatePlainTextRenderTarget: "false" | "true";
 	hasAlternateRenderTargets: "false" | "true";
 	projectToolsPackageVersion: string;
+	requiresAtLeast: string;
+	requiresPhp: string;
 	cssClassName: string;
 	dashCase: string;
 	dataStorageMode: DataStorageMode;
@@ -141,6 +143,7 @@ export interface FlatScaffoldTemplateVariables extends Record<string, string> {
 	slugSnakeCase: string;
 	textDomain: string;
 	textdomain: string;
+	testedUpTo: string;
 	title: string;
 	titleJson: string;
 	titleCase: string;

--- a/packages/wp-typia-project-tools/src/runtime/workspace-inventory.ts
+++ b/packages/wp-typia-project-tools/src/runtime/workspace-inventory.ts
@@ -850,6 +850,10 @@ function appendEntriesAtMarker(source: string, marker: string, entries: string[]
 	return source.replace(marker, `${entries.join("\n")}\n${marker}`);
 }
 
+function escapeRegex(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
 function ensureInterfaceField(
 	source: string,
 	interfaceName: string,
@@ -857,17 +861,45 @@ function ensureInterfaceField(
 	fieldSource: string,
 ): string {
 	const interfacePattern = new RegExp(
-		`(export\\s+interface\\s+${interfaceName}\\s*\\{\\n)([\\s\\S]*?\\n\\})`,
+		`(export\\s+interface\\s+${escapeRegex(
+			interfaceName,
+		)}\\s*\\{\\r?\\n)([\\s\\S]*?)(\\r?\\n\\})`,
 		"u",
 	);
 
-	return source.replace(interfacePattern, (match, start: string, body: string) => {
-		if (body.includes(`\t${fieldName}?:`)) {
-			return match;
-		}
+	return source.replace(
+		interfacePattern,
+		(match, start: string, body: string, end: string) => {
+			if (new RegExp(`\\t${escapeRegex(fieldName)}\\?:`, "u").test(body)) {
+				return match;
+			}
 
-		return `${start}${fieldSource}${body}`;
-	});
+			const lineEnding = start.endsWith("\r\n") ? "\r\n" : "\n";
+			const formattedFieldSource = `${fieldSource
+				.replace(/\r?\n$/u, "")
+				.split("\n")
+				.join(lineEnding)}${lineEnding}`;
+			const memberPattern = /^(\t)([A-Za-z_$][\w$]*)\??:/gmu;
+
+			for (const member of body.matchAll(memberPattern)) {
+				const memberIndex = member.index;
+				const memberName = member[2];
+				if (memberIndex === undefined || !memberName) {
+					continue;
+				}
+				if (memberName.localeCompare(fieldName) > 0) {
+					return `${start}${body.slice(
+						0,
+						memberIndex,
+					)}${formattedFieldSource}${body.slice(memberIndex)}${end}`;
+				}
+			}
+
+			return `${start}${body}${
+				body.length > 0 && !body.endsWith(lineEnding) ? lineEnding : ""
+			}${formattedFieldSource}${end}`;
+		},
+	);
 }
 
 /**

--- a/packages/wp-typia-project-tools/src/runtime/workspace-inventory.ts
+++ b/packages/wp-typia-project-tools/src/runtime/workspace-inventory.ts
@@ -870,7 +870,7 @@ function ensureInterfaceField(
 	return source.replace(
 		interfacePattern,
 		(match, start: string, body: string, end: string) => {
-			if (new RegExp(`\\t${escapeRegex(fieldName)}\\?:`, "u").test(body)) {
+			if (new RegExp(`^[ \t]*${escapeRegex(fieldName)}\\??:`, "mu").test(body)) {
 				return match;
 			}
 
@@ -879,11 +879,11 @@ function ensureInterfaceField(
 				.replace(/\r?\n$/u, "")
 				.split("\n")
 				.join(lineEnding)}${lineEnding}`;
-			const memberPattern = /^(\t)([A-Za-z_$][\w$]*)\??:/gmu;
+			const memberPattern = /^[ \t]*([A-Za-z_$][\w$]*)\??:/gmu;
 
 			for (const member of body.matchAll(memberPattern)) {
 				const memberIndex = member.index;
-				const memberName = member[2];
+				const memberName = member[1];
 				if (memberIndex === undefined || !memberName) {
 					continue;
 				}

--- a/packages/wp-typia-project-tools/src/runtime/workspace-inventory.ts
+++ b/packages/wp-typia-project-tools/src/runtime/workspace-inventory.ts
@@ -209,11 +209,23 @@ export const REST_RESOURCES: WorkspaceRestResourceConfig[] = [
 ];
 `;
 
+const WORKSPACE_COMPATIBILITY_CONFIG_FIELD = `\tcompatibility?: {
+\t\thardMinimums: {
+\t\t\tphp?: string;
+\t\t\twordpress?: string;
+\t\t};
+\t\tmode: 'baseline' | 'optional' | 'required';
+\t\toptionalFeatures: string[];
+\t\trequiredFeatures: string[];
+\t\truntimeGates: string[];
+\t};
+`;
+
 const ABILITIES_INTERFACE_SECTION = `
 
 export interface WorkspaceAbilityConfig {
 \tclientFile: string;
-\tconfigFile: string;
+${WORKSPACE_COMPATIBILITY_CONFIG_FIELD}\tconfigFile: string;
 \tdataFile: string;
 \tinputSchemaFile: string;
 \tinputTypeName: string;
@@ -238,7 +250,7 @@ export interface WorkspaceAiFeatureConfig {
 \taiSchemaFile: string;
 \tapiFile: string;
 \tclientFile: string;
-\tdataFile: string;
+${WORKSPACE_COMPATIBILITY_CONFIG_FIELD}\tdataFile: string;
 \tnamespace: string;
 \topenApiFile: string;
 \tphpFile: string;
@@ -838,6 +850,26 @@ function appendEntriesAtMarker(source: string, marker: string, entries: string[]
 	return source.replace(marker, `${entries.join("\n")}\n${marker}`);
 }
 
+function ensureInterfaceField(
+	source: string,
+	interfaceName: string,
+	fieldName: string,
+	fieldSource: string,
+): string {
+	const interfacePattern = new RegExp(
+		`(export\\s+interface\\s+${interfaceName}\\s*\\{\\n)([\\s\\S]*?\\n\\})`,
+		"u",
+	);
+
+	return source.replace(interfacePattern, (match, start: string, body: string) => {
+		if (body.includes(`\t${fieldName}?:`)) {
+			return match;
+		}
+
+		return `${start}${fieldSource}${body}`;
+	});
+}
+
 /**
  * Update `scripts/block-config.ts` source text with additional inventory entries.
  *
@@ -900,6 +932,18 @@ export function updateWorkspaceInventorySource(
 		nextSource,
 		AI_FEATURE_CONFIG_ENTRY_MARKER,
 		aiFeatureEntries,
+	);
+	nextSource = ensureInterfaceField(
+		nextSource,
+		"WorkspaceAbilityConfig",
+		"compatibility",
+		WORKSPACE_COMPATIBILITY_CONFIG_FIELD,
+	);
+	nextSource = ensureInterfaceField(
+		nextSource,
+		"WorkspaceAiFeatureConfig",
+		"compatibility",
+		WORKSPACE_COMPATIBILITY_CONFIG_FIELD,
 	);
 	nextSource = appendEntriesAtMarker(
 		nextSource,

--- a/packages/wp-typia-project-tools/templates/_shared/base/{{slugKebabCase}}.php.mustache
+++ b/packages/wp-typia-project-tools/templates/_shared/base/{{slugKebabCase}}.php.mustache
@@ -3,9 +3,9 @@
  * Plugin Name:       {{title}}
  * Description:       {{description}}
  * Version:           0.1.0
- * Requires at least: 6.7
- * Tested up to:      6.9
- * Requires PHP:      8.0
+ * Requires at least: {{requiresAtLeast}}
+ * Tested up to:      {{testedUpTo}}
+ * Requires PHP:      {{requiresPhp}}
  * Author:            {{author}}
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/packages/wp-typia-project-tools/templates/_shared/compound/core/{{slugKebabCase}}.php.mustache
+++ b/packages/wp-typia-project-tools/templates/_shared/compound/core/{{slugKebabCase}}.php.mustache
@@ -3,9 +3,9 @@
  * Plugin Name:       {{title}}
  * Description:       {{description}}
  * Version:           0.1.0
- * Requires at least: 6.7
- * Tested up to:      6.9
- * Requires PHP:      8.0
+ * Requires at least: {{requiresAtLeast}}
+ * Tested up to:      {{testedUpTo}}
+ * Requires PHP:      {{requiresPhp}}
  * Author:            {{author}}
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/packages/wp-typia-project-tools/templates/_shared/compound/persistence-auth/{{slugKebabCase}}.php.mustache
+++ b/packages/wp-typia-project-tools/templates/_shared/compound/persistence-auth/{{slugKebabCase}}.php.mustache
@@ -3,9 +3,9 @@
  * Plugin Name:       {{title}}
  * Description:       {{description}}
  * Version:           0.1.0
- * Requires at least: 6.7
- * Tested up to:      6.9
- * Requires PHP:      8.0
+ * Requires at least: {{requiresAtLeast}}
+ * Tested up to:      {{testedUpTo}}
+ * Requires PHP:      {{requiresPhp}}
  * Author:            {{author}}
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/packages/wp-typia-project-tools/templates/_shared/compound/persistence-public/{{slugKebabCase}}.php.mustache
+++ b/packages/wp-typia-project-tools/templates/_shared/compound/persistence-public/{{slugKebabCase}}.php.mustache
@@ -3,9 +3,9 @@
  * Plugin Name:       {{title}}
  * Description:       {{description}}
  * Version:           0.1.0
- * Requires at least: 6.7
- * Tested up to:      6.9
- * Requires PHP:      8.0
+ * Requires at least: {{requiresAtLeast}}
+ * Tested up to:      {{testedUpTo}}
+ * Requires PHP:      {{requiresPhp}}
  * Author:            {{author}}
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/packages/wp-typia-project-tools/templates/_shared/persistence/auth/{{slugKebabCase}}.php.mustache
+++ b/packages/wp-typia-project-tools/templates/_shared/persistence/auth/{{slugKebabCase}}.php.mustache
@@ -3,9 +3,9 @@
  * Plugin Name:       {{title}}
  * Description:       {{description}}
  * Version:           0.1.0
- * Requires at least: 6.7
- * Tested up to:      6.9
- * Requires PHP:      8.0
+ * Requires at least: {{requiresAtLeast}}
+ * Tested up to:      {{testedUpTo}}
+ * Requires PHP:      {{requiresPhp}}
  * Author:            {{author}}
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/packages/wp-typia-project-tools/templates/_shared/persistence/core/{{slugKebabCase}}.php.mustache
+++ b/packages/wp-typia-project-tools/templates/_shared/persistence/core/{{slugKebabCase}}.php.mustache
@@ -3,9 +3,9 @@
  * Plugin Name:       {{title}}
  * Description:       {{description}}
  * Version:           0.1.0
- * Requires at least: 6.7
- * Tested up to:      6.9
- * Requires PHP:      8.0
+ * Requires at least: {{requiresAtLeast}}
+ * Tested up to:      {{testedUpTo}}
+ * Requires PHP:      {{requiresPhp}}
  * Author:            {{author}}
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/packages/wp-typia-project-tools/templates/_shared/persistence/public/{{slugKebabCase}}.php.mustache
+++ b/packages/wp-typia-project-tools/templates/_shared/persistence/public/{{slugKebabCase}}.php.mustache
@@ -3,9 +3,9 @@
  * Plugin Name:       {{title}}
  * Description:       {{description}}
  * Version:           0.1.0
- * Requires at least: 6.7
- * Tested up to:      6.9
- * Requires PHP:      8.0
+ * Requires at least: {{requiresAtLeast}}
+ * Tested up to:      {{testedUpTo}}
+ * Requires PHP:      {{requiresPhp}}
  * Author:            {{author}}
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/packages/wp-typia-project-tools/templates/query-loop/{{slugKebabCase}}.php.mustache
+++ b/packages/wp-typia-project-tools/templates/query-loop/{{slugKebabCase}}.php.mustache
@@ -3,9 +3,9 @@
  * Plugin Name:       {{title}}
  * Description:       {{description}}
  * Version:           0.1.0
- * Requires at least: 6.7
- * Tested up to:      6.9
- * Requires PHP:      8.0
+ * Requires at least: {{requiresAtLeast}}
+ * Tested up to:      {{testedUpTo}}
+ * Requires PHP:      {{requiresPhp}}
  * Author:            {{author}}
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/packages/wp-typia-project-tools/tests/fixtures/create-block-external/plugin-templates/{{slugKebabCase}}.php.mustache
+++ b/packages/wp-typia-project-tools/tests/fixtures/create-block-external/plugin-templates/{{slugKebabCase}}.php.mustache
@@ -3,9 +3,9 @@
  * Plugin Name:       {{title}}
  * Description:       {{description}}
  * Version:           0.1.0
- * Requires at least: 6.7
- * Tested up to:      6.9
- * Requires PHP:      8.0
+ * Requires at least: {{requiresAtLeast}}
+ * Tested up to:      {{testedUpTo}}
+ * Requires PHP:      {{requiresPhp}}
  * Author:            {{author}}
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/packages/wp-typia-project-tools/tests/wordpress-ai-spec.test.ts
+++ b/packages/wp-typia-project-tools/tests/wordpress-ai-spec.test.ts
@@ -352,6 +352,33 @@ describe('WordPress AI AbilitySpec foundation', () => {
     expect(nextSource).toContain(' * Requires PHP:      8.1');
   });
 
+  test('preserves CRLF plugin header line endings when updating compatibility floors', () => {
+    const source = [
+      '<?php',
+      '/**',
+      ' * Plugin Name: Demo',
+      ' * Requires at least: 6.7',
+      ' * Tested up to:      6.9',
+      ' * Requires PHP:      8.0',
+      ' */',
+      '',
+    ].join('\r\n');
+    const nextSource = updatePluginHeaderCompatibility(
+      source,
+      resolveScaffoldCompatibilityPolicy(
+        REQUIRED_WORKSPACE_ABILITY_COMPATIBILITY,
+      ),
+    );
+
+    expect(nextSource).toContain(' * Requires at least: 7.0\r\n');
+    expect(nextSource).toContain(' * Tested up to:      7.0\r\n');
+    expect(nextSource).toContain(' * Requires PHP:      8.0\r\n');
+    const linesBeforeTerminalNewline = nextSource.split('\n').slice(0, -1);
+    expect(
+      linesBeforeTerminalNewline.every((line) => line.endsWith('\r')),
+    ).toBe(true);
+  });
+
   test('rejects invalid version floor segments instead of silently comparing them', () => {
     expect(() =>
       resolveAiFeatureCapabilityPlan(

--- a/packages/wp-typia-project-tools/tests/wordpress-ai-spec.test.ts
+++ b/packages/wp-typia-project-tools/tests/wordpress-ai-spec.test.ts
@@ -379,6 +379,30 @@ describe('WordPress AI AbilitySpec foundation', () => {
     ).toBe(true);
   });
 
+  test('updates empty plugin header values without consuming following header lines', () => {
+    const source = [
+      '<?php',
+      '/**',
+      ' * Plugin Name: Demo',
+      ' * Requires at least:',
+      ' * Tested up to:',
+      ' * Requires PHP:',
+      ' */',
+      '',
+    ].join('\n');
+    const nextSource = updatePluginHeaderCompatibility(
+      source,
+      resolveScaffoldCompatibilityPolicy(
+        REQUIRED_WORKSPACE_ABILITY_COMPATIBILITY,
+      ),
+    );
+
+    expect(nextSource).toContain(' * Requires at least: 7.0\n');
+    expect(nextSource).toContain(' * Tested up to: 7.0\n');
+    expect(nextSource).toContain(' * Requires PHP: 8.0\n');
+    expect(nextSource).toContain(' */');
+  });
+
   test('rejects invalid version floor segments instead of silently comparing them', () => {
     expect(() =>
       resolveAiFeatureCapabilityPlan(

--- a/packages/wp-typia-project-tools/tests/wordpress-ai-spec.test.ts
+++ b/packages/wp-typia-project-tools/tests/wordpress-ai-spec.test.ts
@@ -9,6 +9,14 @@ import {
   AI_FEATURE_DEFINITIONS,
   resolveAiFeatureCapabilityPlan,
 } from '../src/internal/ai-feature-capability.js';
+import {
+  DEFAULT_SCAFFOLD_COMPATIBILITY,
+  OPTIONAL_WORDPRESS_AI_CLIENT_COMPATIBILITY,
+  REQUIRED_WORKSPACE_ABILITY_COMPATIBILITY,
+  createScaffoldCompatibilityConfig,
+  resolveScaffoldCompatibilityPolicy,
+  updatePluginHeaderCompatibility,
+} from '../src/internal/scaffold-compatibility.js';
 import { buildWordPressAbilitiesDocument } from '../src/internal/wordpress-ai.js';
 
 const RESPONSE_SCHEMA = {
@@ -246,6 +254,102 @@ describe('WordPress AI AbilitySpec foundation', () => {
     expect(plan.optionalFeatures.map((feature) => feature.id)).toEqual([
       AI_FEATURE_DEFINITIONS.wordpressAiClient.id,
     ]);
+  });
+
+  test('maps optional and required AI scaffold compatibility into headers and generated config', () => {
+    const optionalPolicy = resolveScaffoldCompatibilityPolicy(
+      OPTIONAL_WORDPRESS_AI_CLIENT_COMPATIBILITY,
+    );
+    expect(optionalPolicy.pluginHeader).toEqual(
+      DEFAULT_SCAFFOLD_COMPATIBILITY,
+    );
+    expect(createScaffoldCompatibilityConfig(optionalPolicy)).toMatchObject({
+      mode: 'optional',
+      optionalFeatures: ['WordPress AI Client'],
+      requiredFeatures: [],
+      runtimeGates: ['WordPress AI Client: wordpress-core-feature WordPress AI Client'],
+    });
+
+    const requiredPolicy = resolveScaffoldCompatibilityPolicy(
+      REQUIRED_WORKSPACE_ABILITY_COMPATIBILITY,
+    );
+    expect(requiredPolicy.pluginHeader).toEqual({
+      requiresAtLeast: '7.0',
+      requiresPhp: '8.0',
+      testedUpTo: '7.0',
+    });
+    expect(createScaffoldCompatibilityConfig(requiredPolicy)).toMatchObject({
+      hardMinimums: {
+        wordpress: '7.0',
+      },
+      mode: 'required',
+      optionalFeatures: [],
+      requiredFeatures: [
+        'WordPress Abilities API',
+        '@wordpress/core-abilities',
+      ],
+    });
+  });
+
+  test('updates generated plugin headers from scaffold compatibility policy', () => {
+    const source = [
+      '<?php',
+      '/**',
+      ' * Plugin Name: Demo',
+      ' * Requires at least: 6.7',
+      ' * Tested up to:      6.9',
+      ' * Requires PHP:      8.0',
+      ' */',
+      '',
+    ].join('\n');
+
+    expect(
+      updatePluginHeaderCompatibility(
+        source,
+        resolveScaffoldCompatibilityPolicy(
+          OPTIONAL_WORDPRESS_AI_CLIENT_COMPATIBILITY,
+        ),
+      ),
+    ).toContain(' * Requires at least: 6.7');
+    expect(
+      updatePluginHeaderCompatibility(
+        source,
+        resolveScaffoldCompatibilityPolicy(
+          REQUIRED_WORKSPACE_ABILITY_COMPATIBILITY,
+        ),
+      ),
+    ).toContain(' * Requires at least: 7.0');
+    expect(
+      updatePluginHeaderCompatibility(
+        source,
+        resolveScaffoldCompatibilityPolicy(
+          REQUIRED_WORKSPACE_ABILITY_COMPATIBILITY,
+        ),
+      ),
+    ).toContain(' * Tested up to:      7.0');
+  });
+
+  test('does not lower custom plugin headers that already exceed the policy floor', () => {
+    const source = [
+      '<?php',
+      '/**',
+      ' * Plugin Name: Demo',
+      ' * Requires at least: 7.1',
+      ' * Tested up to:      7.2',
+      ' * Requires PHP:      8.1',
+      ' */',
+      '',
+    ].join('\n');
+    const nextSource = updatePluginHeaderCompatibility(
+      source,
+      resolveScaffoldCompatibilityPolicy(
+        REQUIRED_WORKSPACE_ABILITY_COMPATIBILITY,
+      ),
+    );
+
+    expect(nextSource).toContain(' * Requires at least: 7.1');
+    expect(nextSource).toContain(' * Tested up to:      7.2');
+    expect(nextSource).toContain(' * Requires PHP:      8.1');
   });
 
   test('rejects invalid version floor segments instead of silently comparing them', () => {

--- a/packages/wp-typia-project-tools/tests/workspace-add.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-add.test.ts
@@ -3033,9 +3033,12 @@ test("canonical CLI can add a server-only AI feature to an official workspace te
   expect(apiSource).toContain("resolveRestNonce");
   expect(dataSource).toContain("useRunBriefSuggestionsAiFeatureMutation");
   expect(phpSource).toContain("wp_ai_client_prompt");
+  expect(phpSource).toContain("static $is_supported = null;");
   expect(phpSource).toContain("is_supported_for_text_generation");
   expect(phpSource).toContain("generate_text_result");
   expect(phpSource).toContain("admin_notices");
+  expect(phpSource).toContain("sprintf(");
+  expect(phpSource).toContain("The %s AI feature is optional");
   expect(phpSource).toContain("optional and remains disabled");
   expect(phpSource).toContain("register_rest_route");
   expect(phpSource).toContain("'demo-space/v1'");

--- a/packages/wp-typia-project-tools/tests/workspace-add.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-add.test.ts
@@ -3040,6 +3040,16 @@ test("canonical CLI can add a server-only AI feature to an official workspace te
   expect(phpSource).toContain("sprintf(");
   expect(phpSource).toContain("The %s AI feature is optional");
   expect(phpSource).toContain("optional and remains disabled");
+  const adminNoticeSource = phpSource.slice(
+    phpSource.indexOf("function demo_space_brief_suggestions_ai_feature_admin_notice")
+  );
+  expect(
+    adminNoticeSource.indexOf("! current_user_can( 'manage_options' )")
+  ).toBeLessThan(
+    adminNoticeSource.indexOf(
+      "demo_space_brief_suggestions_is_ai_feature_supported()"
+    )
+  );
   expect(phpSource).toContain("register_rest_route");
   expect(phpSource).toContain("'demo-space/v1'");
 

--- a/packages/wp-typia-project-tools/tests/workspace-add.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-add.test.ts
@@ -3001,7 +3001,14 @@ test("canonical CLI can add a server-only AI feature to an official workspace te
   expect(blockConfigSource).toContain(
     'phpFile: "inc/ai-features/brief-suggestions.php"'
   );
+  expect(blockConfigSource).toContain('"mode": "optional"');
+  expect(blockConfigSource).toContain("WordPress AI Client");
+  expect(blockConfigSource).toContain(
+    "WordPress AI Client: wordpress-core-feature WordPress AI Client"
+  );
   expect(blockConfigSource).toContain("defineEndpointManifest");
+  expect(bootstrapSource).toContain("Requires at least: 6.7");
+  expect(bootstrapSource).toContain("Tested up to:      6.9");
   expect(bootstrapSource).toContain("function demo_space_register_ai_features()");
   expect(bootstrapSource).toContain("inc/ai-features/*.php");
   expect(packageJson.scripts?.["sync-ai"]).toBe("tsx scripts/sync-ai-features.ts");
@@ -3028,6 +3035,8 @@ test("canonical CLI can add a server-only AI feature to an official workspace te
   expect(phpSource).toContain("wp_ai_client_prompt");
   expect(phpSource).toContain("is_supported_for_text_generation");
   expect(phpSource).toContain("generate_text_result");
+  expect(phpSource).toContain("admin_notices");
+  expect(phpSource).toContain("optional and remains disabled");
   expect(phpSource).toContain("register_rest_route");
   expect(phpSource).toContain("'demo-space/v1'");
 
@@ -3200,6 +3209,11 @@ test("canonical CLI can add a typed workflow ability to an official workspace te
   expect(blockConfigSource).toContain(
     'outputTypeName: "ReviewWorkflowAbilityOutput"'
   );
+  expect(blockConfigSource).toContain('"mode": "required"');
+  expect(blockConfigSource).toContain("WordPress Abilities API");
+  expect(blockConfigSource).toContain("@wordpress/core-abilities");
+  expect(bootstrapSource).toContain("Requires at least: 7.0");
+  expect(bootstrapSource).toContain("Tested up to:      7.0");
   expect(bootstrapSource).toContain("inc/abilities/*.php");
   expect(bootstrapSource).toContain("build/abilities/index.js");
   expect(bootstrapSource).toContain("plugins_loaded");

--- a/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
@@ -476,6 +476,45 @@ export interface WorkspaceAiFeatureConfig {
   expect(repairedSource).toContain("\t};\r\n\tdataFile: string;");
 });
 
+test("workspace inventory repair does not duplicate spaced compatibility fields", () => {
+  const repairedSource = updateWorkspaceInventorySource(`
+export interface WorkspaceAbilityConfig {
+  clientFile: string;
+  compatibility: {
+    hardMinimums: {
+      php?: string;
+      wordpress?: string;
+    };
+    mode: 'baseline' | 'optional' | 'required';
+    optionalFeatures: string[];
+    requiredFeatures: string[];
+    runtimeGates: string[];
+  };
+  configFile: string;
+  slug: string;
+}
+
+export interface WorkspaceAiFeatureConfig {
+  aiSchemaFile: string;
+  clientFile: string;
+  compatibility?: {
+    hardMinimums: {
+      php?: string;
+      wordpress?: string;
+    };
+    mode: 'baseline' | 'optional' | 'required';
+    optionalFeatures: string[];
+    requiredFeatures: string[];
+    runtimeGates: string[];
+  };
+  dataFile: string;
+  slug: string;
+}
+`);
+
+  expect(repairedSource.match(/^[ \t]*compatibility\??:/gmu)?.length).toBe(2);
+});
+
 test("doctor passes on a healthy multi-block workspace", async () => {
   const targetDir = path.join(tempRoot, "demo-workspace-doctor-multi-block");
 

--- a/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
@@ -450,6 +450,32 @@ export const EDITOR_PLUGINS: WorkspaceEditorPluginConfig[] = [
   expect(repairedSource).toContain('slug: "document-tools"');
 });
 
+test("workspace inventory repair inserts compatibility fields in CRLF inventory interfaces", () => {
+  const source = `export interface WorkspaceAbilityConfig {
+\tclientFile: string;
+\tconfigFile: string;
+\tdataFile: string;
+\tslug: string;
+}
+
+export interface WorkspaceAiFeatureConfig {
+\taiSchemaFile: string;
+\tapiFile: string;
+\tclientFile: string;
+\tdataFile: string;
+\tslug: string;
+}
+`.replace(/\n/gu, "\r\n");
+
+  const repairedSource = updateWorkspaceInventorySource(source);
+
+  expect(repairedSource).toContain(
+    "\tclientFile: string;\r\n\tcompatibility?: {\r\n\t\thardMinimums:"
+  );
+  expect(repairedSource).toContain("\t};\r\n\tconfigFile: string;");
+  expect(repairedSource).toContain("\t};\r\n\tdataFile: string;");
+});
+
 test("doctor passes on a healthy multi-block workspace", async () => {
   const targetDir = path.join(tempRoot, "demo-workspace-doctor-multi-block");
 

--- a/tests/helpers/scaffold-template-variables.ts
+++ b/tests/helpers/scaffold-template-variables.ts
@@ -14,7 +14,7 @@ export function createTestScaffoldTemplateVariables(
 		templateFamily,
 		...flatOverrides
 	} = overrides;
-	const base: FlatScaffoldTemplateVariables = {
+		const base: FlatScaffoldTemplateVariables = {
 		alternateRenderTargetsCsv: "",
 		alternateRenderTargetsJson: "[]",
 		apiClientPackageVersion: "^0.2.0",
@@ -65,11 +65,13 @@ export function createTestScaffoldTemplateVariables(
 		phpPrefixUpper: "DEMO_BLOCK",
 		queryAllowedControlsJson: JSON.stringify([]),
 		queryPostType: "post",
-		queryPostTypeJson: JSON.stringify("post"),
-		queryVariationNamespace: "demo/demo-block",
-		queryVariationNamespaceJson: JSON.stringify("demo/demo-block"),
-		publicWriteRequestIdDeclaration: "publicWriteRequestId?: string;",
-		restPackageVersion: "^0.2.0",
+			queryPostTypeJson: JSON.stringify("post"),
+			queryVariationNamespace: "demo/demo-block",
+			queryVariationNamespaceJson: JSON.stringify("demo/demo-block"),
+			publicWriteRequestIdDeclaration: "publicWriteRequestId?: string;",
+			requiresAtLeast: "6.7",
+			requiresPhp: "8.0",
+			restPackageVersion: "^0.2.0",
 		restWriteAuthIntent: "authenticated",
 		restWriteAuthMechanism: "rest-nonce",
 		restWriteAuthMode: "authenticated-rest-nonce",
@@ -79,10 +81,11 @@ export function createTestScaffoldTemplateVariables(
 		slugSnakeCase: "demo_block",
 		textDomain: "demo-block",
 		textdomain: "demo-block",
-		title: "Demo Block",
-		titleCase: "Demo Block",
-		titleJson: JSON.stringify("Demo Block"),
-	};
+			title: "Demo Block",
+			titleCase: "Demo Block",
+			titleJson: JSON.stringify("Demo Block"),
+			testedUpTo: "6.9",
+		};
 
 	const variables: FlatScaffoldTemplateVariables = {
 		...base,
@@ -97,8 +100,6 @@ export function createTestScaffoldTemplateVariables(
 	const family = templateFamily ?? inferTemplateFamily(flatOverrides);
 	const compoundPersistenceEnabled =
 		family === "compound" && variables.compoundPersistenceEnabled === "true";
-	const persistenceEnabled =
-		family === "persistence" || compoundPersistenceEnabled;
 	const alternateRenderTargets = {
 		csv: variables.alternateRenderTargetsCsv,
 		enabled: variables.hasAlternateRenderTargets === "true",
@@ -109,10 +110,15 @@ export function createTestScaffoldTemplateVariables(
 		targets: JSON.parse(variables.alternateRenderTargetsJson) as string[],
 	};
 	const shared = {
-		author: variables.author,
-		blockMetadataVersion: variables.blockMetadataVersion,
-		category: variables.category,
-		cssClassName: variables.cssClassName,
+			author: variables.author,
+			blockMetadataVersion: variables.blockMetadataVersion,
+			category: variables.category,
+			compatibility: {
+				requiresAtLeast: variables.requiresAtLeast,
+				requiresPhp: variables.requiresPhp,
+				testedUpTo: variables.testedUpTo,
+			},
+			cssClassName: variables.cssClassName,
 		description: variables.description,
 		descriptionJson: variables.descriptionJson,
 		frontendCssClassName: variables.frontendCssClassName,


### PR DESCRIPTION
## Summary

- Adds an explicit scaffold compatibility policy for AI-capable generated projects.
- Keeps baseline/non-AI and optional WordPress AI Client scaffolds on the existing WordPress 6.7 / PHP 8.0 plugin header floor.
- Raises typed workflow ability scaffolds to the required WordPress 7.0 floor and records required/optional capability metadata in workspace inventory.
- Adds docs and regression coverage for plugin header updates, runtime gates, admin notices, and generated block-config compatibility metadata.

Closes #561

## Validation

- `bun run --filter @wp-typia/project-tools test:scaffold-core`
- `bun run --filter @wp-typia/project-tools test:workspace`
- `bun test packages/wp-typia-project-tools/tests/wordpress-ai-spec.test.ts`
- `bun test packages/wp-typia-project-tools/tests/workspace-add.test.ts -t "server-only AI feature"`
- `bun test packages/wp-typia-project-tools/tests/workspace-add.test.ts -t "typed workflow ability"`
- `bun run typecheck`
- `bun run format:check`
- `bun run docs:build:site`
- `bun run changesets:validate`
- `bun run runtime-coupling:validate`
- `bun run typescript-strictness:validate`
- `bun run formatting-policy:validate`
- targeted ESLint on touched TypeScript files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Implemented AI scaffold compatibility policy that drives generated plugin header version fields and injects compatibility metadata into workspace config and templates.
  * Generated scaffolds emit admin notices and runtime guards for optional AI features.

* **Documentation**
  * Added a guide and API reference linking the compatibility policy, modes, version baselines, and runtime-gating behavior.

* **Tests**
  * Added tests validating policy resolution, plugin-header updates, workspace inventory compatibility, and generated template variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->