### PR TITLE
fix(ci): align npm smoke project-tools overrides

### DIFF
--- a/scripts/lib/generated-project-smoke-core.mjs
+++ b/scripts/lib/generated-project-smoke-core.mjs
@@ -206,6 +206,14 @@ export function rewriteWorkspaceDependencies(projectDir, packageManager) {
 	if (packageJson.dependencies?.["wp-typia"]) {
 		packageJson.dependencies["wp-typia"] = localCliDependency;
 	}
+	if (packageJson.devDependencies?.["@wp-typia/project-tools"]) {
+		packageJson.devDependencies["@wp-typia/project-tools"] =
+			localProjectToolsDependency;
+	}
+	if (packageJson.dependencies?.["@wp-typia/project-tools"]) {
+		packageJson.dependencies["@wp-typia/project-tools"] =
+			localProjectToolsDependency;
+	}
 
 	const linkedRuntimePackages = [
 		"@wp-typia/block-runtime",

--- a/tests/unit/generated-project-smoke-reference-lane.test.ts
+++ b/tests/unit/generated-project-smoke-reference-lane.test.ts
@@ -193,6 +193,12 @@ test("workspace dependency rewrite keeps npm project-tools overrides compatible 
 	expect(rewrittenPackageJson.overrides["@wp-typia/project-tools"]).toBe(
 		rewrittenPackageJson.devDependencies["@wp-typia/project-tools"],
 	);
+	expect(rewrittenPackageJson.pnpm.overrides["@wp-typia/project-tools"]).toBe(
+		rewrittenPackageJson.devDependencies["@wp-typia/project-tools"],
+	);
+	expect(rewrittenPackageJson.resolutions["@wp-typia/project-tools"]).toBe(
+		rewrittenPackageJson.devDependencies["@wp-typia/project-tools"],
+	);
 });
 
 test("generated project smoke assertions accept local project-tools smoke rewrites", async () => {

--- a/tests/unit/generated-project-smoke-reference-lane.test.ts
+++ b/tests/unit/generated-project-smoke-reference-lane.test.ts
@@ -146,6 +146,55 @@ test("workspace dependency rewrite seeds local runtime packages for linked Bun r
 	);
 });
 
+test("workspace dependency rewrite keeps npm project-tools overrides compatible with direct dependencies", async () => {
+	const projectDir = fs.mkdtempSync(
+		join(os.tmpdir(), "wp-typia-generated-smoke-npm-overrides-"),
+	);
+	tempDirs.push(projectDir);
+
+	const packageJsonPath = join(projectDir, "package.json");
+	fs.writeFileSync(
+		packageJsonPath,
+		`${JSON.stringify(
+			{
+				name: "my-typia-block",
+				private: true,
+				devDependencies: {
+					"@wp-typia/project-tools": "^0.20.0",
+					"wp-typia": "^0.20.3",
+				},
+			},
+			null,
+			2,
+		)}\n`,
+		"utf8",
+	);
+
+	const { rewriteWorkspaceDependencies } = (await import(
+		new URL("../../scripts/lib/generated-project-smoke-core.mjs", import.meta.url).href
+	)) as {
+		rewriteWorkspaceDependencies: (
+			projectDir: string,
+			packageManager: "bun" | "npm" | "pnpm" | "yarn",
+		) => void;
+	};
+
+	rewriteWorkspaceDependencies(projectDir, "npm");
+
+	const rewrittenPackageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+
+	expect(rewrittenPackageJson.packageManager).toBe("npm@11.6.1");
+	expect(rewrittenPackageJson.devDependencies["@wp-typia/project-tools"]).toContain(
+		"packages/wp-typia-project-tools",
+	);
+	expect(rewrittenPackageJson.devDependencies["wp-typia"]).toContain(
+		"packages/wp-typia",
+	);
+	expect(rewrittenPackageJson.overrides["@wp-typia/project-tools"]).toBe(
+		rewrittenPackageJson.devDependencies["@wp-typia/project-tools"],
+	);
+});
+
 test("generated project smoke assertions accept local project-tools smoke rewrites", async () => {
 	const projectDir = fs.mkdtempSync(
 		join(os.tmpdir(), "wp-typia-generated-smoke-boundary-"),


### PR DESCRIPTION
## Summary
- Rewrite generated npm smoke projects' direct `@wp-typia/project-tools` dependency to the local workspace `file:` spec before applying overrides.
- Keep the npm override spec identical to the direct dependency so npm no longer raises `EOVERRIDE`.
- Add a regression test covering the direct-dependency + override combination that failed after the release.

## Context
- Fixes the generated project smoke failures from main CI run: https://github.com/imjlk/wp-typia/actions/runs/24896653969
- Failing jobs were the npm workspace add lanes, all stopping during `npm install` with `Override for @wp-typia/project-tools@^0.20.0 conflicts with direct dependency`.

## Verification
- `bun test tests/unit/generated-project-smoke-reference-lane.test.ts`
- `node scripts/run-generated-project-smoke.mjs --runtime node --package-manager npm --project-name smoke-workspace-add-hooked-block-npm --template @wp-typia/create-workspace-template --add-block-name counter-card --add-template basic --add-hooked-block-slug counter-card --add-hooked-block-anchor core/post-content --add-hooked-block-position after`
- `bun run typecheck`
- `bun run lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit test coverage for workspace dependency rewriting with npm package manager.

* **Chores**
  * Improved workspace dependency localization to include additional package references during build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->