### PR TITLE
fix(project-tools): report unknown template diagnostics

### DIFF
--- a/.sampo/changesets/template-diagnostic-errors.md
+++ b/.sampo/changesets/template-diagnostic-errors.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Fixed invalid create/add template ids to return user-facing unknown-template diagnostics instead of leaking internal prompt callback errors.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-block.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-block.ts
@@ -543,7 +543,7 @@ export async function runAddBlockCommand({
 	}
 	if (!isAddBlockTemplateId(templateId)) {
 		throw new Error(
-			`Unknown add-block template "${templateId}". Expected one of: ${ADD_BLOCK_TEMPLATE_IDS.join(", ")}`,
+			`Unknown add-block template "${templateId}". Expected one of: ${ADD_BLOCK_TEMPLATE_IDS.join(", ")}. Run \`wp-typia templates list\` to inspect available templates.`,
 		);
 	}
 	const resolvedTemplateId = templateId;

--- a/packages/wp-typia-project-tools/src/runtime/cli-diagnostics.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-diagnostics.ts
@@ -256,7 +256,7 @@ function inferCliDiagnosticCode(options: {
 		return CLI_DIAGNOSTIC_CODES.UNKNOWN_TEMPLATE;
 	}
 	if (
-		/Unknown .*subcommand|Unknown add kind|Unknown template|removed in favor|does not support|The Bun-free fallback runtime does not support|The positional alias only accepts/u.test(
+		/Unknown .*subcommand|Unknown add kind|removed in favor|does not support|The Bun-free fallback runtime does not support|The positional alias only accepts/u.test(
 			haystack,
 		)
 	) {

--- a/packages/wp-typia-project-tools/src/runtime/cli-diagnostics.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-diagnostics.ts
@@ -20,6 +20,7 @@ export const CLI_DIAGNOSTIC_CODES = {
 	OUTSIDE_PROJECT_ROOT: "outside-project-root",
 	TEMPLATE_SOURCE_TIMEOUT: "template-source-timeout",
 	TEMPLATE_SOURCE_TOO_LARGE: "template-source-too-large",
+	UNKNOWN_TEMPLATE: "unknown-template",
 	UNSUPPORTED_COMMAND: "unsupported-command",
 } as const;
 
@@ -250,6 +251,9 @@ function inferCliDiagnosticCode(options: {
 	}
 	if (/requires <|requires --|requires a value/u.test(haystack)) {
 		return CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT;
+	}
+	if (/Unknown (?:add-block )?template/u.test(haystack)) {
+		return CLI_DIAGNOSTIC_CODES.UNKNOWN_TEMPLATE;
 	}
 	if (
 		/Unknown .*subcommand|Unknown add kind|Unknown template|removed in favor|does not support|The Bun-free fallback runtime does not support|The positional alias only accepts/u.test(

--- a/packages/wp-typia-project-tools/src/runtime/cli-diagnostics.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-diagnostics.ts
@@ -252,7 +252,7 @@ function inferCliDiagnosticCode(options: {
 	if (/requires <|requires --|requires a value/u.test(haystack)) {
 		return CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT;
 	}
-	if (/Unknown (?:add-block )?template/u.test(haystack)) {
+	if (/Unknown (?:add-block )?template\s+(?:"|\\")/u.test(haystack)) {
 		return CLI_DIAGNOSTIC_CODES.UNKNOWN_TEMPLATE;
 	}
 	if (

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-answer-resolution.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-answer-resolution.ts
@@ -1,4 +1,5 @@
 import { execSync } from 'node:child_process';
+import path from 'node:path';
 
 import {
   PACKAGE_MANAGER_IDS,
@@ -21,6 +22,7 @@ import {
   getRemovedBuiltInTemplateMessage,
   isRemovedBuiltInTemplateId,
 } from './template-defaults.js';
+import { parseNpmTemplateLocator } from './template-source-locators.js';
 import {
   toSnakeCase,
   toTitleCase,
@@ -125,34 +127,26 @@ function normalizeTemplateSelection(templateId: string): string {
     : templateId;
 }
 
-function looksLikeUnscopedNpmTemplateLocator(templateId: string): boolean {
-  const versionSeparatorIndex = templateId.indexOf('@', 1);
-  const packageName =
-    versionSeparatorIndex === -1
-      ? templateId
-      : templateId.slice(0, versionSeparatorIndex);
+function looksLikeWindowsAbsoluteTemplatePath(templateId: string): boolean {
+  return /^[a-z]:[\\/]/iu.test(templateId) || /^\\\\[^\\]+\\[^\\]+/u.test(templateId);
+}
 
-  if (!/^[a-z0-9][a-z0-9._-]*$/u.test(packageName)) {
-    return false;
-  }
-
+function looksLikeExplicitNonNpmExternalTemplateLocator(templateId: string): boolean {
   return (
-    versionSeparatorIndex > 0 ||
-    packageName.includes('-') ||
-    packageName.includes('.') ||
-    packageName.includes('_')
+    path.isAbsolute(templateId) ||
+    looksLikeWindowsAbsoluteTemplatePath(templateId) ||
+    templateId.startsWith('./') ||
+    templateId.startsWith('../') ||
+    templateId.startsWith('@') ||
+    templateId.startsWith('github:') ||
+    templateId.includes('/')
   );
 }
 
 function looksLikeExplicitExternalTemplateLocator(templateId: string): boolean {
   return (
-    templateId.startsWith('./') ||
-    templateId.startsWith('../') ||
-    templateId.startsWith('/') ||
-    templateId.startsWith('@') ||
-    templateId.startsWith('github:') ||
-    templateId.includes('/') ||
-    looksLikeUnscopedNpmTemplateLocator(templateId)
+    looksLikeExplicitNonNpmExternalTemplateLocator(templateId) ||
+    parseNpmTemplateLocator(templateId) !== null
   );
 }
 
@@ -184,7 +178,7 @@ function findMistypedBuiltInTemplateSuggestion(templateId: string): string | nul
   const normalizedTemplateId = templateId.trim().toLowerCase();
   if (
     normalizedTemplateId.length === 0 ||
-    looksLikeExplicitExternalTemplateLocator(normalizedTemplateId)
+    looksLikeExplicitNonNpmExternalTemplateLocator(normalizedTemplateId)
   ) {
     return null;
   }
@@ -326,7 +320,7 @@ export async function collectScaffoldAnswers({
 }: CollectScaffoldAnswersOptions): Promise<ScaffoldAnswers> {
   const defaults = getDefaultAnswers(projectName, templateId);
 
-  if (yes) {
+  if (yes || (!isBuiltInTemplateId(templateId) && !promptText)) {
     const identifiers = resolveScaffoldIdentifiers({
       namespace: namespace ?? defaults.namespace,
       phpPrefix,

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-answer-resolution.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-answer-resolution.ts
@@ -36,7 +36,6 @@ const WORKSPACE_TEMPLATE_ALIAS = 'workspace';
 const TEMPLATE_SELECTION_HINT = `--template <${[
   ...TEMPLATE_IDS,
   WORKSPACE_TEMPLATE_ALIAS,
-  OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE,
 ].join('|')}|./path|github:owner/repo/path[#ref]|npm-package>`;
 const TEMPLATE_SUGGESTION_IDS = [...TEMPLATE_IDS, WORKSPACE_TEMPLATE_ALIAS] as const;
 const QUERY_POST_TYPE_RULE =
@@ -44,7 +43,6 @@ const QUERY_POST_TYPE_RULE =
 const USER_FACING_TEMPLATE_IDS = [
   ...TEMPLATE_IDS,
   WORKSPACE_TEMPLATE_ALIAS,
-  OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE,
 ] as const;
 
 /**
@@ -127,6 +125,25 @@ function normalizeTemplateSelection(templateId: string): string {
     : templateId;
 }
 
+function looksLikeUnscopedNpmTemplateLocator(templateId: string): boolean {
+  const versionSeparatorIndex = templateId.indexOf('@', 1);
+  const packageName =
+    versionSeparatorIndex === -1
+      ? templateId
+      : templateId.slice(0, versionSeparatorIndex);
+
+  if (!/^[a-z0-9][a-z0-9._-]*$/u.test(packageName)) {
+    return false;
+  }
+
+  return (
+    versionSeparatorIndex > 0 ||
+    packageName.includes('-') ||
+    packageName.includes('.') ||
+    packageName.includes('_')
+  );
+}
+
 function looksLikeExplicitExternalTemplateLocator(templateId: string): boolean {
   return (
     templateId.startsWith('./') ||
@@ -134,7 +151,8 @@ function looksLikeExplicitExternalTemplateLocator(templateId: string): boolean {
     templateId.startsWith('/') ||
     templateId.startsWith('@') ||
     templateId.startsWith('github:') ||
-    templateId.includes('/')
+    templateId.includes('/') ||
+    looksLikeUnscopedNpmTemplateLocator(templateId)
   );
 }
 

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-answer-resolution.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-answer-resolution.ts
@@ -36,10 +36,16 @@ const WORKSPACE_TEMPLATE_ALIAS = 'workspace';
 const TEMPLATE_SELECTION_HINT = `--template <${[
   ...TEMPLATE_IDS,
   WORKSPACE_TEMPLATE_ALIAS,
+  OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE,
 ].join('|')}|./path|github:owner/repo/path[#ref]|npm-package>`;
 const TEMPLATE_SUGGESTION_IDS = [...TEMPLATE_IDS, WORKSPACE_TEMPLATE_ALIAS] as const;
 const QUERY_POST_TYPE_RULE =
   'Use lowercase, 1-20 chars, and only a-z, 0-9, "_" or "-".';
+const USER_FACING_TEMPLATE_IDS = [
+  ...TEMPLATE_IDS,
+  WORKSPACE_TEMPLATE_ALIAS,
+  OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE,
+] as const;
 
 /**
  * Detect the current author name from local Git config.
@@ -199,6 +205,14 @@ function getMistypedBuiltInTemplateMessage(templateId: string): string | null {
   return `Unknown template "${templateId}". Did you mean "${suggestion}"? Use \`--template ${suggestion}\` for the ${suggestionDescription}, or pass a local path, \`github:owner/repo/path[#ref]\`, or an npm package spec for an external template.`;
 }
 
+function getUnknownTemplateMessage(templateId: string): string {
+  return [
+    `Unknown template "${templateId}". Expected one of: ${USER_FACING_TEMPLATE_IDS.join(', ')}.`,
+    'Run `wp-typia templates list` to inspect available templates.',
+    'Pass an explicit external template locator such as `./path`, `github:owner/repo/path[#ref]`, or `@scope/template` for custom templates.',
+  ].join(' ');
+}
+
 /**
  * Resolve the scaffold template id from flags, defaults, and interactive selection.
  *
@@ -225,6 +239,9 @@ export async function resolveTemplateId({
     const mistypedBuiltInTemplateMessage = getMistypedBuiltInTemplateMessage(templateId);
     if (mistypedBuiltInTemplateMessage) {
       throw new Error(mistypedBuiltInTemplateMessage);
+    }
+    if (!looksLikeExplicitExternalTemplateLocator(normalizedTemplateId)) {
+      throw new Error(getUnknownTemplateMessage(templateId));
     }
     return normalizedTemplateId;
   }

--- a/packages/wp-typia-project-tools/src/runtime/template-source-seeds.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-seeds.ts
@@ -18,7 +18,9 @@ import {
 } from './external-template-guards.js'
 import {
   OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE,
+  OFFICIAL_WORKSPACE_TEMPLATE_ALIAS,
   PROJECT_TOOLS_PACKAGE_ROOT,
+  TEMPLATE_IDS,
 } from './template-registry.js'
 import { isPlainObject } from './object-utils.js'
 import { createManagedTempRoot } from './temp-roots.js'
@@ -28,6 +30,19 @@ import type {
   RemoteTemplateLocator,
   SeedSource,
 } from './template-source-contracts.js'
+
+const USER_FACING_TEMPLATE_IDS = [
+  ...TEMPLATE_IDS,
+  OFFICIAL_WORKSPACE_TEMPLATE_ALIAS,
+] as const
+
+function getUnknownNpmTemplateMessage(templateId: string): string {
+  return [
+    `Unknown template "${templateId}". Expected one of: ${USER_FACING_TEMPLATE_IDS.join(', ')}.`,
+    'Run `wp-typia templates list` to inspect available templates.',
+    'If you meant an npm template package, verify the package name and configured npm registry.',
+  ].join(' ')
+}
 
 function selectRegistryVersion(
   metadata: Record<string, unknown>,
@@ -90,6 +105,9 @@ async function fetchNpmTemplateSource(
     },
   )
   if (!metadataResponse.ok) {
+    if (metadataResponse.status === 404) {
+      throw new Error(getUnknownNpmTemplateMessage(locator.raw))
+    }
     throw new Error(
       `Failed to fetch npm template metadata for ${locator.raw}: ${metadataResponse.status}`,
     )

--- a/packages/wp-typia-project-tools/tests/cli-entry.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-entry.test.ts
@@ -814,6 +814,35 @@ test("node entry supports dry-run create previews without writing files", () => 
   expect(fs.existsSync(targetDir)).toBe(false);
 });
 
+test("node entry rejects unknown create templates before prompt fallback", () => {
+  const targetDir = path.join(tempRoot, "demo-node-create-unknown-template");
+  const errorMessage = getCommandErrorMessage(() =>
+    runCli(
+      "node",
+      [
+        entryPath,
+        "create",
+        targetDir,
+        "--template",
+        "nonexistent",
+        "--package-manager",
+        "npm",
+        "--no-install",
+        "--format",
+        "json",
+      ],
+      {
+        stdio: "pipe",
+      }
+    )
+  );
+
+  expect(errorMessage).toContain('"code": "unknown-template"');
+  expect(errorMessage).toContain('Unknown template \\"nonexistent\\". Expected one of:');
+  expect(errorMessage).toContain("Run `wp-typia templates list`");
+  expect(errorMessage).not.toContain("Interactive answers require a promptText callback");
+});
+
 test("node entry fails early for sync when scaffold dependencies are missing", () => {
   const targetDir = path.join(tempRoot, "demo-node-sync-no-install");
 
@@ -1120,6 +1149,39 @@ test("node entry rejects add block before workspace dependencies are installed",
   expect(errorMessage).toContain("Workspace dependencies have not been installed yet.");
   expect(errorMessage).toContain("Run `npm install` from the workspace root");
   expect(errorMessage).toContain("`wp-typia add block ...`");
+});
+
+test("node entry rejects unknown add-block templates before workspace dependency checks", async () => {
+  const targetDir = path.join(tempRoot, "node-workspace-add-unknown-template");
+
+  await scaffoldOfficialWorkspace(targetDir);
+
+  const errorMessage = getCommandErrorMessage(() =>
+    runCli(
+      "node",
+      [
+        entryPath,
+        "add",
+        "block",
+        "counter-card",
+        "--template",
+        "nonexistent",
+        "--format",
+        "json",
+      ],
+      {
+        cwd: targetDir,
+        stdio: "pipe",
+      }
+    )
+  );
+
+  expect(errorMessage).toContain('"code": "unknown-template"');
+  expect(errorMessage).toContain('Unknown add-block template \\"nonexistent\\".');
+  expect(errorMessage).toContain("Expected one of: basic, interactivity, persistence, compound");
+  expect(errorMessage).toContain("Run `wp-typia templates list`");
+  expect(errorMessage).not.toContain("Workspace dependencies have not been installed yet.");
+  expect(errorMessage).not.toContain("Interactive answers require a promptText callback");
 });
 
 test("node entry rejects missing values for identifier override flags", () => {

--- a/packages/wp-typia-project-tools/tests/cli-entry.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-entry.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, describe, expect, test } from "bun:test";
 import * as fs from "node:fs";
+import * as http from "node:http";
 import * as path from "node:path";
 import { cleanupScaffoldTempRoot, createBlockExternalFixturePath, createBlockSubsetFixturePath, createScaffoldTempRoot, entryPath, getCommandErrorMessage, runCapturedCli, runCli, scaffoldOfficialWorkspace, templateLayerAmbiguousFixturePath, templateLayerFixturePath } from "./helpers/scaffold-test-harness.js";
 import { formatHelpText, getDoctorChecks, getNextSteps, getOptionalOnboarding, runScaffoldFlow } from "../src/runtime/cli-core.js";
@@ -12,6 +13,37 @@ describe("@wp-typia/project-tools scaffold CLI flow", () => {
   afterAll(() => {
     cleanupScaffoldTempRoot(tempRoot);
   });
+
+  async function startNotFoundRegistry(): Promise<{
+    close: () => Promise<void>;
+    url: string;
+  }> {
+    const server = http.createServer((_request, response) => {
+      response.writeHead(404, { "content-type": "application/json" });
+      response.end(JSON.stringify({ error: "not_found" }));
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Expected test npm registry to listen on a numeric port.");
+    }
+
+    return {
+      close: () =>
+        new Promise<void>((resolve, reject) => {
+          server.close((error) => {
+            if (error) {
+              reject(error);
+              return;
+            }
+            resolve();
+          });
+        }),
+      url: `http://127.0.0.1:${address.port}`,
+    };
+  }
 
 test("runScaffoldFlow defaults persistence scaffolds to custom-table and authenticated in non-interactive mode", async () => {
   const projectInput = "demo-persistence-default";
@@ -598,6 +630,33 @@ test("runScaffoldFlow rejects mistyped built-in template ids before external loo
   );
 });
 
+test("runScaffoldFlow reports missing npm templates before prompt fallback", async () => {
+  const registry = await startNotFoundRegistry();
+  const originalRegistry = process.env.NPM_CONFIG_REGISTRY;
+
+  try {
+    process.env.NPM_CONFIG_REGISTRY = registry.url;
+    await expect(
+      runScaffoldFlow({
+        cwd: tempRoot,
+        noInstall: true,
+        packageManager: "npm",
+        projectInput: "demo-missing-npm-template",
+        templateId: "nonexistent",
+      })
+    ).rejects.toThrow(
+      'Unknown template "nonexistent". Expected one of: basic, interactivity, persistence, compound, query-loop, workspace.'
+    );
+  } finally {
+    if (originalRegistry === undefined) {
+      delete process.env.NPM_CONFIG_REGISTRY;
+    } else {
+      process.env.NPM_CONFIG_REGISTRY = originalRegistry;
+    }
+    await registry.close();
+  }
+});
+
 test("runScaffoldFlow rejects external layers for non-built-in templates", async () => {
   await expect(
     runScaffoldFlow({
@@ -814,9 +873,11 @@ test("node entry supports dry-run create previews without writing files", () => 
   expect(fs.existsSync(targetDir)).toBe(false);
 });
 
-test("node entry rejects unknown create templates before prompt fallback", () => {
+test("node entry rejects unknown create templates before prompt fallback", async () => {
   const targetDir = path.join(tempRoot, "demo-node-create-unknown-template");
-  const errorMessage = getCommandErrorMessage(() =>
+  let errorMessage = "";
+
+  errorMessage = getCommandErrorMessage(() =>
     runCli(
       "node",
       [
@@ -824,7 +885,7 @@ test("node entry rejects unknown create templates before prompt fallback", () =>
         "create",
         targetDir,
         "--template",
-        "nonexistent",
+        "bad template",
         "--package-manager",
         "npm",
         "--no-install",
@@ -838,8 +899,9 @@ test("node entry rejects unknown create templates before prompt fallback", () =>
   );
 
   expect(errorMessage).toContain('"code": "unknown-template"');
-  expect(errorMessage).toContain('Unknown template \\"nonexistent\\". Expected one of:');
+  expect(errorMessage).toContain('Unknown template \\"bad template\\". Expected one of:');
   expect(errorMessage).toContain("Run `wp-typia templates list`");
+  expect(errorMessage).not.toContain("Failed to fetch npm template metadata");
   expect(errorMessage).not.toContain("Interactive answers require a promptText callback");
 });
 

--- a/packages/wp-typia-project-tools/tests/cli-entry.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-entry.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as http from "node:http";
 import * as path from "node:path";
 import { cleanupScaffoldTempRoot, createBlockExternalFixturePath, createBlockSubsetFixturePath, createScaffoldTempRoot, entryPath, getCommandErrorMessage, runCapturedCli, runCli, scaffoldOfficialWorkspace, templateLayerAmbiguousFixturePath, templateLayerFixturePath } from "./helpers/scaffold-test-harness.js";
+import { createCliCommandError, serializeCliDiagnosticError } from "../src/runtime/cli-diagnostics.js";
 import { formatHelpText, getDoctorChecks, getNextSteps, getOptionalOnboarding, runScaffoldFlow } from "../src/runtime/cli-core.js";
 import { collectScaffoldAnswers } from "../src/runtime/scaffold.js";
 import { getQuickStartWorkflowNote } from "../src/runtime/scaffold-onboarding.js";
@@ -44,6 +45,17 @@ describe("@wp-typia/project-tools scaffold CLI flow", () => {
       url: `http://127.0.0.1:${address.port}`,
     };
   }
+
+test("CLI diagnostics do not classify unknown template variants as missing templates", () => {
+  const diagnostic = serializeCliDiagnosticError(
+    createCliCommandError({
+      command: "create",
+      error: new Error('Unknown template variant "hero". Expected one of: standard'),
+    }),
+  );
+
+  expect(diagnostic.code).toBe("invalid-argument");
+});
 
 test("runScaffoldFlow defaults persistence scaffolds to custom-table and authenticated in non-interactive mode", async () => {
   const projectInput = "demo-persistence-default";

--- a/packages/wp-typia-project-tools/tests/template-source.test.ts
+++ b/packages/wp-typia-project-tools/tests/template-source.test.ts
@@ -999,6 +999,12 @@ test("parses npm template locators for package specs", () => {
 test("template id resolution preserves explicit unscoped npm template specs", async () => {
   await expect(
     resolveTemplateId({
+      templateId: "react",
+    })
+  ).resolves.toBe("react");
+
+  await expect(
+    resolveTemplateId({
       templateId: "my-template",
     })
   ).resolves.toBe("my-template");
@@ -1008,6 +1014,14 @@ test("template id resolution preserves explicit unscoped npm template specs", as
       templateId: "my-template@latest",
     })
   ).resolves.toBe("my-template@latest");
+});
+
+test("template id resolution preserves Windows absolute template paths", async () => {
+  await expect(
+    resolveTemplateId({
+      templateId: String.raw`C:\templates\my-template`,
+    })
+  ).resolves.toBe(String.raw`C:\templates\my-template`);
 });
 
 test("normalizes the workspace template alias to the official package id", async () => {

--- a/packages/wp-typia-project-tools/tests/template-source.test.ts
+++ b/packages/wp-typia-project-tools/tests/template-source.test.ts
@@ -996,6 +996,20 @@ test("parses npm template locators for package specs", () => {
   });
 });
 
+test("template id resolution preserves explicit unscoped npm template specs", async () => {
+  await expect(
+    resolveTemplateId({
+      templateId: "my-template",
+    })
+  ).resolves.toBe("my-template");
+
+  await expect(
+    resolveTemplateId({
+      templateId: "my-template@latest",
+    })
+  ).resolves.toBe("my-template@latest");
+});
+
 test("normalizes the workspace template alias to the official package id", async () => {
   await expect(
     resolveTemplateId({


### PR DESCRIPTION
## Summary

- reject unknown `create --template` ids with a user-facing unknown-template diagnostic before scaffold answer collection
- scope invalid `add block --template` values to an add-block diagnostic and keep recovery guidance aligned with `templates list`
- add CLI regression coverage for invalid create and add-block template inputs

Closes #574

## Validation

- `bun test packages/wp-typia-project-tools/tests/cli-entry.test.ts -t "unknown"`
- `bun test tests/unit/template-registry.test.ts`
- `bun test packages/wp-typia-project-tools/tests/cli-entry.test.ts`
- `bun run --filter wp-typia build`
- `bun run --filter @wp-typia/project-tools test:scaffold-core`
- `bun run --filter wp-typia test`
- `bun run typecheck`
- `bun run lint:repo`
- `bun run changesets:validate`
- `bun run runtime-coupling:validate`
- `bun run manifest-policy:validate`
- `bun run format:check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unknown or invalid template IDs now produce a clear "unknown-template" error with an "Run wp-typia templates list" hint and avoid leaking internal errors.
  * Registry 404s for npm templates are reported as unknown-template.

* **New Features**
  * CLI now fails fast for unknown templates (no unexpected interactive prompts) and gives actionable guidance.

* **Tests**
  * Added regression tests covering create/add-block CLI behavior and template resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->