### PR TITLE
fix(cli): prefer explicit diagnostic codes

### DIFF
--- a/.sampo/changesets/explicit-cli-diagnostic-codes.md
+++ b/.sampo/changesets/explicit-cli-diagnostic-codes.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Tagged high-frequency CLI validation failures with explicit diagnostic codes so structured JSON errors rely less on message regex inference.

--- a/apps/docs/src/content/docs/maintainers/bunli-cli-migration.md
+++ b/apps/docs/src/content/docs/maintainers/bunli-cli-migration.md
@@ -90,11 +90,18 @@ Current stable `error.code` vocabulary:
 - `outside-project-root`
 - `template-source-timeout`
 - `template-source-too-large`
+- `unknown-template`
 - `unsupported-command`
 
 That same JSON contract should apply both to command-handler failures and to
 top-level parse/normalization failures that happen before Bunli dispatches a
 command, as long as the caller explicitly requested `--format json`.
+
+New user-facing CLI failures should own their diagnostic code at the throw site
+by using `createCliDiagnosticCodeError(code, message)` in shared runtime code or
+`createCliCommandError({ code, ... })` at command boundaries. Regex-based
+`inferCliDiagnosticCode()` classification is retained only as a compatibility
+fallback for legacy or third-party errors.
 
 Shorthand references like `npx wp-typia` and `bunx wp-typia` should still map
 to the canonical `create` surface in docs and review notes.

--- a/packages/wp-typia-project-tools/src/runtime/cli-core.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-core.ts
@@ -28,7 +28,9 @@
 export { getDoctorChecks, runDoctor, type DoctorCheck } from "./cli-doctor.js";
 export {
 	createCliCommandError,
+	createCliDiagnosticCodeError,
 	CliDiagnosticError,
+	CLI_DIAGNOSTIC_CODES,
 	formatCliDiagnosticError,
 	formatDoctorCheckLine,
 	formatDoctorSummaryLine,
@@ -36,7 +38,11 @@ export {
 	getFailingDoctorChecks,
 	isCliDiagnosticError,
 } from "./cli-diagnostics.js";
-export type { CliDiagnosticMessage } from "./cli-diagnostics.js";
+export type {
+	CliDiagnosticCode,
+	CliDiagnosticCodeError,
+	CliDiagnosticMessage,
+} from "./cli-diagnostics.js";
 export {
 	EDITOR_PLUGIN_SLOT_IDS,
 	formatAddHelpText,

--- a/packages/wp-typia-project-tools/src/runtime/cli-core.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-core.ts
@@ -15,8 +15,9 @@
  * `runAddAiFeatureCommand` for server-owned WordPress AI feature scaffolds,
  * `runAddRestResourceCommand` for plugin-level REST resource scaffolds,
  * `getDoctorChecks`, `runDoctor`, and `DoctorCheck` for diagnostics,
- * `createCliCommandError` and `formatCliDiagnosticError` for shared
- * non-interactive failure rendering,
+ * `createCliCommandError`, `createCliDiagnosticCodeError`,
+ * `CLI_DIAGNOSTIC_CODES`, and `formatCliDiagnosticError` for shared
+ * non-interactive failure rendering and explicit diagnostic-code ownership,
  * `formatHelpText` for top-level CLI usage output, scaffold helpers such as
  * `createReadlinePrompt`, `getNextSteps`, `getOptionalOnboarding`,
  * `runScaffoldFlow`, and `ReadlinePrompt` for interactive project creation,

--- a/packages/wp-typia-project-tools/src/runtime/cli-diagnostics.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-diagnostics.ts
@@ -27,6 +27,9 @@ export const CLI_DIAGNOSTIC_CODES = {
 export type CliDiagnosticCode =
 	(typeof CLI_DIAGNOSTIC_CODES)[keyof typeof CLI_DIAGNOSTIC_CODES];
 
+export type CliDiagnosticCodeError<TCode extends CliDiagnosticCode = CliDiagnosticCode> =
+	Error & { code: TCode };
+
 type DoctorCheckLike = {
 	detail: string;
 	label: string;
@@ -211,6 +214,23 @@ function readCliDiagnosticCode(error: unknown): CliDiagnosticCode | null {
 	}
 
 	return null;
+}
+
+/**
+ * Tag a user-facing CLI throw site with a stable diagnostic code.
+ *
+ * Prefer this helper, or `createCliCommandError({ code })`, for new known CLI
+ * failures. `inferCliDiagnosticCode()` remains only a compatibility fallback
+ * for legacy or untyped errors.
+ */
+export function createCliDiagnosticCodeError<TCode extends CliDiagnosticCode>(
+	code: TCode,
+	message: string,
+	options?: ErrorOptions,
+): CliDiagnosticCodeError<TCode> {
+	const error = new Error(message, options) as CliDiagnosticCodeError<TCode>;
+	error.code = code;
+	return error;
 }
 
 function inferCliDiagnosticCode(options: {

--- a/packages/wp-typia-project-tools/src/runtime/cli-validation.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-validation.ts
@@ -1,5 +1,9 @@
 import fs from "node:fs";
 import path from "node:path";
+import {
+	CLI_DIAGNOSTIC_CODES,
+	createCliDiagnosticCodeError,
+} from "./cli-diagnostics.js";
 
 /**
  * Normalize one optional CLI string flag by trimming whitespace and collapsing
@@ -55,7 +59,8 @@ export function resolveLocalCliPathOption(options: {
 
 	const resolvedPath = path.resolve(options.cwd, normalizedValue);
 	if (!fs.existsSync(resolvedPath)) {
-		throw new Error(
+		throw createCliDiagnosticCodeError(
+			CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
 			`\`${options.label}\` path does not exist: ${resolvedPath}. Check the path relative to ${options.cwd}.`,
 		);
 	}
@@ -76,7 +81,8 @@ export function assertExternalLayerCompositionOptions(options: {
 	externalLayerSource?: string;
 }): void {
 	if (options.externalLayerId && !options.externalLayerSource) {
-		throw new Error(
+		throw createCliDiagnosticCodeError(
+			CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
 			"externalLayerId requires externalLayerSource when composing built-in template layers.",
 		);
 	}
@@ -114,7 +120,8 @@ export function assertBuiltInTemplateVariantAllowed(options: {
 		return;
 	}
 
-	throw new Error(
+	throw createCliDiagnosticCodeError(
+		CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
 		createBuiltInVariantErrorMessage({
 			templateId: options.templateId,
 			variant: options.variant,

--- a/packages/wp-typia-project-tools/src/runtime/index.ts
+++ b/packages/wp-typia-project-tools/src/runtime/index.ts
@@ -155,7 +155,9 @@ export {
 export {
 	createReadlinePrompt,
 	createCliCommandError,
+	createCliDiagnosticCodeError,
 	CliDiagnosticError,
+	CLI_DIAGNOSTIC_CODES,
 	formatCliDiagnosticError,
 	formatAddHelpText,
 	formatDoctorCheckLine,
@@ -185,6 +187,8 @@ export {
 	runScaffoldFlow,
 } from "./cli-core.js";
 export type {
+	CliDiagnosticCode,
+	CliDiagnosticCodeError,
 	CliDiagnosticMessage,
 	DoctorCheck,
 	EditorPluginSlotId,

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-answer-resolution.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-answer-resolution.ts
@@ -13,6 +13,10 @@ import {
   validateNamespace,
 } from './scaffold-identifiers.js';
 import {
+  CLI_DIAGNOSTIC_CODES,
+  createCliDiagnosticCodeError,
+} from './cli-diagnostics.js';
+import {
   OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE,
   TEMPLATE_IDS,
   getTemplateById,
@@ -115,7 +119,10 @@ function normalizeQueryPostType(value: string | undefined): string | undefined {
 
   const validationResult = validateQueryPostType(value);
   if (validationResult !== true) {
-    throw new Error(validationResult);
+    throw createCliDiagnosticCodeError(
+      CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
+      validationResult,
+    );
   }
 
   return value.trim().toLowerCase();
@@ -240,7 +247,10 @@ export async function resolveTemplateId({
   if (templateId) {
     const normalizedTemplateId = normalizeTemplateSelection(templateId);
     if (isRemovedBuiltInTemplateId(templateId)) {
-      throw new Error(getRemovedBuiltInTemplateMessage(templateId));
+      throw createCliDiagnosticCodeError(
+        CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
+        getRemovedBuiltInTemplateMessage(templateId),
+      );
     }
     if (normalizedTemplateId === OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE) {
       return normalizedTemplateId;
@@ -250,10 +260,16 @@ export async function resolveTemplateId({
     }
     const mistypedBuiltInTemplateMessage = getMistypedBuiltInTemplateMessage(templateId);
     if (mistypedBuiltInTemplateMessage) {
-      throw new Error(mistypedBuiltInTemplateMessage);
+      throw createCliDiagnosticCodeError(
+        CLI_DIAGNOSTIC_CODES.UNKNOWN_TEMPLATE,
+        mistypedBuiltInTemplateMessage,
+      );
     }
     if (!looksLikeExplicitExternalTemplateLocator(normalizedTemplateId)) {
-      throw new Error(getUnknownTemplateMessage(templateId));
+      throw createCliDiagnosticCodeError(
+        CLI_DIAGNOSTIC_CODES.UNKNOWN_TEMPLATE,
+        getUnknownTemplateMessage(templateId),
+      );
     }
     return normalizedTemplateId;
   }
@@ -263,7 +279,8 @@ export async function resolveTemplateId({
   }
 
   if (!isInteractive || !selectTemplate) {
-    throw new Error(
+    throw createCliDiagnosticCodeError(
+      CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
       `Template is required in non-interactive mode. Use ${TEMPLATE_SELECTION_HINT}.`,
     );
   }
@@ -292,7 +309,8 @@ export async function resolvePackageManagerId({
   }
 
   if (!isInteractive || !selectPackageManager) {
-    throw new Error(
+    throw createCliDiagnosticCodeError(
+      CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
       `Package manager is required in non-interactive mode. Use --package-manager <${PACKAGE_MANAGER_IDS.join('|')}>.`,
     );
   }

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-answer-resolution.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-answer-resolution.ts
@@ -248,7 +248,7 @@ export async function resolveTemplateId({
     const normalizedTemplateId = normalizeTemplateSelection(templateId);
     if (isRemovedBuiltInTemplateId(templateId)) {
       throw createCliDiagnosticCodeError(
-        CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
+        CLI_DIAGNOSTIC_CODES.UNKNOWN_TEMPLATE,
         getRemovedBuiltInTemplateMessage(templateId),
       );
     }

--- a/packages/wp-typia-project-tools/src/runtime/template-source-seeds.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-seeds.ts
@@ -17,6 +17,10 @@ import {
   readJsonResponseWithLimit,
 } from './external-template-guards.js'
 import {
+  CLI_DIAGNOSTIC_CODES,
+  createCliDiagnosticCodeError,
+} from './cli-diagnostics.js'
+import {
   OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE,
   OFFICIAL_WORKSPACE_TEMPLATE_ALIAS,
   PROJECT_TOOLS_PACKAGE_ROOT,
@@ -106,7 +110,10 @@ async function fetchNpmTemplateSource(
   )
   if (!metadataResponse.ok) {
     if (metadataResponse.status === 404) {
-      throw new Error(getUnknownNpmTemplateMessage(locator.raw))
+      throw createCliDiagnosticCodeError(
+        CLI_DIAGNOSTIC_CODES.UNKNOWN_TEMPLATE,
+        getUnknownNpmTemplateMessage(locator.raw),
+      )
     }
     throw new Error(
       `Failed to fetch npm template metadata for ${locator.raw}: ${metadataResponse.status}`,

--- a/packages/wp-typia-project-tools/tests/cli-entry.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-entry.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as http from "node:http";
 import * as path from "node:path";
 import { cleanupScaffoldTempRoot, createBlockExternalFixturePath, createBlockSubsetFixturePath, createScaffoldTempRoot, entryPath, getCommandErrorMessage, runCapturedCli, runCli, scaffoldOfficialWorkspace, templateLayerAmbiguousFixturePath, templateLayerFixturePath } from "./helpers/scaffold-test-harness.js";
-import { createCliCommandError, serializeCliDiagnosticError } from "../src/runtime/cli-diagnostics.js";
+import { CLI_DIAGNOSTIC_CODES, createCliCommandError, createCliDiagnosticCodeError, serializeCliDiagnosticError } from "../src/runtime/cli-diagnostics.js";
 import { formatHelpText, getDoctorChecks, getNextSteps, getOptionalOnboarding, runScaffoldFlow } from "../src/runtime/cli-core.js";
 import { collectScaffoldAnswers } from "../src/runtime/scaffold.js";
 import { getQuickStartWorkflowNote } from "../src/runtime/scaffold-onboarding.js";
@@ -55,6 +55,21 @@ test("CLI diagnostics do not classify unknown template variants as missing templ
   );
 
   expect(diagnostic.code).toBe("invalid-argument");
+});
+
+test("CLI diagnostics preserve explicit throw-site codes without message inference", () => {
+  const diagnostic = serializeCliDiagnosticError(
+    createCliCommandError({
+      command: "create",
+      error: createCliDiagnosticCodeError(
+        CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
+        "Opaque scaffold preflight failure.",
+      ),
+    }),
+  );
+
+  expect(diagnostic.code).toBe("missing-argument");
+  expect(diagnostic.message).toContain("Opaque scaffold preflight failure.");
 });
 
 test("runScaffoldFlow defaults persistence scaffolds to custom-table and authenticated in non-interactive mode", async () => {

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -2,6 +2,7 @@ import packageJson from '../package.json';
 import {
   CLI_DIAGNOSTIC_CODES,
   createCliCommandError,
+  createCliDiagnosticCodeError,
   formatCliDiagnosticError,
   serializeCliDiagnosticError,
 } from '@wp-typia/project-tools/cli-diagnostics';
@@ -122,7 +123,10 @@ export function parseGlobalFlags(argv: string[]): {
     if (arg === '--format' || arg === '--id') {
       const next = argv[index + 1];
       if (!next || next.startsWith('-')) {
-        throw new Error(`\`${arg}\` requires a value.`);
+        throw createCliDiagnosticCodeError(
+          CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
+          `\`${arg}\` requires a value.`,
+        );
       }
       if (arg === '--format') {
         flags.format = next;
@@ -467,7 +471,8 @@ export async function runNodeCli(argv = process.argv.slice(2)): Promise<void> {
         : (positionals[2] as string | undefined);
     const resolvedSubcommand = templateId ? 'inspect' : (subcommand ?? 'list');
     if (resolvedSubcommand !== 'list' && resolvedSubcommand !== 'inspect') {
-      throw new Error(
+      throw createCliDiagnosticCodeError(
+        CLI_DIAGNOSTIC_CODES.INVALID_COMMAND,
         `Unknown templates subcommand "${resolvedSubcommand}". Expected list or inspect.`,
       );
     }
@@ -494,6 +499,7 @@ export async function runNodeCli(argv = process.argv.slice(2)): Promise<void> {
     const projectDir = positionals[1];
     if (!projectDir) {
       throw createCliCommandError({
+        code: CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
         command: 'create',
         detailLines: [
           '`wp-typia create` requires <project-dir>.',
@@ -540,6 +546,7 @@ export async function runNodeCli(argv = process.argv.slice(2)): Promise<void> {
         await import('@wp-typia/project-tools/cli-add');
       printLine(formatAddHelpText());
       throw createCliCommandError({
+        code: CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
         command: 'add',
         detailLines: [
           `\`wp-typia add\` requires <kind>. Usage: wp-typia add ${formatAddKindUsagePlaceholder()} ...`,

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -471,10 +471,13 @@ export async function runNodeCli(argv = process.argv.slice(2)): Promise<void> {
         : (positionals[2] as string | undefined);
     const resolvedSubcommand = templateId ? 'inspect' : (subcommand ?? 'list');
     if (resolvedSubcommand !== 'list' && resolvedSubcommand !== 'inspect') {
-      throw createCliDiagnosticCodeError(
-        CLI_DIAGNOSTIC_CODES.INVALID_COMMAND,
-        `Unknown templates subcommand "${resolvedSubcommand}". Expected list or inspect.`,
-      );
+      throw createCliCommandError({
+        code: CLI_DIAGNOSTIC_CODES.INVALID_COMMAND,
+        command: 'templates',
+        detailLines: [
+          `Unknown templates subcommand "${resolvedSubcommand}". Expected list or inspect.`,
+        ],
+      });
     }
     if (mergedFlags.format === 'json') {
       renderTemplatesJson(

--- a/packages/wp-typia/src/runtime-bridge-sync.ts
+++ b/packages/wp-typia/src/runtime-bridge-sync.ts
@@ -1,6 +1,10 @@
 import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
+import {
+  CLI_DIAGNOSTIC_CODES,
+  createCliDiagnosticCodeError,
+} from '@wp-typia/project-tools/cli-diagnostics';
 
 type PackageManagerId = 'bun' | 'npm' | 'pnpm' | 'yarn';
 type SyncScriptName = 'sync' | 'sync-ai' | 'sync-rest' | 'sync-types';
@@ -70,7 +74,8 @@ export function resolveSyncExecutionTarget(
     return 'ai';
   }
 
-  throw new Error(
+  throw createCliDiagnosticCodeError(
+    CLI_DIAGNOSTIC_CODES.INVALID_COMMAND,
     `Unknown sync subcommand "${subcommand}". Expected one of: "ai".`,
   );
 }
@@ -107,7 +112,8 @@ function formatInstallCommand(packageManagerId: PackageManagerId): string {
 }
 
 function getSyncRootError(cwd: string): Error {
-  return new Error(
+  return createCliDiagnosticCodeError(
+    CLI_DIAGNOSTIC_CODES.OUTSIDE_PROJECT_ROOT,
     `No generated wp-typia project root was found at ${cwd}. Run \`wp-typia sync\` from a scaffolded project or official workspace root that already contains generated sync scripts. If you expected this directory to work, cd into the scaffold root first or rerun the scaffold before syncing.`,
   );
 }
@@ -257,7 +263,8 @@ function assertSyncDependenciesInstalled(
     return;
   }
 
-  throw new Error(
+  throw createCliDiagnosticCodeError(
+    CLI_DIAGNOSTIC_CODES.DEPENDENCIES_NOT_INSTALLED,
     `Project dependencies have not been installed yet. Run \`${formatInstallCommand(project.packageManager)}\` from the project root before \`wp-typia sync\`. The generated sync scripts rely on local tools such as \`tsx\`.`,
   );
 }
@@ -326,7 +333,8 @@ function buildSyncPlannedCommands(
       extraArgs,
     );
     if (!syncAiCommand) {
-      throw new Error(
+      throw createCliDiagnosticCodeError(
+        CLI_DIAGNOSTIC_CODES.CONFIGURATION_MISSING,
         `Expected ${project.packageJsonPath} to define a \`sync-ai\` script for \`wp-typia sync ai\`.`,
       );
     }
@@ -344,7 +352,8 @@ function buildSyncPlannedCommands(
     extraArgs,
   );
   if (!syncTypesCommand) {
-    throw new Error(
+    throw createCliDiagnosticCodeError(
+      CLI_DIAGNOSTIC_CODES.CONFIGURATION_MISSING,
       `Expected ${project.packageJsonPath} to define either a \`sync\` or \`sync-types\` script.`,
     );
   }

--- a/packages/wp-typia/src/runtime-bridge.ts
+++ b/packages/wp-typia/src/runtime-bridge.ts
@@ -1,5 +1,9 @@
 import type { ReadlinePrompt } from '@wp-typia/project-tools/cli-prompt';
 import {
+  CLI_DIAGNOSTIC_CODES,
+  createCliDiagnosticCodeError,
+} from '@wp-typia/project-tools/cli-diagnostics';
+import {
   type AddKindId,
   formatAddKindList,
   formatAddKindUsagePlaceholder,
@@ -168,7 +172,10 @@ function readOptionalStringFlag(
     return undefined;
   }
   if (typeof value !== 'string' || value.trim().length === 0) {
-    throw new Error(`\`--${name}\` requires a value.`);
+    throw createCliDiagnosticCodeError(
+      CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
+      `\`--${name}\` requires a value.`,
+    );
   }
   return value;
 }
@@ -182,7 +189,10 @@ function readOptionalLooseStringFlag(
     return undefined;
   }
   if (typeof value !== 'string') {
-    throw new Error(`\`--${name}\` requires a value.`);
+    throw createCliDiagnosticCodeError(
+      CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
+      `\`--${name}\` requires a value.`,
+    );
   }
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : undefined;
@@ -204,7 +214,10 @@ function requireAddKindName(
   message: string,
 ): string {
   if (!context.name) {
-    throw new Error(message);
+    throw createCliDiagnosticCodeError(
+      CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
+      message,
+    );
   }
 
   return context.name;
@@ -282,7 +295,8 @@ const ADD_KIND_EXECUTION_REGISTRY: Record<
     );
 
     if (!context.flags.template && context.isInteractiveSession) {
-      throw new Error(
+      throw createCliDiagnosticCodeError(
+        CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
         '`wp-typia add block` requires --template <basic|interactivity|persistence|compound> in interactive terminals. Non-interactive runs default to --template basic.',
       );
     }
@@ -418,13 +432,15 @@ const ADD_KIND_EXECUTION_REGISTRY: Record<
     );
     const anchorBlockName = readOptionalStringFlag(context.flags, 'anchor');
     if (!anchorBlockName) {
-      throw new Error(
+      throw createCliDiagnosticCodeError(
+        CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
         '`wp-typia add hooked-block` requires --anchor <anchor-block-name>.',
       );
     }
     const position = readOptionalStringFlag(context.flags, 'position');
     if (!position) {
-      throw new Error(
+      throw createCliDiagnosticCodeError(
+        CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
         '`wp-typia add hooked-block` requires --position <before|after|firstChild|lastChild>.',
       );
     }
@@ -506,7 +522,8 @@ const ADD_KIND_EXECUTION_REGISTRY: Record<
     );
     const blockSlug = readOptionalStringFlag(context.flags, 'block');
     if (!blockSlug) {
-      throw new Error(
+      throw createCliDiagnosticCodeError(
+        CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
         '`wp-typia add variation` requires --block <block-slug>.',
       );
     }
@@ -811,12 +828,14 @@ export async function executeAddCommand({
       if (emitOutput) {
         printLine(addRuntime.formatAddHelpText());
       }
-      throw new Error(
+      throw createCliDiagnosticCodeError(
+        CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
         `\`wp-typia add\` requires <kind>. Usage: wp-typia add ${formatAddKindUsagePlaceholder()} ...`,
       );
     }
     if (!isAddKindId(kind)) {
-      throw new Error(
+      throw createCliDiagnosticCodeError(
+        CLI_DIAGNOSTIC_CODES.INVALID_COMMAND,
         `Unknown add kind "${kind}". Expected one of: ${formatAddKindList()}.`,
       );
     }
@@ -878,17 +897,24 @@ export async function executeTemplatesCommand(
 
   if (subcommand === 'inspect') {
     if (!flags.id) {
-      throw new Error('`wp-typia templates inspect` requires <template-id>.');
+      throw createCliDiagnosticCodeError(
+        CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
+        '`wp-typia templates inspect` requires <template-id>.',
+      );
     }
     const template = getTemplateById(flags.id);
     if (!template) {
-      throw new Error(`Unknown template "${flags.id}".`);
+      throw createCliDiagnosticCodeError(
+        CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
+        `Unknown template "${flags.id}".`,
+      );
     }
     printBlock([formatTemplateDetails(template)], printLine);
     return;
   }
 
-  throw new Error(
+  throw createCliDiagnosticCodeError(
+    CLI_DIAGNOSTIC_CODES.INVALID_COMMAND,
     `Unknown templates subcommand "${subcommand}". Expected list or inspect.`,
   );
 }

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -1180,6 +1180,48 @@ describe('wp-typia package', () => {
     }
   });
 
+  test('emits a machine-readable unknown-template error code for removed built-in template ids', () => {
+    const targetDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'wp-typia-create-removed-template-'),
+    );
+    fs.rmSync(targetDir, { force: true, recursive: true });
+
+    try {
+      const result = runCapturedCommand(
+        process.execPath,
+        [
+          entryPath,
+          'create',
+          targetDir,
+          '--template',
+          'data',
+          '--yes',
+          '--no-install',
+          '--format',
+          'json',
+        ],
+        {
+          env: withoutLocalBunEnv(),
+        },
+      );
+      const parsed = parseJsonObjectFromOutput<{
+        error?: { code?: string; command?: string; message?: string };
+        ok?: boolean;
+      }>(result.stderr);
+
+      expect(result.status).toBe(1);
+      expect(result.stdout).toBe('');
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error?.command).toBe('create');
+      expect(parsed.error?.code).toBe('unknown-template');
+      expect(parsed.error?.message).toContain(
+        'Built-in template "data" was removed.',
+      );
+    } finally {
+      fs.rmSync(targetDir, { force: true, recursive: true });
+    }
+  });
+
   test('formats add failures with a shared non-interactive diagnostic block', () => {
     const result = runCapturedCommand('node', [
       entryPath,
@@ -1308,6 +1350,15 @@ describe('wp-typia package', () => {
     expect(parsed.error?.kind).toBe('command-execution');
     expect(parsed.error?.command).toBe('sync');
     expect(parsed.error?.code).toBe('invalid-command');
+  });
+
+  test('preserves command metadata for invalid templates subcommands in Node fallback JSON mode', async () => {
+    await expect(
+      runNodeCli(['templates', 'unknown', '--format', 'json']),
+    ).rejects.toMatchObject({
+      code: 'invalid-command',
+      command: 'templates',
+    });
   });
 
   test('treats missing add kinds as an error while still printing help text', () => {

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -1136,6 +1136,50 @@ describe('wp-typia package', () => {
     expect(parsed.error?.code).toBe('missing-argument');
   });
 
+  test('emits a machine-readable invalid-argument error code for create variant failures', () => {
+    const targetDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'wp-typia-create-invalid-variant-'),
+    );
+    fs.rmSync(targetDir, { force: true, recursive: true });
+
+    try {
+      const result = runCapturedCommand(
+        process.execPath,
+        [
+          entryPath,
+          'create',
+          targetDir,
+          '--template',
+          'basic',
+          '--variant',
+          'hero',
+          '--yes',
+          '--no-install',
+          '--format',
+          'json',
+        ],
+        {
+          env: withoutLocalBunEnv(),
+        },
+      );
+      const parsed = parseJsonObjectFromOutput<{
+        error?: { code?: string; command?: string; message?: string };
+        ok?: boolean;
+      }>(result.stderr);
+
+      expect(result.status).toBe(1);
+      expect(result.stdout).toBe('');
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error?.command).toBe('create');
+      expect(parsed.error?.code).toBe('invalid-argument');
+      expect(parsed.error?.message).toContain(
+        '--variant is only supported for official external template configs',
+      );
+    } finally {
+      fs.rmSync(targetDir, { force: true, recursive: true });
+    }
+  });
+
   test('formats add failures with a shared non-interactive diagnostic block', () => {
     const result = runCapturedCommand('node', [
       entryPath,
@@ -1243,6 +1287,27 @@ describe('wp-typia package', () => {
     } finally {
       fs.rmSync(tempRoot, { force: true, recursive: true });
     }
+  });
+
+  test('emits a machine-readable invalid-command error code for sync subcommands in Node fallback JSON mode', () => {
+    const result = runCapturedCommand(
+      process.execPath,
+      [entryPath, 'sync', 'unknown', '--format', 'json'],
+      {
+        env: withoutLocalBunEnv(),
+      },
+    );
+    const parsed = parseJsonObjectFromOutput<{
+      error?: { code?: string; command?: string; kind?: string };
+      ok?: boolean;
+    }>(result.stderr);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe('');
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error?.kind).toBe('command-execution');
+    expect(parsed.error?.command).toBe('sync');
+    expect(parsed.error?.code).toBe('invalid-command');
   });
 
   test('treats missing add kinds as an error while still printing help text', () => {


### PR DESCRIPTION
## Summary
- add a shared helper for tagging known CLI throw sites with stable diagnostic codes
- move high-frequency create/add/sync/template validation failures away from regex-only inference
- document the explicit-code rule and add regression coverage for structured JSON errors

Closes #581

## Validation
- bun test packages/wp-typia-project-tools/tests/cli-entry.test.ts -t "CLI diagnostics|mistyped|missing npm|variant"
- bun test packages/wp-typia/tests/cli-package.test.ts -t "machine-readable invalid-argument|machine-readable invalid-command|missing-argument error code for create|outside-project-root error code for sync"
- bun run typecheck
- bun run lint:repo
- bun run format:check
- git diff --check
- bun run changesets:validate
- bun run --filter @wp-typia/project-tools test:scaffold-core
- bun run --filter wp-typia test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * CLI validation failures now emit errors with explicit diagnostic codes, enabling structured JSON error output with codes like `missing-argument`, `invalid-command`, and `unknown-template`.

* **Documentation**
  * Updated maintainer guides with diagnostic code requirements and backward compatibility conventions for CLI error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->