### PR TITLE
fix(cli): honor NO_COLOR for output markers

### DIFF
--- a/.sampo/changesets/no-color-output-markers.md
+++ b/.sampo/changesets/no-color-output-markers.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Honor `NO_COLOR` as an ASCII-safe CLI output marker signal while documenting `WP_TYPIA_ASCII` precedence.

--- a/packages/wp-typia-project-tools/src/runtime/cli-help.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-help.ts
@@ -38,6 +38,9 @@ export function formatHelpText(): string {
 
 Built-in templates: ${TEMPLATE_IDS.join(", ")}
 Package managers: ${PACKAGE_MANAGER_IDS.join(", ")}
+Output environment:
+  WP_TYPIA_ASCII=1 forces ASCII status markers; WP_TYPIA_ASCII=0 opts back into Unicode markers even when NO_COLOR is set.
+  NO_COLOR requests ASCII-safe markers such as [ok], [dry-run], [!], and [...] when WP_TYPIA_ASCII is not set.
 Notes:
   \`wp-typia create\` is the canonical scaffold command.
   \`wp-typia <project-dir>\` remains a backward-compatible alias to \`create\` when \`<project-dir>\` is the only positional argument.

--- a/packages/wp-typia-project-tools/src/runtime/cli-help.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-help.ts
@@ -40,7 +40,7 @@ Built-in templates: ${TEMPLATE_IDS.join(", ")}
 Package managers: ${PACKAGE_MANAGER_IDS.join(", ")}
 Output environment:
   WP_TYPIA_ASCII=1 forces ASCII status markers; WP_TYPIA_ASCII=0 opts back into Unicode markers even when NO_COLOR is set.
-  NO_COLOR requests ASCII-safe markers such as [ok], [dry-run], [!], and [...] when WP_TYPIA_ASCII is not set.
+  A non-empty NO_COLOR requests ASCII-safe markers such as [ok], [dry-run], [!], and [...] when WP_TYPIA_ASCII is not set.
 Notes:
   \`wp-typia create\` is the canonical scaffold command.
   \`wp-typia <project-dir>\` remains a backward-compatible alias to \`create\` when \`<project-dir>\` is the only positional argument.

--- a/packages/wp-typia-project-tools/tests/cli-entry.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-entry.test.ts
@@ -775,7 +775,7 @@ test("formatHelpText keeps migration UI flags out of external template usage", (
   expect(helpText).toContain("--external-layer-id");
   expect(helpText).toContain("@wp-typia/create-workspace-template");
   expect(helpText).toContain("WP_TYPIA_ASCII=1 forces ASCII status markers");
-  expect(helpText).toContain("NO_COLOR requests ASCII-safe markers");
+  expect(helpText).toContain("non-empty NO_COLOR requests ASCII-safe markers");
   expect(helpText).toContain("`query-loop` is create-only.");
   expect(helpText).toContain("wp-typia add ai-feature <name>");
   expect(helpText).toContain(

--- a/packages/wp-typia-project-tools/tests/cli-entry.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-entry.test.ts
@@ -774,6 +774,8 @@ test("formatHelpText keeps migration UI flags out of external template usage", (
   expect(helpText).toContain("--external-layer-source");
   expect(helpText).toContain("--external-layer-id");
   expect(helpText).toContain("@wp-typia/create-workspace-template");
+  expect(helpText).toContain("WP_TYPIA_ASCII=1 forces ASCII status markers");
+  expect(helpText).toContain("NO_COLOR requests ASCII-safe markers");
   expect(helpText).toContain("`query-loop` is create-only.");
   expect(helpText).toContain("wp-typia add ai-feature <name>");
   expect(helpText).toContain(

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -77,6 +77,7 @@ const NODE_FALLBACK_RUNTIME_SUMMARY_LINES = [
   'Runtime: Node fallback',
   'Human-readable fallback for common non-interactive create/init/add/migrate flows, doctor, sync, templates, --help, and --version when Bun is unavailable.',
   `Install Bun 1.3.11+ or use \`bunx wp-typia ...\` for the full Bunli/OpenTUI runtime and Bun-only command surfaces such as \`skills\`, \`completions\`, and \`mcp\`. ${STANDALONE_GUIDANCE_LINE}`,
+  'Output markers: WP_TYPIA_ASCII=1 forces ASCII markers, WP_TYPIA_ASCII=0 opts back into Unicode markers, and NO_COLOR requests ASCII markers when WP_TYPIA_ASCII is unset.',
 ];
 
 function printLine(line = '') {

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -77,7 +77,7 @@ const NODE_FALLBACK_RUNTIME_SUMMARY_LINES = [
   'Runtime: Node fallback',
   'Human-readable fallback for common non-interactive create/init/add/migrate flows, doctor, sync, templates, --help, and --version when Bun is unavailable.',
   `Install Bun 1.3.11+ or use \`bunx wp-typia ...\` for the full Bunli/OpenTUI runtime and Bun-only command surfaces such as \`skills\`, \`completions\`, and \`mcp\`. ${STANDALONE_GUIDANCE_LINE}`,
-  'Output markers: WP_TYPIA_ASCII=1 forces ASCII markers, WP_TYPIA_ASCII=0 opts back into Unicode markers, and NO_COLOR requests ASCII markers when WP_TYPIA_ASCII is unset.',
+  'Output markers: WP_TYPIA_ASCII=1 forces ASCII markers, WP_TYPIA_ASCII=0 opts back into Unicode markers, and non-empty NO_COLOR requests ASCII markers when WP_TYPIA_ASCII is unset.',
 ];
 
 function printLine(line = '') {

--- a/packages/wp-typia/src/output-markers.ts
+++ b/packages/wp-typia/src/output-markers.ts
@@ -47,7 +47,7 @@ function readAsciiPreferenceFromEnv(
 }
 
 function hasNoColorPreference(env: NodeJS.ProcessEnv): boolean {
-  return typeof env.NO_COLOR === 'string';
+  return typeof env.NO_COLOR === 'string' && env.NO_COLOR.length > 0;
 }
 
 export function prefersAsciiOutput(options: OutputMarkerOptions = {}): boolean {

--- a/packages/wp-typia/src/output-markers.ts
+++ b/packages/wp-typia/src/output-markers.ts
@@ -46,6 +46,10 @@ function readAsciiPreferenceFromEnv(
   return undefined;
 }
 
+function hasNoColorPreference(env: NodeJS.ProcessEnv): boolean {
+  return typeof env.NO_COLOR === 'string';
+}
+
 export function prefersAsciiOutput(options: OutputMarkerOptions = {}): boolean {
   if (options.forceAscii) {
     return true;
@@ -55,6 +59,9 @@ export function prefersAsciiOutput(options: OutputMarkerOptions = {}): boolean {
   const envPreference = readAsciiPreferenceFromEnv(env);
   if (envPreference !== undefined) {
     return envPreference;
+  }
+  if (hasNoColorPreference(env)) {
+    return true;
   }
 
   const term = options.term ?? env.TERM;

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -352,7 +352,7 @@ describe('wp-typia package', () => {
       expect(helpOutput).toContain(commandName);
     }
     expect(helpOutput).toContain('Runtime: Node fallback');
-    expect(helpOutput).toContain('NO_COLOR requests ASCII markers');
+    expect(helpOutput).toContain('non-empty NO_COLOR requests ASCII markers');
     expect(helpOutput).toContain('create: Scaffold a new wp-typia project.');
     expect(createHelpOutput).toContain('--external-layer-source');
     expect(createHelpOutput).toContain('--external-layer-id');

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -352,6 +352,7 @@ describe('wp-typia package', () => {
       expect(helpOutput).toContain(commandName);
     }
     expect(helpOutput).toContain('Runtime: Node fallback');
+    expect(helpOutput).toContain('NO_COLOR requests ASCII markers');
     expect(helpOutput).toContain('create: Scaffold a new wp-typia project.');
     expect(createHelpOutput).toContain('--external-layer-source');
     expect(createHelpOutput).toContain('--external-layer-id');
@@ -409,6 +410,73 @@ describe('wp-typia package', () => {
     expect(output.trim()).toBe(`wp-typia ${packageManifest.version}`);
   });
 
+  test('honors NO_COLOR for ASCII-safe status markers through the canonical bin', () => {
+    const tempRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'wp-typia-no-color-markers-'),
+    );
+
+    try {
+      const asciiOutput = runUtf8Command(
+        'node',
+        [
+          entryPath,
+          'create',
+          'demo-no-color',
+          '--template',
+          'basic',
+          '--package-manager',
+          'npm',
+          '--yes',
+          '--dry-run',
+          '--no-install',
+        ],
+        {
+          cwd: tempRoot,
+          env: {
+            ...withoutAIAgentEnv(),
+            LANG: 'en_US.UTF-8',
+            LC_ALL: 'en_US.UTF-8',
+            NO_COLOR: '1',
+          },
+        },
+      );
+      const unicodeOutput = runUtf8Command(
+        'node',
+        [
+          entryPath,
+          'create',
+          'demo-unicode',
+          '--template',
+          'basic',
+          '--package-manager',
+          'npm',
+          '--yes',
+          '--dry-run',
+          '--no-install',
+        ],
+        {
+          cwd: tempRoot,
+          env: {
+            ...withoutAIAgentEnv(),
+            LANG: 'en_US.UTF-8',
+            LC_ALL: 'en_US.UTF-8',
+            NO_COLOR: '1',
+            WP_TYPIA_ASCII: '0',
+          },
+        },
+      );
+
+      expect(asciiOutput).toContain('[...] Resolving scaffold template');
+      expect(asciiOutput).toContain('[dry-run] Dry run for Demo No Color');
+      expect(asciiOutput).not.toContain('⏳');
+      expect(asciiOutput).not.toContain('🧪');
+      expect(unicodeOutput).toContain('⏳ Resolving scaffold template');
+      expect(unicodeOutput).toContain('🧪 Dry run for Demo Unicode');
+    } finally {
+      fs.rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
   test('keeps structured version output opt-in through --format json', () => {
     const output = runUtf8Command('node', [
       entryPath,
@@ -464,6 +532,7 @@ describe('wp-typia package', () => {
     );
     expect(helpResult.stdout).toContain('Runtime: Node fallback');
     expect(helpResult.stdout).toContain('standalone wp-typia binary');
+    expect(helpResult.stdout).toContain('WP_TYPIA_ASCII=1 forces ASCII markers');
     expect(createHelpResult.status).toBe(0);
     expect(createHelpResult.stderr).toBe('');
     expect(createHelpResult.stdout).toContain('--external-layer-source');

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -371,7 +371,7 @@ describe('wp-typia package', () => {
 
     try {
       const output = runUtf8Command(
-        'node',
+        process.execPath,
         [entryPath, 'init', '--format', 'json'],
         {
           cwd: fixtureRoot,
@@ -410,14 +410,14 @@ describe('wp-typia package', () => {
     expect(output.trim()).toBe(`wp-typia ${packageManifest.version}`);
   });
 
-  test('honors NO_COLOR for ASCII-safe status markers through the canonical bin', () => {
+  test('honors NO_COLOR for ASCII-safe status markers through the Node fallback bin', () => {
     const tempRoot = fs.mkdtempSync(
       path.join(os.tmpdir(), 'wp-typia-no-color-markers-'),
     );
 
     try {
       const asciiOutput = runUtf8Command(
-        'node',
+        process.execPath,
         [
           entryPath,
           'create',
@@ -433,7 +433,7 @@ describe('wp-typia package', () => {
         {
           cwd: tempRoot,
           env: {
-            ...withoutAIAgentEnv(),
+            ...withoutLocalBunEnv(),
             LANG: 'en_US.UTF-8',
             LC_ALL: 'en_US.UTF-8',
             NO_COLOR: '1',
@@ -441,7 +441,7 @@ describe('wp-typia package', () => {
         },
       );
       const unicodeOutput = runUtf8Command(
-        'node',
+        process.execPath,
         [
           entryPath,
           'create',
@@ -457,7 +457,7 @@ describe('wp-typia package', () => {
         {
           cwd: tempRoot,
           env: {
-            ...withoutAIAgentEnv(),
+            ...withoutLocalBunEnv(),
             LANG: 'en_US.UTF-8',
             LC_ALL: 'en_US.UTF-8',
             NO_COLOR: '1',
@@ -466,12 +466,12 @@ describe('wp-typia package', () => {
         },
       );
 
-      expect(asciiOutput).toContain('[...] Resolving scaffold template');
-      expect(asciiOutput).toContain('[dry-run] Dry run for Demo No Color');
+      expect(asciiOutput).toContain('[...]');
+      expect(asciiOutput).toContain('[dry-run]');
       expect(asciiOutput).not.toContain('⏳');
       expect(asciiOutput).not.toContain('🧪');
-      expect(unicodeOutput).toContain('⏳ Resolving scaffold template');
-      expect(unicodeOutput).toContain('🧪 Dry run for Demo Unicode');
+      expect(unicodeOutput).toContain('⏳');
+      expect(unicodeOutput).toContain('🧪');
     } finally {
       fs.rmSync(tempRoot, { force: true, recursive: true });
     }

--- a/packages/wp-typia/tests/output-markers.test.ts
+++ b/packages/wp-typia/tests/output-markers.test.ts
@@ -37,7 +37,7 @@ describe('output marker helpers', () => {
       prefersAsciiOutput({
         env: { LANG: 'en_US.UTF-8', NO_COLOR: '' },
       }),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       prefersAsciiOutput({
         env: { LANG: 'en_US.UTF-8', NO_COLOR: undefined },

--- a/packages/wp-typia/tests/output-markers.test.ts
+++ b/packages/wp-typia/tests/output-markers.test.ts
@@ -10,6 +10,7 @@ import {
 describe('output marker helpers', () => {
   test('prefers ASCII markers for explicit overrides and non-UTF locales', () => {
     expect(prefersAsciiOutput({ forceAscii: true })).toBe(true);
+    expect(prefersAsciiOutput({ env: { NO_COLOR: '1' } })).toBe(true);
     expect(prefersAsciiOutput({ env: { LANG: 'C' } })).toBe(true);
     expect(prefersAsciiOutput({ env: { TERM: 'dumb' } })).toBe(true);
     expect(prefersAsciiOutput({ env: { LANG: 'en_US.ISO-8859-1' } })).toBe(
@@ -20,10 +21,43 @@ describe('output marker helpers', () => {
   test('keeps Unicode markers for UTF-8 locales and modern default Windows', () => {
     expect(prefersAsciiOutput({ env: { LANG: 'en_US.UTF-8' } })).toBe(false);
     expect(prefersAsciiOutput({ env: { WP_TYPIA_ASCII: '0' } })).toBe(false);
+    expect(
+      prefersAsciiOutput({
+        env: { NO_COLOR: '1', WP_TYPIA_ASCII: '0' },
+      }),
+    ).toBe(false);
     expect(getOutputMarker('success', { forceAscii: true })).toBe('[ok]');
     expect(getOutputMarker('success', { env: { LANG: 'en_US.UTF-8' } })).toBe(
       '✅',
     );
+  });
+
+  test('documents marker precedence through TERM and locale fallbacks', () => {
+    expect(
+      prefersAsciiOutput({
+        env: { LANG: 'en_US.UTF-8', NO_COLOR: '' },
+      }),
+    ).toBe(true);
+    expect(
+      prefersAsciiOutput({
+        env: { LANG: 'en_US.UTF-8', NO_COLOR: undefined },
+      }),
+    ).toBe(false);
+    expect(
+      prefersAsciiOutput({
+        env: { LANG: 'en_US.UTF-8', TERM: 'dumb' },
+      }),
+    ).toBe(true);
+    expect(
+      prefersAsciiOutput({
+        env: { LANG: 'C', WP_TYPIA_ASCII: '0' },
+      }),
+    ).toBe(false);
+    expect(
+      prefersAsciiOutput({
+        env: { LANG: 'C', WP_TYPIA_ASCII: '1' },
+      }),
+    ).toBe(true);
   });
 
   test('formats and strips status markers across Unicode and ASCII styles', () => {


### PR DESCRIPTION
## Summary

- Honor `NO_COLOR` as an ASCII-safe output marker signal for `wp-typia` status/dry-run/progress markers.
- Keep project-specific `WP_TYPIA_ASCII` precedence explicit: `WP_TYPIA_ASCII=0` opts back into Unicode even when `NO_COLOR` is set, while `WP_TYPIA_ASCII=1` forces ASCII.
- Surface the supported output environment variables in both the project-tools help text and Node fallback help.

Closes #580

## Validation

- `bun test packages/wp-typia/tests/output-markers.test.ts`
- `bun test packages/wp-typia/tests/cli-package.test.ts -t "NO_COLOR|renders help output|renders general and command help"`
- `bun test packages/wp-typia-project-tools/tests/cli-entry.test.ts -t "formatHelpText"`
- `bun run --filter wp-typia test`
- `bun run typecheck`
- `bun run lint:repo`
- `bun run format:check`
- `bun run changesets:validate`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI now respects the `NO_COLOR` environment variable to use ASCII-safe status markers instead of Unicode characters.

* **Documentation**
  * Added help text explaining `NO_COLOR` and `WP_TYPIA_ASCII` environment variable behavior and their precedence rules.

* **Tests**
  * Expanded test coverage for environment variable-based output marker control and interaction between flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->