### PR TITLE
feat(cli): emit structured success json

### DIFF
--- a/.sampo/changesets/structured-success-json.md
+++ b/.sampo/changesets/structured-success-json.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Emit `ok: true` structured JSON success payloads for `wp-typia create --format json` and `wp-typia add --format json`.

--- a/packages/wp-typia/src/commands/add.ts
+++ b/packages/wp-typia/src/commands/add.ts
@@ -15,6 +15,7 @@ import {
 import { getAddBlockDefaults } from '../config';
 import { resolveBundledModuleHref } from '../render-loader';
 import { executeAddCommand } from '../runtime-bridge';
+import { buildStructuredCompletionSuccessPayload } from '../runtime-bridge-output';
 import { supportsInteractiveTui } from '../runtime-capabilities';
 import type { WpTypiaRenderArgs } from './render-types';
 import { LazyFlow } from '../ui/lazy-flow';
@@ -50,7 +51,14 @@ export const addCommand = defineCommand({
           kind: args.positional[0],
           name: args.positional[1],
         });
-        args.output({ completion });
+        args.output(
+          buildStructuredCompletionSuccessPayload('add', completion, {
+            dryRun: Boolean(args.flags['dry-run']),
+            kind: args.positional[0],
+            name: args.positional[1],
+            projectDir: args.cwd,
+          }),
+        );
         return;
       }
 

--- a/packages/wp-typia/src/commands/add.ts
+++ b/packages/wp-typia/src/commands/add.ts
@@ -15,7 +15,10 @@ import {
 import { getAddBlockDefaults } from '../config';
 import { resolveBundledModuleHref } from '../render-loader';
 import { executeAddCommand } from '../runtime-bridge';
-import { buildStructuredCompletionSuccessPayload } from '../runtime-bridge-output';
+import {
+  buildStructuredCompletionSuccessPayload,
+  extractCompletionProjectDir,
+} from '../runtime-bridge-output';
 import { supportsInteractiveTui } from '../runtime-capabilities';
 import type { WpTypiaRenderArgs } from './render-types';
 import { LazyFlow } from '../ui/lazy-flow';
@@ -56,7 +59,7 @@ export const addCommand = defineCommand({
             dryRun: Boolean(args.flags['dry-run']),
             kind: args.positional[0],
             name: args.positional[1],
-            projectDir: args.cwd,
+            projectDir: extractCompletionProjectDir(completion) ?? args.cwd,
           }),
         );
         return;

--- a/packages/wp-typia/src/commands/create.ts
+++ b/packages/wp-typia/src/commands/create.ts
@@ -14,7 +14,10 @@ import {
 import { getCreateDefaults } from "../config";
 import { resolveBundledModuleHref } from "../render-loader";
 import { executeCreateCommand } from "../runtime-bridge";
-import { buildStructuredCompletionSuccessPayload } from "../runtime-bridge-output";
+import {
+	buildStructuredCompletionSuccessPayload,
+	extractCompletionProjectDir,
+} from "../runtime-bridge-output";
 import { supportsInteractiveTui } from "../runtime-capabilities";
 import type { WpTypiaRenderArgs } from "./render-types";
 import { LazyFlow } from "../ui/lazy-flow";
@@ -61,7 +64,7 @@ export const createCommand = defineCommand({
 				args.output(
 					buildStructuredCompletionSuccessPayload("create", completion, {
 						dryRun: Boolean(args.flags["dry-run"]),
-						projectDir,
+						projectDir: extractCompletionProjectDir(completion) ?? projectDir,
 						template:
 							typeof args.flags.template === "string"
 								? args.flags.template

--- a/packages/wp-typia/src/commands/create.ts
+++ b/packages/wp-typia/src/commands/create.ts
@@ -7,10 +7,14 @@ import {
 	CREATE_OPTION_METADATA,
 	resolveCommandOptionValues,
 } from "../command-option-metadata";
-import { emitCliDiagnosticFailure } from "../cli-diagnostic-output";
+import {
+	emitCliDiagnosticFailure,
+	prefersStructuredCliOutput,
+} from "../cli-diagnostic-output";
 import { getCreateDefaults } from "../config";
 import { resolveBundledModuleHref } from "../render-loader";
 import { executeCreateCommand } from "../runtime-bridge";
+import { buildStructuredCompletionSuccessPayload } from "../runtime-bridge-output";
 import { supportsInteractiveTui } from "../runtime-capabilities";
 import type { WpTypiaRenderArgs } from "./render-types";
 import { LazyFlow } from "../ui/lazy-flow";
@@ -33,6 +37,7 @@ export const createCommand = defineCommand({
 	defaultFormat: "toon",
 	description: "Scaffold a new wp-typia project.",
 	handler: async (args) => {
+		const prefersStructuredOutput = prefersStructuredCliOutput(args);
 		const projectDir = args.positional[0];
 		if (!projectDir) {
 			emitCliDiagnosticFailure(args, {
@@ -45,11 +50,25 @@ export const createCommand = defineCommand({
 			return;
 		}
 		try {
-			await executeCreateCommand({
+			const completion = await executeCreateCommand({
 				cwd: args.cwd,
+				emitOutput: !prefersStructuredOutput,
 				flags: args.flags as Record<string, unknown>,
+				interactive: prefersStructuredOutput ? false : undefined,
 				projectDir,
 			});
+			if (prefersStructuredOutput) {
+				args.output(
+					buildStructuredCompletionSuccessPayload("create", completion, {
+						dryRun: Boolean(args.flags["dry-run"]),
+						projectDir,
+						template:
+							typeof args.flags.template === "string"
+								? args.flags.template
+								: undefined,
+					}),
+				);
+			}
 		} catch (error) {
 			emitCliDiagnosticFailure(args, {
 				command: "create",

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -533,7 +533,7 @@ export async function runNodeCli(argv = process.argv.slice(2)): Promise<void> {
         JSON.stringify(
           buildStructuredCompletionSuccessPayload('create', completion, {
             dryRun: Boolean(mergedFlags['dry-run']),
-            projectDir,
+            projectDir: extractCompletionProjectDir(completion) ?? projectDir,
             template:
               typeof mergedFlags.template === 'string'
                 ? mergedFlags.template

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -46,6 +46,7 @@ import {
 import {
   buildStructuredCompletionSuccessPayload,
   buildSyncDryRunPayload,
+  extractCompletionProjectDir,
   printCompletionPayload,
 } from './runtime-bridge-output';
 import { resolveSyncExecutionTarget } from './runtime-bridge-sync';
@@ -606,7 +607,7 @@ export async function runNodeCli(argv = process.argv.slice(2)): Promise<void> {
             dryRun: Boolean(mergedFlags['dry-run']),
             kind: positionals[1],
             name: positionals[2],
-            projectDir: process.cwd(),
+            projectDir: extractCompletionProjectDir(completion) ?? process.cwd(),
           }),
           null,
           2,

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -44,6 +44,7 @@ import {
   executeTemplatesCommand,
 } from './runtime-bridge';
 import {
+  buildStructuredCompletionSuccessPayload,
   buildSyncDryRunPayload,
   printCompletionPayload,
 } from './runtime-bridge-output';
@@ -511,12 +512,37 @@ export async function runNodeCli(argv = process.argv.slice(2)): Promise<void> {
         ],
       });
     }
-    await executeCreateCommand({
-      cwd: process.cwd(),
-      flags: mergedFlags,
-      interactive: false,
-      projectDir,
-    });
+    let completion;
+    try {
+      completion = await executeCreateCommand({
+        cwd: process.cwd(),
+        emitOutput: mergedFlags.format !== 'json',
+        flags: mergedFlags,
+        interactive: false,
+        projectDir,
+      });
+    } catch (error) {
+      throw createCliCommandError({
+        command: 'create',
+        error,
+      });
+    }
+    if (mergedFlags.format === 'json') {
+      printLine(
+        JSON.stringify(
+          buildStructuredCompletionSuccessPayload('create', completion, {
+            dryRun: Boolean(mergedFlags['dry-run']),
+            projectDir,
+            template:
+              typeof mergedFlags.template === 'string'
+                ? mergedFlags.template
+                : undefined,
+          }),
+          null,
+          2,
+        ),
+      );
+    }
     return;
   }
 
@@ -576,9 +602,12 @@ export async function runNodeCli(argv = process.argv.slice(2)): Promise<void> {
       }
       printLine(
         JSON.stringify(
-          {
-            completion,
-          },
+          buildStructuredCompletionSuccessPayload('add', completion, {
+            dryRun: Boolean(mergedFlags['dry-run']),
+            kind: positionals[1],
+            name: positionals[2],
+            projectDir: process.cwd(),
+          }),
           null,
           2,
         ),

--- a/packages/wp-typia/src/runtime-bridge-output.ts
+++ b/packages/wp-typia/src/runtime-bridge-output.ts
@@ -156,7 +156,7 @@ export function serializeCompletionPayload(
  */
 export function buildStructuredCompletionSuccessPayload(
   command: string,
-  completion: AlternateBufferCompletionPayload | undefined | void,
+  completion: AlternateBufferCompletionPayload | void,
   metadata: Record<string, unknown> = {},
 ): StructuredCompletionSuccessPayload {
   const serializedCompletion = completion
@@ -166,8 +166,8 @@ export function buildStructuredCompletionSuccessPayload(
   return {
     ok: true,
     data: {
-      command,
       ...metadata,
+      command,
       ...(serializedCompletion
         ? {
             completion: serializedCompletion,

--- a/packages/wp-typia/src/runtime-bridge-output.ts
+++ b/packages/wp-typia/src/runtime-bridge-output.ts
@@ -125,6 +125,25 @@ function extractPlannedFiles(payload: SerializableCompletionPayload): string[] |
   return toNonEmptyArray(files);
 }
 
+const PROJECT_DIRECTORY_SUMMARY_PREFIX = 'Project directory: ';
+
+/**
+ * Reads the normalized workspace path from a completion summary when present.
+ *
+ * @param completion Completion payload returned by an add/create runtime.
+ * @returns The runtime-resolved project directory, or undefined when absent.
+ */
+export function extractCompletionProjectDir(
+  completion: AlternateBufferCompletionPayload | void,
+): string | undefined {
+  const projectDir = completion?.summaryLines
+    ?.find((line) => line.startsWith(PROJECT_DIRECTORY_SUMMARY_PREFIX))
+    ?.slice(PROJECT_DIRECTORY_SUMMARY_PREFIX.length)
+    .trim();
+
+  return projectDir && projectDir.length > 0 ? projectDir : undefined;
+}
+
 /**
  * Converts a completion payload into a JSON-safe shape without terminal markers.
  *

--- a/packages/wp-typia/src/runtime-bridge-output.ts
+++ b/packages/wp-typia/src/runtime-bridge-output.ts
@@ -119,7 +119,7 @@ function toNonEmptyArray(values: string[] | undefined): string[] | undefined {
 
 function extractPlannedFiles(payload: SerializableCompletionPayload): string[] | undefined {
   const files = payload.optionalLines
-    ?.map((line) => line.match(/^write\s+(.+)$/u)?.[1])
+    ?.map((line) => line.match(/^(?:delete|update|write)\s+(.+)$/u)?.[1])
     .filter((value): value is string => typeof value === 'string' && value.length > 0);
 
   return toNonEmptyArray(files);

--- a/packages/wp-typia/src/runtime-bridge-output.ts
+++ b/packages/wp-typia/src/runtime-bridge-output.ts
@@ -22,6 +22,34 @@ export type CreateProgressPayload = {
   title: string;
 };
 
+export type StructuredCompletionSuccessPayload = {
+  ok: true;
+  data: {
+    command: string;
+    completion?: SerializableCompletionPayload;
+    files?: string[];
+    nextSteps?: string[];
+    optionalLines?: string[];
+    optionalNote?: string;
+    optionalTitle?: string;
+    preambleLines?: string[];
+    summaryLines?: string[];
+    title?: string;
+    warnings?: string[];
+  } & Record<string, unknown>;
+};
+
+export type SerializableCompletionPayload = {
+  nextSteps?: string[];
+  optionalLines?: string[];
+  optionalNote?: string;
+  optionalTitle?: string;
+  preambleLines?: string[];
+  summaryLines?: string[];
+  title: string;
+  warningLines?: string[];
+};
+
 type ExternalLayerSelectOption = {
   description?: string;
   extends: string[];
@@ -83,6 +111,79 @@ export function printCompletionPayload(
   if (payload.optionalNote) {
     printLine(`Note: ${payload.optionalNote}`);
   }
+}
+
+function toNonEmptyArray(values: string[] | undefined): string[] | undefined {
+  return values && values.length > 0 ? values : undefined;
+}
+
+function extractPlannedFiles(payload: SerializableCompletionPayload): string[] | undefined {
+  const files = payload.optionalLines
+    ?.map((line) => line.match(/^write\s+(.+)$/u)?.[1])
+    .filter((value): value is string => typeof value === 'string' && value.length > 0);
+
+  return toNonEmptyArray(files);
+}
+
+/**
+ * Converts a completion payload into a JSON-safe shape without terminal markers.
+ *
+ * @param payload Human-readable completion payload.
+ * @returns A marker-free payload suitable for structured CLI success output.
+ */
+export function serializeCompletionPayload(
+  payload: AlternateBufferCompletionPayload,
+): SerializableCompletionPayload {
+  return {
+    nextSteps: toNonEmptyArray(payload.nextSteps),
+    optionalLines: toNonEmptyArray(payload.optionalLines),
+    optionalNote: payload.optionalNote,
+    optionalTitle: payload.optionalTitle,
+    preambleLines: toNonEmptyArray(payload.preambleLines),
+    summaryLines: toNonEmptyArray(payload.summaryLines),
+    title: stripLeadingOutputMarker(payload.title),
+    warningLines: toNonEmptyArray(payload.warningLines),
+  };
+}
+
+/**
+ * Wraps structured completion data in the same success envelope used by JSON CLI output.
+ *
+ * @param command Command name that produced the completion payload.
+ * @param completion Completion payload returned by the runtime bridge.
+ * @param metadata Additional command-specific fields for automation.
+ * @returns JSON-serializable success payload.
+ */
+export function buildStructuredCompletionSuccessPayload(
+  command: string,
+  completion: AlternateBufferCompletionPayload | undefined | void,
+  metadata: Record<string, unknown> = {},
+): StructuredCompletionSuccessPayload {
+  const serializedCompletion = completion
+    ? serializeCompletionPayload(completion)
+    : undefined;
+
+  return {
+    ok: true,
+    data: {
+      command,
+      ...metadata,
+      ...(serializedCompletion
+        ? {
+            completion: serializedCompletion,
+            files: extractPlannedFiles(serializedCompletion),
+            nextSteps: serializedCompletion.nextSteps,
+            optionalLines: serializedCompletion.optionalLines,
+            optionalNote: serializedCompletion.optionalNote,
+            optionalTitle: serializedCompletion.optionalTitle,
+            preambleLines: serializedCompletion.preambleLines,
+            summaryLines: serializedCompletion.summaryLines,
+            title: serializedCompletion.title,
+            warnings: serializedCompletion.warningLines,
+          }
+        : {}),
+    },
+  };
 }
 
 /**

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -1375,12 +1375,14 @@ describe('wp-typia package', () => {
     try {
       await scaffoldOfficialWorkspace(projectDir);
       linkWorkspaceNodeModules(projectDir);
+      const nestedCwd = path.join(projectDir, 'src', 'nested-cwd');
+      fs.mkdirSync(nestedCwd, { recursive: true });
 
       const result = runCapturedCommand(
         process.execPath,
         [entryPath, 'add', 'block', 'promo-card', '--format', 'json'],
         {
-          cwd: projectDir,
+          cwd: nestedCwd,
           env: withoutLocalBunEnv(),
         },
       );
@@ -1393,6 +1395,7 @@ describe('wp-typia package', () => {
           };
           kind?: string;
           name?: string;
+          projectDir?: string;
           summaryLines?: string[];
           title?: string;
         };
@@ -1406,6 +1409,7 @@ describe('wp-typia package', () => {
       expect(parsed.data?.command).toBe('add');
       expect(parsed.data?.kind).toBe('block');
       expect(parsed.data?.name).toBe('promo-card');
+      expect(parsed.data?.projectDir).toBe(fs.realpathSync(projectDir));
       expect(parsed.data?.title).toContain('Added workspace block');
       expect(parsed.data?.completion?.title).toBe(parsed.data?.title);
       expect(parsed.data?.summaryLines).toContain('Template family: basic');

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -439,6 +439,7 @@ describe('wp-typia package', () => {
           };
           dryRun?: boolean;
           files?: string[];
+          projectDir?: string;
           template?: string;
           title?: string;
         };
@@ -451,6 +452,9 @@ describe('wp-typia package', () => {
       expect(parsed.ok).toBe(true);
       expect(parsed.data?.command).toBe('create');
       expect(parsed.data?.dryRun).toBe(true);
+      expect(parsed.data?.projectDir).toBe(
+        path.join(fs.realpathSync(tempRoot), 'demo-json'),
+      );
       expect(parsed.data?.template).toBe('basic');
       expect(parsed.data?.title).toContain('Dry run for Demo Json');
       expect(parsed.data?.completion?.title).toBe(parsed.data?.title);

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -404,6 +404,64 @@ describe('wp-typia package', () => {
     }
   });
 
+  test('emits structured create completion output in Node fallback JSON mode', () => {
+    const tempRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'wp-typia-create-json-'),
+    );
+
+    try {
+      const result = runCapturedCommand(
+        process.execPath,
+        [
+          entryPath,
+          'create',
+          'demo-json',
+          '--template',
+          'basic',
+          '--package-manager',
+          'npm',
+          '--yes',
+          '--dry-run',
+          '--no-install',
+          '--format',
+          'json',
+        ],
+        {
+          cwd: tempRoot,
+          env: withoutLocalBunEnv(),
+        },
+      );
+      const parsed = parseJsonObjectFromOutput<{
+        data?: {
+          command?: string;
+          completion?: {
+            title?: string;
+          };
+          dryRun?: boolean;
+          files?: string[];
+          template?: string;
+          title?: string;
+        };
+        ok?: boolean;
+      }>(result.stdout);
+      const serialized = JSON.stringify(parsed);
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe('');
+      expect(parsed.ok).toBe(true);
+      expect(parsed.data?.command).toBe('create');
+      expect(parsed.data?.dryRun).toBe(true);
+      expect(parsed.data?.template).toBe('basic');
+      expect(parsed.data?.title).toContain('Dry run for Demo Json');
+      expect(parsed.data?.completion?.title).toBe(parsed.data?.title);
+      expect(parsed.data?.files).toContain('package.json');
+      expect(parsed.data?.files).toContain('src/index.tsx');
+      expect(serialized).not.toMatch(/[✅🧪⏳⚠]/u);
+    } finally {
+      fs.rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
   test('renders a human-readable version line through the canonical bin', () => {
     const output = runUtf8Command('node', [entryPath, '--version']);
 
@@ -1327,18 +1385,31 @@ describe('wp-typia package', () => {
         },
       );
       const parsed = parseJsonObjectFromOutput<{
-        completion?: {
+        data?: {
+          command?: string;
+          completion?: {
+            summaryLines?: string[];
+            title?: string;
+          };
+          kind?: string;
+          name?: string;
           summaryLines?: string[];
           title?: string;
         };
+        ok?: boolean;
       }>(result.stdout);
+      const serialized = JSON.stringify(parsed);
 
       expect(result.status).toBe(0);
       expect(result.stderr).toBe('');
-      expect(parsed.completion?.title).toContain('Added workspace block');
-      expect(parsed.completion?.summaryLines).toContain(
-        'Template family: basic',
-      );
+      expect(parsed.ok).toBe(true);
+      expect(parsed.data?.command).toBe('add');
+      expect(parsed.data?.kind).toBe('block');
+      expect(parsed.data?.name).toBe('promo-card');
+      expect(parsed.data?.title).toContain('Added workspace block');
+      expect(parsed.data?.completion?.title).toBe(parsed.data?.title);
+      expect(parsed.data?.summaryLines).toContain('Template family: basic');
+      expect(serialized).not.toMatch(/[✅🧪⏳⚠]/u);
       expect(
         fs.existsSync(
           path.join(projectDir, 'src', 'blocks', 'promo-card', 'block.json'),

--- a/packages/wp-typia/tests/completion-output.test.ts
+++ b/packages/wp-typia/tests/completion-output.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   buildAddCompletionPayload,
   buildAddDryRunPayload,
+  buildStructuredCompletionSuccessPayload,
   buildSyncDryRunPayload,
 } from '../src/runtime-bridge-output';
 
@@ -307,6 +308,24 @@ describe('alternate-buffer completion output helpers', () => {
     expect(payload.warningLines).toBeUndefined();
     expect(payload.optionalTitle).toBe('Planned workspace updates (1):');
     expect(payload.optionalLines).toEqual(['write src/blocks/faq/block.json']);
+  });
+
+  test('structured completion files include all dry-run file operations', () => {
+    const payload = buildStructuredCompletionSuccessPayload('add', {
+      optionalLines: [
+        'write src/blocks/promo-card/block.json',
+        'update scripts/block-config.ts',
+        'delete src/blocks/old-card/block.json',
+        `npx --yes wp-typia@${packageJson.version} doctor`,
+      ],
+      title: 'Dry run for workspace add command',
+    });
+
+    expect(payload.data.files).toEqual([
+      'src/blocks/promo-card/block.json',
+      'scripts/block-config.ts',
+      'src/blocks/old-card/block.json',
+    ]);
   });
 
   test('dry-run sync payload previews the generated sync commands', () => {


### PR DESCRIPTION
## Summary
- add a structured JSON success envelope for create/add completion output
- keep human-readable create/add output unchanged while stripping terminal-only markers from JSON
- align Node fallback and Bunli command paths on the same serialized success payload

## Validation
- bun run --filter wp-typia build
- bun run typecheck
- bun run format:check
- bun run lint:repo
- bun run changesets:validate
- bun test packages/wp-typia/tests/cli-package.test.ts -t "structured create completion|structured add completion|invalid-argument error code for create variant|unknown-template error code for removed"
- bun run --filter wp-typia test
- git diff --check

Closes #578

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `create` and `add` now emit consistent structured JSON success responses (`ok: true`) for `--format json`, including command, dry-run flag, project directory, template (when provided), and other completion details.
* **Tests**
  * Added/updated tests to validate the new structured JSON schema, file-operation listings, and absence of terminal status markers in serialized output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->