### PR TITLE
refactor(project-tools): consolidate runtime helpers

### DIFF
--- a/.sampo/changesets/project-tools-runtime-utils.md
+++ b/.sampo/changesets/project-tools-runtime-utils.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Consolidated generated workspace PHP/string helpers and package metadata types behind shared runtime utilities.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ability.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ability.ts
@@ -10,7 +10,14 @@ import {
 	readWorkspaceInventory,
 } from "./workspace-inventory.js";
 import { resolveWorkspaceProject, type WorkspaceProject } from "./workspace-project.js";
-import { toTitleCase } from "./string-case.js";
+import { toPascalCase, toTitleCase } from "./string-case.js";
+import {
+	escapeRegex,
+	findPhpFunctionRange,
+	hasPhpFunctionDefinition,
+	quotePhpString,
+	replacePhpFunctionDefinition,
+} from "./php-utils.js";
 import {
 	assertAbilityDoesNotExist,
 	assertValidGeneratedSlug,
@@ -41,62 +48,6 @@ const WP_CORE_ABILITIES_PACKAGE_VERSION = "^0.9.0";
 const WP_ABILITIES_SCRIPT_MODULE_ID = "@wordpress/abilities";
 const WP_CORE_ABILITIES_SCRIPT_MODULE_ID = "@wordpress/core-abilities";
 
-function escapeRegex(value: string): string {
-	return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
-}
-
-function quotePhpString(value: string): string {
-	return `'${value.replace(/\\/gu, "\\\\").replace(/'/gu, "\\'")}'`;
-}
-
-function findPhpFunctionRange(
-	source: string,
-	functionName: string,
-): { end: number; source: string; start: number } | null {
-	const functionPattern = new RegExp(
-		`function\\s+${escapeRegex(functionName)}\\s*\\([^)]*\\)\\s*\\{`,
-		"u",
-	);
-	const match = functionPattern.exec(source);
-	if (!match) {
-		return null;
-	}
-
-	const openingBraceIndex = match.index + match[0].length - 1;
-	let depth = 0;
-	for (let index = openingBraceIndex; index < source.length; index += 1) {
-		const character = source[index];
-		if (character === "{") {
-			depth += 1;
-		} else if (character === "}") {
-			depth -= 1;
-			if (depth === 0) {
-				const end = index + 1;
-				return {
-					end,
-					source: source.slice(match.index, end),
-					start: match.index,
-				};
-			}
-		}
-	}
-
-	return null;
-}
-
-function replacePhpFunctionDefinition(
-	source: string,
-	functionName: string,
-	replacement: string,
-): string {
-	const functionRange = findPhpFunctionRange(source, functionName);
-	if (!functionRange) {
-		return source;
-	}
-
-	return `${source.slice(0, functionRange.start)}${replacement.trimStart()}${source.slice(functionRange.end)}`;
-}
-
 function resolveManagedDependencyVersion(
 	existingVersion: string | undefined,
 	requiredVersion: string,
@@ -116,14 +67,6 @@ function resolveManagedDependencyVersion(
 		: requiredVersion;
 }
 
-function toPascalCaseFromAbilitySlug(abilitySlug: string): string {
-	return normalizeBlockSlug(abilitySlug)
-		.split("-")
-		.filter(Boolean)
-		.map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
-		.join("");
-}
-
 function toAbilityCategorySlug(workspaceNamespace: string): string {
 	const normalizedNamespace = workspaceNamespace
 		.replace(/[^a-z0-9-]+/gu, "-")
@@ -137,7 +80,7 @@ function buildAbilityConfigEntry(
 	abilitySlug: string,
 	compatibilityPolicy: ScaffoldCompatibilityPolicy,
 ): string {
-	const pascalCase = toPascalCaseFromAbilitySlug(abilitySlug);
+	const pascalCase = toPascalCase(abilitySlug);
 
 	return [
 		"\t{",
@@ -192,7 +135,7 @@ function buildAbilityConfigSource(
 }
 
 function buildAbilityTypesSource(abilitySlug: string): string {
-	const pascalCase = toPascalCaseFromAbilitySlug(abilitySlug);
+	const pascalCase = toPascalCase(abilitySlug);
 
 	return `export interface ${pascalCase}AbilityInput {
 \tcontextId: number;
@@ -209,7 +152,7 @@ export interface ${pascalCase}AbilityOutput {
 }
 
 function buildAbilityDataSource(abilitySlug: string): string {
-	const pascalCase = toPascalCaseFromAbilitySlug(abilitySlug);
+	const pascalCase = toPascalCase(abilitySlug);
 	const abilityConstBase = abilitySlug
 		.toUpperCase()
 		.replace(/[^A-Z0-9]+/gu, "_")
@@ -311,7 +254,7 @@ export async function run${pascalCase}Ability(
 }
 
 function buildAbilityClientSource(abilitySlug: string): string {
-	const pascalCase = toPascalCaseFromAbilitySlug(abilitySlug);
+	const pascalCase = toPascalCase(abilitySlug);
 
 	return `/**
  * Re-export the typed ${pascalCase} ability client helpers.
@@ -760,10 +703,6 @@ function ${enqueueFunctionName}() {
 			/add_action\(\s*["']init["']\s*,\s*["'][^"']+_load_textdomain["']\s*\);\s*\n/u,
 			/\?>\s*$/u,
 		];
-		const hasPhpFunctionDefinition = (functionName: string): boolean =>
-			new RegExp(`function\\s+${escapeRegex(functionName)}\\s*\\(`, "u").test(
-				nextSource,
-			);
 		const insertPhpSnippet = (snippet: string): void => {
 			for (const anchor of insertionAnchors) {
 				const candidate = nextSource.replace(anchor, (match) => `${snippet}\n${match}`);
@@ -783,21 +722,23 @@ function ${enqueueFunctionName}() {
 			nextSource = `${nextSource.trimEnd()}\n${snippet}\n`;
 		};
 
-		if (!hasPhpFunctionDefinition(loadFunctionName)) {
+		if (!hasPhpFunctionDefinition(nextSource, loadFunctionName)) {
 			insertPhpSnippet(loadFunction);
 		}
-		if (!hasPhpFunctionDefinition(enqueueFunctionName)) {
+		if (!hasPhpFunctionDefinition(nextSource, enqueueFunctionName)) {
 			insertPhpSnippet(enqueueFunction);
 		} else if (
 			!findPhpFunctionRange(nextSource, enqueueFunctionName)?.source.includes(
 				"wp_enqueue_script_module",
 			)
 		) {
-			nextSource = replacePhpFunctionDefinition(
-				nextSource,
-				enqueueFunctionName,
-				enqueueFunction,
-			);
+			nextSource =
+				replacePhpFunctionDefinition(
+					nextSource,
+					enqueueFunctionName,
+					enqueueFunction,
+					{ trimReplacementStart: true },
+				) ?? nextSource;
 		}
 
 		if (!nextSource.includes(loadHook)) {
@@ -1139,7 +1080,7 @@ export async function runAddAbilityCommand({
 			"utf8",
 		);
 
-		const pascalCase = toPascalCaseFromAbilitySlug(abilitySlug);
+		const pascalCase = toPascalCase(abilitySlug);
 		await syncTypeSchemas({
 			jsonSchemaFile: `src/abilities/${abilitySlug}/input.schema.json`,
 			projectRoot: workspace.projectDir,

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai-anchors.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai-anchors.ts
@@ -6,13 +6,10 @@ import {
 	getWorkspaceBootstrapPath,
 	patchFile,
 } from "./cli-add-shared.js";
+import { hasPhpFunctionDefinition } from "./php-utils.js";
 import type { WorkspaceProject } from "./workspace-project.js";
 
 const AI_FEATURE_SERVER_GLOB = "/inc/ai-features/*.php";
-
-function escapeRegex(value: string): string {
-	return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
-}
 
 /**
  * Patch the workspace bootstrap file so it loads generated AI feature PHP modules.
@@ -38,8 +35,6 @@ function ${registerFunctionName}() {
 			/add_action\(\s*["']init["']\s*,\s*["'][^"']+_load_textdomain["']\s*\);\s*\n/u,
 			/\?>\s*$/u,
 		];
-		const hasPhpFunctionDefinition = (functionName: string): boolean =>
-			new RegExp(`function\\s+${escapeRegex(functionName)}\\s*\\(`, "u").test(nextSource);
 		const insertPhpSnippet = (snippet: string): void => {
 			for (const anchor of insertionAnchors) {
 				const candidate = nextSource.replace(anchor, (match) => `${snippet}\n${match}`);
@@ -59,7 +54,7 @@ function ${registerFunctionName}() {
 			nextSource = `${nextSource.trimEnd()}\n${snippet}\n`;
 		};
 
-		if (!hasPhpFunctionDefinition(registerFunctionName)) {
+		if (!hasPhpFunctionDefinition(nextSource, registerFunctionName)) {
 			insertPhpSnippet(registerFunction);
 		} else if (!nextSource.includes(AI_FEATURE_SERVER_GLOB)) {
 			throw new Error(

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai-source-emitters.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai-source-emitters.ts
@@ -1,25 +1,11 @@
-import {
-	normalizeBlockSlug,
-	quoteTsString,
-} from "./cli-add-shared.js";
+import { quoteTsString } from "./cli-add-shared.js";
 import { buildAiFeatureEndpointManifest } from "./ai-feature-artifacts.js";
 import {
 	OPTIONAL_WORDPRESS_AI_CLIENT_COMPATIBILITY,
 	renderScaffoldCompatibilityConfig,
 	resolveScaffoldCompatibilityPolicy,
 } from "./scaffold-compatibility.js";
-import { toTitleCase } from "./string-case.js";
-
-/**
- * Convert an AI feature slug into the PascalCase identifier used by generated types.
- */
-export function toPascalCaseFromAiFeatureSlug(slug: string): string {
-	return normalizeBlockSlug(slug)
-		.split("-")
-		.filter(Boolean)
-		.map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
-		.join("");
-}
+import { toPascalCase, toTitleCase } from "./string-case.js";
 
 function indentMultiline(source: string, prefix: string): string {
 	return source
@@ -35,7 +21,7 @@ export function buildAiFeatureConfigEntry(
 	aiFeatureSlug: string,
 	namespace: string,
 ): string {
-	const pascalCase = toPascalCaseFromAiFeatureSlug(aiFeatureSlug);
+	const pascalCase = toPascalCase(aiFeatureSlug);
 	const title = toTitleCase(aiFeatureSlug);
 	const compatibilityPolicy = resolveScaffoldCompatibilityPolicy(
 		OPTIONAL_WORDPRESS_AI_CLIENT_COMPATIBILITY,
@@ -83,7 +69,7 @@ export function buildAiFeatureConfigEntry(
  * Generate TypeScript request, response, and telemetry contracts for an AI feature scaffold.
  */
 export function buildAiFeatureTypesSource(aiFeatureSlug: string): string {
-	const pascalCase = toPascalCaseFromAiFeatureSlug(aiFeatureSlug);
+	const pascalCase = toPascalCase(aiFeatureSlug);
 
 	return `import { tags } from 'typia';
 
@@ -128,7 +114,7 @@ export interface ${pascalCase}AiFeatureResponse {
 export function buildAiFeatureValidatorsSource(
 	aiFeatureSlug: string,
 ): string {
-	const pascalCase = toPascalCaseFromAiFeatureSlug(aiFeatureSlug);
+	const pascalCase = toPascalCase(aiFeatureSlug);
 
 	return `import typia from 'typia';
 
@@ -164,7 +150,7 @@ export const apiValidators = {
  * Generate the typed client wrapper that calls the scaffolded AI feature endpoint.
  */
 export function buildAiFeatureApiSource(aiFeatureSlug: string): string {
-	const pascalCase = toPascalCaseFromAiFeatureSlug(aiFeatureSlug);
+	const pascalCase = toPascalCase(aiFeatureSlug);
 
 	return `import {
 \tcallEndpoint,
@@ -224,7 +210,7 @@ export function runAiFeature( request: ${pascalCase}AiFeatureRequest ) {
  * Generate React endpoint-mutation hooks for the scaffolded AI feature client wrapper.
  */
 export function buildAiFeatureDataSource(aiFeatureSlug: string): string {
-	const pascalCase = toPascalCaseFromAiFeatureSlug(aiFeatureSlug);
+	const pascalCase = toPascalCase(aiFeatureSlug);
 
 	return `import {
 \tuseEndpointMutation,

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai.ts
@@ -21,7 +21,6 @@ import {
 	buildAiFeatureTypesSource,
 	buildAiFeatureValidatorsSource,
 	buildAiFeatureApiSource,
-	toPascalCaseFromAiFeatureSlug,
 } from "./cli-add-workspace-ai-source-emitters.js";
 import {
 	ensureAiFeatureBootstrapAnchors,
@@ -40,11 +39,8 @@ import {
 	resolveScaffoldCompatibilityPolicy,
 	updatePluginHeaderCompatibility,
 } from "./scaffold-compatibility.js";
-import { toTitleCase } from "./string-case.js";
-
-function quotePhpString(value: string): string {
-	return `'${value.replace(/\\/gu, "\\\\").replace(/'/gu, "\\'")}'`;
-}
+import { quotePhpString } from "./php-utils.js";
+import { toPascalCase, toTitleCase } from "./string-case.js";
 
 function buildAiFeaturePhpSource(
 	aiFeatureSlug: string,
@@ -545,7 +541,7 @@ export async function runAddAiFeatureCommand({
 			"utf8",
 		);
 
-		const pascalCase = toPascalCaseFromAiFeatureSlug(aiFeatureSlug);
+		const pascalCase = toPascalCase(aiFeatureSlug);
 		await syncAiFeatureRestArtifacts({
 			clientFile: `src/ai-features/${aiFeatureSlug}/api-client.ts`,
 			outputDir: path.join("src", "ai-features", aiFeatureSlug),

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-assets.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-assets.ts
@@ -7,7 +7,13 @@ import {
 	type WorkspaceProject,
 } from "./workspace-project.js";
 import { readWorkspaceInventory, appendWorkspaceInventoryEntries } from "./workspace-inventory.js";
-import { toTitleCase } from "./string-case.js";
+import { toPascalCase, toTitleCase } from "./string-case.js";
+import {
+	findPhpFunctionRange,
+	hasPhpFunctionDefinition,
+	quotePhpString,
+	replacePhpFunctionDefinition,
+} from "./php-utils.js";
 import {
 	assertBindingSourceDoesNotExist,
 	assertEditorPluginDoesNotExist,
@@ -34,76 +40,6 @@ const EDITOR_PLUGIN_EDITOR_SCRIPT = "build/editor-plugins/index.js";
 const EDITOR_PLUGIN_EDITOR_ASSET = "build/editor-plugins/index.asset.php";
 const EDITOR_PLUGIN_EDITOR_STYLE = "build/editor-plugins/style-index.css";
 const EDITOR_PLUGIN_EDITOR_STYLE_RTL = "build/editor-plugins/style-index-rtl.css";
-
-function escapeRegex(value: string): string {
-	return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
-}
-
-function quotePhpString(value: string): string {
-	return `'${value.replace(/\\/gu, "\\\\").replace(/'/gu, "\\'")}'`;
-}
-
-function findPhpFunctionRange(
-	source: string,
-	functionName: string,
-): {
-	end: number;
-	start: number;
-} | null {
-	const signaturePattern = new RegExp(`function\\s+${escapeRegex(functionName)}\\s*\\(`, "u");
-	const signatureMatch = signaturePattern.exec(source);
-	if (!signatureMatch || signatureMatch.index === undefined) {
-		return null;
-	}
-
-	const functionStart = signatureMatch.index;
-	const openBraceIndex = source.indexOf("{", functionStart);
-	if (openBraceIndex === -1) {
-		return null;
-	}
-
-	let depth = 0;
-	for (let index = openBraceIndex; index < source.length; index += 1) {
-		const character = source[index];
-		if (character === "{") {
-			depth += 1;
-			continue;
-		}
-		if (character !== "}") {
-			continue;
-		}
-		depth -= 1;
-		if (depth === 0) {
-			let functionEnd = index + 1;
-			while (functionEnd < source.length && /[\r\n]/u.test(source[functionEnd] ?? "")) {
-				functionEnd += 1;
-			}
-			return {
-				end: functionEnd,
-				start: functionStart,
-			};
-		}
-	}
-
-	return null;
-}
-
-function replacePhpFunctionDefinition(
-	source: string,
-	functionName: string,
-	replacement: string,
-): string | null {
-	const functionRange = findPhpFunctionRange(source, functionName);
-	if (!functionRange) {
-		return null;
-	}
-
-	return [
-		source.slice(0, functionRange.start),
-		replacement,
-		source.slice(functionRange.end),
-	].join("");
-}
 
 function buildPatternConfigEntry(patternSlug: string): string {
 	return [
@@ -135,14 +71,6 @@ function buildEditorPluginConfigEntry(
 		`\t\tslot: ${quoteTsString(slot)},`,
 		"\t},",
 	].join("\n");
-}
-
-function toPascalCaseFromSlug(slug: string): string {
-	return normalizeBlockSlug(slug)
-		.split("-")
-		.filter(Boolean)
-		.map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
-		.join("");
 }
 
 function buildPatternSource(
@@ -277,7 +205,7 @@ registerBlockBindingsSource( {
 }
 
 function buildEditorPluginTypesSource(editorPluginSlug: string): string {
-	const typeName = `${toPascalCaseFromSlug(editorPluginSlug)}SidebarModel`;
+	const typeName = `${toPascalCase(editorPluginSlug)}SidebarModel`;
 
 	return `export interface ${typeName} {
 \tprimaryActionLabel: string;
@@ -290,10 +218,10 @@ function buildEditorPluginDataSource(
 	editorPluginSlug: string,
 	slot: string,
 ): string {
-	const typeName = `${toPascalCaseFromSlug(editorPluginSlug)}SidebarModel`;
+	const typeName = `${toPascalCase(editorPluginSlug)}SidebarModel`;
 	const pluginTitle = toTitleCase(editorPluginSlug);
-	const modelFactoryName = `get${toPascalCaseFromSlug(editorPluginSlug)}SidebarModel`;
-	const enabledFactoryName = `is${toPascalCaseFromSlug(editorPluginSlug)}Enabled`;
+	const modelFactoryName = `get${toPascalCase(editorPluginSlug)}SidebarModel`;
+	const enabledFactoryName = `is${toPascalCase(editorPluginSlug)}Enabled`;
 
 	return `import type { ${typeName} } from './types';
 
@@ -319,7 +247,7 @@ function buildEditorPluginSidebarSource(
 	editorPluginSlug: string,
 	textDomain: string,
 ): string {
-	const pascalName = toPascalCaseFromSlug(editorPluginSlug);
+	const pascalName = toPascalCase(editorPluginSlug);
 	const modelFactoryName = `get${pascalName}SidebarModel`;
 	const enabledFactoryName = `is${pascalName}Enabled`;
 	const componentName = `${pascalName}Sidebar`;
@@ -375,7 +303,7 @@ function buildEditorPluginEntrySource(
 	namespace: string,
 	textDomain: string,
 ): string {
-	const pascalName = toPascalCaseFromSlug(editorPluginSlug);
+	const pascalName = toPascalCase(editorPluginSlug);
 	const componentName = `${pascalName}Sidebar`;
 	const pluginName = `${namespace}-${editorPluginSlug}`;
 	const pluginTitle = toTitleCase(editorPluginSlug);
@@ -548,8 +476,6 @@ function ${bindingEditorEnqueueFunctionName}() {
 			/add_action\(\s*["']init["']\s*,\s*["'][^"']+_load_textdomain["']\s*\);\s*\n/u,
 			/\?>\s*$/u,
 		];
-		const hasPhpFunctionDefinition = (functionName: string): boolean =>
-			new RegExp(`function\\s+${escapeRegex(functionName)}\\s*\\(`, "u").test(nextSource);
 		const insertPhpSnippet = (snippet: string): void => {
 			for (const anchor of insertionAnchors) {
 				const candidate = nextSource.replace(anchor, (match) => `${snippet}\n${match}`);
@@ -569,10 +495,10 @@ function ${bindingEditorEnqueueFunctionName}() {
 			nextSource = `${nextSource.trimEnd()}\n${snippet}\n`;
 		};
 
-		if (!hasPhpFunctionDefinition(bindingRegistrationFunctionName)) {
+		if (!hasPhpFunctionDefinition(nextSource, bindingRegistrationFunctionName)) {
 			insertPhpSnippet(bindingRegistrationFunction);
 		}
-		if (!hasPhpFunctionDefinition(bindingEditorEnqueueFunctionName)) {
+		if (!hasPhpFunctionDefinition(nextSource, bindingEditorEnqueueFunctionName)) {
 			insertPhpSnippet(bindingEditorEnqueueFunction);
 		}
 
@@ -638,8 +564,6 @@ function ${enqueueFunctionName}() {
 			/add_action\(\s*["']init["']\s*,\s*["'][^"']+_load_textdomain["']\s*\);\s*\n/u,
 			/\?>\s*$/u,
 		];
-		const hasPhpFunctionDefinition = (functionName: string): boolean =>
-			new RegExp(`function\\s+${escapeRegex(functionName)}\\s*\\(`, "u").test(nextSource);
 		const insertPhpSnippet = (snippet: string): void => {
 			for (const anchor of insertionAnchors) {
 				const candidate = nextSource.replace(anchor, (match) => `${snippet}\n${match}`);
@@ -659,7 +583,7 @@ function ${enqueueFunctionName}() {
 			nextSource = `${nextSource.trimEnd()}\n${snippet}\n`;
 		};
 
-		if (!hasPhpFunctionDefinition(enqueueFunctionName)) {
+		if (!hasPhpFunctionDefinition(nextSource, enqueueFunctionName)) {
 			insertPhpSnippet(enqueueFunction);
 		} else {
 			const requiredReferences = [

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest-anchors.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest-anchors.ts
@@ -4,13 +4,10 @@ import {
 	getWorkspaceBootstrapPath,
 	patchFile,
 } from "./cli-add-shared.js";
+import { hasPhpFunctionDefinition } from "./php-utils.js";
 import type { WorkspaceProject } from "./workspace-project.js";
 
 const REST_RESOURCE_SERVER_GLOB = "/inc/rest/*.php";
-
-function escapeRegex(value: string): string {
-	return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
-}
 
 export async function ensureRestResourceBootstrapAnchors(
 	workspace: WorkspaceProject,
@@ -33,8 +30,6 @@ function ${registerFunctionName}() {
 			/add_action\(\s*["']init["']\s*,\s*["'][^"']+_load_textdomain["']\s*\);\s*\n/u,
 			/\?>\s*$/u,
 		];
-		const hasPhpFunctionDefinition = (functionName: string): boolean =>
-			new RegExp(`function\\s+${escapeRegex(functionName)}\\s*\\(`, "u").test(nextSource);
 		const insertPhpSnippet = (snippet: string): void => {
 			for (const anchor of insertionAnchors) {
 				const candidate = nextSource.replace(anchor, (match) => `${snippet}\n${match}`);
@@ -54,7 +49,7 @@ function ${registerFunctionName}() {
 			nextSource = `${nextSource.trimEnd()}\n${snippet}\n`;
 		};
 
-		if (!hasPhpFunctionDefinition(registerFunctionName)) {
+		if (!hasPhpFunctionDefinition(nextSource, registerFunctionName)) {
 			insertPhpSnippet(registerFunction);
 		} else if (!nextSource.includes(REST_RESOURCE_SERVER_GLOB)) {
 			throw new Error(

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest-source-emitters.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest-source-emitters.ts
@@ -1,18 +1,9 @@
 import {
-	normalizeBlockSlug,
 	quoteTsString,
 	type RestResourceMethodId,
 } from "./cli-add-shared.js";
 import { buildRestResourceEndpointManifest } from "./rest-resource-artifacts.js";
-import { toTitleCase } from "./string-case.js";
-
-export function toPascalCaseFromSlug(slug: string): string {
-	return normalizeBlockSlug(slug)
-		.split("-")
-		.filter(Boolean)
-		.map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
-		.join("");
-}
+import { toPascalCase, toTitleCase } from "./string-case.js";
 
 function indentMultiline(source: string, prefix: string): string {
 	return source
@@ -26,7 +17,7 @@ export function buildRestResourceConfigEntry(
 	namespace: string,
 	methods: RestResourceMethodId[],
 ): string {
-	const pascalCase = toPascalCaseFromSlug(restResourceSlug);
+	const pascalCase = toPascalCase(restResourceSlug);
 	const title = toTitleCase(restResourceSlug);
 	const manifest = buildRestResourceEndpointManifest(
 		{
@@ -61,7 +52,7 @@ export function buildRestResourceTypesSource(
 	restResourceSlug: string,
 	methods: RestResourceMethodId[],
 ): string {
-	const pascalCase = toPascalCaseFromSlug(restResourceSlug);
+	const pascalCase = toPascalCase(restResourceSlug);
 	const lines = [
 		"import { tags } from 'typia';",
 		"",
@@ -156,7 +147,7 @@ export function buildRestResourceValidatorsSource(
 	restResourceSlug: string,
 	methods: RestResourceMethodId[],
 ): string {
-	const pascalCase = toPascalCaseFromSlug(restResourceSlug);
+	const pascalCase = toPascalCase(restResourceSlug);
 	const importedTypes = new Set<string>();
 	const validatorDeclarations: string[] = [];
 	const validatorEntries: string[] = [];
@@ -216,7 +207,7 @@ export function buildRestResourceApiSource(
 	restResourceSlug: string,
 	methods: RestResourceMethodId[],
 ): string {
-	const pascalCase = toPascalCaseFromSlug(restResourceSlug);
+	const pascalCase = toPascalCase(restResourceSlug);
 	const typeImports = new Set<string>();
 	const clientEndpointImports: string[] = [];
 	const exportedBindings: string[] = [];
@@ -373,7 +364,7 @@ export function buildRestResourceDataSource(
 	restResourceSlug: string,
 	methods: RestResourceMethodId[],
 ): string {
-	const pascalCase = toPascalCaseFromSlug(restResourceSlug);
+	const pascalCase = toPascalCase(restResourceSlug);
 	const typeImports = new Set<string>();
 	const endpointImports: string[] = [];
 	const exportedBindings: string[] = [];

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest.ts
@@ -25,19 +25,15 @@ import {
 	buildRestResourceDataSource,
 	buildRestResourceTypesSource,
 	buildRestResourceValidatorsSource,
-	toPascalCaseFromSlug,
 } from "./cli-add-workspace-rest-source-emitters.js";
+import { quotePhpString } from "./php-utils.js";
 import { syncRestResourceArtifacts } from "./rest-resource-artifacts.js";
-import { toTitleCase } from "./string-case.js";
+import { toPascalCase, toTitleCase } from "./string-case.js";
 import {
 	appendWorkspaceInventoryEntries,
 	readWorkspaceInventory,
 } from "./workspace-inventory.js";
 import { resolveWorkspaceProject } from "./workspace-project.js";
-
-function quotePhpString(value: string): string {
-	return `'${value.replace(/\\/gu, "\\\\").replace(/'/gu, "\\'")}'`;
-}
 
 function buildRestResourceRouteRegistrations(
 	restResourceSlug: string,
@@ -572,7 +568,7 @@ export async function runAddRestResourceCommand({
 			validatorsFile: `src/rest/${restResourceSlug}/api-validators.ts`,
 			variables: {
 				namespace: resolvedNamespace,
-				pascalCase: toPascalCaseFromSlug(restResourceSlug),
+				pascalCase: toPascalCase(restResourceSlug),
 				slugKebabCase: restResourceSlug,
 				title: toTitleCase(restResourceSlug),
 			},

--- a/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace.ts
@@ -21,6 +21,7 @@ import {
 	type WorkspacePackageJson,
 	type WorkspaceProject,
 } from "./workspace-project.js";
+import { escapeRegex } from "./php-utils.js";
 
 import type { DoctorCheck } from "./cli-doctor.js";
 
@@ -58,10 +59,6 @@ function createDoctorScopeCheck(
 	detail: string,
 ): DoctorCheck {
 	return createDoctorCheck("Doctor scope", status, detail);
-}
-
-function escapeRegex(value: string): string {
-	return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
 }
 
 function getWorkspaceBootstrapRelativePath(packageName: string): string {

--- a/packages/wp-typia-project-tools/src/runtime/package-json-types.ts
+++ b/packages/wp-typia-project-tools/src/runtime/package-json-types.ts
@@ -1,0 +1,12 @@
+export interface GeneratedPackageJson {
+	dependencies?: Record<string, string>;
+	devDependencies?: Record<string, string>;
+	packageManager?: string;
+	scripts?: Record<string, string>;
+	wpTypia?: {
+		projectType?: string;
+		templatePackage?: string;
+		[key: string]: unknown;
+	};
+	[key: string]: unknown;
+}

--- a/packages/wp-typia-project-tools/src/runtime/php-utils.ts
+++ b/packages/wp-typia-project-tools/src/runtime/php-utils.ts
@@ -1,0 +1,96 @@
+export type PhpFunctionRange = {
+	end: number;
+	source: string;
+	start: number;
+};
+
+export type PhpFunctionRangeOptions = {
+	includeTrailingNewlines?: boolean;
+};
+
+export type ReplacePhpFunctionDefinitionOptions = PhpFunctionRangeOptions & {
+	trimReplacementStart?: boolean;
+};
+
+export function escapeRegex(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+export function quotePhpString(value: string): string {
+	return `'${value.replace(/\\/gu, "\\\\").replace(/'/gu, "\\'")}'`;
+}
+
+export function hasPhpFunctionDefinition(
+	source: string,
+	functionName: string,
+): boolean {
+	return new RegExp(`function\\s+${escapeRegex(functionName)}\\s*\\(`, "u").test(source);
+}
+
+export function findPhpFunctionRange(
+	source: string,
+	functionName: string,
+	options: PhpFunctionRangeOptions = {},
+): PhpFunctionRange | null {
+	const signaturePattern = new RegExp(
+		`function\\s+${escapeRegex(functionName)}\\s*\\([^)]*\\)\\s*(?::\\s*[^{};]+)?\\s*\\{`,
+		"u",
+	);
+	const signatureMatch = signaturePattern.exec(source);
+	if (!signatureMatch) {
+		return null;
+	}
+
+	const functionStart = signatureMatch.index;
+	const openBraceOffset = signatureMatch[0].lastIndexOf("{");
+	if (openBraceOffset === -1) {
+		return null;
+	}
+	const openBraceIndex = functionStart + openBraceOffset;
+
+	let depth = 0;
+	for (let index = openBraceIndex; index < source.length; index += 1) {
+		const character = source[index];
+		if (character === "{") {
+			depth += 1;
+			continue;
+		}
+		if (character !== "}") {
+			continue;
+		}
+		depth -= 1;
+		if (depth === 0) {
+			let end = index + 1;
+			if (options.includeTrailingNewlines ?? true) {
+				while (end < source.length && /[\r\n]/u.test(source[end] ?? "")) {
+					end += 1;
+				}
+			}
+			return {
+				end,
+				source: source.slice(functionStart, end),
+				start: functionStart,
+			};
+		}
+	}
+
+	return null;
+}
+
+export function replacePhpFunctionDefinition(
+	source: string,
+	functionName: string,
+	replacement: string,
+	options: ReplacePhpFunctionDefinitionOptions = {},
+): string | null {
+	const functionRange = findPhpFunctionRange(source, functionName, options);
+	if (!functionRange) {
+		return null;
+	}
+
+	return [
+		source.slice(0, functionRange.start),
+		options.trimReplacementStart ? replacement.trimStart() : replacement,
+		source.slice(functionRange.end),
+	].join("");
+}

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-apply-utils.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-apply-utils.ts
@@ -9,12 +9,6 @@ import {
 	applyLocalDevPresetFiles,
 } from "./local-dev-presets.js";
 import { applyMigrationUiCapability } from "./migration-ui-capability.js";
-import { getPackageVersions } from "./package-versions.js";
-import {
-	ensureMigrationDirectories,
-	writeInitialMigrationScaffold,
-	writeMigrationConfig,
-} from "./migration-project.js";
 import {
 	syncPersistenceRestArtifacts,
 } from "./persistence-rest-artifacts.js";
@@ -36,17 +30,19 @@ import {
 } from "./built-in-block-artifacts.js";
 import type { BuiltInCodeArtifact } from "./built-in-block-code-artifacts.js";
 import {
-	OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE,
 	type BuiltInTemplateId,
 } from "./template-registry.js";
 import { copyInterpolatedDirectory } from "./template-render.js";
 import type { PackageManagerId } from "./package-managers.js";
 import {
 	formatInstallCommand,
-	formatPackageExecCommand,
 	transformPackageManagerText,
 } from "./package-managers.js";
 import { normalizePackageJson } from "./scaffold-package-manager-files.js";
+export {
+	applyWorkspaceMigrationCapability,
+	isOfficialWorkspaceProject,
+} from "./scaffold-bootstrap.js";
 import {
 	replaceRepositoryReferencePlaceholders,
 	resolveScaffoldRepositoryReference,
@@ -55,12 +51,7 @@ import type {
 	ScaffoldProgressEvent,
 	ScaffoldTemplateVariables,
 } from "./scaffold.js";
-
-export {
-	buildGitignore,
-	buildReadme,
-	mergeTextLines,
-} from "./scaffold-documents.js";
+export { buildGitignore, buildReadme, mergeTextLines } from "./scaffold-documents.js";
 
 export interface InstallDependenciesOptions {
 	packageManager: PackageManagerId;
@@ -74,16 +65,6 @@ async function reportScaffoldProgress(
 	event: ScaffoldProgressEvent,
 ): Promise<void> {
 	await onProgress?.(event);
-}
-
-interface GeneratedPackageJson {
-	dependencies?: Record<string, string>;
-	scripts?: Record<string, string>;
-	wpTypia?: {
-		projectType?: string;
-		templatePackage?: string;
-	};
-	packageManager?: string;
 }
 
 const EPHEMERAL_NODE_MODULES_LINK_TYPE = process.platform === "win32" ? "junction" : "dir";
@@ -361,59 +342,6 @@ export async function defaultInstallDependencies({
 		cwd: projectDir,
 		stdio: "inherit",
 	});
-}
-
-export function isOfficialWorkspaceProject(projectDir: string): boolean {
-	const packageJsonPath = path.join(projectDir, "package.json");
-	if (!fs.existsSync(packageJsonPath)) {
-		return false;
-	}
-
-	const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as GeneratedPackageJson;
-	return (
-		packageJson.wpTypia?.projectType === "workspace" &&
-		packageJson.wpTypia?.templatePackage === OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE
-	);
-}
-
-export async function applyWorkspaceMigrationCapability(
-	projectDir: string,
-	packageManager: PackageManagerId,
-): Promise<void> {
-	const packageJsonPath = path.join(projectDir, "package.json");
-	const packageJson = JSON.parse(
-		await fsp.readFile(packageJsonPath, "utf8"),
-	) as GeneratedPackageJson;
-	const wpTypiaPackageVersion = getPackageVersions().wpTypiaPackageVersion;
-	const canonicalCliSpecifier =
-		wpTypiaPackageVersion === "^0.0.0"
-			? "wp-typia"
-			: `wp-typia@${wpTypiaPackageVersion.replace(/^[~^]/u, "")}`;
-	const migrationCli = (args: string) =>
-		formatPackageExecCommand(packageManager, canonicalCliSpecifier, `migrate ${args}`);
-
-	packageJson.scripts = {
-		...(packageJson.scripts ?? {}),
-		"migration:init": migrationCli("init --current-migration-version v1"),
-		"migration:snapshot": migrationCli("snapshot"),
-		"migration:diff": migrationCli("diff"),
-		"migration:scaffold": migrationCli("scaffold"),
-		"migration:doctor": migrationCli("doctor --all"),
-		"migration:fixtures": migrationCli("fixtures --all"),
-		"migration:verify": migrationCli("verify --all"),
-		"migration:fuzz": migrationCli("fuzz --all"),
-	};
-
-	await fsp.writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, "\t")}\n`, "utf8");
-
-	writeMigrationConfig(projectDir, {
-		blocks: [],
-		currentMigrationVersion: "v1",
-		snapshotDir: "src/migrations/versions",
-		supportedMigrationVersions: ["v1"],
-	});
-	ensureMigrationDirectories(projectDir, []);
-	writeInitialMigrationScaffold(projectDir, "v1", []);
 }
 
 /**

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-bootstrap.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-bootstrap.ts
@@ -19,16 +19,9 @@ import {
 } from "./template-registry.js";
 import type { BuiltInTemplateId } from "./template-registry.js";
 import { getScaffoldTemplateVariableGroups } from "./scaffold-template-variable-groups.js";
+import type { GeneratedPackageJson } from "./package-json-types.js";
 
 const EPHEMERAL_NODE_MODULES_LINK_TYPE = process.platform === "win32" ? "junction" : "dir";
-
-interface GeneratedPackageJson {
-	scripts?: Record<string, string>;
-	wpTypia?: {
-		projectType?: string;
-		templatePackage?: string;
-	};
-}
 
 /**
  * Ensures the scaffold target directory exists and is empty unless explicitly allowed.

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-package-manager-files.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-package-manager-files.ts
@@ -9,6 +9,7 @@ import {
 	transformPackageManagerText,
 } from "./package-managers.js";
 import type { PackageManagerId } from "./package-managers.js";
+import type { GeneratedPackageJson } from "./package-json-types.js";
 
 const LOCKFILES: Record<PackageManagerId, string[]> = {
 	bun: ["bun.lock", "bun.lockb"],
@@ -16,11 +17,6 @@ const LOCKFILES: Record<PackageManagerId, string[]> = {
 	pnpm: ["pnpm-lock.yaml"],
 	yarn: ["yarn.lock"],
 };
-
-interface GeneratedPackageJson {
-	packageManager?: string;
-	scripts?: Record<string, string>;
-}
 
 /**
  * Normalizes scaffolded package-manager specific files for the selected toolchain.

--- a/packages/wp-typia-project-tools/src/runtime/scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold.ts
@@ -38,8 +38,6 @@ import { resolveTemplateSource } from "./template-source.js";
 import {
 	BlockGeneratorService,
 } from "./block-generator-service.js";
-import {
-} from "./scaffold-answer-resolution.js";
 import { getTemplateVariables } from "./scaffold-template-variables.js";
 import { getScaffoldTemplateVariableGroups } from "./scaffold-template-variable-groups.js";
 import type {

--- a/packages/wp-typia-project-tools/src/runtime/workspace-inventory.ts
+++ b/packages/wp-typia-project-tools/src/runtime/workspace-inventory.ts
@@ -5,6 +5,7 @@ import { readFile, writeFile } from "node:fs/promises";
 import ts from "typescript";
 
 import { REST_RESOURCE_METHOD_IDS } from "./cli-add-shared.js";
+import { escapeRegex } from "./php-utils.js";
 
 export interface WorkspaceBlockInventoryEntry {
 	apiTypesFile?: string;
@@ -848,10 +849,6 @@ function appendEntriesAtMarker(source: string, marker: string, entries: string[]
 	}
 
 	return source.replace(marker, `${entries.join("\n")}\n${marker}`);
-}
-
-function escapeRegex(value: string): string {
-	return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
 }
 
 function ensureInterfaceField(

--- a/packages/wp-typia-project-tools/tests/php-utils.test.ts
+++ b/packages/wp-typia-project-tools/tests/php-utils.test.ts
@@ -1,0 +1,101 @@
+import { expect, test } from "bun:test";
+
+import {
+	escapeRegex,
+	findPhpFunctionRange,
+	hasPhpFunctionDefinition,
+	quotePhpString,
+	replacePhpFunctionDefinition,
+} from "../src/runtime/php-utils.js";
+
+test("quotePhpString escapes single quotes and backslashes for generated PHP", () => {
+	expect(quotePhpString("Bob's \\ path")).toBe("'Bob\\'s \\\\ path'");
+});
+
+test("escapeRegex produces a literal-safe regular expression fragment", () => {
+	const literal = "feature.value[1](draft)?";
+	const pattern = new RegExp(`^${escapeRegex(literal)}$`, "u");
+
+	expect(pattern.test(literal)).toBe(true);
+	expect(pattern.test("featureXvalue[1](draft)?")).toBe(false);
+});
+
+test("findPhpFunctionRange locates a complete PHP function with nested braces", () => {
+	const source = `<?php
+function keep_me() {
+\treturn true;
+}
+
+function wp_typia_demo() {
+\tif ( true ) {
+\t\treturn array( 'ok' => true );
+\t}
+
+\treturn array();
+}
+
+add_action( 'init', 'wp_typia_demo' );
+`;
+
+	const range = findPhpFunctionRange(source, "wp_typia_demo");
+
+	expect(range?.source).toContain("function wp_typia_demo()");
+	expect(range?.source).toContain("return array( 'ok' => true );");
+	expect(range?.source).not.toContain("add_action");
+});
+
+test("findPhpFunctionRange supports return types without spilling into later functions", () => {
+	const source = `<?php
+function malformed()
+
+function wp_typia_typed() : array {
+\treturn array();
+}
+`;
+
+	expect(findPhpFunctionRange(source, "malformed")).toBeNull();
+	expect(findPhpFunctionRange(source, "wp_typia_typed")?.source).toContain(
+		"function wp_typia_typed() : array",
+	);
+});
+
+test("replacePhpFunctionDefinition replaces only the targeted PHP function", () => {
+	const source = `<?php
+function wp_typia_demo() {
+\tif ( true ) {
+\t\treturn array( 'old' => true );
+\t}
+}
+
+function keep_me() {
+\treturn true;
+}
+`;
+
+	const replaced = replacePhpFunctionDefinition(
+		source,
+		"wp_typia_demo",
+		`
+function wp_typia_demo() {
+\treturn array( 'new' => true );
+}
+`,
+		{ trimReplacementStart: true },
+	);
+
+	expect(replaced).not.toBeNull();
+	expect(replaced).toContain("return array( 'new' => true );");
+	expect(replaced).not.toContain("return array( 'old' => true );");
+	expect(replaced).toContain("function keep_me()");
+});
+
+test("hasPhpFunctionDefinition treats function names as literal identifiers", () => {
+	const source = `<?php
+function wp_typia_feature_value() {
+\treturn true;
+}
+`;
+
+	expect(hasPhpFunctionDefinition(source, "wp_typia_feature_value")).toBe(true);
+	expect(hasPhpFunctionDefinition(source, "wp_typia_feature.value")).toBe(false);
+});

--- a/packages/wp-typia-project-tools/tests/scaffold-runtime-boundaries.test.ts
+++ b/packages/wp-typia-project-tools/tests/scaffold-runtime-boundaries.test.ts
@@ -36,6 +36,9 @@ test("scaffold runtime delegates identifier, document, bootstrap, and package he
 	expect(scaffoldSource).toContain('from "./scaffold-apply-utils.js"');
 	expect(scaffoldSource).toContain('from "./scaffold-bootstrap.js"');
 	expect(scaffoldSource).toContain('from "./scaffold-package-manager-files.js"');
+	expect(scaffoldSource).not.toContain(
+		'import {\n} from "./scaffold-answer-resolution.js";',
+	);
 	expect(scaffoldSource).toContain(
 		'export { buildBlockCssClassName } from "./scaffold-identifiers.js";',
 	);
@@ -53,12 +56,18 @@ test("scaffold runtime delegates identifier, document, bootstrap, and package he
 	);
 	expect(documentsReExportPattern.test(applyUtilsSource)).toBe(true);
 	expect(applyUtilsSource).toContain('from "./scaffold-package-manager-files.js"');
+	expect(applyUtilsSource).toContain('from "./scaffold-bootstrap.js"');
+	expect(applyUtilsSource).not.toContain(
+		"export async function applyWorkspaceMigrationCapability(",
+	);
 	expect(applyUtilsSource).not.toContain("async function normalizePackageJson(");
 	expect(documentsSource).toContain("export function buildReadme(");
 	expect(documentsSource).toContain("export function buildGitignore(");
 	expect(documentsSource).toContain("export function mergeTextLines(");
 	expect(bootstrapSource).toContain("export async function ensureScaffoldDirectory(");
 	expect(bootstrapSource).toContain("export async function applyWorkspaceMigrationCapability(");
+	expect(bootstrapSource).toContain('from "./package-json-types.js"');
+	expect(packageManagerFilesSource).toContain('from "./package-json-types.js"');
 	expect(packageManagerFilesSource).toContain("export async function normalizePackageJson(");
 	expect(packageManagerFilesSource).toContain("export async function defaultInstallDependencies(");
 });


### PR DESCRIPTION
## Summary
- consolidate duplicated PHP string/function helpers behind shared runtime utilities
- replace per-workflow PascalCase helper variants with the shared string-case implementation
- share GeneratedPackageJson typing across scaffold bootstrap/package-manager paths and remove the empty scaffold import
- add focused PHP helper coverage and a Sampo changeset

Closes #579

## Validation
- bun test packages/wp-typia-project-tools/tests/php-utils.test.ts packages/wp-typia-project-tools/tests/scaffold-runtime-boundaries.test.ts
- bun run --filter @wp-typia/project-tools build
- bun run --filter @wp-typia/project-tools test:scaffold-core
- bun run --filter @wp-typia/project-tools test:workspace
- bun run --filter @wp-typia/project-tools test
- bun run changesets:validate
- bun run format:check
- bun run typecheck
- git diff --check