### PR TITLE
feat(project-tools): expose package version cache clearing

### DIFF
--- a/.sampo/changesets/project-tools-package-version-cache.md
+++ b/.sampo/changesets/project-tools-package-version-cache.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Documented package version cache invalidation and exposed `clearPackageVersionsCache()` for long-lived linked integrations.

--- a/apps/docs/src/content/docs/maintainers/scaffold-toolchain-policy.md
+++ b/apps/docs/src/content/docs/maintainers/scaffold-toolchain-policy.md
@@ -67,6 +67,28 @@ Why caret ranges are still the default for scaffolded package manifests:
 - the CLI and generated tests already validate the current package surface
   against that ranged dependency strategy before release
 
+## Package version cache policy
+
+`getPackageVersions()` uses a process-local cache to avoid reparsing package
+metadata when repeated scaffold operations run inside one CLI or integration
+process. The cache key includes the resolved project-tools manifest, sibling
+workspace package manifests, installed dependency manifests, file metadata, and
+a content fingerprint. When any of those manifests changes on disk, the next
+lookup recomputes versions and replaces the cached object.
+
+Long-lived integrations such as MCP servers, watch processes, and linked
+development shells should call `clearPackageVersionsCache()` from
+`@wp-typia/project-tools` after running `bun install`, changing package
+manifests, or relinking local packages. The next `getPackageVersions()` call
+then re-resolves the same manifest set synchronously. The older
+`invalidatePackageVersionsCache()` name remains available as a compatibility
+alias, but new integrations should prefer `clearPackageVersionsCache()`.
+
+`WP_TYPIA_PROJECT_TOOLS_PACKAGE_ROOT` is still an import-time package-root
+override. Set it before loading `@wp-typia/project-tools`; clearing the version
+cache refreshes package metadata under the already resolved root, not the module
+root itself.
+
 ## Practical summary
 
 When touching scaffolded package metadata:
@@ -77,3 +99,5 @@ When touching scaffolded package metadata:
   scaffolds unless this policy changes explicitly
 - keep generated `@wp-typia/*` dependencies on caret ranges sourced from
   `package-versions.ts`
+- use `clearPackageVersionsCache()` in long-lived integrations after package
+  metadata or linked package installs change

--- a/packages/wp-typia-project-tools/package.json
+++ b/packages/wp-typia-project-tools/package.json
@@ -105,7 +105,7 @@
     "prepack": "bun run build && node ./scripts/publish-manifest.mjs prepare",
     "postpack": "node ./scripts/publish-manifest.mjs restore",
     "test": "bun run build && bun test tests/*.test.ts",
-    "test:scaffold-core": "bun run build && bun test tests/block-generator-service.test.ts tests/built-in-block-artifacts.test.ts tests/scaffold-basic.test.ts tests/scaffold-persistence.test.ts tests/template-source.test.ts tests/init-command.test.ts tests/cli-entry.test.ts tests/cli-prompt.test.ts tests/import-policy.test.ts tests/wordpress-ai-spec.test.ts tests/typia-llm.test.ts",
+    "test:scaffold-core": "bun run build && bun test tests/block-generator-service.test.ts tests/built-in-block-artifacts.test.ts tests/scaffold-basic.test.ts tests/scaffold-persistence.test.ts tests/template-source.test.ts tests/init-command.test.ts tests/package-versions.test.ts tests/cli-entry.test.ts tests/cli-prompt.test.ts tests/import-policy.test.ts tests/wordpress-ai-spec.test.ts tests/typia-llm.test.ts",
     "test:workspace": "bun run build && bun test tests/workspace-add.test.ts tests/workspace-doctor.test.ts",
     "test:compound": "bun run build && bun test tests/scaffold-compound.test.ts",
     "test:migration-planning": "bun run build && bun test tests/migration-init.test.ts tests/migration-config.test.ts tests/migration-plan-wizard.test.ts",

--- a/packages/wp-typia-project-tools/src/runtime/index.ts
+++ b/packages/wp-typia-project-tools/src/runtime/index.ts
@@ -138,6 +138,12 @@ export {
 	transformPackageManagerText,
 } from "./package-managers.js";
 export {
+	clearPackageVersionsCache,
+	getPackageVersions,
+	invalidatePackageVersionsCache,
+} from "./package-versions.js";
+export type { PackageVersions } from "./package-versions.js";
+export {
 	TEMPLATE_IDS,
 	TEMPLATE_REGISTRY,
 	getTemplateById,

--- a/packages/wp-typia-project-tools/src/runtime/package-versions.ts
+++ b/packages/wp-typia-project-tools/src/runtime/package-versions.ts
@@ -9,7 +9,7 @@ interface PackageManifest {
 	version?: string;
 }
 
-interface PackageVersions {
+export interface PackageVersions {
 	apiClientPackageVersion: string;
 	blockRuntimePackageVersion: string;
 	blockTypesPackageVersion: string;
@@ -132,10 +132,25 @@ function composePackageVersionsCacheKey(
  * manifests when they want the next lookup to recompute version metadata
  * synchronously from disk.
  */
-export function invalidatePackageVersionsCache(): void {
+export function clearPackageVersionsCache(): void {
 	cachedPackageVersions = null;
 }
 
+/**
+ * Backwards-compatible alias for integrations that adopted the original
+ * internal invalidation name before the public cache policy was documented.
+ */
+export function invalidatePackageVersionsCache(): void {
+	clearPackageVersionsCache();
+}
+
+/**
+ * Resolve package versions used in generated manifests and onboarding text.
+ *
+ * The lookup keeps a process-local cached result while recomputing manifest
+ * fingerprints on each call. When the relevant package metadata changes on
+ * disk, the cache key changes and the returned version object is refreshed.
+ */
 export function getPackageVersions(): PackageVersions {
 	const createManifestLocation = resolvePackageManifestLocation(
 		path.join(PROJECT_TOOLS_PACKAGE_ROOT, "package.json"),

--- a/packages/wp-typia-project-tools/tests/import-policy.test.ts
+++ b/packages/wp-typia-project-tools/tests/import-policy.test.ts
@@ -29,6 +29,7 @@ describe('@wp-typia/project-tools import policy', () => {
     expect(typeof rootModule.formatAddHelpText).toBe('function');
     expect(typeof rootModule.formatMigrationHelpText).toBe('function');
     expect(typeof rootModule.getDoctorChecks).toBe('function');
+    expect(typeof rootModule.getPackageVersions).toBe('function');
     expect(typeof rootModule.getTemplateById).toBe('function');
     expect(typeof rootModule.inspectBlockGeneration).toBe('function');
     expect(typeof rootModule.listTemplates).toBe('function');
@@ -38,6 +39,8 @@ describe('@wp-typia/project-tools import policy', () => {
     expect(typeof rootModule.runAddBlockCommand).toBe('function');
     expect(typeof rootModule.runMigrationCommand).toBe('function');
     expect(typeof rootModule.runScaffoldFlow).toBe('function');
+    expect(typeof rootModule.clearPackageVersionsCache).toBe('function');
+    expect(typeof rootModule.invalidatePackageVersionsCache).toBe('function');
     expect(typeof aiArtifactsModule.syncWordPressAiArtifacts).toBe('function');
     expect(typeof aiArtifactsModule.projectWordPressAiSchema).toBe('function');
     expect(

--- a/packages/wp-typia-project-tools/tests/package-versions.test.ts
+++ b/packages/wp-typia-project-tools/tests/package-versions.test.ts
@@ -1,0 +1,117 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import {
+	cleanupScaffoldTempRoot,
+	createScaffoldTempRoot,
+} from "./helpers/scaffold-test-harness.js";
+
+function writeProjectToolsManifest(
+	projectToolsRoot: string,
+	options: {
+		apiClientVersion: string;
+		projectToolsVersion: string;
+	},
+): void {
+	fs.writeFileSync(
+		path.join(projectToolsRoot, "package.json"),
+		`${JSON.stringify(
+			{
+				dependencies: {
+					"@wp-typia/api-client": options.apiClientVersion,
+				},
+				name: "@wp-typia/project-tools",
+				version: options.projectToolsVersion,
+			},
+			null,
+			2,
+		)}\n`,
+		"utf8",
+	);
+}
+
+describe("package version cache invalidation", () => {
+	const tempRoot = createScaffoldTempRoot("wp-typia-package-versions-");
+
+	afterAll(() => {
+		cleanupScaffoldTempRoot(tempRoot);
+	});
+
+	test("refreshes linked package metadata and exposes explicit cache clearing", () => {
+		const linkedProjectToolsRoot = fs.mkdtempSync(
+			path.join(tempRoot, "linked-project-tools-"),
+		);
+		writeProjectToolsManifest(linkedProjectToolsRoot, {
+			apiClientVersion: "^0.4.0",
+			projectToolsVersion: "1.2.3",
+		});
+
+		const packageVersionsModuleUrl = pathToFileURL(
+			path.join(import.meta.dir, "..", "src", "runtime", "package-versions.ts"),
+		).href;
+		const script = `
+			import assert from "node:assert/strict";
+			import fs from "node:fs";
+			import path from "node:path";
+			import {
+				clearPackageVersionsCache,
+				getPackageVersions,
+				invalidatePackageVersionsCache,
+			} from ${JSON.stringify(packageVersionsModuleUrl)};
+
+			const projectToolsRoot = ${JSON.stringify(linkedProjectToolsRoot)};
+			const first = getPackageVersions();
+			const second = getPackageVersions();
+			assert.equal(first, second);
+			assert.equal(first.projectToolsPackageVersion, "^1.2.3");
+			assert.equal(first.apiClientPackageVersion, "^0.4.0");
+
+			fs.writeFileSync(
+				path.join(projectToolsRoot, "package.json"),
+				JSON.stringify(
+					{
+						dependencies: {
+							"@wp-typia/api-client": "0.5.0"
+						},
+						name: "@wp-typia/project-tools",
+						version: "1.2.4"
+					},
+					null,
+					2
+				) + "\\n",
+				"utf8"
+			);
+
+			const refreshedByFingerprint = getPackageVersions();
+			assert.notEqual(refreshedByFingerprint, first);
+			assert.equal(refreshedByFingerprint.projectToolsPackageVersion, "^1.2.4");
+			assert.equal(refreshedByFingerprint.apiClientPackageVersion, "^0.5.0");
+
+			clearPackageVersionsCache();
+			const refreshedByClear = getPackageVersions();
+			assert.notEqual(refreshedByClear, refreshedByFingerprint);
+			assert.equal(refreshedByClear.projectToolsPackageVersion, "^1.2.4");
+
+			invalidatePackageVersionsCache();
+			const refreshedByAlias = getPackageVersions();
+			assert.notEqual(refreshedByAlias, refreshedByClear);
+			assert.equal(refreshedByAlias.projectToolsPackageVersion, "^1.2.4");
+		`;
+
+		const result = spawnSync(process.execPath, ["--eval", script], {
+			cwd: linkedProjectToolsRoot,
+			encoding: "utf8",
+			env: {
+				...process.env,
+				WP_TYPIA_PROJECT_TOOLS_PACKAGE_ROOT: linkedProjectToolsRoot,
+			},
+		});
+
+		expect(result.stderr).toBe("");
+		expect(result.stdout).toBe("");
+		expect(result.status).toBe(0);
+	});
+});

--- a/packages/wp-typia-project-tools/tests/package-versions.test.ts
+++ b/packages/wp-typia-project-tools/tests/package-versions.test.ts
@@ -101,7 +101,11 @@ describe("package version cache invalidation", () => {
 			assert.equal(refreshedByAlias.projectToolsPackageVersion, "^1.2.4");
 		`;
 
-		const result = spawnSync(process.execPath, ["--eval", script], {
+		// The inline script imports TypeScript source, so keep the child process on Bun
+		// even if this test is ever launched through a Node-based wrapper.
+		const bunBinary =
+			process.env.BUN_BINARY ?? ("Bun" in globalThis ? process.execPath : "bun");
+		const result = spawnSync(bunBinary, ["--eval", script], {
 			cwd: linkedProjectToolsRoot,
 			encoding: "utf8",
 			env: {
@@ -110,8 +114,15 @@ describe("package version cache invalidation", () => {
 			},
 		});
 
-		expect(result.stderr).toBe("");
-		expect(result.stdout).toBe("");
+		if (result.status !== 0) {
+			throw new Error(
+				`package-versions cache script failed (status=${result.status}, error=${
+					result.error?.message ?? "none"
+				}):\n${result.stderr}`,
+			);
+		}
 		expect(result.status).toBe(0);
+		expect(result.stdout).toBe("");
+		expect(result.stderr).toBe("");
 	});
 });


### PR DESCRIPTION
## Summary
- expose `clearPackageVersionsCache()` and export the package version runtime surface
- keep `invalidatePackageVersionsCache()` as a compatibility alias
- document long-lived linked-process cache invalidation policy
- add linked package cache refresh coverage to scaffold-core tests

Closes #582

## Validation
- `bun test packages/wp-typia-project-tools/tests/package-versions.test.ts packages/wp-typia-project-tools/tests/import-policy.test.ts`
- `bun run --filter @wp-typia/project-tools test:scaffold-core`
- `bun run --filter @wp-typia/project-tools build`
- `bun run typecheck`
- `bun run docs:build`
- `bun run changesets:validate`
- `bun run format:check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `clearPackageVersionsCache()` API for clearing cached package version metadata in long-lived integrations, with backward compatibility maintained.

* **Documentation**
  * Enhanced documentation explaining package version caching behavior and recommendations for cache management in persistent tooling environments.

* **Tests**
  * Added comprehensive test coverage for package version cache invalidation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->