### PR TITLE
docs(cli): add command reference and doctor help

### DIFF
--- a/.sampo/changesets/wp-typia-cli-reference-help.md
+++ b/.sampo/changesets/wp-typia-cli-reference-help.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Added command-specific `doctor --help` coverage and documented the supported CLI command surface.

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -142,6 +142,10 @@ export default defineConfig({
           label: 'Reference',
           items: [
             {
+              label: 'CLI Reference',
+              link: '/reference/cli/',
+            },
+            {
               label: 'Error Export Contracts',
               link: '/reference/error-export-contracts/',
             },

--- a/apps/docs/src/content/docs/reference/api.md
+++ b/apps/docs/src/content/docs/reference/api.md
@@ -24,8 +24,6 @@ The advanced and internal sections are documented so maintainers and power users
 can understand the published surface area, but they should be treated as
 secondary imports compared with the core package roots and primary subpaths.
 
-This repository has multiple public surfaces:
-
 ## Package Map
 
 - `wp-typia`
@@ -82,6 +80,9 @@ The CLI is the primary entrypoint for new users.
 bunx wp-typia create my-block
 npx wp-typia create my-block
 ```
+
+For command-by-command usage and flags, see the
+[CLI Reference](./cli.md).
 
 Common commands:
 
@@ -344,7 +345,7 @@ Error contract:
   `RestRootResolutionError`, or `RestQueryHookUsageError`
 - assertion APIs may throw `RestValidationAssertionError`
 
-## 5. `@wp-typia/api-client`
+## 4. `@wp-typia/api-client`
 
 `@wp-typia/api-client` is the transport-neutral sibling to `@wp-typia/rest`.
 
@@ -403,7 +404,7 @@ as `{ mechanism: "rest-nonce" }` or
 Legacy `authMode` is still accepted for compatibility, but it is now adapter
 metadata rather than the primary authored meaning.
 
-## 6. `@wp-typia/block-runtime`
+## 5. `@wp-typia/block-runtime`
 
 `@wp-typia/block-runtime` is the normative generated-project runtime package for
 shared block helpers, while `@wp-typia/block-runtime/metadata-core` owns the
@@ -439,7 +440,7 @@ Those splits improve ownership and maintainability without changing the
 supported import paths. For lower-level helper entrypoints that sit adjacent to
 these facades, use the hosted Advanced Helpers section under `/api/advanced/`.
 
-## 7. Generated project runtime
+## 6. Generated project runtime
 
 Each scaffolded project exposes a few predictable files:
 
@@ -749,7 +750,7 @@ When you opt `compound` into persistence with `--data-storage` or `--persistence
 
 For persistence-enabled `compound`, the parent block follows the same REST extension pattern as `persistence`, including the dedicated `/bootstrap` endpoint for fresh session-only write data. The hidden child block does not own REST routes or storage behavior.
 
-## 8. Repo-local example app
+## 7. Repo-local example app
 
 The repository keeps two reference apps:
 
@@ -780,7 +781,7 @@ bun run examples:test:e2e
 
 Legacy root shortcuts such as `bun run dev` and `bun run test:e2e` remain available as compatibility aliases.
 
-## 9. Generated reference docs
+## 8. Generated reference docs
 
 Contributor note:
 

--- a/apps/docs/src/content/docs/reference/cli.md
+++ b/apps/docs/src/content/docs/reference/cli.md
@@ -1,0 +1,213 @@
+---
+title: 'CLI Reference'
+---
+
+`wp-typia` is the canonical command-line entrypoint for scaffold, adoption,
+sync, doctor, migration, and workspace extension workflows.
+
+```bash
+npx wp-typia --help
+bunx wp-typia --help
+wp-typia --version
+```
+
+The published binary keeps common non-interactive commands available through the
+Node fallback runtime. Bun-powered command surfaces such as `mcp`, `skills`, and
+shell `completions` require Bun 1.3.11+ or the standalone release binary.
+
+## Global flags
+
+| Flag              | Description                                                               |
+| ----------------- | ------------------------------------------------------------------------- |
+| `--help`          | Show top-level or command-specific help.                                  |
+| `--version`       | Print the installed `wp-typia` version.                                   |
+| `--config <path>` | Load a config override file for the current invocation.                   |
+| `--format json`   | Emit machine-readable output for commands that support structured output. |
+
+Status markers honor `WP_TYPIA_ASCII=1`, `WP_TYPIA_ASCII=0`, and `NO_COLOR` in
+the same way as generated project onboarding output.
+
+## `create`
+
+Scaffold a new project.
+
+```bash
+wp-typia create <project-dir> --template basic --package-manager npm --yes
+wp-typia create <project-dir> --template persistence --data-storage custom-table --persistence-policy public
+wp-typia create <project-dir> --template workspace
+```
+
+Common flags:
+
+| Flag                                                   | Description                                                                                                                                              |
+| ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--template <id \| path \| github:... \| npm-package>` | Template id or external template source. Built-ins include `basic`, `interactivity`, `persistence`, `compound`, `query-loop`, and the `workspace` alias. |
+| `--package-manager <bun \| npm \| pnpm \| yarn>`       | Package manager for generated install and script commands.                                                                                               |
+| `--yes`                                                | Accept non-interactive defaults.                                                                                                                         |
+| `--no-install`                                         | Skip dependency installation.                                                                                                                            |
+| `--dry-run`                                            | Preview generated files without writing the target directory.                                                                                            |
+| `--namespace <value>`                                  | Override the generated block namespace.                                                                                                                  |
+| `--text-domain <value>`                                | Override the generated text domain.                                                                                                                      |
+| `--php-prefix <value>`                                 | Override generated PHP symbol prefixes.                                                                                                                  |
+| `--with-migration-ui`                                  | Add migration UI support where the selected template supports it.                                                                                        |
+| `--with-wp-env`                                        | Add local `wp-env` preset files and scripts.                                                                                                             |
+| `--with-test-preset`                                   | Add a test-only `wp-env` preset and smoke-test wiring.                                                                                                   |
+| `--external-layer-source <source>`                     | Compose an external layer package on top of a built-in template.                                                                                         |
+| `--external-layer-id <id>`                             | Select a specific external layer when a package exposes multiple layers.                                                                                 |
+| `--variant <name>`                                     | Select a variant from an official external template config.                                                                                              |
+| `--query-post-type <post-type>`                        | Set the default post type for `query-loop` scaffolds.                                                                                                    |
+| `--inner-blocks-preset <id>`                           | Select a compound `InnerBlocks` preset.                                                                                                                  |
+| `--alternate-render-targets <list>`                    | Add alternate render targets for persistence-capable dynamic scaffolds.                                                                                  |
+| `--data-storage <post-meta \| custom-table>`           | Select persistence storage for persistence-capable scaffolds.                                                                                            |
+| `--persistence-policy <authenticated \| public>`       | Select persistence write policy.                                                                                                                         |
+
+The positional alias `wp-typia <project-dir>` remains available only for
+unambiguous create invocations with a single local project directory.
+
+## `add`
+
+Extend an official wp-typia workspace from the workspace root.
+
+```bash
+wp-typia add block <name> --template basic
+wp-typia add variation <name> --block <block-slug>
+wp-typia add pattern <name>
+wp-typia add binding-source <name>
+wp-typia add rest-resource <name> --namespace <vendor/v1> --methods GET,POST
+wp-typia add ability <name>
+wp-typia add ai-feature <name> --namespace <vendor/v1>
+wp-typia add editor-plugin <name> --slot PluginSidebar
+wp-typia add hooked-block <block-slug> --anchor core/post-content --position after
+```
+
+Common flags:
+
+| Flag                                                             | Description                                                             |
+| ---------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `--template <basic \| interactivity \| persistence \| compound>` | Built-in block family for `add block`.                                  |
+| `--dry-run`                                                      | Preview workspace file updates and completion guidance.                 |
+| `--block <block-slug>`                                           | Target block for variation workflows.                                   |
+| `--anchor <block-name>`                                          | Anchor block for hooked-block workflows.                                |
+| `--position <before \| after \| firstChild \| lastChild>`        | Hook position for hooked blocks.                                        |
+| `--slot <PluginSidebar>`                                         | Editor shell slot for editor-plugin scaffolds.                          |
+| `--namespace <vendor/v1>`                                        | REST namespace for REST resource and AI feature workflows.              |
+| `--methods <method[,method...]>`                                 | REST methods for REST resource workflows.                               |
+| `--external-layer-source <source>`                               | Compose an external layer package on top of a built-in block template.  |
+| `--external-layer-id <id>`                                       | Select a specific external layer.                                       |
+| `--inner-blocks-preset <id>`                                     | Select a compound `InnerBlocks` preset.                                 |
+| `--alternate-render-targets <list>`                              | Add alternate render targets for persistence-capable dynamic scaffolds. |
+| `--data-storage <post-meta \| custom-table>`                     | Select persistence storage.                                             |
+| `--persistence-policy <authenticated \| public>`                 | Select persistence write policy.                                        |
+
+## `init`
+
+Preview the minimum adoption plan for an existing project. The command is
+read-only today.
+
+```bash
+wp-typia init [project-dir]
+wp-typia init [project-dir] --format json
+```
+
+`init` reports dependency, script, generated artifact, and migration follow-up
+steps for supported single-block and multi-block layouts.
+
+## `sync`
+
+Run the generated-project sync workflow from a scaffolded project or official
+workspace root.
+
+```bash
+wp-typia sync
+wp-typia sync --check
+wp-typia sync --dry-run
+wp-typia sync ai
+```
+
+| Flag            | Description                                             |
+| --------------- | ------------------------------------------------------- |
+| `--check`       | Check generated artifacts without writing changes.      |
+| `--dry-run`     | Preview generated sync commands without executing them. |
+| `--format json` | Emit structured sync completion output.                 |
+
+`sync ai` runs the supported WordPress AI artifact target when the project
+provides a compatible script.
+
+## `doctor`
+
+Run read-only diagnostics.
+
+```bash
+wp-typia doctor
+wp-typia doctor --format json
+wp-typia doctor --help
+```
+
+`doctor` always checks environment readiness. Official wp-typia workspace roots
+also get inventory, source-tree drift, and shared convention checks. Use
+`--format json` for CI, IDE, and wrapper integrations that need stable
+machine-readable check results.
+
+## `templates`
+
+Inspect scaffold templates.
+
+```bash
+wp-typia templates list
+wp-typia templates inspect basic
+wp-typia templates inspect --id basic
+```
+
+| Flag                 | Description                          |
+| -------------------- | ------------------------------------ |
+| `--id <template-id>` | Template id for `templates inspect`. |
+| `--format json`      | Emit structured template data.       |
+
+## `migrate`
+
+Run migration workflows for migration-capable projects.
+
+```bash
+wp-typia migrate init --current-migration-version v1
+wp-typia migrate snapshot --migration-version v1
+wp-typia migrate wizard
+wp-typia migrate plan --from-migration-version v1
+wp-typia migrate diff --from-migration-version v1
+wp-typia migrate scaffold --from-migration-version v1
+wp-typia migrate verify --all
+wp-typia migrate doctor --all
+wp-typia migrate fixtures --all --force
+wp-typia migrate fuzz --all --iterations 25 --seed 1
+```
+
+Common flags:
+
+| Flag                                  | Description                                                     |
+| ------------------------------------- | --------------------------------------------------------------- |
+| `--current-migration-version <label>` | Current migration version label for `migrate init`.             |
+| `--migration-version <label>`         | Version label to capture with `migrate snapshot`.               |
+| `--from-migration-version <label>`    | Source migration version label.                                 |
+| `--to-migration-version <label>`      | Target migration version label.                                 |
+| `--all`                               | Run across every configured migration version and block target. |
+| `--force`                             | Force overwrite behavior where supported.                       |
+| `--iterations <count>`                | Iteration count for `migrate fuzz`.                             |
+| `--seed <value>`                      | Deterministic fuzz seed.                                        |
+
+`migrate` is the canonical command. The older `migrations` alias is no longer
+supported.
+
+## Bun-powered utility commands
+
+These commands require the Bun-powered runtime.
+
+```bash
+wp-typia mcp list
+wp-typia mcp sync --output-dir .bunli/mcp
+wp-typia skills list
+wp-typia skills sync
+wp-typia completions zsh
+```
+
+`mcp` reads configured `mcp.schemaSources` and can emit MCP metadata for
+downstream tooling. `skills` and `completions` are provided by the Bunli plugin
+surface.

--- a/apps/docs/src/content/docs/tutorials/basic-block-tutorial.md
+++ b/apps/docs/src/content/docs/tutorials/basic-block-tutorial.md
@@ -6,7 +6,7 @@ Welcome to the basic block tutorial for `wp-typia`. This hands-on guide walks th
 
 ## Prerequisites
 
-- Node.js 24+ installed
+- Node.js 20+ installed
 - WordPress development environment
 - Basic knowledge of TypeScript and React
 
@@ -310,7 +310,7 @@ Update `src/style.scss`:
 
 ## Step 8: Add a Validator Test
 
-The basic template does not scaffold a dedicated unit test runner, so we'll use Node.js 24's built-in test runner together with `tsx`.
+The basic template does not scaffold a dedicated unit test runner, so we'll use Node.js' built-in test runner together with `tsx`. This works on the supported Node.js 20+ baseline.
 
 Create `src/validators.test.ts`:
 

--- a/apps/docs/src/content/docs/tutorials/compound-block-tutorial.md
+++ b/apps/docs/src/content/docs/tutorials/compound-block-tutorial.md
@@ -6,7 +6,7 @@ This tutorial walks through the `compound` built-in template. It is the starting
 
 ## Prerequisites
 
-- Node.js 24+ installed
+- Node.js 20+ installed
 - WordPress development environment (wp-env or local server)
 - Familiarity with the [Basic Block Tutorial](./basic-block-tutorial.md)
 

--- a/apps/docs/src/content/docs/tutorials/persistence-block-tutorial.md
+++ b/apps/docs/src/content/docs/tutorials/persistence-block-tutorial.md
@@ -6,7 +6,7 @@ This tutorial walks through creating a WordPress block with server-side persiste
 
 ## Prerequisites
 
-- Node.js 24+ installed
+- Node.js 20+ installed
 - WordPress development environment (wp-env or local server)
 - Basic knowledge of TypeScript, React, and WordPress REST API
 - Familiarity with the [Basic Block Tutorial](./basic-block-tutorial.md)

--- a/packages/wp-typia-project-tools/tests/cli-entry.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-entry.test.ts
@@ -986,6 +986,8 @@ test("node entry supports external layer flags for built-in create scaffolds", (
 
 test("node entry exposes fallback help and rejects the removed migrations alias", () => {
   const helpOutput = runCli("node", [entryPath, "--help"]);
+  const doctorHelpOutput = runCli("node", [entryPath, "doctor", "--help"]);
+  const doctorHelpAliasOutput = runCli("node", [entryPath, "help", "doctor"]);
   const errorMessage = getCommandErrorMessage(() =>
     runCli("node", [entryPath, "migrations", "init"], { stdio: "pipe" })
   );
@@ -995,6 +997,13 @@ test("node entry exposes fallback help and rejects the removed migrations alias"
   expect(helpOutput).toContain("Run migration workflows.");
   expect(helpOutput).toContain(
     "Inspect or sync schema-driven MCP metadata."
+  );
+  expect(doctorHelpOutput).toContain("Usage: wp-typia doctor [--format json]");
+  expect(doctorHelpOutput).toContain("Supported flags:");
+  expect(doctorHelpOutput).toContain("--format");
+  expect(doctorHelpOutput).toContain("machine-readable doctor check output");
+  expect(doctorHelpAliasOutput).toContain(
+    "Usage: wp-typia doctor [--format json]"
   );
   expect(errorMessage).toContain(
     "`wp-typia migrations` was removed in favor of `wp-typia migrate`."
@@ -1019,6 +1028,7 @@ test("bun entry exposes templates and doctor commands", () => {
 
 test("bun entry exposes fallback help and rejects the removed migrations alias", () => {
   const helpOutput = runCli("bun", [entryPath, "--help"]);
+  const doctorHelpOutput = runCli("bun", [entryPath, "doctor", "--help"]);
   const errorMessage = getCommandErrorMessage(() =>
     runCli("bun", [entryPath, "migrations", "init"], { stdio: "pipe" })
   );
@@ -1029,6 +1039,10 @@ test("bun entry exposes fallback help and rejects the removed migrations alias",
   expect(helpOutput).toContain(
     "Inspect or sync schema-driven MCP metadata."
   );
+  expect(doctorHelpOutput).toContain("Usage: wp-typia doctor [--format json]");
+  expect(doctorHelpOutput).toContain("Supported flags:");
+  expect(doctorHelpOutput).toContain("--format");
+  expect(doctorHelpOutput).toContain("machine-readable doctor check output");
   expect(errorMessage).toContain(
     "`wp-typia migrations` was removed in favor of `wp-typia migrate`."
   );

--- a/packages/wp-typia/src/command-option-metadata.ts
+++ b/packages/wp-typia/src/command-option-metadata.ts
@@ -242,6 +242,16 @@ export const SYNC_OPTION_METADATA = {
 } as const satisfies CommandOptionMetadataMap;
 
 /**
+ * Shared `wp-typia doctor` option metadata.
+ */
+export const DOCTOR_OPTION_METADATA = {
+	format: {
+		description: "Use `json` for machine-readable doctor check output.",
+		type: "string",
+	},
+} as const satisfies CommandOptionMetadataMap;
+
+/**
  * Shared `wp-typia templates` option metadata.
  */
 export const TEMPLATES_OPTION_METADATA = {

--- a/packages/wp-typia/src/commands/doctor.ts
+++ b/packages/wp-typia/src/commands/doctor.ts
@@ -4,6 +4,10 @@ import {
 	emitCliDiagnosticFailure,
 	prefersStructuredCliOutput,
 } from "../cli-diagnostic-output";
+import {
+	buildCommandOptions,
+	DOCTOR_OPTION_METADATA,
+} from "../command-option-metadata";
 import { executeDoctorCommand } from "../runtime-bridge";
 
 export const doctorCommand = defineCommand({
@@ -41,6 +45,7 @@ export const doctorCommand = defineCommand({
 		}
 	},
 	name: "doctor",
+	options: buildCommandOptions(DOCTOR_OPTION_METADATA),
 });
 
 export default doctorCommand;

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -10,6 +10,7 @@ import {
   ADD_OPTION_METADATA,
   buildCommandOptionParser,
   CREATE_OPTION_METADATA,
+  DOCTOR_OPTION_METADATA,
   formatNodeFallbackOptionHelp,
   GLOBAL_OPTION_METADATA,
   MIGRATE_OPTION_METADATA,
@@ -68,6 +69,7 @@ const NODE_FALLBACK_OPTION_PARSER = buildCommandOptionParser(
   CREATE_OPTION_METADATA,
   ADD_OPTION_METADATA,
   MIGRATE_OPTION_METADATA,
+  DOCTOR_OPTION_METADATA,
   SYNC_OPTION_METADATA,
   TEMPLATES_OPTION_METADATA,
 );
@@ -293,6 +295,19 @@ function renderSyncHelp() {
   ]);
 }
 
+function renderDoctorHelp() {
+  printBlock([
+    'Usage: wp-typia doctor [--format json]',
+    '',
+    ...NODE_FALLBACK_RUNTIME_SUMMARY_LINES,
+    '',
+    'Runs read-only environment readiness checks. Official wp-typia workspace roots also get inventory, source-tree drift, and shared convention checks.',
+    '',
+    'Supported flags:',
+    ...formatNodeFallbackOptionHelp(DOCTOR_OPTION_METADATA),
+  ]);
+}
+
 function renderVersion(
   options: {
     format?: string;
@@ -417,32 +432,37 @@ export async function runNodeCli(argv = process.argv.slice(2)): Promise<void> {
     cliArgv.length === 0 ||
     hasFlagBeforeTerminator(cliArgv, '--help') ||
     command === 'help';
+  const helpTarget = command === 'help' ? subcommand : command;
   const versionRequested =
     hasFlagBeforeTerminator(cliArgv, '--version') || command === 'version';
 
   if (helpRequested) {
-    if (command === 'templates') {
+    if (helpTarget === 'templates') {
       renderTemplatesHelp();
       return;
     }
-    if (command === 'create') {
+    if (helpTarget === 'create') {
       renderCreateHelp();
       return;
     }
-    if (command === 'init') {
+    if (helpTarget === 'init') {
       renderInitHelp();
       return;
     }
-    if (command === 'add') {
+    if (helpTarget === 'add') {
       renderAddHelp();
       return;
     }
-    if (command === 'migrate') {
+    if (helpTarget === 'migrate') {
       renderMigrateHelp();
       return;
     }
-    if (command === 'sync') {
+    if (helpTarget === 'sync') {
       renderSyncHelp();
+      return;
+    }
+    if (helpTarget === 'doctor') {
+      renderDoctorHelp();
       return;
     }
     renderGeneralHelp();

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -662,6 +662,9 @@ describe('wp-typia package', () => {
     expect(syncCommandSource).toContain(
       'buildCommandOptions(SYNC_OPTION_METADATA)',
     );
+    expect(doctorCommandSource).toContain(
+      'buildCommandOptions(DOCTOR_OPTION_METADATA)',
+    );
     expect(migrateCommandSource).toContain(
       'buildCommandOptions(MIGRATE_OPTION_METADATA)',
     );
@@ -677,6 +680,9 @@ describe('wp-typia package', () => {
     );
     expect(nodeCliSource).toContain(
       'formatNodeFallbackOptionHelp(SYNC_OPTION_METADATA)',
+    );
+    expect(nodeCliSource).toContain(
+      'formatNodeFallbackOptionHelp(DOCTOR_OPTION_METADATA)',
     );
     expect(nodeCliSource).toContain(
       'formatNodeFallbackOptionHelp(MIGRATE_OPTION_METADATA)',

--- a/packages/wp-typia/tests/command-option-metadata.test.ts
+++ b/packages/wp-typia/tests/command-option-metadata.test.ts
@@ -4,6 +4,7 @@ import {
 	ADD_OPTION_METADATA,
 	buildCommandOptionParser,
 	CREATE_OPTION_METADATA,
+	DOCTOR_OPTION_METADATA,
 	GLOBAL_OPTION_METADATA,
 	parseCommandArgvWithMetadata,
 	resolveCommandOptionValues,
@@ -84,5 +85,20 @@ describe("command option metadata helpers", () => {
 			"dry-run": true,
 		});
 		expect(parsed.positionals).toEqual([]);
+	});
+
+	test("parses doctor structured output flags from shared metadata", () => {
+		const parsed = parseCommandArgvWithMetadata(["doctor", "--format", "json"], {
+			extraBooleanOptionNames: ["help", "version"],
+			parser: buildCommandOptionParser(
+				GLOBAL_OPTION_METADATA,
+				DOCTOR_OPTION_METADATA,
+			),
+		});
+
+		expect(parsed.flags).toEqual({
+			format: "json",
+		});
+		expect(parsed.positionals).toEqual(["doctor"]);
 	});
 });


### PR DESCRIPTION
## Summary
- add a dedicated CLI reference page covering supported wp-typia commands and command-specific flags
- add command-specific `doctor --help` coverage for both Node fallback and Bunli command metadata
- update tutorial prerequisites from Node.js 24+ to the supported Node.js 20+ baseline and fix nearby API reference numbering

Closes #583

## Validation
- `bun test packages/wp-typia/tests/command-option-metadata.test.ts packages/wp-typia/tests/cli-package.test.ts`
- `bun test packages/wp-typia-project-tools/tests/cli-entry.test.ts`
- `bun run --filter @wp-typia/project-tools test:scaffold-core`
- `bun run --filter wp-typia test`
- `bun run typecheck`
- `bun run changesets:validate`
- `bun run format:check`
- `bun run docs:build`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--help` support for the `doctor` command with detailed flag documentation
  * Introduced `--format json` flag for structured, machine-readable doctor output

* **Documentation**
  * Added comprehensive CLI reference guide covering all commands, global flags, and per-command options with examples
  * Updated Node.js minimum version requirement from 24+ to 20+ across tutorials and documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->