### PR TITLE
feat(dataviews): add typed config definition api

### DIFF
--- a/apps/docs/src/content/docs/reference/dataviews.md
+++ b/apps/docs/src/content/docs/reference/dataviews.md
@@ -82,12 +82,15 @@ const productViews = defineDataViews<Product>({
 const config = productViews.createConfig({ data: [] });
 ```
 
-The field map rejects ids outside `keyof T`, and sort/filter fields in
-`defaultView` stay tied to the same model. Runtime metadata maps common schema
-types into DataViews fields: `string` to `text`, `number`/`integer` to numeric
-fields, `boolean` to `boolean`, `date`/`date-time` formats to `date`/`datetime`,
-and `email`/`uri`/`url` formats to `email`/`url`. Literal and enum metadata can
-generate `elements` without hand-writing the repetitive value/label objects.
+The field map rejects ids outside `keyof T`, `idField` only accepts string or
+number model keys for automatic DataViews row identity, and sort/filter fields
+in `defaultView` stay tied to the same model. Use `getItemId` for custom,
+nullable, or object-backed identity values. Runtime metadata maps common schema
+types through `normalizeDataViewsFieldType`: `string` to `text`,
+`number`/`integer` to numeric fields, `boolean` to `boolean`, `date`/`date-time`
+formats to `date`/`datetime`, and `email`/`uri`/`url` formats to `email`/`url`.
+Literal and enum metadata can generate `elements` without hand-writing the
+repetitive value/label objects.
 
 ## Styles
 

--- a/apps/docs/src/content/docs/reference/dataviews.md
+++ b/apps/docs/src/content/docs/reference/dataviews.md
@@ -85,9 +85,9 @@ const config = productViews.createConfig({ data: [] });
 The field map rejects ids outside `keyof T`, and sort/filter fields in
 `defaultView` stay tied to the same model. Runtime metadata maps common schema
 types into DataViews fields: `string` to `text`, `number`/`integer` to numeric
-fields, `boolean` to `boolean`, and `date`/`date-time` formats to
-`date`/`datetime`. Literal and enum metadata can generate `elements` without
-hand-writing the repetitive value/label objects.
+fields, `boolean` to `boolean`, `date`/`date-time` formats to `date`/`datetime`,
+and `email`/`uri`/`url` formats to `email`/`url`. Literal and enum metadata can
+generate `elements` without hand-writing the repetitive value/label objects.
 
 ## Styles
 

--- a/apps/docs/src/content/docs/reference/dataviews.md
+++ b/apps/docs/src/content/docs/reference/dataviews.md
@@ -16,6 +16,7 @@ admin screens:
 - `DataViewsAction`
 - `DataFormConfig`
 - `QueryAdapter`
+- `defineDataViews`
 
 The facade intentionally does not re-export upstream Gutenberg types. This keeps
 generated projects insulated from DataViews/DataForm API churn while wp-typia
@@ -33,12 +34,60 @@ import type {
   DataViewsView,
   QueryAdapter,
 } from '@wp-typia/dataviews';
+import { defineDataViews } from '@wp-typia/dataviews';
 import { DataForm, DataViews } from '@wordpress/dataviews/wp';
 ```
 
 WordPress' package docs require the `/wp` import path when plugins or themes are
 built with `@wordpress/scripts`. Do not import components from
 `@wordpress/dataviews` directly in generated WordPress scripts.
+
+## Typed Config
+
+Use `defineDataViews<T>()` when field ids, defaults, and metadata should be tied
+to a TypeScript model:
+
+```ts
+interface Product {
+  id: number;
+  status: 'draft' | 'publish';
+  title: string;
+  views: number;
+}
+
+const productViews = defineDataViews<Product>({
+  idField: 'id',
+  titleField: 'title',
+  defaultView: {
+    sort: { direction: 'desc', field: 'views' },
+    type: 'table',
+  },
+  fields: {
+    title: { schema: { type: 'string' } },
+    status: {
+      filterBy: { operators: ['isAny', 'isNone'] },
+      schema: {
+        enum: ['draft', 'publish'],
+        enumLabels: { publish: 'Published' },
+        type: 'string',
+      },
+    },
+    views: {
+      enableSorting: true,
+      schema: { type: 'integer' },
+    },
+  },
+});
+
+const config = productViews.createConfig({ data: [] });
+```
+
+The field map rejects ids outside `keyof T`, and sort/filter fields in
+`defaultView` stay tied to the same model. Runtime metadata maps common schema
+types into DataViews fields: `string` to `text`, `number`/`integer` to numeric
+fields, `boolean` to `boolean`, and `date`/`date-time` formats to
+`date`/`datetime`. Literal and enum metadata can generate `elements` without
+hand-writing the repetitive value/label objects.
 
 ## Styles
 

--- a/packages/wp-typia-dataviews/README.md
+++ b/packages/wp-typia-dataviews/README.md
@@ -53,6 +53,10 @@ const productViews = defineDataViews<Product>({
 const config = productViews.createConfig({ data: [] });
 ```
 
+Common schema metadata is normalized for DataViews defaults, including
+`string` to `text`, numeric schemas to numeric fields, date formats to
+`date`/`datetime`, and `email`/`uri`/`url` formats to `email`/`url`.
+
 Use WordPress' package for the actual components in WordPress-built scripts:
 
 ```ts

--- a/packages/wp-typia-dataviews/README.md
+++ b/packages/wp-typia-dataviews/README.md
@@ -19,6 +19,38 @@ import type {
   DataViewsView,
   QueryAdapter,
 } from '@wp-typia/dataviews';
+import { defineDataViews } from '@wp-typia/dataviews';
+```
+
+`defineDataViews<T>()` adds the typed convenience layer for field maps,
+defaults, and common schema metadata:
+
+```ts
+interface Product {
+  id: number;
+  status: 'draft' | 'publish';
+  title: string;
+  views: number;
+}
+
+const productViews = defineDataViews<Product>({
+  idField: 'id',
+  titleField: 'title',
+  defaultView: { type: 'table', page: 1, perPage: 20 },
+  fields: {
+    title: { schema: { type: 'string' } },
+    status: {
+      schema: {
+        type: 'string',
+        enum: ['draft', 'publish'],
+        enumLabels: { publish: 'Published' },
+      },
+    },
+    views: { enableSorting: true, schema: { type: 'integer' } },
+  },
+});
+
+const config = productViews.createConfig({ data: [] });
 ```
 
 Use WordPress' package for the actual components in WordPress-built scripts:

--- a/packages/wp-typia-dataviews/README.md
+++ b/packages/wp-typia-dataviews/README.md
@@ -56,6 +56,9 @@ const config = productViews.createConfig({ data: [] });
 Common schema metadata is normalized for DataViews defaults, including
 `string` to `text`, numeric schemas to numeric fields, date formats to
 `date`/`datetime`, and `email`/`uri`/`url` formats to `email`/`url`.
+`idField` is limited to string or number model keys for automatic row identity;
+use `getItemId` when identity comes from a nullable, object-backed, or custom
+value.
 
 Use WordPress' package for the actual components in WordPress-built scripts:
 

--- a/packages/wp-typia-dataviews/src/index.ts
+++ b/packages/wp-typia-dataviews/src/index.ts
@@ -348,6 +348,8 @@ export interface DefineDataViewsInput<TItem extends object> {
 export interface DefineDataViewsConfigOptions<TItem extends object> {
   readonly actions?: readonly DataViewsAction<TItem>[];
   readonly data: readonly TItem[];
+  readonly getItemId?: (item: TItem) => string;
+  readonly getItemLevel?: (item: TItem) => number;
   readonly isLoading?: boolean;
   readonly onChangeSelection?: (selection: readonly string[]) => void;
   readonly onChangeView?: (view: DataViewsView<TItem>) => void;
@@ -394,8 +396,8 @@ export function defineDataViews<TItem extends object>(
       data: options.data,
       defaultLayouts: definition.defaultLayouts,
       fields,
-      getItemId: defaultGetItemId,
-      getItemLevel: definition.getItemLevel,
+      getItemId: options.getItemId ?? defaultGetItemId,
+      getItemLevel: options.getItemLevel ?? definition.getItemLevel,
       isLoading: options.isLoading,
       onChangeSelection: options.onChangeSelection,
       onChangeView: options.onChangeView,
@@ -423,9 +425,19 @@ function normalizeDefineDataViewsFields<TItem extends object>(
 ): readonly DataViewsResolvedField<TItem>[] {
   return (
     Object.entries(fields) as Array<
-      [DataViewsFieldId<TItem>, DefineDataViewsFieldDefinition<TItem, DataViewsFieldId<TItem>>]
+      [
+        DataViewsFieldId<TItem>,
+        DefineDataViewsFieldDefinition<TItem, DataViewsFieldId<TItem>> | undefined,
+      ]
     >
-  ).map(([id, field]) => normalizeDefineDataViewsField(id, field));
+  )
+    .filter(
+      (entry): entry is [
+        DataViewsFieldId<TItem>,
+        DefineDataViewsFieldDefinition<TItem, DataViewsFieldId<TItem>>,
+      ] => entry[1] !== undefined,
+    )
+    .map(([id, field]) => normalizeDefineDataViewsField(id, field));
 }
 
 function normalizeDefineDataViewsField<
@@ -527,7 +539,9 @@ function getDataViewsSchemaElementValues<TValue>(
 function getFirstDataViewsSchemaType(
   type: DataViewsFieldSchemaMetadata["type"] | undefined,
 ): DataViewsFieldType | undefined {
-  const schemaType = Array.isArray(type) ? type.find((candidate) => candidate !== "object") : type;
+  const schemaType = Array.isArray(type)
+    ? (type.find((candidate) => candidate !== "object") ?? type[0])
+    : type;
 
   if (schemaType === "string") {
     return "text";

--- a/packages/wp-typia-dataviews/src/index.ts
+++ b/packages/wp-typia-dataviews/src/index.ts
@@ -81,6 +81,22 @@ export type DataViewsFieldId<TItem extends object = DataViewsRecord> = Extract<
 
 export type DataViewsScalar = boolean | number | string;
 
+export type DataViewsFieldElementValue<TValue> =
+  Extract<NonNullable<TValue>, DataViewsScalar> extends never
+    ? DataViewsScalar
+    : Extract<NonNullable<TValue>, DataViewsScalar>;
+
+export type DataViewsWeekStart = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+
+export interface DataViewsFieldFormat {
+  readonly date?: string;
+  readonly datetime?: string;
+  readonly decimals?: number;
+  readonly separatorDecimal?: string;
+  readonly separatorThousand?: string;
+  readonly weekStartsOn?: DataViewsWeekStart;
+}
+
 export interface DataViewsFieldElement<TValue = DataViewsScalar> {
   readonly label: string;
   readonly value: TValue;
@@ -117,11 +133,12 @@ export interface DataViewsField<
   TValue = unknown,
 > {
   readonly description?: string;
-  readonly elements?: readonly DataViewsFieldElement<TValue>[];
+  readonly elements?: readonly DataViewsFieldElement<DataViewsFieldElementValue<TValue>>[];
   readonly enableGlobalSearch?: boolean;
   readonly enableHiding?: boolean;
   readonly enableSorting?: boolean;
   readonly filterBy?: DataViewsFieldFilter;
+  readonly format?: DataViewsFieldFormat;
   readonly getValue?: (context: DataViewsFieldContext<TItem, TValue>) => TValue;
   readonly getValueFormatted?: (context: DataViewsFieldContext<TItem, TValue>) => string;
   readonly header?: string;
@@ -215,11 +232,19 @@ export interface DataViewsAction<TItem extends object = DataViewsRecord> {
   readonly supportsBulk?: boolean;
 }
 
+export type DataViewsResolvedField<TItem extends object = DataViewsRecord> = {
+  readonly [TKey in DataViewsFieldId<TItem>]: DataViewsField<TItem, TItem[TKey]>;
+}[DataViewsFieldId<TItem>];
+
+export type DataViewsConfigField<TItem extends object = DataViewsRecord> =
+  | DataViewsField<TItem>
+  | DataViewsResolvedField<TItem>;
+
 export interface DataViewsConfig<TItem extends object = DataViewsRecord> {
   readonly actions?: readonly DataViewsAction<TItem>[];
   readonly data: readonly TItem[];
   readonly defaultLayouts?: DataViewsDefaultLayouts;
-  readonly fields: readonly DataViewsField<TItem>[];
+  readonly fields: readonly DataViewsConfigField<TItem>[];
   readonly getItemId?: (item: TItem) => string;
   readonly getItemLevel?: (item: TItem) => number;
   readonly isLoading?: boolean;
@@ -246,13 +271,307 @@ export interface DataFormConfig<TItem extends object = DataViewsRecord> {
 }
 
 export interface QueryAdapterContext<TItem extends object = DataViewsRecord> {
-  readonly fields: readonly DataViewsField<TItem>[];
+  readonly fields: readonly DataViewsConfigField<TItem>[];
 }
 
 export type QueryAdapter<
   TItem extends object = DataViewsRecord,
   TQuery = Record<string, unknown>,
 > = (view: DataViewsView<TItem>, context: QueryAdapterContext<TItem>) => TQuery;
+
+export type DataViewsCompatibleFieldType<TValue> =
+  NonNullable<TValue> extends boolean
+    ? "boolean"
+    : NonNullable<TValue> extends number
+      ? "integer" | "number"
+      : NonNullable<TValue> extends string
+        ? "date" | "datetime" | "email" | "text" | "url"
+        : NonNullable<TValue> extends readonly unknown[]
+          ? "array"
+          : NonNullable<TValue> extends object
+            ? "media" | "object"
+            : DataViewsFieldType;
+
+export type DataViewsFieldSchemaType =
+  | "array"
+  | "boolean"
+  | "integer"
+  | "number"
+  | "object"
+  | "string";
+
+export type DataViewsFieldSchemaFormat =
+  | "date"
+  | "date-time"
+  | "datetime"
+  | "email"
+  | "uri"
+  | "url"
+  | (string & {});
+
+export interface DataViewsFieldSchemaMetadata<TValue = DataViewsScalar> {
+  readonly const?: DataViewsFieldElementValue<TValue>;
+  readonly description?: string;
+  readonly enum?: readonly DataViewsFieldElementValue<TValue>[];
+  readonly enumLabels?: Readonly<Record<string, string>>;
+  readonly format?: DataViewsFieldSchemaFormat;
+  readonly type?: DataViewsFieldSchemaType | readonly DataViewsFieldSchemaType[];
+}
+
+export interface DefineDataViewsFieldDefinition<
+  TItem extends object,
+  TKey extends DataViewsFieldId<TItem>,
+> extends Omit<DataViewsField<TItem, TItem[TKey]>, "elements" | "id" | "label" | "type"> {
+  readonly elements?: readonly DataViewsFieldElement<DataViewsFieldElementValue<TItem[TKey]>>[];
+  readonly label?: string;
+  readonly schema?: DataViewsFieldSchemaMetadata<TItem[TKey]>;
+  readonly type?: DataViewsCompatibleFieldType<TItem[TKey]>;
+}
+
+export type DefineDataViewsFields<TItem extends object> = {
+  readonly [TKey in DataViewsFieldId<TItem>]?: DefineDataViewsFieldDefinition<TItem, TKey>;
+};
+
+export interface DefineDataViewsInput<TItem extends object> {
+  readonly actions?: readonly DataViewsAction<TItem>[];
+  readonly defaultLayouts?: DataViewsDefaultLayouts;
+  readonly defaultView: DataViewsView<TItem>;
+  readonly fields: DefineDataViewsFields<TItem>;
+  readonly getItemId?: (item: TItem) => string;
+  readonly getItemLevel?: (item: TItem) => number;
+  readonly idField?: DataViewsFieldId<TItem>;
+  readonly search?: boolean;
+  readonly searchLabel?: string;
+  readonly titleField?: DataViewsFieldId<TItem>;
+}
+
+export interface DefineDataViewsConfigOptions<TItem extends object> {
+  readonly actions?: readonly DataViewsAction<TItem>[];
+  readonly data: readonly TItem[];
+  readonly isLoading?: boolean;
+  readonly onChangeSelection?: (selection: readonly string[]) => void;
+  readonly onChangeView?: (view: DataViewsView<TItem>) => void;
+  readonly paginationInfo?: DataViewsPaginationInfo;
+  readonly search?: boolean;
+  readonly searchLabel?: string;
+  readonly selection?: readonly string[];
+  readonly view?: DataViewsView<TItem>;
+}
+
+export type DefinedDataViewsFieldMap<TItem extends object> = Readonly<
+  Partial<Record<DataViewsFieldId<TItem>, DataViewsResolvedField<TItem>>>
+>;
+
+export interface DefinedDataViews<TItem extends object> {
+  readonly actions?: readonly DataViewsAction<TItem>[];
+  readonly defaultLayouts?: DataViewsDefaultLayouts;
+  readonly defaultView: DataViewsView<TItem>;
+  readonly fieldMap: DefinedDataViewsFieldMap<TItem>;
+  readonly fields: readonly DataViewsResolvedField<TItem>[];
+  readonly getItemId?: (item: TItem) => string;
+  readonly getItemLevel?: (item: TItem) => number;
+  readonly idField?: DataViewsFieldId<TItem>;
+  readonly search?: boolean;
+  readonly searchLabel?: string;
+  readonly titleField?: DataViewsFieldId<TItem>;
+  readonly createConfig: (options: DefineDataViewsConfigOptions<TItem>) => DataViewsConfig<TItem>;
+}
+
+export function defineDataViews<TItem extends object>(
+  definition: DefineDataViewsInput<TItem>,
+): DefinedDataViews<TItem> {
+  const fields = normalizeDefineDataViewsFields(definition.fields);
+  const fieldMap = Object.fromEntries(
+    fields.map((field) => [field.id, field]),
+  ) as DefinedDataViewsFieldMap<TItem>;
+  const defaultView = normalizeDefineDataViewsDefaultView(definition, fields);
+  const defaultGetItemId = definition.getItemId ?? createGetItemId(definition.idField);
+
+  return {
+    actions: definition.actions,
+    createConfig: (options) => ({
+      actions: options.actions ?? definition.actions,
+      data: options.data,
+      defaultLayouts: definition.defaultLayouts,
+      fields,
+      getItemId: defaultGetItemId,
+      getItemLevel: definition.getItemLevel,
+      isLoading: options.isLoading,
+      onChangeSelection: options.onChangeSelection,
+      onChangeView: options.onChangeView,
+      paginationInfo: options.paginationInfo,
+      search: options.search ?? definition.search,
+      searchLabel: options.searchLabel ?? definition.searchLabel,
+      selection: options.selection,
+      view: options.view ?? defaultView,
+    }),
+    defaultLayouts: definition.defaultLayouts,
+    defaultView,
+    fieldMap,
+    fields,
+    getItemId: defaultGetItemId,
+    getItemLevel: definition.getItemLevel,
+    idField: definition.idField,
+    search: definition.search,
+    searchLabel: definition.searchLabel,
+    titleField: definition.titleField,
+  };
+}
+
+function normalizeDefineDataViewsFields<TItem extends object>(
+  fields: DefineDataViewsFields<TItem>,
+): readonly DataViewsResolvedField<TItem>[] {
+  return (
+    Object.entries(fields) as Array<
+      [DataViewsFieldId<TItem>, DefineDataViewsFieldDefinition<TItem, DataViewsFieldId<TItem>>]
+    >
+  ).map(([id, field]) => normalizeDefineDataViewsField(id, field));
+}
+
+function normalizeDefineDataViewsField<
+  TItem extends object,
+  TKey extends DataViewsFieldId<TItem>,
+>(
+  id: TKey,
+  field: DefineDataViewsFieldDefinition<TItem, TKey>,
+): DataViewsField<TItem, TItem[TKey]> {
+  const { schema, ...fieldDefinition } = field;
+  const label = fieldDefinition.label ?? formatDataViewsFieldLabel(id);
+  const description = fieldDefinition.description ?? schema?.description;
+  const type = normalizeDataViewsFieldType(fieldDefinition.type, schema);
+  const elements = fieldDefinition.elements ?? normalizeDataViewsFieldElements(schema);
+
+  return {
+    ...fieldDefinition,
+    description,
+    elements,
+    id,
+    label,
+    type,
+  };
+}
+
+function normalizeDefineDataViewsDefaultView<TItem extends object>(
+  definition: DefineDataViewsInput<TItem>,
+  fields: readonly DataViewsResolvedField<TItem>[],
+): DataViewsView<TItem> {
+  const defaults =
+    definition.titleField === undefined
+      ? { fields: fields.map((field) => field.id) }
+      : { fields: fields.map((field) => field.id), titleField: definition.titleField };
+
+  return {
+    ...defaults,
+    ...definition.defaultView,
+  };
+}
+
+function normalizeDataViewsFieldType<TValue>(
+  type: DataViewsCompatibleFieldType<TValue> | undefined,
+  schema: DataViewsFieldSchemaMetadata<TValue> | undefined,
+): DataViewsFieldType | undefined {
+  if (type !== undefined) {
+    return type;
+  }
+
+  if (schema?.format === "date-time" || schema?.format === "datetime") {
+    return "datetime";
+  }
+
+  if (schema?.format === "date") {
+    return "date";
+  }
+
+  if (schema?.format === "email") {
+    return "email";
+  }
+
+  if (schema?.format === "uri" || schema?.format === "url") {
+    return "url";
+  }
+
+  const schemaType = getFirstDataViewsSchemaType(schema?.type);
+
+  return schemaType;
+}
+
+function normalizeDataViewsFieldElements<TValue>(
+  schema: DataViewsFieldSchemaMetadata<TValue> | undefined,
+): readonly DataViewsFieldElement<DataViewsFieldElementValue<TValue>>[] | undefined {
+  const values = getDataViewsSchemaElementValues(schema);
+
+  if (values.length === 0) {
+    return undefined;
+  }
+
+  return values.map((value) => ({
+    label: schema?.enumLabels?.[String(value)] ?? formatDataViewsElementLabel(value),
+    value,
+  }));
+}
+
+function getDataViewsSchemaElementValues<TValue>(
+  schema: DataViewsFieldSchemaMetadata<TValue> | undefined,
+): readonly DataViewsFieldElementValue<TValue>[] {
+  if (schema?.enum !== undefined) {
+    return schema.enum;
+  }
+
+  if (schema?.const !== undefined) {
+    return [schema.const];
+  }
+
+  return [];
+}
+
+function getFirstDataViewsSchemaType(
+  type: DataViewsFieldSchemaMetadata["type"] | undefined,
+): DataViewsFieldType | undefined {
+  const schemaType = Array.isArray(type) ? type.find((candidate) => candidate !== "object") : type;
+
+  if (schemaType === "string") {
+    return "text";
+  }
+
+  if (
+    schemaType === "array" ||
+    schemaType === "boolean" ||
+    schemaType === "integer" ||
+    schemaType === "number" ||
+    schemaType === "object"
+  ) {
+    return schemaType;
+  }
+
+  return undefined;
+}
+
+function createGetItemId<TItem extends object>(
+  idField: DataViewsFieldId<TItem> | undefined,
+): ((item: TItem) => string) | undefined {
+  if (idField === undefined) {
+    return undefined;
+  }
+
+  return (item) => String(item[idField]);
+}
+
+function formatDataViewsFieldLabel(id: string): string {
+  return id
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[-_]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function formatDataViewsElementLabel(value: DataViewsScalar): string {
+  if (typeof value === "boolean") {
+    return value ? "True" : "False";
+  }
+
+  return formatDataViewsFieldLabel(String(value));
+}
 
 /**
  * WordPress-script import path for actual DataViews/DataForm components.

--- a/packages/wp-typia-dataviews/src/index.ts
+++ b/packages/wp-typia-dataviews/src/index.ts
@@ -81,6 +81,14 @@ export type DataViewsFieldId<TItem extends object = DataViewsRecord> = Extract<
 
 export type DataViewsScalar = boolean | number | string;
 
+export type DataViewsItemIdValue = number | string;
+
+export type DataViewsItemIdField<TItem extends object = DataViewsRecord> = {
+  readonly [TKey in DataViewsFieldId<TItem>]-?: TItem[TKey] extends DataViewsItemIdValue
+    ? TKey
+    : never;
+}[DataViewsFieldId<TItem>];
+
 export type DataViewsFieldElementValue<TValue> =
   Extract<NonNullable<TValue>, DataViewsScalar> extends never
     ? DataViewsScalar
@@ -339,7 +347,7 @@ export interface DefineDataViewsInput<TItem extends object> {
   readonly fields: DefineDataViewsFields<TItem>;
   readonly getItemId?: (item: TItem) => string;
   readonly getItemLevel?: (item: TItem) => number;
-  readonly idField?: DataViewsFieldId<TItem>;
+  readonly idField?: DataViewsItemIdField<TItem>;
   readonly search?: boolean;
   readonly searchLabel?: string;
   readonly titleField?: DataViewsFieldId<TItem>;
@@ -372,7 +380,7 @@ export interface DefinedDataViews<TItem extends object> {
   readonly fields: readonly DataViewsResolvedField<TItem>[];
   readonly getItemId?: (item: TItem) => string;
   readonly getItemLevel?: (item: TItem) => number;
-  readonly idField?: DataViewsFieldId<TItem>;
+  readonly idField?: DataViewsItemIdField<TItem>;
   readonly search?: boolean;
   readonly searchLabel?: string;
   readonly titleField?: DataViewsFieldId<TItem>;
@@ -561,13 +569,27 @@ function getFirstDataViewsSchemaType(
 }
 
 function createGetItemId<TItem extends object>(
-  idField: DataViewsFieldId<TItem> | undefined,
+  idField: DataViewsItemIdField<TItem> | undefined,
 ): ((item: TItem) => string) | undefined {
   if (idField === undefined) {
     return undefined;
   }
 
-  return (item) => String(item[idField]);
+  return (item) => {
+    const idValue = item[idField];
+
+    if (typeof idValue === "string") {
+      return idValue;
+    }
+
+    if (typeof idValue === "number" && Number.isFinite(idValue)) {
+      return String(idValue);
+    }
+
+    throw new TypeError(
+      `defineDataViews idField "${idField}" must resolve to a string or finite number. Provide getItemId for custom item identity values.`,
+    );
+  };
 }
 
 function formatDataViewsFieldLabel(id: string): string {

--- a/packages/wp-typia-dataviews/tests/define-data-views.test.ts
+++ b/packages/wp-typia-dataviews/tests/define-data-views.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from "bun:test";
+
+import { defineDataViews } from "../src/index.js";
+
+interface Product {
+  readonly createdAt: string;
+  readonly featured: boolean;
+  readonly homepage: string;
+  readonly id: number;
+  readonly price: number;
+  readonly publishedOn: string;
+  readonly status: "draft" | "publish";
+  readonly title: string;
+  readonly views: number;
+}
+
+describe("defineDataViews", () => {
+  test("normalizes primitive schema metadata into DataViews field types", () => {
+    const views = defineDataViews<Product>({
+      defaultView: { type: "table" },
+      fields: {
+        featured: { schema: { type: "boolean" } },
+        price: { schema: { type: "number" } },
+        title: { schema: { type: "string" } },
+        views: { schema: { type: "integer" } },
+      },
+      idField: "id",
+      titleField: "title",
+    });
+
+    expect(views.fields).toEqual([
+      { id: "featured", label: "Featured", type: "boolean" },
+      { id: "price", label: "Price", type: "number" },
+      { id: "title", label: "Title", type: "text" },
+      { id: "views", label: "Views", type: "integer" },
+    ]);
+    expect(views.defaultView).toEqual({
+      fields: ["featured", "price", "title", "views"],
+      titleField: "title",
+      type: "table",
+    });
+    expect(views.createConfig({ data: [{ ...sampleProduct, id: 7 }] }).getItemId?.(sampleProduct)).toBe(
+      "1",
+    );
+  });
+
+  test("normalizes enum metadata into typed field elements", () => {
+    const views = defineDataViews<Product>({
+      defaultView: { type: "table" },
+      fields: {
+        status: {
+          schema: {
+            enum: ["draft", "publish"],
+            enumLabels: { publish: "Published" },
+            type: "string",
+          },
+        },
+      },
+    });
+
+    expect(views.fieldMap.status?.elements).toEqual([
+      { label: "Draft", value: "draft" },
+      { label: "Published", value: "publish" },
+    ]);
+  });
+
+  test("normalizes date-like and URL metadata while preserving field options", () => {
+    const views = defineDataViews<Product>({
+      defaultView: {
+        filters: [{ field: "createdAt", operator: "after", value: "2026-01-01" }],
+        sort: { direction: "desc", field: "createdAt" },
+        type: "table",
+      },
+      fields: {
+        createdAt: {
+          enableGlobalSearch: true,
+          enableHiding: false,
+          enableSorting: true,
+          format: { datetime: "M j, Y g:i a", weekStartsOn: 1 },
+          label: "Created",
+          schema: { description: "Creation time", format: "date-time", type: "string" },
+        },
+        homepage: {
+          schema: { format: "uri", type: "string" },
+        },
+        publishedOn: {
+          filterBy: { operators: ["on", "beforeInc", "afterInc"] },
+          schema: { format: "date", type: "string" },
+        },
+      },
+    });
+
+    expect(views.fieldMap.createdAt).toMatchObject({
+      description: "Creation time",
+      enableGlobalSearch: true,
+      enableHiding: false,
+      enableSorting: true,
+      format: { datetime: "M j, Y g:i a", weekStartsOn: 1 },
+      id: "createdAt",
+      label: "Created",
+      type: "datetime",
+    });
+    expect(views.fieldMap.homepage).toMatchObject({
+      id: "homepage",
+      label: "Homepage",
+      type: "url",
+    });
+    expect(views.fieldMap.publishedOn).toMatchObject({
+      filterBy: { operators: ["on", "beforeInc", "afterInc"] },
+      id: "publishedOn",
+      label: "Published On",
+      type: "date",
+    });
+  });
+});
+
+const sampleProduct: Product = {
+  createdAt: "2026-04-26T00:00:00Z",
+  featured: true,
+  homepage: "https://example.com",
+  id: 1,
+  price: 19.99,
+  publishedOn: "2026-04-26",
+  status: "publish",
+  title: "Typed block patterns",
+  views: 42,
+};

--- a/packages/wp-typia-dataviews/tests/define-data-views.test.ts
+++ b/packages/wp-typia-dataviews/tests/define-data-views.test.ts
@@ -7,12 +7,26 @@ interface Product {
   readonly featured: boolean;
   readonly homepage: string;
   readonly id: number;
+  readonly metadata: { readonly sku: string };
   readonly price: number;
   readonly publishedOn: string;
   readonly status: "draft" | "publish";
   readonly title: string;
   readonly views: number;
 }
+
+const sampleProduct: Product = {
+  createdAt: "2026-04-26T00:00:00Z",
+  featured: true,
+  homepage: "https://example.com",
+  id: 1,
+  metadata: { sku: "WP-TYPIA-1" },
+  price: 19.99,
+  publishedOn: "2026-04-26",
+  status: "publish",
+  title: "Typed block patterns",
+  views: 42,
+};
 
 describe("defineDataViews", () => {
   test("normalizes primitive schema metadata into DataViews field types", () => {
@@ -39,9 +53,7 @@ describe("defineDataViews", () => {
       titleField: "title",
       type: "table",
     });
-    expect(views.createConfig({ data: [{ ...sampleProduct, id: 7 }] }).getItemId?.(sampleProduct)).toBe(
-      "1",
-    );
+    expect(views.createConfig({ data: [sampleProduct] }).getItemId?.(sampleProduct)).toBe("1");
   });
 
   test("normalizes enum metadata into typed field elements", () => {
@@ -112,16 +124,51 @@ describe("defineDataViews", () => {
       type: "date",
     });
   });
-});
 
-const sampleProduct: Product = {
-  createdAt: "2026-04-26T00:00:00Z",
-  featured: true,
-  homepage: "https://example.com",
-  id: 1,
-  price: 19.99,
-  publishedOn: "2026-04-26",
-  status: "publish",
-  title: "Typed block patterns",
-  views: 42,
-};
+  test("skips optional field entries explicitly set to undefined", () => {
+    const views = defineDataViews<Product>({
+      defaultView: { type: "table" },
+      fields: {
+        title: undefined,
+        views: { schema: { type: "integer" } },
+      },
+    });
+
+    expect(views.fields).toEqual([{ id: "views", label: "Views", type: "integer" }]);
+    expect(views.defaultView.fields).toEqual(["views"]);
+  });
+
+  test("preserves object schema metadata when object is the only array type", () => {
+    const views = defineDataViews<Product>({
+      defaultView: { type: "table" },
+      fields: {
+        metadata: { schema: { type: ["object"] } },
+      },
+    });
+
+    expect(views.fieldMap.metadata).toMatchObject({
+      id: "metadata",
+      label: "Metadata",
+      type: "object",
+    });
+  });
+
+  test("allows createConfig callers to override item identity callbacks", () => {
+    const views = defineDataViews<Product>({
+      defaultView: { type: "table" },
+      fields: {
+        title: { schema: { type: "string" } },
+      },
+      getItemLevel: (product) => product.views,
+      idField: "id",
+    });
+    const config = views.createConfig({
+      data: [sampleProduct],
+      getItemId: (product) => `product:${product.id}`,
+      getItemLevel: () => 2,
+    });
+
+    expect(config.getItemId?.(sampleProduct)).toBe("product:1");
+    expect(config.getItemLevel?.(sampleProduct)).toBe(2);
+  });
+});

--- a/packages/wp-typia-dataviews/tests/define-data-views.test.ts
+++ b/packages/wp-typia-dataviews/tests/define-data-views.test.ts
@@ -171,4 +171,18 @@ describe("defineDataViews", () => {
     expect(config.getItemId?.(sampleProduct)).toBe("product:1");
     expect(config.getItemLevel?.(sampleProduct)).toBe(2);
   });
+
+  test("guards unsafe idField values when runtime input bypasses the type contract", () => {
+    const views = defineDataViews<Product>({
+      defaultView: { type: "table" },
+      fields: {
+        title: { schema: { type: "string" } },
+      },
+      idField: "metadata" as never,
+    });
+
+    expect(() => views.createConfig({ data: [sampleProduct] }).getItemId?.(sampleProduct)).toThrow(
+      'idField "metadata" must resolve to a string or finite number',
+    );
+  });
 });

--- a/packages/wp-typia-dataviews/tests/fixtures/public-type-contracts.ts
+++ b/packages/wp-typia-dataviews/tests/fixtures/public-type-contracts.ts
@@ -13,6 +13,7 @@ import { defineDataViews } from "@wp-typia/dataviews";
 interface Book {
   readonly createdAt: string;
   readonly id: number;
+  readonly metadata: { readonly isbn: string };
   readonly published: boolean;
   readonly status: "draft" | "publish";
   readonly title: string;
@@ -151,6 +152,13 @@ defineDataViews<Book>({
   fields: {},
   // @ts-expect-error idField must be a key of Book.
   idField: "missing",
+});
+
+defineDataViews<Book>({
+  defaultView: { type: "table" },
+  fields: {},
+  // @ts-expect-error idField must reference a string or number field.
+  idField: "metadata",
 });
 
 defineDataViews<Book>({

--- a/packages/wp-typia-dataviews/tests/fixtures/public-type-contracts.ts
+++ b/packages/wp-typia-dataviews/tests/fixtures/public-type-contracts.ts
@@ -4,11 +4,16 @@ import type {
   DataViewsConfig,
   DataViewsField,
   DataViewsView,
+  DefinedDataViews,
+  DefineDataViewsInput,
   QueryAdapter,
 } from "@wp-typia/dataviews";
+import { defineDataViews } from "@wp-typia/dataviews";
 
 interface Book {
+  readonly createdAt: string;
   readonly id: number;
+  readonly published: boolean;
   readonly status: "draft" | "publish";
   readonly title: string;
   readonly views: number;
@@ -69,6 +74,49 @@ const form = {
   fields: [{ id: "title", label: "Title" }],
 } satisfies DataFormConfig<Book>;
 
+const bookViews = defineDataViews<Book>({
+  defaultView: {
+    filters: [{ field: "status", operator: "isAny", value: ["draft", "publish"] }],
+    sort: { direction: "desc", field: "views" },
+    type: "table",
+  },
+  fields: {
+    createdAt: {
+      format: { datetime: "M j, Y g:i a" },
+      schema: { format: "date-time", type: "string" },
+    },
+    published: { schema: { type: "boolean" } },
+    status: {
+      elements: [
+        { label: "Draft", value: "draft" },
+        { label: "Published", value: "publish" },
+      ],
+      filterBy: { operators: ["isAny", "isNone"] },
+      schema: { enum: ["draft", "publish"], type: "string" },
+    },
+    title: {
+      description: "Book title",
+      enableGlobalSearch: true,
+      enableHiding: false,
+      label: "Title",
+      schema: { type: "string" },
+    },
+    views: {
+      enableSorting: true,
+      schema: { type: "integer" },
+    },
+  },
+  idField: "id",
+  titleField: "title",
+}) satisfies DefinedDataViews<Book>;
+
+const configInput = {
+  defaultView: { type: "table" },
+  fields: {
+    title: { schema: { type: "string" } },
+  },
+} satisfies DefineDataViewsInput<Book>;
+
 const adapter: QueryAdapter<Book, { page?: number; per_page?: number; search?: string }> = (
   currentView,
 ) => {
@@ -90,7 +138,43 @@ const adapter: QueryAdapter<Book, { page?: number; per_page?: number; search?: s
 // @ts-expect-error wp-typia owns the initial supported layout union.
 const unsupportedView = { type: "calendar" } satisfies DataViewsView<Book>;
 
+defineDataViews<Book>({
+  defaultView: { type: "table" },
+  fields: {
+    // @ts-expect-error field ids must be keys of Book.
+    missing: { label: "Missing" },
+  },
+});
+
+defineDataViews<Book>({
+  defaultView: { type: "table" },
+  fields: {},
+  // @ts-expect-error idField must be a key of Book.
+  idField: "missing",
+});
+
+defineDataViews<Book>({
+  defaultView: { type: "table" },
+  fields: {
+    status: {
+      elements: [
+        // @ts-expect-error element values must match the field value type.
+        { label: "Private", value: "private" },
+      ],
+    },
+  },
+});
+
+const invalidSortView = {
+  // @ts-expect-error sort fields must be keys of Book.
+  sort: { direction: "asc", field: "missing" },
+  type: "table",
+} satisfies DataViewsView<Book>;
+
 void config;
+void configInput;
 void form;
 void adapter(view, { fields });
+void bookViews.createConfig({ data: [] });
+void invalidSortView;
 void unsupportedView;

--- a/packages/wp-typia-dataviews/tests/type-contracts.test.ts
+++ b/packages/wp-typia-dataviews/tests/type-contracts.test.ts
@@ -37,9 +37,12 @@ describe("@wp-typia/dataviews type contracts", () => {
     const fixtureSource = readFileSync(fixtureSourcePath, "utf8");
 
     expect(fixtureSource).toContain("@wp-typia/dataviews");
+    expect(fixtureSource).toContain("defineDataViews");
     expect(fixtureSource).toContain("DataViewsField");
     expect(fixtureSource).toContain("DataViewsView");
     expect(fixtureSource).toContain("DataFormConfig");
+    expect(fixtureSource).toContain("DefinedDataViews");
+    expect(fixtureSource).toContain("DefineDataViewsInput");
     expect(fixtureSource).toContain("QueryAdapter");
     expect(fixtureSource).toContain("@ts-expect-error");
   });


### PR DESCRIPTION
## Summary
- Add defineDataViews<T>() for typed DataViews field maps, defaults, fieldMap access, and createConfig() output.
- Add schema metadata normalization for primitive field types, date/datetime/email/url formats, enum/const elements, labels, descriptions, filter/sort metadata, and format options.
- Extend public type fixtures, runtime tests, README, and DataViews reference docs for the typed config API.

Closes #599

## Validation
- bun run --filter @wp-typia/dataviews test
- bun run typecheck
- bun run packages:build
- bun run manifest-policy:validate
- bun run publish:validate
- bun run changesets:validate
- bun run docs:build
- bun run format:check
- bun run runtime-coupling:validate
- bun test packages/wp-typia-project-tools/tests/dataviews-opt-in-policy.test.ts
- bun run lint:repo
- git diff --check
- git diff --cached --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `defineDataViews` helper for creating type-safe DataViews configurations bound to TypeScript models
  * Added support for field formatting and schema-driven field definitions with automatic normalization

* **Documentation**
  * Added comprehensive guide with examples for the new typed configuration API in official documentation
  * Updated README with practical usage examples and import statements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->