### PR TITLE
feat(dataviews): add typed query adapter helpers

### DIFF
--- a/apps/docs/src/content/docs/reference/dataviews.md
+++ b/apps/docs/src/content/docs/reference/dataviews.md
@@ -16,7 +16,10 @@ admin screens:
 - `DataViewsAction`
 - `DataFormConfig`
 - `QueryAdapter`
+- `DataViewsQueryAdapterOptions`
 - `defineDataViews`
+- `createDataViewsQueryAdapter`
+- `toDataViewsQueryArgs`
 
 The facade intentionally does not re-export upstream Gutenberg types. This keeps
 generated projects insulated from DataViews/DataForm API churn while wp-typia
@@ -31,10 +34,15 @@ actual components:
 import type {
   DataFormConfig,
   DataViewsField,
+  DataViewsQueryAdapterOptions,
   DataViewsView,
   QueryAdapter,
 } from '@wp-typia/dataviews';
-import { defineDataViews } from '@wp-typia/dataviews';
+import {
+  createDataViewsQueryAdapter,
+  defineDataViews,
+  toDataViewsQueryArgs,
+} from '@wp-typia/dataviews';
 import { DataForm, DataViews } from '@wordpress/dataviews/wp';
 ```
 
@@ -113,21 +121,48 @@ Generated and hand-authored integrations should map view state into project
 queries explicitly:
 
 ```ts
-import type { QueryAdapter } from '@wp-typia/dataviews';
+import { toDataViewsQueryArgs } from '@wp-typia/dataviews';
 
 interface Book {
   id: number;
+  createdAt: string;
   status: 'draft' | 'publish';
   title: string;
 }
 
-const toQueryArgs: QueryAdapter<Book, Record<string, unknown>> = (view) => ({
-  page: view.page,
-  per_page: view.perPage,
-  search: view.search,
-  status: view.filters?.find((filter) => filter.field === 'status')?.value,
+interface BookRestQuery {
+  order?: 'asc' | 'desc';
+  orderby?: 'date' | 'title';
+  page?: number;
+  per_page?: number;
+  search?: string;
+  status?: readonly Book['status'][];
+}
+
+const queryArgs = toDataViewsQueryArgs<Book, BookRestQuery>(view, {
+  mapSort: {
+    createdAt: 'date',
+    title: 'title',
+  },
+  mapFilter(filter) {
+    if (filter.field === 'status' && filter.operator === 'isAny') {
+      return { status: filter.value as readonly Book['status'][] };
+    }
+
+    return undefined;
+  },
 });
 ```
+
+`page`, `perPage`, and `search` map to `page`, `per_page`, and `search` by
+default. Sorts are only emitted when `mapSort` maps the DataViews field to a
+query value such as a WordPress REST `orderby` value. Filters are only emitted
+when `mapFilter` returns query args, so unknown filters remain explicit no-ops
+instead of being guessed.
+
+Use `createDataViewsQueryAdapter(options)` when a reusable `QueryAdapter` is
+more convenient, or call `definedViews.toQueryArgs(view, options)` from a
+`defineDataViews<T>()` result to reuse the normalized field context.
 
 This boundary lets future scaffold support generate typed fields, actions,
 forms, and query adapters without hiding application-specific data fetching.

--- a/apps/docs/src/content/docs/reference/dataviews.md
+++ b/apps/docs/src/content/docs/reference/dataviews.md
@@ -172,6 +172,10 @@ query value such as a WordPress REST `orderby` value. Filters are only emitted
 when `mapFilter` returns query args, so unknown filters remain explicit no-ops
 instead of being guessed.
 
+When your query type omits any default pagination or search key, explicitly
+remap it with `pageParam`, `perPageParam`, or `searchParam`, or set that param to
+`false`.
+
 When multiple filters return the same query key, the adapter uses the last
 returned value. Return an array value from `mapFilter` when a data source needs
 combined filter semantics.

--- a/apps/docs/src/content/docs/reference/dataviews.md
+++ b/apps/docs/src/content/docs/reference/dataviews.md
@@ -121,6 +121,7 @@ Generated and hand-authored integrations should map view state into project
 queries explicitly:
 
 ```ts
+import type { DataViewsView } from '@wp-typia/dataviews';
 import { toDataViewsQueryArgs } from '@wp-typia/dataviews';
 
 interface Book {
@@ -138,6 +139,17 @@ interface BookRestQuery {
   search?: string;
   status?: readonly Book['status'][];
 }
+
+const view: DataViewsView<Book> = {
+  filters: [
+    { field: 'status', operator: 'isAny', value: ['draft', 'publish'] },
+  ],
+  page: 1,
+  perPage: 20,
+  search: 'patterns',
+  sort: { direction: 'desc', field: 'createdAt' },
+  type: 'table',
+};
 
 const queryArgs = toDataViewsQueryArgs<Book, BookRestQuery>(view, {
   mapSort: {
@@ -159,6 +171,10 @@ default. Sorts are only emitted when `mapSort` maps the DataViews field to a
 query value such as a WordPress REST `orderby` value. Filters are only emitted
 when `mapFilter` returns query args, so unknown filters remain explicit no-ops
 instead of being guessed.
+
+When multiple filters return the same query key, the adapter uses the last
+returned value. Return an array value from `mapFilter` when a data source needs
+combined filter semantics.
 
 Use `createDataViewsQueryAdapter(options)` when a reusable `QueryAdapter` is
 more convenient, or call `definedViews.toQueryArgs(view, options)` from a

--- a/packages/wp-typia-dataviews/README.md
+++ b/packages/wp-typia-dataviews/README.md
@@ -106,6 +106,9 @@ Pagination and search use WordPress REST-style names by default: `page`,
 `per_page`, and `search`. Sorts and filters are emitted only when `mapSort` or
 `mapFilter` handles them, so unsupported filters stay explicit no-ops instead of
 being guessed.
+If your query type does not declare those default keys, explicitly remap them
+with `pageParam`, `perPageParam`, and `searchParam`, or set the unused params to
+`false`.
 If multiple filters return the same query key, the last returned value wins; use
 array values from `mapFilter` when your data source needs combined semantics.
 

--- a/packages/wp-typia-dataviews/README.md
+++ b/packages/wp-typia-dataviews/README.md
@@ -106,6 +106,8 @@ Pagination and search use WordPress REST-style names by default: `page`,
 `per_page`, and `search`. Sorts and filters are emitted only when `mapSort` or
 `mapFilter` handles them, so unsupported filters stay explicit no-ops instead of
 being guessed.
+If multiple filters return the same query key, the last returned value wins; use
+array values from `mapFilter` when your data source needs combined semantics.
 
 Use WordPress' package for the actual components in WordPress-built scripts:
 

--- a/packages/wp-typia-dataviews/README.md
+++ b/packages/wp-typia-dataviews/README.md
@@ -16,10 +16,15 @@ import type {
   DataFormConfig,
   DataViewsAction,
   DataViewsField,
+  DataViewsQueryAdapterOptions,
   DataViewsView,
   QueryAdapter,
 } from '@wp-typia/dataviews';
-import { defineDataViews } from '@wp-typia/dataviews';
+import {
+  createDataViewsQueryAdapter,
+  defineDataViews,
+  toDataViewsQueryArgs,
+} from '@wp-typia/dataviews';
 ```
 
 `defineDataViews<T>()` adds the typed convenience layer for field maps,
@@ -59,6 +64,48 @@ Common schema metadata is normalized for DataViews defaults, including
 `idField` is limited to string or number model keys for automatic row identity;
 use `getItemId` when identity comes from a nullable, object-backed, or custom
 value.
+
+Map DataViews state into REST or custom data-provider args explicitly:
+
+```ts
+interface ProductRestQuery {
+  order?: 'asc' | 'desc';
+  orderby?: 'date' | 'title';
+  page?: number;
+  per_page?: number;
+  search?: string;
+  status?: readonly Product['status'][];
+}
+
+const queryArgs = productViews.toQueryArgs<ProductRestQuery>(config.view, {
+  mapSort: {
+    title: 'title',
+  },
+  mapFilter(filter) {
+    if (filter.field === 'status' && filter.operator === 'isAny') {
+      return { status: filter.value as readonly Product['status'][] };
+    }
+
+    return undefined;
+  },
+});
+
+const reusableAdapter = createDataViewsQueryAdapter<Product, ProductRestQuery>({
+  mapSort: { title: 'title' },
+});
+
+const standaloneArgs = toDataViewsQueryArgs<Product, ProductRestQuery>(
+  config.view,
+  {
+    mapSort: { title: 'title' },
+  },
+);
+```
+
+Pagination and search use WordPress REST-style names by default: `page`,
+`per_page`, and `search`. Sorts and filters are emitted only when `mapSort` or
+`mapFilter` handles them, so unsupported filters stay explicit no-ops instead of
+being guessed.
 
 Use WordPress' package for the actual components in WordPress-built scripts:
 

--- a/packages/wp-typia-dataviews/src/index.ts
+++ b/packages/wp-typia-dataviews/src/index.ts
@@ -309,8 +309,7 @@ export interface DataViewsQueryAdapterMapContext<
 export type DataViewsQueryMapperResult<TQuery extends object = DataViewsQueryArgs> =
   | Partial<TQuery>
   | null
-  | undefined
-  | void;
+  | undefined;
 
 export type DataViewsQuerySortMapper<
   TItem extends object = DataViewsRecord,
@@ -714,6 +713,10 @@ function mergeDataViewsSortQuery<TItem extends object, TQuery extends object>(
   const orderBy = options.mapSort[view.sort.field];
 
   if (orderBy === undefined) {
+    return;
+  }
+
+  if (options.orderByParam === false) {
     return;
   }
 

--- a/packages/wp-typia-dataviews/src/index.ts
+++ b/packages/wp-typia-dataviews/src/index.ts
@@ -710,7 +710,7 @@ function mergeDataViewsSortQuery<TItem extends object, TQuery extends object>(
     return;
   }
 
-  const orderBy = options.mapSort[view.sort.field];
+  const orderBy = getDataViewsQuerySortMapValue(options.mapSort, view.sort.field);
 
   if (orderBy === undefined) {
     return;
@@ -722,6 +722,17 @@ function mergeDataViewsSortQuery<TItem extends object, TQuery extends object>(
 
   assignDataViewsQueryParam(query, options.orderByParam, "orderby", orderBy);
   assignDataViewsQueryParam(query, options.orderParam, "order", view.sort.direction);
+}
+
+function getDataViewsQuerySortMapValue<TItem extends object>(
+  mapSort: DataViewsQuerySortMap<TItem>,
+  field: DataViewsFieldId<TItem>,
+): DataViewsQuerySortValue | undefined {
+  if (!Object.prototype.hasOwnProperty.call(mapSort, field)) {
+    return undefined;
+  }
+
+  return mapSort[field];
 }
 
 function mergeDataViewsFilterQueries<TItem extends object, TQuery extends object>(

--- a/packages/wp-typia-dataviews/src/index.ts
+++ b/packages/wp-typia-dataviews/src/index.ts
@@ -294,6 +294,34 @@ export type DataViewsQueryParamName<TQuery extends object = DataViewsQueryArgs> 
   string
 >;
 
+type DataViewsQueryDefaultParamName = "page" | "per_page" | "search";
+
+type DataViewsQueryParamOption<TQuery extends object> =
+  | DataViewsQueryParamName<TQuery>
+  | false;
+
+type DataViewsQueryDefaultParamOption<
+  TQuery extends object,
+  TDefaultParam extends string,
+  TOptionName extends string,
+> = TDefaultParam extends DataViewsQueryParamName<TQuery>
+  ? { readonly [TKey in TOptionName]?: DataViewsQueryParamOption<TQuery> }
+  : { readonly [TKey in TOptionName]: DataViewsQueryParamOption<TQuery> };
+
+type DataViewsQueryDefaultParamOptions<TQuery extends object> =
+  DataViewsQueryDefaultParamOption<TQuery, "page", "pageParam"> &
+    DataViewsQueryDefaultParamOption<TQuery, "per_page", "perPageParam"> &
+    DataViewsQueryDefaultParamOption<TQuery, "search", "searchParam">;
+
+type DataViewsQueryDefaultSortParamOptions<TQuery extends object> =
+  DataViewsQueryDefaultParamOption<TQuery, "orderby", "orderByParam"> &
+    DataViewsQueryDefaultParamOption<TQuery, "order", "orderParam">;
+
+type DataViewsQueryMissingDefaultParamNames<TQuery extends object> = Exclude<
+  DataViewsQueryDefaultParamName,
+  DataViewsQueryParamName<TQuery>
+>;
+
 export type DataViewsQuerySortValue = boolean | number | string;
 
 export type DataViewsQuerySortMap<TItem extends object = DataViewsRecord> = Readonly<
@@ -327,18 +355,65 @@ export type DataViewsQueryFilterMapper<
   context: DataViewsQueryAdapterMapContext<TItem>,
 ) => DataViewsQueryMapperResult<TQuery>;
 
-export interface DataViewsQueryAdapterOptions<
+interface DataViewsQueryAdapterBaseOptions<
   TItem extends object = DataViewsRecord,
   TQuery extends object = DataViewsQueryArgs,
 > {
   readonly mapFilter?: DataViewsQueryFilterMapper<TItem, TQuery>;
-  readonly mapSort?: DataViewsQuerySortMap<TItem> | DataViewsQuerySortMapper<TItem, TQuery>;
-  readonly orderByParam?: DataViewsQueryParamName<TQuery> | false;
-  readonly orderParam?: DataViewsQueryParamName<TQuery> | false;
-  readonly pageParam?: DataViewsQueryParamName<TQuery> | false;
-  readonly perPageParam?: DataViewsQueryParamName<TQuery> | false;
-  readonly searchParam?: DataViewsQueryParamName<TQuery> | false;
+  readonly orderByParam?: DataViewsQueryParamOption<TQuery>;
+  readonly orderParam?: DataViewsQueryParamOption<TQuery>;
+  readonly pageParam?: DataViewsQueryParamOption<TQuery>;
+  readonly perPageParam?: DataViewsQueryParamOption<TQuery>;
+  readonly searchParam?: DataViewsQueryParamOption<TQuery>;
 }
+
+type DataViewsQueryAdapterSortOptions<
+  TItem extends object = DataViewsRecord,
+  TQuery extends object = DataViewsQueryArgs,
+> =
+  | { readonly mapSort?: DataViewsQuerySortMapper<TItem, TQuery> }
+  | ({
+      readonly mapSort: DataViewsQuerySortMap<TItem>;
+    } & DataViewsQueryDefaultSortParamOptions<TQuery>);
+
+type DataViewsQueryAdapterRuntimeOptions<
+  TItem extends object = DataViewsRecord,
+  TQuery extends object = DataViewsQueryArgs,
+> = DataViewsQueryAdapterBaseOptions<TItem, TQuery> & {
+  readonly mapSort?: DataViewsQuerySortMap<TItem> | DataViewsQuerySortMapper<TItem, TQuery>;
+};
+
+export type DataViewsQueryAdapterOptions<
+  TItem extends object = DataViewsRecord,
+  TQuery extends object = DataViewsQueryArgs,
+> = DataViewsQueryAdapterBaseOptions<TItem, TQuery> &
+  DataViewsQueryDefaultParamOptions<TQuery> &
+  DataViewsQueryAdapterSortOptions<TItem, TQuery>;
+
+type DataViewsQueryAdapterArguments<
+  TItem extends object = DataViewsRecord,
+  TQuery extends object = DataViewsQueryArgs,
+> = [DataViewsQueryMissingDefaultParamNames<TQuery>] extends [never]
+  ? [
+      options?: DataViewsQueryAdapterOptions<TItem, TQuery>,
+      context?: QueryAdapterContext<TItem>,
+    ]
+  : [
+      options: DataViewsQueryAdapterOptions<TItem, TQuery>,
+      context?: QueryAdapterContext<TItem>,
+    ];
+
+type DataViewsQueryAdapterFactoryArguments<
+  TItem extends object = DataViewsRecord,
+  TQuery extends object = DataViewsQueryArgs,
+> = [DataViewsQueryMissingDefaultParamNames<TQuery>] extends [never]
+  ? [options?: DataViewsQueryAdapterOptions<TItem, TQuery>]
+  : [options: DataViewsQueryAdapterOptions<TItem, TQuery>];
+
+type DefinedDataViewsQueryAdapterArguments<
+  TItem extends object = DataViewsRecord,
+  TQuery extends object = DataViewsQueryArgs,
+> = DataViewsQueryAdapterFactoryArguments<TItem, TQuery>;
 
 export type DataViewsCompatibleFieldType<TValue> =
   NonNullable<TValue> extends boolean
@@ -440,7 +515,7 @@ export interface DefinedDataViews<TItem extends object> {
   readonly createConfig: (options: DefineDataViewsConfigOptions<TItem>) => DataViewsConfig<TItem>;
   readonly toQueryArgs: <TQuery extends object = DataViewsQueryArgs>(
     view: DataViewsView<TItem>,
-    options?: DataViewsQueryAdapterOptions<TItem, TQuery>,
+    ...args: DefinedDataViewsQueryAdapterArguments<TItem, TQuery>
   ) => Partial<TQuery>;
 }
 
@@ -453,6 +528,14 @@ export function defineDataViews<TItem extends object>(
   ) as DefinedDataViewsFieldMap<TItem>;
   const defaultView = normalizeDefineDataViewsDefaultView(definition, fields);
   const defaultGetItemId = definition.getItemId ?? createGetItemId(definition.idField);
+  const toQueryArgs = <TQuery extends object = DataViewsQueryArgs>(
+    view: DataViewsView<TItem>,
+    ...args: DefinedDataViewsQueryAdapterArguments<TItem, TQuery>
+  ): Partial<TQuery> =>
+    toDataViewsQueryArgs<TItem, TQuery>(
+      view,
+      ...([args[0], { fields }] as DataViewsQueryAdapterArguments<TItem, TQuery>),
+    );
 
   return {
     actions: definition.actions,
@@ -472,7 +555,7 @@ export function defineDataViews<TItem extends object>(
       selection: options.selection,
       view: options.view ?? defaultView,
     }),
-    toQueryArgs: (view, options) => toDataViewsQueryArgs(view, options, { fields }),
+    toQueryArgs,
     defaultLayouts: definition.defaultLayouts,
     defaultView,
     fieldMap,
@@ -490,9 +573,13 @@ export function createDataViewsQueryAdapter<
   TItem extends object = DataViewsRecord,
   TQuery extends object = DataViewsQueryArgs,
 >(
-  options: DataViewsQueryAdapterOptions<TItem, TQuery> = {},
+  ...args: DataViewsQueryAdapterFactoryArguments<TItem, TQuery>
 ): QueryAdapter<TItem, Partial<TQuery>> {
-  return (view, context) => toDataViewsQueryArgs(view, options, context);
+  return (view, context) =>
+    toDataViewsQueryArgs<TItem, TQuery>(
+      view,
+      ...([args[0], context] as DataViewsQueryAdapterArguments<TItem, TQuery>),
+    );
 }
 
 export function toDataViewsQueryArgs<
@@ -500,9 +587,10 @@ export function toDataViewsQueryArgs<
   TQuery extends object = DataViewsQueryArgs,
 >(
   view: DataViewsView<TItem>,
-  options: DataViewsQueryAdapterOptions<TItem, TQuery> = {},
-  context: QueryAdapterContext<TItem> = { fields: [] },
+  ...args: DataViewsQueryAdapterArguments<TItem, TQuery>
 ): Partial<TQuery> {
+  const options = (args[0] ?? {}) as DataViewsQueryAdapterRuntimeOptions<TItem, TQuery>;
+  const context = args[1] ?? { fields: [] };
   const query: Record<string, unknown> = {};
   const mapContext: DataViewsQueryAdapterMapContext<TItem> = {
     ...context,
@@ -698,7 +786,7 @@ function assignDataViewsQueryParam<TQuery extends object>(
 function mergeDataViewsSortQuery<TItem extends object, TQuery extends object>(
   query: Record<string, unknown>,
   view: DataViewsView<TItem>,
-  options: DataViewsQueryAdapterOptions<TItem, TQuery>,
+  options: DataViewsQueryAdapterRuntimeOptions<TItem, TQuery>,
   context: DataViewsQueryAdapterMapContext<TItem>,
 ): void {
   if (view.sort === undefined || options.mapSort === undefined) {
@@ -738,7 +826,7 @@ function getDataViewsQuerySortMapValue<TItem extends object>(
 function mergeDataViewsFilterQueries<TItem extends object, TQuery extends object>(
   query: Record<string, unknown>,
   view: DataViewsView<TItem>,
-  options: DataViewsQueryAdapterOptions<TItem, TQuery>,
+  options: DataViewsQueryAdapterRuntimeOptions<TItem, TQuery>,
   context: DataViewsQueryAdapterMapContext<TItem>,
 ): void {
   if (options.mapFilter === undefined) {

--- a/packages/wp-typia-dataviews/src/index.ts
+++ b/packages/wp-typia-dataviews/src/index.ts
@@ -287,6 +287,60 @@ export type QueryAdapter<
   TQuery = Record<string, unknown>,
 > = (view: DataViewsView<TItem>, context: QueryAdapterContext<TItem>) => TQuery;
 
+export type DataViewsQueryArgs = Record<string, unknown>;
+
+export type DataViewsQueryParamName<TQuery extends object = DataViewsQueryArgs> = Extract<
+  keyof TQuery,
+  string
+>;
+
+export type DataViewsQuerySortValue = boolean | number | string;
+
+export type DataViewsQuerySortMap<TItem extends object = DataViewsRecord> = Readonly<
+  Partial<Record<DataViewsFieldId<TItem>, DataViewsQuerySortValue>>
+>;
+
+export interface DataViewsQueryAdapterMapContext<
+  TItem extends object = DataViewsRecord,
+> extends QueryAdapterContext<TItem> {
+  readonly view: DataViewsView<TItem>;
+}
+
+export type DataViewsQueryMapperResult<TQuery extends object = DataViewsQueryArgs> =
+  | Partial<TQuery>
+  | null
+  | undefined
+  | void;
+
+export type DataViewsQuerySortMapper<
+  TItem extends object = DataViewsRecord,
+  TQuery extends object = DataViewsQueryArgs,
+> = (
+  sort: DataViewsSort<TItem>,
+  context: DataViewsQueryAdapterMapContext<TItem>,
+) => DataViewsQueryMapperResult<TQuery>;
+
+export type DataViewsQueryFilterMapper<
+  TItem extends object = DataViewsRecord,
+  TQuery extends object = DataViewsQueryArgs,
+> = (
+  filter: DataViewsFilter<TItem>,
+  context: DataViewsQueryAdapterMapContext<TItem>,
+) => DataViewsQueryMapperResult<TQuery>;
+
+export interface DataViewsQueryAdapterOptions<
+  TItem extends object = DataViewsRecord,
+  TQuery extends object = DataViewsQueryArgs,
+> {
+  readonly mapFilter?: DataViewsQueryFilterMapper<TItem, TQuery>;
+  readonly mapSort?: DataViewsQuerySortMap<TItem> | DataViewsQuerySortMapper<TItem, TQuery>;
+  readonly orderByParam?: DataViewsQueryParamName<TQuery> | false;
+  readonly orderParam?: DataViewsQueryParamName<TQuery> | false;
+  readonly pageParam?: DataViewsQueryParamName<TQuery> | false;
+  readonly perPageParam?: DataViewsQueryParamName<TQuery> | false;
+  readonly searchParam?: DataViewsQueryParamName<TQuery> | false;
+}
+
 export type DataViewsCompatibleFieldType<TValue> =
   NonNullable<TValue> extends boolean
     ? "boolean"
@@ -385,6 +439,10 @@ export interface DefinedDataViews<TItem extends object> {
   readonly searchLabel?: string;
   readonly titleField?: DataViewsFieldId<TItem>;
   readonly createConfig: (options: DefineDataViewsConfigOptions<TItem>) => DataViewsConfig<TItem>;
+  readonly toQueryArgs: <TQuery extends object = DataViewsQueryArgs>(
+    view: DataViewsView<TItem>,
+    options?: DataViewsQueryAdapterOptions<TItem, TQuery>,
+  ) => Partial<TQuery>;
 }
 
 export function defineDataViews<TItem extends object>(
@@ -415,6 +473,7 @@ export function defineDataViews<TItem extends object>(
       selection: options.selection,
       view: options.view ?? defaultView,
     }),
+    toQueryArgs: (view, options) => toDataViewsQueryArgs(view, options, { fields }),
     defaultLayouts: definition.defaultLayouts,
     defaultView,
     fieldMap,
@@ -426,6 +485,38 @@ export function defineDataViews<TItem extends object>(
     searchLabel: definition.searchLabel,
     titleField: definition.titleField,
   };
+}
+
+export function createDataViewsQueryAdapter<
+  TItem extends object = DataViewsRecord,
+  TQuery extends object = DataViewsQueryArgs,
+>(
+  options: DataViewsQueryAdapterOptions<TItem, TQuery> = {},
+): QueryAdapter<TItem, Partial<TQuery>> {
+  return (view, context) => toDataViewsQueryArgs(view, options, context);
+}
+
+export function toDataViewsQueryArgs<
+  TItem extends object = DataViewsRecord,
+  TQuery extends object = DataViewsQueryArgs,
+>(
+  view: DataViewsView<TItem>,
+  options: DataViewsQueryAdapterOptions<TItem, TQuery> = {},
+  context: QueryAdapterContext<TItem> = { fields: [] },
+): Partial<TQuery> {
+  const query: Record<string, unknown> = {};
+  const mapContext: DataViewsQueryAdapterMapContext<TItem> = {
+    ...context,
+    view,
+  };
+
+  assignDataViewsQueryParam(query, options.pageParam, "page", view.page);
+  assignDataViewsQueryParam(query, options.perPageParam, "per_page", view.perPage);
+  assignDataViewsQueryParam(query, options.searchParam, "search", view.search);
+  mergeDataViewsSortQuery(query, view, options, mapContext);
+  mergeDataViewsFilterQueries(query, view, options, mapContext);
+
+  return query as Partial<TQuery>;
 }
 
 function normalizeDefineDataViewsFields<TItem extends object>(
@@ -590,6 +681,70 @@ function createGetItemId<TItem extends object>(
       `defineDataViews idField "${idField}" must resolve to a string or finite number. Provide getItemId for custom item identity values.`,
     );
   };
+}
+
+function assignDataViewsQueryParam<TQuery extends object>(
+  query: Record<string, unknown>,
+  param: DataViewsQueryParamName<TQuery> | false | undefined,
+  defaultParam: string,
+  value: unknown,
+): void {
+  if (param === false || value === undefined) {
+    return;
+  }
+
+  query[param ?? defaultParam] = value;
+}
+
+function mergeDataViewsSortQuery<TItem extends object, TQuery extends object>(
+  query: Record<string, unknown>,
+  view: DataViewsView<TItem>,
+  options: DataViewsQueryAdapterOptions<TItem, TQuery>,
+  context: DataViewsQueryAdapterMapContext<TItem>,
+): void {
+  if (view.sort === undefined || options.mapSort === undefined) {
+    return;
+  }
+
+  if (typeof options.mapSort === "function") {
+    mergeDataViewsQueryResult(query, options.mapSort(view.sort, context));
+    return;
+  }
+
+  const orderBy = options.mapSort[view.sort.field];
+
+  if (orderBy === undefined) {
+    return;
+  }
+
+  assignDataViewsQueryParam(query, options.orderByParam, "orderby", orderBy);
+  assignDataViewsQueryParam(query, options.orderParam, "order", view.sort.direction);
+}
+
+function mergeDataViewsFilterQueries<TItem extends object, TQuery extends object>(
+  query: Record<string, unknown>,
+  view: DataViewsView<TItem>,
+  options: DataViewsQueryAdapterOptions<TItem, TQuery>,
+  context: DataViewsQueryAdapterMapContext<TItem>,
+): void {
+  if (options.mapFilter === undefined) {
+    return;
+  }
+
+  for (const filter of view.filters ?? []) {
+    mergeDataViewsQueryResult(query, options.mapFilter(filter, context));
+  }
+}
+
+function mergeDataViewsQueryResult<TQuery extends object>(
+  query: Record<string, unknown>,
+  result: DataViewsQueryMapperResult<TQuery>,
+): void {
+  if (result === undefined || result === null) {
+    return;
+  }
+
+  Object.assign(query, result);
 }
 
 function formatDataViewsFieldLabel(id: string): string {

--- a/packages/wp-typia-dataviews/tests/fixtures/public-type-contracts.ts
+++ b/packages/wp-typia-dataviews/tests/fixtures/public-type-contracts.ts
@@ -34,6 +34,10 @@ interface BookQuery {
   readonly status?: readonly Book["status"][];
 }
 
+interface CompactBookQuery {
+  readonly q?: string;
+}
+
 const fields = [
   {
     id: "title",
@@ -169,6 +173,43 @@ const reusableQueryAdapter = createDataViewsQueryAdapter<Book, BookQuery>(queryO
 const queryArgs = toDataViewsQueryArgs<Book, BookQuery>(view, queryOptions);
 const definedQueryArgs = bookViews.toQueryArgs<BookQuery>(view, queryOptions);
 
+const compactQueryOptions = {
+  pageParam: false,
+  perPageParam: false,
+  searchParam: "q",
+} satisfies DataViewsQueryAdapterOptions<Book, CompactBookQuery>;
+
+const compactReusableQueryAdapter = createDataViewsQueryAdapter<Book, CompactBookQuery>(
+  compactQueryOptions,
+);
+const compactQueryArgs = toDataViewsQueryArgs<Book, CompactBookQuery>(
+  view,
+  compactQueryOptions,
+);
+const definedCompactQueryArgs = bookViews.toQueryArgs<CompactBookQuery>(
+  view,
+  compactQueryOptions,
+);
+
+// @ts-expect-error strict query types must disable or remap default query params.
+toDataViewsQueryArgs<Book, CompactBookQuery>(view);
+
+// @ts-expect-error strict query adapter factories must disable or remap default query params.
+createDataViewsQueryAdapter<Book, CompactBookQuery>();
+
+// @ts-expect-error defined helpers must disable or remap default query params.
+bookViews.toQueryArgs<CompactBookQuery>(view);
+
+const invalidCompactSortQueryOptions = {
+  mapSort: {
+    views: "views",
+  },
+  pageParam: false,
+  perPageParam: false,
+  searchParam: "q",
+  // @ts-expect-error static sort maps must disable or remap default sort params.
+} satisfies DataViewsQueryAdapterOptions<Book, CompactBookQuery>;
+
 const invalidQueryOptions = {
   mapSort: {
     // @ts-expect-error mapSort fields must be keys of Book.
@@ -226,7 +267,11 @@ const invalidSortView = {
 
 void config;
 void configInput;
+void compactQueryArgs;
+void compactReusableQueryAdapter(view, { fields });
+void definedCompactQueryArgs;
 void form;
+void invalidCompactSortQueryOptions;
 void adapter(view, { fields });
 void bookViews.createConfig({ data: [] });
 void definedQueryArgs;

--- a/packages/wp-typia-dataviews/tests/fixtures/public-type-contracts.ts
+++ b/packages/wp-typia-dataviews/tests/fixtures/public-type-contracts.ts
@@ -3,12 +3,17 @@ import type {
   DataViewsAction,
   DataViewsConfig,
   DataViewsField,
+  DataViewsQueryAdapterOptions,
   DataViewsView,
   DefinedDataViews,
   DefineDataViewsInput,
   QueryAdapter,
 } from "@wp-typia/dataviews";
-import { defineDataViews } from "@wp-typia/dataviews";
+import {
+  createDataViewsQueryAdapter,
+  defineDataViews,
+  toDataViewsQueryArgs,
+} from "@wp-typia/dataviews";
 
 interface Book {
   readonly createdAt: string;
@@ -18,6 +23,15 @@ interface Book {
   readonly status: "draft" | "publish";
   readonly title: string;
   readonly views: number;
+}
+
+interface BookQuery {
+  readonly order?: "asc" | "desc";
+  readonly orderby?: "date" | "title" | "views";
+  readonly page?: number;
+  readonly per_page?: number;
+  readonly search?: string;
+  readonly status?: readonly Book["status"][];
 }
 
 const fields = [
@@ -136,6 +150,37 @@ const adapter: QueryAdapter<Book, { page?: number; per_page?: number; search?: s
   return query;
 };
 
+const queryOptions = {
+  mapFilter: (filter) => {
+    if (filter.field === "status" && filter.operator === "isAny") {
+      return { status: filter.value as readonly Book["status"][] };
+    }
+
+    return undefined;
+  },
+  mapSort: {
+    createdAt: "date",
+    title: "title",
+    views: "views",
+  },
+} satisfies DataViewsQueryAdapterOptions<Book, BookQuery>;
+
+const reusableQueryAdapter = createDataViewsQueryAdapter<Book, BookQuery>(queryOptions);
+const queryArgs = toDataViewsQueryArgs<Book, BookQuery>(view, queryOptions);
+const definedQueryArgs = bookViews.toQueryArgs<BookQuery>(view, queryOptions);
+
+const invalidQueryOptions = {
+  mapSort: {
+    // @ts-expect-error mapSort fields must be keys of Book.
+    missing: "missing",
+  },
+} satisfies DataViewsQueryAdapterOptions<Book, BookQuery>;
+
+const invalidQueryParamOptions = {
+  // @ts-expect-error pageParam must be a BookQuery key or false.
+  pageParam: "paged",
+} satisfies DataViewsQueryAdapterOptions<Book, BookQuery>;
+
 // @ts-expect-error wp-typia owns the initial supported layout union.
 const unsupportedView = { type: "calendar" } satisfies DataViewsView<Book>;
 
@@ -184,5 +229,10 @@ void configInput;
 void form;
 void adapter(view, { fields });
 void bookViews.createConfig({ data: [] });
+void definedQueryArgs;
+void invalidQueryOptions;
+void invalidQueryParamOptions;
 void invalidSortView;
+void queryArgs;
+void reusableQueryAdapter(view, { fields });
 void unsupportedView;

--- a/packages/wp-typia-dataviews/tests/query-adapter.test.ts
+++ b/packages/wp-typia-dataviews/tests/query-adapter.test.ts
@@ -4,6 +4,7 @@ import {
   createDataViewsQueryAdapter,
   defineDataViews,
   toDataViewsQueryArgs,
+  type DataViewsRecord,
   type DataViewsView,
 } from "../src/index.js";
 
@@ -117,6 +118,22 @@ describe("DataViews query adapters", () => {
       perPageParam: false,
       searchParam: false,
     });
+
+    expect(query).toEqual({});
+  });
+
+  test("ignores inherited keys when static sort maps do not own the field", () => {
+    const query = toDataViewsQueryArgs<DataViewsRecord, WordPressProductQuery>(
+      {
+        sort: { direction: "asc", field: "toString" },
+        type: "table",
+      },
+      {
+        mapSort: {
+          createdAt: "date",
+        },
+      },
+    );
 
     expect(query).toEqual({});
   });

--- a/packages/wp-typia-dataviews/tests/query-adapter.test.ts
+++ b/packages/wp-typia-dataviews/tests/query-adapter.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  createDataViewsQueryAdapter,
+  defineDataViews,
+  toDataViewsQueryArgs,
+  type DataViewsView,
+} from "../src/index.js";
+
+interface Product {
+  readonly createdAt: string;
+  readonly featured: boolean;
+  readonly id: number;
+  readonly status: "draft" | "publish";
+  readonly title: string;
+  readonly views: number;
+}
+
+interface WordPressProductQuery {
+  readonly max_views?: number;
+  readonly order?: "asc" | "desc";
+  readonly orderby?: "date" | "title" | "views";
+  readonly page?: number;
+  readonly per_page?: number;
+  readonly search?: string;
+  readonly status?: readonly Product["status"][];
+}
+
+const productView = {
+  filters: [
+    { field: "status", operator: "isAny", value: ["draft", "publish"] },
+    { field: "views", operator: "lessThanOrEqual", value: 500 },
+    { field: "featured", operator: "is", value: true },
+  ],
+  page: 2,
+  perPage: 20,
+  search: "typed blocks",
+  sort: { direction: "desc", field: "createdAt" },
+  type: "table",
+} as const satisfies DataViewsView<Product>;
+
+describe("DataViews query adapters", () => {
+  test("maps pagination, search, sort, and supported filters into WordPress REST args", () => {
+    const query = toDataViewsQueryArgs<Product, WordPressProductQuery>(productView, {
+      mapFilter: (filter) => {
+        if (filter.field === "status" && filter.operator === "isAny") {
+          return { status: filter.value as readonly Product["status"][] };
+        }
+
+        if (filter.field === "views" && filter.operator === "lessThanOrEqual") {
+          return { max_views: filter.value as number };
+        }
+
+        return undefined;
+      },
+      mapSort: {
+        createdAt: "date",
+        title: "title",
+        views: "views",
+      },
+    });
+
+    expect(query).toEqual({
+      max_views: 500,
+      order: "desc",
+      orderby: "date",
+      page: 2,
+      per_page: 20,
+      search: "typed blocks",
+      status: ["draft", "publish"],
+    });
+  });
+
+  test("leaves filters and unmapped sort fields as explicit no-ops", () => {
+    const query = toDataViewsQueryArgs<Product, WordPressProductQuery>(
+      {
+        ...productView,
+        filters: [{ field: "featured", operator: "is", value: true }],
+        sort: { direction: "asc", field: "featured" },
+      },
+      {
+        mapFilter: () => undefined,
+        mapSort: {
+          createdAt: "date",
+        },
+      },
+    );
+
+    expect(query).toEqual({
+      page: 2,
+      per_page: 20,
+      search: "typed blocks",
+    });
+  });
+
+  test("supports custom sort mapper functions and disabled default param names", () => {
+    const query = toDataViewsQueryArgs<Product, WordPressProductQuery>(productView, {
+      mapSort: (sort) => ({ order: sort.direction, orderby: "date" }),
+      pageParam: false,
+      perPageParam: false,
+      searchParam: false,
+    });
+
+    expect(query).toEqual({
+      order: "desc",
+      orderby: "date",
+    });
+  });
+
+  test("creates reusable QueryAdapter functions with field context", () => {
+    const adapter = createDataViewsQueryAdapter<Product, WordPressProductQuery>({
+      mapFilter: (filter, context) => {
+        const hasField = context.fields.some((field) => field.id === filter.field);
+
+        if (hasField && filter.field === "status" && filter.operator === "isAny") {
+          return { status: filter.value as readonly Product["status"][] };
+        }
+
+        return undefined;
+      },
+    });
+
+    expect(
+      adapter(productView, {
+        fields: [
+          { id: "status", label: "Status", type: "text" },
+          { id: "title", label: "Title", type: "text" },
+        ],
+      }),
+    ).toEqual({
+      page: 2,
+      per_page: 20,
+      search: "typed blocks",
+      status: ["draft", "publish"],
+    });
+  });
+
+  test("exposes toQueryArgs from defineDataViews with normalized fields context", () => {
+    const productViews = defineDataViews<Product>({
+      defaultView: productView,
+      fields: {
+        status: { schema: { enum: ["draft", "publish"], type: "string" } },
+        title: { schema: { type: "string" } },
+      },
+      idField: "id",
+    });
+
+    const query = productViews.toQueryArgs<WordPressProductQuery>(productView, {
+      mapFilter: (filter, context) => {
+        const statusField = context.fields.find((field) => field.id === "status");
+
+        if (statusField !== undefined && filter.field === "status") {
+          return { status: filter.value as readonly Product["status"][] };
+        }
+
+        return undefined;
+      },
+    });
+
+    expect(query).toEqual({
+      page: 2,
+      per_page: 20,
+      search: "typed blocks",
+      status: ["draft", "publish"],
+    });
+  });
+});

--- a/packages/wp-typia-dataviews/tests/query-adapter.test.ts
+++ b/packages/wp-typia-dataviews/tests/query-adapter.test.ts
@@ -107,6 +107,20 @@ describe("DataViews query adapters", () => {
     });
   });
 
+  test("treats orderByParam false as static sort map suppression", () => {
+    const query = toDataViewsQueryArgs<Product, WordPressProductQuery>(productView, {
+      mapSort: {
+        createdAt: "date",
+      },
+      orderByParam: false,
+      pageParam: false,
+      perPageParam: false,
+      searchParam: false,
+    });
+
+    expect(query).toEqual({});
+  });
+
   test("creates reusable QueryAdapter functions with field context", () => {
     const adapter = createDataViewsQueryAdapter<Product, WordPressProductQuery>({
       mapFilter: (filter, context) => {

--- a/packages/wp-typia-dataviews/tests/query-adapter.test.ts
+++ b/packages/wp-typia-dataviews/tests/query-adapter.test.ts
@@ -27,6 +27,11 @@ interface WordPressProductQuery {
   readonly status?: readonly Product["status"][];
 }
 
+interface CompactProductQuery {
+  readonly pageNo?: number;
+  readonly q?: string;
+}
+
 const productView = {
   filters: [
     { field: "status", operator: "isAny", value: ["draft", "publish"] },
@@ -163,6 +168,19 @@ describe("DataViews query adapters", () => {
       per_page: 20,
       search: "typed blocks",
       status: ["draft", "publish"],
+    });
+  });
+
+  test("requires explicit default param remapping for compact query shapes", () => {
+    const query = toDataViewsQueryArgs<Product, CompactProductQuery>(productView, {
+      pageParam: "pageNo",
+      perPageParam: false,
+      searchParam: "q",
+    });
+
+    expect(query).toEqual({
+      pageNo: 2,
+      q: "typed blocks",
     });
   });
 

--- a/packages/wp-typia-dataviews/tests/type-contracts.test.ts
+++ b/packages/wp-typia-dataviews/tests/type-contracts.test.ts
@@ -39,11 +39,14 @@ describe("@wp-typia/dataviews type contracts", () => {
     expect(fixtureSource).toContain("@wp-typia/dataviews");
     expect(fixtureSource).toContain("defineDataViews");
     expect(fixtureSource).toContain("DataViewsField");
+    expect(fixtureSource).toContain("DataViewsQueryAdapterOptions");
     expect(fixtureSource).toContain("DataViewsView");
     expect(fixtureSource).toContain("DataFormConfig");
     expect(fixtureSource).toContain("DefinedDataViews");
     expect(fixtureSource).toContain("DefineDataViewsInput");
     expect(fixtureSource).toContain("QueryAdapter");
+    expect(fixtureSource).toContain("createDataViewsQueryAdapter");
+    expect(fixtureSource).toContain("toDataViewsQueryArgs");
     expect(fixtureSource).toContain("@ts-expect-error");
   });
 });


### PR DESCRIPTION
## Summary

- add typed DataViews query adapter options and helpers for mapping view state into query args
- expose `toDataViewsQueryArgs`, `createDataViewsQueryAdapter`, and `defineDataViews().toQueryArgs`
- document WordPress REST-style query mapping and explicit unsupported-filter no-op behavior

Closes #600

## Validation

- `bun run --filter @wp-typia/dataviews test`
- `bun run typecheck`
- `bun run packages:build`
- `bun run format:check`
- `bun run lint:repo`
- `bun run docs:build`
- `bun run manifest-policy:validate`
- `bun run publish:validate`
- `bun run changesets:validate`
- `bun run runtime-coupling:validate`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added query adapter API to convert DataViews state into REST-style query arguments with customizable sort and filter mapping.
  * Exposed new API utilities: `createDataViewsQueryAdapter`, `toDataViewsQueryArgs`, and `DataViewsQueryAdapterOptions` for building custom query adapters.

* **Documentation**
  * Updated library documentation with practical examples and guidance on query parameter mapping for DataViews integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->