### PR TITLE
feat(scaffold): add DataViews admin view workflow

### DIFF
--- a/.sampo/changesets/dataviews-admin-view-workflow.md
+++ b/.sampo/changesets/dataviews-admin-view-workflow.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Added an opt-in DataViews admin view scaffold with REST resource source wiring and CLI metadata.

--- a/apps/docs/src/content/docs/reference/dataviews.md
+++ b/apps/docs/src/content/docs/reference/dataviews.md
@@ -152,6 +152,31 @@ import '@wordpress/components/build-style/style.css';
 import '@wordpress/dataviews/build-style/style.css';
 ```
 
+## Admin Screen Scaffold
+
+Use `wp-typia add admin-view <name>` when you want an opt-in WordPress admin
+screen that demonstrates typed DataViews config, explicit fetching, loading
+state, and pagination without changing default block scaffolds:
+
+```sh
+wp-typia add admin-view products
+wp-typia add admin-view products --source rest-resource:products
+```
+
+The scaffold writes `src/admin-views/<name>/` plus
+`inc/admin-views/<name>.php`, adds `@wp-typia/dataviews` and
+`@wordpress/dataviews` only to that workspace, and wires the screen under the
+WordPress Tools menu. The generated `data.ts` file is intentionally small and
+replaceable. Without `--source` it uses a local fetcher; with
+`--source rest-resource:<slug>` it calls the list endpoint from an existing
+list-capable `wp-typia add rest-resource` scaffold.
+
+Prefer custom UI instead of DataViews when the interaction is primarily a
+guided flow, a canvas/editor experience, a dense dashboard with unrelated
+widgets, or a purpose-built form where table/list/grid view state is incidental.
+DataViews works best for browse, filter, search, sort, select, and paginate
+screens over one coherent collection.
+
 ## Query Ownership
 
 DataViews is a UI layer. It does not own REST or entity fetching for wp-typia.

--- a/packages/create-workspace-template/scripts/block-config.ts.mustache
+++ b/packages/create-workspace-template/scripts/block-config.ts.mustache
@@ -48,6 +48,13 @@ export interface WorkspaceEditorPluginConfig {
 	slot: string;
 }
 
+export interface WorkspaceAdminViewConfig {
+	file: string;
+	phpFile: string;
+	slug: string;
+	source?: string;
+}
+
 export const BLOCKS: WorkspaceBlockConfig[] = [
 	// wp-typia add block entries
 ];
@@ -70,4 +77,8 @@ export const REST_RESOURCES: WorkspaceRestResourceConfig[] = [
 
 export const EDITOR_PLUGINS: WorkspaceEditorPluginConfig[] = [
 	// wp-typia add editor-plugin entries
+];
+
+export const ADMIN_VIEWS: WorkspaceAdminViewConfig[] = [
+	// wp-typia add admin-view entries
 ];

--- a/packages/create-workspace-template/scripts/build-workspace.mjs.mustache
+++ b/packages/create-workspace-template/scripts/build-workspace.mjs.mustache
@@ -27,6 +27,8 @@ function hasSharedEditorEntries() {
 		'src/bindings/index.js',
 		'src/editor-plugins/index.ts',
 		'src/editor-plugins/index.js',
+		'src/admin-views/index.ts',
+		'src/admin-views/index.js',
 	] ) {
 		if ( fs.existsSync( path.join( process.cwd(), relativePath ) ) ) {
 			return true;

--- a/packages/create-workspace-template/webpack.config.js.mustache
+++ b/packages/create-workspace-template/webpack.config.js.mustache
@@ -198,6 +198,10 @@ function getSharedEditorEntries() {
 			'editor-plugins/index',
 			[ 'src/editor-plugins/index.ts', 'src/editor-plugins/index.js' ],
 		],
+		[
+			'admin-views/index',
+			[ 'src/admin-views/index.ts', 'src/admin-views/index.js' ],
+		],
 	] ) {
 		for ( const relativePath of candidates ) {
 			const entryPath = path.resolve( process.cwd(), relativePath );

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-shared.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-shared.ts
@@ -26,6 +26,7 @@ export {
  * Supported top-level `wp-typia add` kinds exposed by the canonical CLI.
  */
 export const ADD_KIND_IDS = [
+	"admin-view",
 	"block",
 	"variation",
 	"pattern",
@@ -92,6 +93,23 @@ export interface RunAddRestResourceCommandOptions {
 	methods?: string;
 	namespace?: string;
 	restResourceName: string;
+}
+
+/**
+ * Options for `wp-typia add admin-view`.
+ *
+ * @property adminViewName Human-entered admin screen name that will be
+ * normalized into the generated slug.
+ * @property cwd Working directory used to resolve the nearest official workspace.
+ * Defaults to `process.cwd()`.
+ * @property source Optional data source locator. The first supported source is
+ * `rest-resource:<slug>`, which wires the generated screen to an existing
+ * list-capable REST resource.
+ */
+export interface RunAddAdminViewCommandOptions {
+	adminViewName: string;
+	cwd?: string;
+	source?: string;
 }
 
 /**
@@ -513,6 +531,39 @@ export function assertRestResourceDoesNotExist(
 }
 
 /**
+ * Ensure a DataViews admin screen scaffold does not already exist on disk or in
+ * the workspace inventory.
+ *
+ * @param projectDir Workspace root directory.
+ * @param adminViewSlug Normalized admin screen slug.
+ * @param inventory Parsed workspace inventory.
+ * @throws {Error} When the directory, PHP bootstrap, or inventory entry already exists.
+ */
+export function assertAdminViewDoesNotExist(
+	projectDir: string,
+	adminViewSlug: string,
+	inventory: WorkspaceInventory,
+): void {
+	const adminViewDir = path.join(projectDir, "src", "admin-views", adminViewSlug);
+	const adminViewPhpPath = path.join(projectDir, "inc", "admin-views", `${adminViewSlug}.php`);
+	if (fs.existsSync(adminViewDir)) {
+		throw new Error(
+			`An admin view already exists at ${path.relative(projectDir, adminViewDir)}. Choose a different name.`,
+		);
+	}
+	if (fs.existsSync(adminViewPhpPath)) {
+		throw new Error(
+			`An admin view bootstrap already exists at ${path.relative(projectDir, adminViewPhpPath)}. Choose a different name.`,
+		);
+	}
+	if (inventory.adminViews.some((entry) => entry.slug === adminViewSlug)) {
+		throw new Error(
+			`An admin view inventory entry already exists for ${adminViewSlug}. Choose a different name.`,
+		);
+	}
+}
+
+/**
  * Ensure a workflow ability scaffold does not already exist on disk or in the
  * workspace inventory.
  *
@@ -605,6 +656,7 @@ export function assertEditorPluginDoesNotExist(projectDir: string, editorPluginS
  */
 export function formatAddHelpText(): string {
 	return `Usage:
+  wp-typia add admin-view <name> [--source <rest-resource:slug>] [--dry-run]
   wp-typia add block <name> --template <${ADD_BLOCK_TEMPLATE_IDS.join("|")}> [--external-layer-source <./path|github:owner/repo/path[#ref]|npm-package>] [--external-layer-id <layer-id>] [--inner-blocks-preset <freeform|ordered|horizontal|locked-structure>] [--alternate-render-targets <email,mjml,plain-text>] [--data-storage <post-meta|custom-table>] [--persistence-policy <authenticated|public>] [--dry-run]
   wp-typia add variation <name> --block <block-slug> [--dry-run]
   wp-typia add pattern <name> [--dry-run]
@@ -618,6 +670,7 @@ export function formatAddHelpText(): string {
 Notes:
   \`wp-typia add\` runs only inside official ${WORKSPACE_TEMPLATE_PACKAGE} workspaces scaffolded via \`wp-typia create <project-dir> --template workspace\`.
   Pass \`--dry-run\` to preview the workspace files that would change without writing them.
+  \`add admin-view\` scaffolds an opt-in DataViews-powered WordPress admin screen under \`src/admin-views/\`; pass \`--source rest-resource:<slug>\` to reuse a list-capable REST resource.
   \`query-loop\` is a create-time scaffold family. Use \`wp-typia create <project-dir> --template query-loop\` instead of \`wp-typia add block\`.
   \`add variation\` targets an existing block slug from \`scripts/block-config.ts\`.
   \`add pattern\` scaffolds a namespaced PHP pattern shell under \`src/patterns/\`.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-admin-view.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-admin-view.ts
@@ -876,13 +876,11 @@ async function ensureAdminViewWebpackAnchors(workspace: WorkspaceProject): Promi
 			return source;
 		}
 
-		const editorPluginEntry = `\t\t[
-\t\t\t'editor-plugins/index',
-\t\t\t[ 'src/editor-plugins/index.ts', 'src/editor-plugins/index.js' ],
-\t\t],`;
+		const editorPluginEntryPattern =
+			/(\n\s*\[\s*['"]editor-plugins\/index['"][\s\S]*?['"]src\/editor-plugins\/index\.js['"][\s\S]*?\]\s*\])\s*,?/u;
 		let nextSource = source.replace(
-			editorPluginEntry,
-			`${editorPluginEntry}
+			editorPluginEntryPattern,
+			`$1,
 \t\t[
 \t\t\t'admin-views/index',
 \t\t\t[ 'src/admin-views/index.ts', 'src/admin-views/index.js' ],

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-admin-view.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-admin-view.ts
@@ -1,0 +1,1083 @@
+import fs from "node:fs";
+import { promises as fsp } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+import {
+	resolveWorkspaceProject,
+	type WorkspaceProject,
+} from "./workspace-project.js";
+import { readWorkspaceInventory, appendWorkspaceInventoryEntries } from "./workspace-inventory.js";
+import { PROJECT_TOOLS_PACKAGE_ROOT } from "./template-registry.js";
+import { toPascalCase, toTitleCase } from "./string-case.js";
+import {
+	findPhpFunctionRange,
+	hasPhpFunctionDefinition,
+	quotePhpString,
+	replacePhpFunctionDefinition,
+} from "./php-utils.js";
+import {
+	assertAdminViewDoesNotExist,
+	assertValidGeneratedSlug,
+	getWorkspaceBootstrapPath,
+	normalizeBlockSlug,
+	patchFile,
+	quoteTsString,
+	rollbackWorkspaceMutation,
+	type RunAddAdminViewCommandOptions,
+	type WorkspaceMutationSnapshot,
+	snapshotWorkspaceFiles,
+} from "./cli-add-shared.js";
+
+const ADMIN_VIEW_SOURCE_KIND = "rest-resource";
+const ADMIN_VIEWS_SCRIPT = "build/admin-views/index.js";
+const ADMIN_VIEWS_ASSET = "build/admin-views/index.asset.php";
+const ADMIN_VIEWS_STYLE = "build/admin-views/style-index.css";
+const ADMIN_VIEWS_STYLE_RTL = "build/admin-views/style-index-rtl.css";
+const ADMIN_VIEWS_PHP_GLOB = "/inc/admin-views/*.php";
+const DEFAULT_WP_TYPIA_DATAVIEWS_VERSION = "^0.1.0";
+const DEFAULT_WORDPRESS_DATAVIEWS_VERSION = "^14.1.0";
+
+const require = createRequire(import.meta.url);
+
+interface AdminViewRestResourceSource {
+	kind: typeof ADMIN_VIEW_SOURCE_KIND;
+	slug: string;
+}
+
+type AdminViewSource = AdminViewRestResourceSource;
+
+type AdminViewRestResource = ReturnType<typeof readWorkspaceInventory>["restResources"][number];
+
+function toCamelCase(input: string): string {
+	const pascalCase = toPascalCase(input);
+	return `${pascalCase.charAt(0).toLowerCase()}${pascalCase.slice(1)}`;
+}
+
+function normalizeVersionRange(value: string | undefined, fallback: string): string {
+	const trimmed = value?.trim();
+	if (!trimmed || trimmed.startsWith("workspace:")) {
+		return fallback;
+	}
+
+	return /^[~^<>=]/u.test(trimmed) ? trimmed : `^${trimmed}`;
+}
+
+function readPackageManifestVersion(packageJsonPath: string): string | undefined {
+	try {
+		const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as {
+			version?: string;
+		};
+		return packageJson.version;
+	} catch {
+		return undefined;
+	}
+}
+
+function resolvePackageVersionRange(
+	packageName: string,
+	fallback: string,
+	workspacePackageDirName?: string,
+): string {
+	if (workspacePackageDirName) {
+		const workspaceVersion = readPackageManifestVersion(
+			path.join(PROJECT_TOOLS_PACKAGE_ROOT, "..", workspacePackageDirName, "package.json"),
+		);
+		if (workspaceVersion) {
+			return normalizeVersionRange(workspaceVersion, fallback);
+		}
+	}
+
+	try {
+		return normalizeVersionRange(
+			readPackageManifestVersion(require.resolve(`${packageName}/package.json`)),
+			fallback,
+		);
+	} catch {
+		return fallback;
+	}
+}
+
+function parseAdminViewSource(source?: string): AdminViewSource | undefined {
+	const trimmed = source?.trim();
+	if (!trimmed) {
+		return undefined;
+	}
+
+	const [kind, slug, extra] = trimmed.split(":");
+	if (kind !== ADMIN_VIEW_SOURCE_KIND || !slug || extra !== undefined) {
+		throw new Error(
+			"Admin view source must use `rest-resource:<slug>` for now.",
+		);
+	}
+
+	return {
+		kind,
+		slug: assertValidGeneratedSlug(
+			"Admin view source slug",
+			normalizeBlockSlug(slug),
+			"wp-typia add admin-view <name> --source rest-resource:<slug>",
+		),
+	};
+}
+
+function resolveRestResourceSource(
+	restResources: AdminViewRestResource[],
+	source: AdminViewSource | undefined,
+): AdminViewRestResource | undefined {
+	if (!source) {
+		return undefined;
+	}
+
+	const restResource = restResources.find((entry) => entry.slug === source.slug);
+	if (!restResource) {
+		throw new Error(
+			`Unknown REST resource source "${source.slug}". Choose one of: ${restResources
+				.map((entry) => entry.slug)
+				.join(", ") || "<none>"}.`,
+		);
+	}
+	if (!restResource.methods.includes("list")) {
+		throw new Error(
+			`REST resource source "${source.slug}" must include the list method for DataViews pagination.`,
+		);
+	}
+
+	return restResource;
+}
+
+function buildAdminViewConfigEntry(
+	adminViewSlug: string,
+	source: AdminViewSource | undefined,
+): string {
+	return [
+		"\t{",
+		`\t\tfile: ${quoteTsString(`src/admin-views/${adminViewSlug}/index.tsx`)},`,
+		`\t\tphpFile: ${quoteTsString(`inc/admin-views/${adminViewSlug}.php`)},`,
+		`\t\tslug: ${quoteTsString(adminViewSlug)},`,
+		source ? `\t\tsource: ${quoteTsString(`${source.kind}:${source.slug}`)},` : null,
+		"\t},",
+	]
+		.filter((line): line is string => typeof line === "string")
+		.join("\n");
+}
+
+function buildAdminViewRegistrySource(adminViewSlugs: string[]): string {
+	const importLines = adminViewSlugs
+		.map((adminViewSlug) => `import './${adminViewSlug}';`)
+		.join("\n");
+
+	return `${importLines}${importLines ? "\n\n" : ""}// wp-typia add admin-view entries\n`;
+}
+
+function buildAdminViewTypesSource(
+	adminViewSlug: string,
+	restResource: AdminViewRestResource | undefined,
+): string {
+	const pascalName = toPascalCase(adminViewSlug);
+	const itemTypeName = `${pascalName}AdminViewItem`;
+	const dataSetTypeName = `${pascalName}AdminViewDataSet`;
+
+	if (restResource) {
+		const restPascalName = toPascalCase(restResource.slug);
+
+		return `import type { ${restPascalName}Record } from '../../rest/${restResource.slug}/api-types';
+
+export type ${itemTypeName} = ${restPascalName}Record;
+
+export interface ${dataSetTypeName} {
+\titems: ${itemTypeName}[];
+\tpaginationInfo: {
+\t\ttotalItems: number;
+\t\ttotalPages: number;
+\t};
+}
+`;
+	}
+
+	return `export type ${pascalName}AdminViewStatus = 'draft' | 'published';
+
+export interface ${itemTypeName} {
+\tid: number;
+\towner: string;
+\tstatus: ${pascalName}AdminViewStatus;
+\ttitle: string;
+\tupdatedAt: string;
+}
+
+export interface ${dataSetTypeName} {
+\titems: ${itemTypeName}[];
+\tpaginationInfo: {
+\t\ttotalItems: number;
+\t\ttotalPages: number;
+\t};
+}
+`;
+}
+
+function buildAdminViewConfigSource(
+	adminViewSlug: string,
+	textDomain: string,
+	restResource: AdminViewRestResource | undefined,
+): string {
+	const pascalName = toPascalCase(adminViewSlug);
+	const camelName = toCamelCase(adminViewSlug);
+	const itemTypeName = `${pascalName}AdminViewItem`;
+	const dataViewsName = `${camelName}AdminDataViews`;
+	const secondaryFieldSource = restResource
+		? `\t\tcontent: {
+\t\t\tlabel: __( 'Content', ${quoteTsString(textDomain)} ),
+\t\t\tschema: { type: 'string' },
+\t\t},`
+		: `\t\towner: {
+\t\t\tlabel: __( 'Owner', ${quoteTsString(textDomain)} ),
+\t\t\tschema: { type: 'string' },
+\t\t},`;
+
+	return `import { defineDataViews } from '@wp-typia/dataviews';
+import { __ } from '@wordpress/i18n';
+
+import type { ${itemTypeName} } from './types';
+
+export const ${dataViewsName} = defineDataViews<${itemTypeName}>({
+\tidField: 'id',
+\tsearch: true,
+\tsearchLabel: __( 'Search records', ${quoteTsString(textDomain)} ),
+\ttitleField: 'title',
+\tdefaultView: {
+\t\tfields: ['title', 'status', 'updatedAt'],
+\t\tpage: 1,
+\t\tperPage: 10,
+\t\tsort: {
+\t\t\tdirection: 'desc',
+\t\t\tfield: 'updatedAt',
+\t\t},
+\t\ttitleField: 'title',
+\t\ttype: 'table',
+\t},
+\tfields: {
+\t\tid: {
+\t\t\tenableHiding: false,
+\t\t\tlabel: __( 'ID', ${quoteTsString(textDomain)} ),
+\t\t\treadOnly: true,
+\t\t\tschema: { type: 'integer' },
+\t\t},
+${secondaryFieldSource}
+\t\tstatus: {
+\t\t\tfilterBy: { operators: ['isAny', 'isNone'] },
+\t\t\tlabel: __( 'Status', ${quoteTsString(textDomain)} ),
+\t\t\tschema: {
+\t\t\t\tenum: ['draft', 'published'],
+\t\t\t\tenumLabels: {
+\t\t\t\t\tdraft: __( 'Draft', ${quoteTsString(textDomain)} ),
+\t\t\t\t\tpublished: __( 'Published', ${quoteTsString(textDomain)} ),
+\t\t\t\t},
+\t\t\t\ttype: 'string',
+\t\t\t},
+\t\t},
+\t\ttitle: {
+\t\t\tenableGlobalSearch: true,
+\t\t\tenableSorting: true,
+\t\t\tlabel: __( 'Title', ${quoteTsString(textDomain)} ),
+\t\t\tschema: { type: 'string' },
+\t\t},
+\t\tupdatedAt: {
+\t\t\tenableSorting: true,
+\t\t\tlabel: __( 'Updated', ${quoteTsString(textDomain)} ),
+\t\t\tschema: { format: 'date-time', type: 'string' },
+\t\t\ttype: 'datetime',
+\t\t},
+\t},
+});
+`;
+}
+
+function buildDefaultAdminViewDataSource(adminViewSlug: string): string {
+	const pascalName = toPascalCase(adminViewSlug);
+	const camelName = toCamelCase(adminViewSlug);
+	const title = toTitleCase(adminViewSlug);
+	const itemTypeName = `${pascalName}AdminViewItem`;
+	const dataSetTypeName = `${pascalName}AdminViewDataSet`;
+	const queryTypeName = `${pascalName}AdminViewQuery`;
+	const dataViewsName = `${camelName}AdminDataViews`;
+	const fetchName = `fetch${pascalName}AdminViewData`;
+
+	return `import type { DataViewsView } from '@wp-typia/dataviews';
+
+import { ${dataViewsName} } from './config';
+import type { ${dataSetTypeName}, ${itemTypeName} } from './types';
+
+export interface ${queryTypeName} {
+\tpage?: number;
+\tperPage?: number;
+\tsearch?: string;
+}
+
+const STARTER_ITEMS: ${itemTypeName}[] = [
+\t{
+\t\tid: 1,
+\t\towner: 'Editorial',
+\t\tstatus: 'published',
+\t\ttitle: ${quoteTsString(`${title} launch checklist`)},
+\t\tupdatedAt: '2026-04-01T10:30:00Z',
+\t},
+\t{
+\t\tid: 2,
+\t\towner: 'Design',
+\t\tstatus: 'draft',
+\t\ttitle: ${quoteTsString(`${title} content refresh`)},
+\t\tupdatedAt: '2026-04-03T14:15:00Z',
+\t},
+\t{
+\t\tid: 3,
+\t\towner: 'Operations',
+\t\tstatus: 'published',
+\t\ttitle: ${quoteTsString(`${title} support handoff`)},
+\t\tupdatedAt: '2026-04-08T08:45:00Z',
+\t},
+];
+
+function matchesSearch(item: ${itemTypeName}, search: string | undefined): boolean {
+\tif (!search) {
+\t\treturn true;
+\t}
+
+\tconst needle = search.toLowerCase();
+\treturn [item.title, item.owner, item.status].some((value) =>
+\t\tvalue.toLowerCase().includes(needle),
+\t);
+}
+
+export async function ${fetchName}(
+\tview: DataViewsView<${itemTypeName}>,
+): Promise<${dataSetTypeName}> {
+\tconst query = ${dataViewsName}.toQueryArgs<${queryTypeName}>(view, {
+\t\tperPageParam: 'perPage',
+\t});
+\tconst page = query.page ?? 1;
+\tconst perPage = query.perPage ?? view.perPage ?? 10;
+\tconst filteredItems = STARTER_ITEMS.filter((item) =>
+\t\tmatchesSearch(item, query.search),
+\t);
+\tconst offset = (page - 1) * perPage;
+\tconst items = filteredItems.slice(offset, offset + perPage);
+
+\treturn {
+\t\titems,
+\t\tpaginationInfo: {
+\t\t\ttotalItems: filteredItems.length,
+\t\t\ttotalPages: Math.max(1, Math.ceil(filteredItems.length / perPage)),
+\t\t},
+\t};
+}
+`;
+}
+
+function buildRestAdminViewDataSource(
+	adminViewSlug: string,
+	restResource: AdminViewRestResource,
+): string {
+	const pascalName = toPascalCase(adminViewSlug);
+	const restPascalName = toPascalCase(restResource.slug);
+	const camelName = toCamelCase(adminViewSlug);
+	const itemTypeName = `${pascalName}AdminViewItem`;
+	const dataSetTypeName = `${pascalName}AdminViewDataSet`;
+	const dataViewsName = `${camelName}AdminDataViews`;
+	const fetchName = `fetch${pascalName}AdminViewData`;
+
+	return `import type { DataViewsView } from '@wp-typia/dataviews';
+
+import { listResource } from '../../rest/${restResource.slug}/api';
+import type { ${restPascalName}ListQuery } from '../../rest/${restResource.slug}/api-types';
+import { ${dataViewsName} } from './config';
+import type { ${dataSetTypeName}, ${itemTypeName} } from './types';
+
+function resolveTotalPages(total: number, perPage: number | undefined): number {
+\tconst resolvedPerPage = perPage && perPage > 0 ? perPage : 1;
+\treturn Math.max(1, Math.ceil(total / resolvedPerPage));
+}
+
+export async function ${fetchName}(
+\tview: DataViewsView<${itemTypeName}>,
+): Promise<${dataSetTypeName}> {
+\tconst query = ${dataViewsName}.toQueryArgs<${restPascalName}ListQuery>(view, {
+\t\tperPageParam: 'perPage',
+\t});
+\tconst response = await listResource({
+\t\tpage: query.page,
+\t\tperPage: query.perPage,
+\t\tsearch: query.search,
+\t});
+
+\treturn {
+\t\titems: response.items,
+\t\tpaginationInfo: {
+\t\t\ttotalItems: response.total,
+\t\t\ttotalPages: resolveTotalPages(response.total, response.perPage ?? query.perPage),
+\t\t},
+\t};
+}
+`;
+}
+
+function buildAdminViewScreenSource(
+	adminViewSlug: string,
+	textDomain: string,
+): string {
+	const pascalName = toPascalCase(adminViewSlug);
+	const camelName = toCamelCase(adminViewSlug);
+	const itemTypeName = `${pascalName}AdminViewItem`;
+	const dataSetTypeName = `${pascalName}AdminViewDataSet`;
+	const componentName = `${pascalName}AdminViewScreen`;
+	const dataViewsName = `${camelName}AdminDataViews`;
+	const fetchName = `fetch${pascalName}AdminViewData`;
+	const title = toTitleCase(adminViewSlug);
+
+	return `import type { DataViewsConfig, DataViewsView } from '@wp-typia/dataviews';
+import { Button, Notice, Spinner } from '@wordpress/components';
+import { useEffect, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { DataViews } from '@wordpress/dataviews/wp';
+
+import { ${dataViewsName} } from './config';
+import { ${fetchName} } from './data';
+import type { ${dataSetTypeName}, ${itemTypeName} } from './types';
+
+const TypedDataViews = DataViews as <TItem extends object>(
+\tprops: DataViewsConfig<TItem>,
+) => ReturnType<typeof DataViews>;
+
+const EMPTY_DATA_SET: ${dataSetTypeName} = {
+\titems: [],
+\tpaginationInfo: {
+\t\ttotalItems: 0,
+\t\ttotalPages: 1,
+\t},
+};
+
+export function ${componentName}() {
+\tconst [view, setView] = useState<DataViewsView<${itemTypeName}>>(
+\t\t${dataViewsName}.defaultView,
+\t);
+\tconst [dataSet, setDataSet] = useState<${dataSetTypeName}>(EMPTY_DATA_SET);
+\tconst [error, setError] = useState<string | null>(null);
+\tconst [isLoading, setIsLoading] = useState(true);
+\tconst [reloadToken, setReloadToken] = useState(0);
+
+\tuseEffect(() => {
+\t\tlet isCurrentRequest = true;
+\t\tsetIsLoading(true);
+\t\tsetError(null);
+
+\t\tvoid ${fetchName}(view)
+\t\t\t.then((nextDataSet) => {
+\t\t\t\tif (isCurrentRequest) {
+\t\t\t\t\tsetDataSet(nextDataSet);
+\t\t\t\t}
+\t\t\t})
+\t\t\t.catch((nextError: unknown) => {
+\t\t\t\tif (isCurrentRequest) {
+\t\t\t\t\tsetError(
+\t\t\t\t\t\tnextError instanceof Error
+\t\t\t\t\t\t\t? nextError.message
+\t\t\t\t\t\t\t: __( 'Unable to load records.', ${quoteTsString(textDomain)} ),
+\t\t\t\t\t);
+\t\t\t\t}
+\t\t\t})
+\t\t\t.finally(() => {
+\t\t\t\tif (isCurrentRequest) {
+\t\t\t\t\tsetIsLoading(false);
+\t\t\t\t}
+\t\t\t});
+
+\t\treturn () => {
+\t\t\tisCurrentRequest = false;
+\t\t};
+\t}, [reloadToken, view]);
+
+\tconst config = ${dataViewsName}.createConfig({
+\t\tdata: dataSet.items,
+\t\tisLoading,
+\t\tonChangeView: setView,
+\t\tpaginationInfo: dataSet.paginationInfo,
+\t\tview,
+\t});
+
+\treturn (
+\t\t<div className="wp-typia-admin-view-screen">
+\t\t\t<header className="wp-typia-admin-view-screen__header">
+\t\t\t\t<div>
+\t\t\t\t\t<p className="wp-typia-admin-view-screen__eyebrow">
+\t\t\t\t\t\t{ __( 'DataViews admin screen', ${quoteTsString(textDomain)} ) }
+\t\t\t\t\t</p>
+\t\t\t\t\t<h1>{ __( ${quoteTsString(title)}, ${quoteTsString(textDomain)} ) }</h1>
+\t\t\t\t\t<p>
+\t\t\t\t\t\t{ __( 'Replace the fetcher in data.ts with your project data source when this screen graduates from scaffold to product UI.', ${quoteTsString(textDomain)} ) }
+\t\t\t\t\t</p>
+\t\t\t\t</div>
+\t\t\t\t<div className="wp-typia-admin-view-screen__actions">
+\t\t\t\t\t{ isLoading ? <Spinner /> : null }
+\t\t\t\t\t<Button
+\t\t\t\t\t\tisBusy={ isLoading }
+\t\t\t\t\t\tonClick={ () => setReloadToken((token) => token + 1) }
+\t\t\t\t\t\tvariant="secondary"
+\t\t\t\t\t>
+\t\t\t\t\t\t{ __( 'Reload', ${quoteTsString(textDomain)} ) }
+\t\t\t\t\t</Button>
+\t\t\t\t</div>
+\t\t\t</header>
+\t\t\t{ error ? (
+\t\t\t\t<Notice isDismissible={ false } status="error">
+\t\t\t\t\t{ error }
+\t\t\t\t</Notice>
+\t\t\t) : null }
+\t\t\t<TypedDataViews<${itemTypeName}> { ...config } />
+\t\t</div>
+\t);
+}
+`;
+}
+
+function buildAdminViewEntrySource(adminViewSlug: string): string {
+	const pascalName = toPascalCase(adminViewSlug);
+	const componentName = `${pascalName}AdminViewScreen`;
+	const rootId = `wp-typia-admin-view-${adminViewSlug}`;
+
+	return `import { createRoot } from '@wordpress/element';
+
+import '@wordpress/dataviews/build-style/style.css';
+import { ${componentName} } from './Screen';
+import './style.scss';
+
+const ROOT_ELEMENT_ID = ${quoteTsString(rootId)};
+
+function mountAdminView() {
+\tconst rootElement = document.getElementById(ROOT_ELEMENT_ID);
+\tif (!rootElement) {
+\t\treturn;
+\t}
+
+\tcreateRoot(rootElement).render(<${componentName} />);
+}
+
+if (document.readyState === 'loading') {
+\tdocument.addEventListener('DOMContentLoaded', mountAdminView);
+} else {
+\tmountAdminView();
+}
+`;
+}
+
+function buildAdminViewStyleSource(): string {
+	return `.wp-typia-admin-view-screen {
+\tbox-sizing: border-box;
+\tmax-width: 1180px;
+\tpadding: 24px 24px 48px 0;
+}
+
+.wp-typia-admin-view-screen__header {
+\talign-items: flex-start;
+\tdisplay: flex;
+\tgap: 24px;
+\tjustify-content: space-between;
+\tmargin-bottom: 24px;
+}
+
+.wp-typia-admin-view-screen__header h1 {
+\tfont-size: 28px;
+\tline-height: 1.2;
+\tmargin: 0 0 8px;
+}
+
+.wp-typia-admin-view-screen__header p {
+\tmax-width: 680px;
+}
+
+.wp-typia-admin-view-screen__eyebrow {
+\tcolor: #3858e9;
+\tfont-size: 11px;
+\tfont-weight: 600;
+\tletter-spacing: 0.08em;
+\tmargin: 0 0 8px;
+\ttext-transform: uppercase;
+}
+
+.wp-typia-admin-view-screen__actions {
+\talign-items: center;
+\tdisplay: flex;
+\tgap: 12px;
+}
+`;
+}
+
+function buildAdminViewPhpSource(
+	adminViewSlug: string,
+	workspace: WorkspaceProject,
+): string {
+	const workspaceBaseName = workspace.packageName.split("/").pop() ?? workspace.packageName;
+	const phpSlug = adminViewSlug.replace(/-/g, "_");
+	const functionPrefix = `${workspace.workspace.phpPrefix}_${phpSlug}`;
+	const menuSlugFunctionName = `${functionPrefix}_admin_view_menu_slug`;
+	const renderFunctionName = `${functionPrefix}_render_admin_view`;
+	const registerFunctionName = `${functionPrefix}_register_admin_view`;
+	const enqueueFunctionName = `${functionPrefix}_enqueue_admin_view`;
+	const hookGlobalName = `${functionPrefix}_admin_view_hook`;
+	const rootId = `wp-typia-admin-view-${adminViewSlug}`;
+	const title = toTitleCase(adminViewSlug);
+
+	return `<?php
+if ( ! defined( 'ABSPATH' ) ) {
+\treturn;
+}
+
+if ( ! function_exists( '${menuSlugFunctionName}' ) ) {
+\tfunction ${menuSlugFunctionName}() : string {
+\t\treturn '${workspaceBaseName}-${adminViewSlug}';
+\t}
+}
+
+if ( ! function_exists( '${renderFunctionName}' ) ) {
+\tfunction ${renderFunctionName}() : void {
+\t\t?>
+\t\t<div class="wrap">
+\t\t\t<div id="${rootId}"></div>
+\t\t</div>
+\t\t<?php
+\t}
+}
+
+if ( ! function_exists( '${registerFunctionName}' ) ) {
+\tfunction ${registerFunctionName}() : void {
+\t\t$GLOBALS['${hookGlobalName}'] = add_submenu_page(
+\t\t\t'tools.php',
+\t\t\t__( ${quotePhpString(title)}, ${quotePhpString(workspace.workspace.textDomain)} ),
+\t\t\t__( ${quotePhpString(title)}, ${quotePhpString(workspace.workspace.textDomain)} ),
+\t\t\t'edit_posts',
+\t\t\t${menuSlugFunctionName}(),
+\t\t\t'${renderFunctionName}'
+\t\t);
+\t}
+}
+
+if ( ! function_exists( '${enqueueFunctionName}' ) ) {
+\tfunction ${enqueueFunctionName}( string $hook_suffix ) : void {
+\t\t$page_hook = isset( $GLOBALS['${hookGlobalName}'] ) && is_string( $GLOBALS['${hookGlobalName}'] )
+\t\t\t? $GLOBALS['${hookGlobalName}']
+\t\t\t: '';
+
+\t\tif ( $page_hook !== $hook_suffix ) {
+\t\t\treturn;
+\t\t}
+
+\t\t$plugin_file = dirname( __DIR__, 2 ) . '/${workspaceBaseName}.php';
+\t\t$script_path = dirname( __DIR__, 2 ) . '/${ADMIN_VIEWS_SCRIPT}';
+\t\t$asset_path  = dirname( __DIR__, 2 ) . '/${ADMIN_VIEWS_ASSET}';
+\t\t$style_path  = dirname( __DIR__, 2 ) . '/${ADMIN_VIEWS_STYLE}';
+\t\t$style_rtl_path = dirname( __DIR__, 2 ) . '/${ADMIN_VIEWS_STYLE_RTL}';
+
+\t\tif ( ! file_exists( $script_path ) || ! file_exists( $asset_path ) ) {
+\t\t\treturn;
+\t\t}
+
+\t\t$asset = require $asset_path;
+\t\tif ( ! is_array( $asset ) ) {
+\t\t\t$asset = array();
+\t\t}
+
+\t\t$dependencies = isset( $asset['dependencies'] ) && is_array( $asset['dependencies'] )
+\t\t\t? $asset['dependencies']
+\t\t\t: array();
+
+\t\twp_enqueue_script(
+\t\t\t'${workspaceBaseName}-${adminViewSlug}-admin-view',
+\t\t\tplugins_url( '${ADMIN_VIEWS_SCRIPT}', $plugin_file ),
+\t\t\t$dependencies,
+\t\t\tisset( $asset['version'] ) ? $asset['version'] : filemtime( $script_path ),
+\t\t\ttrue
+\t\t);
+
+\t\tif ( file_exists( $style_path ) ) {
+\t\t\twp_enqueue_style(
+\t\t\t\t'${workspaceBaseName}-${adminViewSlug}-admin-view',
+\t\t\t\tplugins_url( '${ADMIN_VIEWS_STYLE}', $plugin_file ),
+\t\t\t\tarray( 'wp-components' ),
+\t\t\t\tisset( $asset['version'] ) ? $asset['version'] : filemtime( $style_path )
+\t\t\t);
+\t\t\tif ( file_exists( $style_rtl_path ) ) {
+\t\t\t\twp_style_add_data( '${workspaceBaseName}-${adminViewSlug}-admin-view', 'rtl', 'replace' );
+\t\t\t}
+\t\t}
+\t}
+}
+
+add_action( 'admin_menu', '${registerFunctionName}' );
+add_action( 'admin_enqueue_scripts', '${enqueueFunctionName}' );
+`;
+}
+
+async function ensureAdminViewPackageDependencies(workspace: WorkspaceProject): Promise<void> {
+	const packageJsonPath = path.join(workspace.projectDir, "package.json");
+	const wpTypiaDataViewsVersion = resolvePackageVersionRange(
+		"@wp-typia/dataviews",
+		DEFAULT_WP_TYPIA_DATAVIEWS_VERSION,
+		"wp-typia-dataviews",
+	);
+	const wordpressDataViewsVersion = resolvePackageVersionRange(
+		"@wordpress/dataviews",
+		DEFAULT_WORDPRESS_DATAVIEWS_VERSION,
+	);
+
+	await patchFile(packageJsonPath, (source) => {
+		const packageJson = JSON.parse(source) as {
+			dependencies?: Record<string, string>;
+			devDependencies?: Record<string, string>;
+		};
+		const nextDependencies = {
+			...(packageJson.dependencies ?? {}),
+			"@wordpress/dataviews":
+				packageJson.dependencies?.["@wordpress/dataviews"] ?? wordpressDataViewsVersion,
+		};
+		const nextDevDependencies = {
+			...(packageJson.devDependencies ?? {}),
+			"@wp-typia/dataviews":
+				packageJson.devDependencies?.["@wp-typia/dataviews"] ??
+				wpTypiaDataViewsVersion,
+		};
+		if (
+			JSON.stringify(nextDependencies) === JSON.stringify(packageJson.dependencies ?? {}) &&
+			JSON.stringify(nextDevDependencies) ===
+				JSON.stringify(packageJson.devDependencies ?? {})
+		) {
+			return source;
+		}
+
+		packageJson.dependencies = nextDependencies;
+		packageJson.devDependencies = nextDevDependencies;
+		return `${JSON.stringify(packageJson, null, 2)}\n`;
+	});
+}
+
+async function ensureAdminViewBootstrapAnchors(workspace: WorkspaceProject): Promise<void> {
+	const bootstrapPath = getWorkspaceBootstrapPath(workspace);
+
+	await patchFile(bootstrapPath, (source) => {
+		let nextSource = source;
+		const loadFunctionName = `${workspace.workspace.phpPrefix}_load_admin_views`;
+		const loadHook = `add_action( 'plugins_loaded', '${loadFunctionName}' );`;
+		const loadFunction = `
+
+function ${loadFunctionName}() {
+\tforeach ( glob( __DIR__ . '${ADMIN_VIEWS_PHP_GLOB}' ) ?: array() as $admin_view_module ) {
+\t\trequire_once $admin_view_module;
+\t}
+}
+`;
+		const insertionAnchors = [
+			/add_action\(\s*["']init["']\s*,\s*["'][^"']+_load_textdomain["']\s*\);\s*\n/u,
+			/\?>\s*$/u,
+		];
+		const insertPhpSnippet = (snippet: string): void => {
+			for (const anchor of insertionAnchors) {
+				const candidate = nextSource.replace(anchor, (match) => `${snippet}\n${match}`);
+				if (candidate !== nextSource) {
+					nextSource = candidate;
+					return;
+				}
+			}
+			nextSource = `${nextSource.trimEnd()}\n${snippet}\n`;
+		};
+		const appendPhpSnippet = (snippet: string): void => {
+			const closingTagPattern = /\?>\s*$/u;
+			if (closingTagPattern.test(nextSource)) {
+				nextSource = nextSource.replace(closingTagPattern, `${snippet}\n?>`);
+				return;
+			}
+			nextSource = `${nextSource.trimEnd()}\n${snippet}\n`;
+		};
+
+		if (!hasPhpFunctionDefinition(nextSource, loadFunctionName)) {
+			insertPhpSnippet(loadFunction);
+		} else {
+			const functionRange = findPhpFunctionRange(nextSource, loadFunctionName);
+			const functionSource = functionRange
+				? nextSource.slice(functionRange.start, functionRange.end)
+				: "";
+			if (!functionSource.includes(ADMIN_VIEWS_PHP_GLOB)) {
+				const replacedSource = replacePhpFunctionDefinition(
+					nextSource,
+					loadFunctionName,
+					loadFunction,
+				);
+				if (!replacedSource) {
+					throw new Error(
+						`Unable to repair ${path.basename(bootstrapPath)} for ${loadFunctionName}.`,
+					);
+				}
+				nextSource = replacedSource;
+			}
+		}
+
+		if (!nextSource.includes(loadHook)) {
+			appendPhpSnippet(loadHook);
+		}
+
+		return nextSource;
+	});
+}
+
+async function ensureAdminViewBuildScriptAnchors(workspace: WorkspaceProject): Promise<void> {
+	const buildScriptPath = path.join(workspace.projectDir, "scripts", "build-workspace.mjs");
+
+	await patchFile(buildScriptPath, (source) => {
+		if (/['"]src\/admin-views\/index\.(?:ts|js)['"]/u.test(source)) {
+			return source;
+		}
+
+		const currentSharedEntriesPattern =
+			/(\n\t\t['"]src\/editor-plugins\/index\.js['"],)(\n\t\])/u;
+		let nextSource = source.replace(
+			currentSharedEntriesPattern,
+			`$1
+\t\t'src/admin-views/index.ts',
+\t\t'src/admin-views/index.js',$2`,
+		);
+		if (nextSource !== source) {
+			return nextSource;
+		}
+
+		const legacySharedEntriesPattern =
+			/\[\s*['"]src\/bindings\/index\.ts['"]\s*,\s*['"]src\/bindings\/index\.js['"]\s*(?:,\s*)?\]/u;
+		nextSource = source.replace(
+			legacySharedEntriesPattern,
+			`[
+\t\t'src/bindings/index.ts',
+\t\t'src/bindings/index.js',
+\t\t'src/editor-plugins/index.ts',
+\t\t'src/editor-plugins/index.js',
+\t\t'src/admin-views/index.ts',
+\t\t'src/admin-views/index.js',
+\t]`,
+		);
+		if (nextSource === source) {
+			throw new Error(
+				`Unable to update ${path.relative(workspace.projectDir, buildScriptPath)} for admin view shared entries.`,
+			);
+		}
+
+		return nextSource;
+	});
+}
+
+async function ensureAdminViewWebpackAnchors(workspace: WorkspaceProject): Promise<void> {
+	const webpackConfigPath = path.join(workspace.projectDir, "webpack.config.js");
+
+	await patchFile(webpackConfigPath, (source) => {
+		if (/['"]admin-views\/index['"]/u.test(source)) {
+			return source;
+		}
+
+		const editorPluginEntry = `\t\t[
+\t\t\t'editor-plugins/index',
+\t\t\t[ 'src/editor-plugins/index.ts', 'src/editor-plugins/index.js' ],
+\t\t],`;
+		let nextSource = source.replace(
+			editorPluginEntry,
+			`${editorPluginEntry}
+\t\t[
+\t\t\t'admin-views/index',
+\t\t\t[ 'src/admin-views/index.ts', 'src/admin-views/index.js' ],
+\t\t],`,
+		);
+		if (nextSource !== source) {
+			return nextSource;
+		}
+
+		const legacySharedEntriesBlockPattern =
+			/for\s*\(\s*const\s+relativePath\s+of\s+\[\s*['"]src\/bindings\/index\.ts['"]\s*,\s*['"]src\/bindings\/index\.js['"]\s*(?:,\s*)?\]\s*\)\s*\{[\s\S]*?entries\.push\(\s*\[\s*['"]bindings\/index['"]\s*,\s*entryPath\s*\]\s*\);\s*break;\s*\}/u;
+		const nextSharedEntriesBlock = `\tfor ( const [ entryName, candidates ] of [\n\t\t[\n\t\t\t'bindings/index',\n\t\t\t[ 'src/bindings/index.ts', 'src/bindings/index.js' ],\n\t\t],\n\t\t[\n\t\t\t'editor-plugins/index',\n\t\t\t[ 'src/editor-plugins/index.ts', 'src/editor-plugins/index.js' ],\n\t\t],\n\t\t[\n\t\t\t'admin-views/index',\n\t\t\t[ 'src/admin-views/index.ts', 'src/admin-views/index.js' ],\n\t\t],\n\t] ) {\n\t\tfor ( const relativePath of candidates ) {\n\t\t\tconst entryPath = path.resolve( process.cwd(), relativePath );\n\t\t\tif ( ! fs.existsSync( entryPath ) ) {\n\t\t\t\tcontinue;\n\t\t\t}\n\n\t\t\tentries.push( [ entryName, entryPath ] );\n\t\t\tbreak;\n\t\t}\n\t}`;
+		nextSource = source.replace(
+			legacySharedEntriesBlockPattern,
+			nextSharedEntriesBlock,
+		);
+		if (nextSource === source) {
+			throw new Error(
+				`Unable to update ${path.relative(workspace.projectDir, webpackConfigPath)} for admin view shared entries.`,
+			);
+		}
+
+		return nextSource;
+	});
+}
+
+function resolveAdminViewRegistryPath(projectDir: string): string {
+	const adminViewsDir = path.join(projectDir, "src", "admin-views");
+	return [
+		path.join(adminViewsDir, "index.ts"),
+		path.join(adminViewsDir, "index.js"),
+	].find((candidatePath) => fs.existsSync(candidatePath)) ?? path.join(adminViewsDir, "index.ts");
+}
+
+function readAdminViewRegistrySlugs(registryPath: string): string[] {
+	if (!fs.existsSync(registryPath)) {
+		return [];
+	}
+
+	const source = fs.readFileSync(registryPath, "utf8");
+	return Array.from(
+		source.matchAll(
+			/^\s*import\s+['"]\.\/([^/'"]+)(?:\/index(?:\.[cm]?[jt]sx?)?)?['"];?\s*$/gmu,
+		),
+	).map((match) => match[1]);
+}
+
+async function writeAdminViewRegistry(
+	projectDir: string,
+	adminViewSlug: string,
+): Promise<void> {
+	const adminViewsDir = path.join(projectDir, "src", "admin-views");
+	const registryPath = resolveAdminViewRegistryPath(projectDir);
+	await fsp.mkdir(adminViewsDir, { recursive: true });
+
+	const existingAdminViewSlugs = readWorkspaceInventory(projectDir).adminViews.map((entry) =>
+		entry.slug,
+	);
+	const existingRegistrySlugs = readAdminViewRegistrySlugs(registryPath);
+	const nextAdminViewSlugs = Array.from(
+		new Set([...existingAdminViewSlugs, ...existingRegistrySlugs, adminViewSlug]),
+	).sort();
+	await fsp.writeFile(
+		registryPath,
+		buildAdminViewRegistrySource(nextAdminViewSlugs),
+		"utf8",
+	);
+}
+
+/**
+ * Add one DataViews-powered WordPress admin screen scaffold to an official
+ * workspace project.
+ *
+ * @param options Command options for the admin-view scaffold workflow.
+ * @param options.adminViewName Human-entered admin screen name that will be
+ * normalized and validated before files are written.
+ * @param options.cwd Working directory used to resolve the nearest official workspace.
+ * Defaults to `process.cwd()`.
+ * @param options.source Optional data source locator. `rest-resource:<slug>`
+ * wires the screen to an existing list-capable REST resource.
+ * @returns A promise that resolves with the normalized `adminViewSlug`, optional
+ * `source`, and owning `projectDir` after scaffold files and inventory entries
+ * are written successfully.
+ * @throws {Error} When the command is run outside an official workspace, when
+ * the slug/source is invalid, or when a conflicting file or inventory entry exists.
+ */
+export async function runAddAdminViewCommand({
+	adminViewName,
+	cwd = process.cwd(),
+	source,
+}: RunAddAdminViewCommandOptions): Promise<{
+	adminViewSlug: string;
+	projectDir: string;
+	source?: string;
+}> {
+	const workspace = resolveWorkspaceProject(cwd);
+	const adminViewSlug = assertValidGeneratedSlug(
+		"Admin view name",
+		normalizeBlockSlug(adminViewName),
+		"wp-typia add admin-view <name> [--source rest-resource:<slug>]",
+	);
+	const parsedSource = parseAdminViewSource(source);
+	const inventory = readWorkspaceInventory(workspace.projectDir);
+	const restResource = resolveRestResourceSource(
+		inventory.restResources,
+		parsedSource,
+	);
+	assertAdminViewDoesNotExist(workspace.projectDir, adminViewSlug, inventory);
+
+	const blockConfigPath = path.join(workspace.projectDir, "scripts", "block-config.ts");
+	const bootstrapPath = getWorkspaceBootstrapPath(workspace);
+	const buildScriptPath = path.join(workspace.projectDir, "scripts", "build-workspace.mjs");
+	const packageJsonPath = path.join(workspace.projectDir, "package.json");
+	const webpackConfigPath = path.join(workspace.projectDir, "webpack.config.js");
+	const adminViewsIndexPath = resolveAdminViewRegistryPath(workspace.projectDir);
+	const adminViewDir = path.join(workspace.projectDir, "src", "admin-views", adminViewSlug);
+	const adminViewPhpPath = path.join(
+		workspace.projectDir,
+		"inc",
+		"admin-views",
+		`${adminViewSlug}.php`,
+	);
+	const mutationSnapshot: WorkspaceMutationSnapshot = {
+		fileSources: await snapshotWorkspaceFiles([
+			adminViewsIndexPath,
+			blockConfigPath,
+			bootstrapPath,
+			buildScriptPath,
+			packageJsonPath,
+			webpackConfigPath,
+		]),
+		snapshotDirs: [],
+		targetPaths: [adminViewDir, adminViewPhpPath],
+	};
+
+	try {
+		await fsp.mkdir(adminViewDir, { recursive: true });
+		await fsp.mkdir(path.dirname(adminViewPhpPath), { recursive: true });
+		await ensureAdminViewPackageDependencies(workspace);
+		await ensureAdminViewBootstrapAnchors(workspace);
+		await ensureAdminViewBuildScriptAnchors(workspace);
+		await ensureAdminViewWebpackAnchors(workspace);
+		await fsp.writeFile(
+			path.join(adminViewDir, "types.ts"),
+			buildAdminViewTypesSource(adminViewSlug, restResource),
+			"utf8",
+		);
+		await fsp.writeFile(
+			path.join(adminViewDir, "config.ts"),
+			buildAdminViewConfigSource(
+				adminViewSlug,
+				workspace.workspace.textDomain,
+				restResource,
+			),
+			"utf8",
+		);
+		await fsp.writeFile(
+			path.join(adminViewDir, "data.ts"),
+			restResource
+				? buildRestAdminViewDataSource(adminViewSlug, restResource)
+				: buildDefaultAdminViewDataSource(adminViewSlug),
+			"utf8",
+		);
+		await fsp.writeFile(
+			path.join(adminViewDir, "Screen.tsx"),
+			buildAdminViewScreenSource(adminViewSlug, workspace.workspace.textDomain),
+			"utf8",
+		);
+		await fsp.writeFile(
+			path.join(adminViewDir, "index.tsx"),
+			buildAdminViewEntrySource(adminViewSlug),
+			"utf8",
+		);
+		await fsp.writeFile(
+			path.join(adminViewDir, "style.scss"),
+			buildAdminViewStyleSource(),
+			"utf8",
+		);
+		await fsp.writeFile(
+			adminViewPhpPath,
+			buildAdminViewPhpSource(adminViewSlug, workspace),
+			"utf8",
+		);
+		await writeAdminViewRegistry(workspace.projectDir, adminViewSlug);
+		await appendWorkspaceInventoryEntries(workspace.projectDir, {
+			adminViewEntries: [buildAdminViewConfigEntry(adminViewSlug, parsedSource)],
+		});
+
+		return {
+			adminViewSlug,
+			projectDir: workspace.projectDir,
+			source: parsedSource ? `${parsedSource.kind}:${parsedSource.slug}` : undefined,
+		};
+	} catch (error) {
+		await rollbackWorkspaceMutation(mutationSnapshot);
+		throw error;
+	}
+}

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-admin-view.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-admin-view.ts
@@ -834,12 +834,12 @@ async function ensureAdminViewBuildScriptAnchors(workspace: WorkspaceProject): P
 		}
 
 		const currentSharedEntriesPattern =
-			/(\n\t\t['"]src\/editor-plugins\/index\.js['"],)(\n\t\])/u;
+			/(\r?\n\s*['"]src\/editor-plugins\/index\.js['"])\s*,?/u;
 		let nextSource = source.replace(
 			currentSharedEntriesPattern,
-			`$1
+			`$1,
 \t\t'src/admin-views/index.ts',
-\t\t'src/admin-views/index.js',$2`,
+\t\t'src/admin-views/index.js',`,
 		);
 		if (nextSource !== source) {
 			return nextSource;
@@ -858,13 +858,13 @@ async function ensureAdminViewBuildScriptAnchors(workspace: WorkspaceProject): P
 \t\t'src/admin-views/index.js',
 \t]`,
 		);
-		if (nextSource === source) {
-			throw new Error(
-				`Unable to update ${path.relative(workspace.projectDir, buildScriptPath)} for admin view shared entries.`,
-			);
+		if (nextSource !== source) {
+			return nextSource;
 		}
 
-		return nextSource;
+		throw new Error(
+			`Unable to update ${path.relative(workspace.projectDir, buildScriptPath)} for admin view shared entries.`,
+		);
 	});
 }
 

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-admin-view.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-admin-view.ts
@@ -103,6 +103,15 @@ function resolvePackageVersionRange(
 	}
 }
 
+function getAdminViewRelativeModuleSpecifier(adminViewSlug: string, workspaceFile: string): string {
+	const adminViewDir = `src/admin-views/${adminViewSlug}`;
+	const normalizedFile = workspaceFile.replace(/\\/gu, "/");
+	const modulePath = normalizedFile.replace(/\.[cm]?[jt]sx?$/u, "");
+	const relativeModulePath = path.posix.relative(adminViewDir, modulePath);
+
+	return relativeModulePath.startsWith(".") ? relativeModulePath : `./${relativeModulePath}`;
+}
+
 function parseAdminViewSource(source?: string): AdminViewSource | undefined {
 	const trimmed = source?.trim();
 	if (!trimmed) {
@@ -185,8 +194,12 @@ function buildAdminViewTypesSource(
 
 	if (restResource) {
 		const restPascalName = toPascalCase(restResource.slug);
+		const restTypesModule = getAdminViewRelativeModuleSpecifier(
+			adminViewSlug,
+			restResource.typesFile,
+		);
 
-		return `import type { ${restPascalName}Record } from '../../rest/${restResource.slug}/api-types';
+		return `import type { ${restPascalName}Record } from ${quoteTsString(restTypesModule)};
 
 export type ${itemTypeName} = ${restPascalName}Record;
 
@@ -230,13 +243,20 @@ function buildAdminViewConfigSource(
 	const itemTypeName = `${pascalName}AdminViewItem`;
 	const dataViewsName = `${camelName}AdminDataViews`;
 	const defaultViewFields = restResource
-		? "['title', 'content', 'updatedAt']"
+		? "['id']"
 		: "['title', 'status', 'updatedAt']";
-	const contextualFieldSource = restResource
-		? `\t\tcontent: {
-\t\t\tlabel: __( 'Content', ${quoteTsString(textDomain)} ),
-\t\t\tschema: { type: 'string' },
-\t\t},`
+	const searchEnabled = restResource ? "false" : "true";
+	const titleFieldSource = restResource ? "" : "\ttitleField: 'title',\n";
+	const defaultViewEnhancementsSource = restResource
+		? ""
+		: `\t\tsort: {
+\t\t\tdirection: 'desc',
+\t\t\tfield: 'updatedAt',
+\t\t},
+\t\ttitleField: 'title',
+`;
+	const additionalFieldsSource = restResource
+		? "\t\t// REST-backed screens start with the guaranteed ID column. Add project-owned fields here once they are declared on the REST record type."
 		: `\t\towner: {
 \t\t\tlabel: __( 'Owner', ${quoteTsString(textDomain)} ),
 \t\t\tschema: { type: 'string' },
@@ -252,37 +272,7 @@ function buildAdminViewConfigSource(
 \t\t\t\t},
 \t\t\t\ttype: 'string',
 \t\t\t},
-\t\t},`;
-
-	return `import { defineDataViews } from '@wp-typia/dataviews';
-import { __ } from '@wordpress/i18n';
-
-import type { ${itemTypeName} } from './types';
-
-export const ${dataViewsName} = defineDataViews<${itemTypeName}>({
-\tidField: 'id',
-\tsearch: true,
-\tsearchLabel: __( 'Search records', ${quoteTsString(textDomain)} ),
-\ttitleField: 'title',
-\tdefaultView: {
-\t\tfields: ${defaultViewFields},
-\t\tpage: 1,
-\t\tperPage: 10,
-\t\tsort: {
-\t\t\tdirection: 'desc',
-\t\t\tfield: 'updatedAt',
 \t\t},
-\t\ttitleField: 'title',
-\t\ttype: 'table',
-\t},
-\tfields: {
-\t\tid: {
-\t\t\tenableHiding: false,
-\t\t\tlabel: __( 'ID', ${quoteTsString(textDomain)} ),
-\t\t\treadOnly: true,
-\t\t\tschema: { type: 'integer' },
-\t\t},
-${contextualFieldSource}
 \t\ttitle: {
 \t\t\tenableGlobalSearch: true,
 \t\t\tenableSorting: true,
@@ -294,7 +284,33 @@ ${contextualFieldSource}
 \t\t\tlabel: __( 'Updated', ${quoteTsString(textDomain)} ),
 \t\t\tschema: { format: 'date-time', type: 'string' },
 \t\t\ttype: 'datetime',
+\t\t},`;
+
+	return `import { defineDataViews } from '@wp-typia/dataviews';
+import { __ } from '@wordpress/i18n';
+
+import type { ${itemTypeName} } from './types';
+
+export const ${dataViewsName} = defineDataViews<${itemTypeName}>({
+\tidField: 'id',
+\tsearch: ${searchEnabled},
+\tsearchLabel: __( 'Search records', ${quoteTsString(textDomain)} ),
+${titleFieldSource}
+\tdefaultView: {
+\t\tfields: ${defaultViewFields},
+\t\tpage: 1,
+\t\tperPage: 10,
+${defaultViewEnhancementsSource}
+\t\ttype: 'table',
+\t},
+\tfields: {
+\t\tid: {
+\t\t\tenableHiding: false,
+\t\t\tlabel: __( 'ID', ${quoteTsString(textDomain)} ),
+\t\t\treadOnly: true,
+\t\t\tschema: { type: 'integer' },
 \t\t},
+${additionalFieldsSource}
 \t},
 });
 `;
@@ -394,11 +410,19 @@ function buildRestAdminViewDataSource(
 	const dataSetTypeName = `${pascalName}AdminViewDataSet`;
 	const dataViewsName = `${camelName}AdminDataViews`;
 	const fetchName = `fetch${pascalName}AdminViewData`;
+	const restApiModule = getAdminViewRelativeModuleSpecifier(
+		adminViewSlug,
+		restResource.apiFile,
+	);
+	const restTypesModule = getAdminViewRelativeModuleSpecifier(
+		adminViewSlug,
+		restResource.typesFile,
+	);
 
 	return `import type { DataViewsView } from '@wp-typia/dataviews';
 
-import { listResource } from '../../rest/${restResource.slug}/api';
-import type { ${restPascalName}ListQuery } from '../../rest/${restResource.slug}/api-types';
+import { listResource } from ${quoteTsString(restApiModule)};
+import type { ${restPascalName}ListQuery } from ${quoteTsString(restTypesModule)};
 import { ${dataViewsName} } from './config';
 import type { ${dataSetTypeName}, ${itemTypeName} } from './types';
 
@@ -412,12 +436,17 @@ export async function ${fetchName}(
 ): Promise<${dataSetTypeName}> {
 \tconst query = ${dataViewsName}.toQueryArgs<${restPascalName}ListQuery>(view, {
 \t\tperPageParam: 'perPage',
+\t\tsearchParam: false,
 \t});
-\tconst response = await listResource({
+\tconst result = await listResource({
 \t\tpage: query.page,
 \t\tperPage: query.perPage,
-\t\tsearch: query.search,
 \t});
+\tif (!result.isValid || !result.data) {
+\t\tthrow new Error('Unable to load REST resource records.');
+\t}
+
+\tconst response = result.data;
 
 \treturn {
 \t\titems: response.items,
@@ -453,7 +482,7 @@ import { ${dataViewsName} } from './config';
 import { ${fetchName} } from './data';
 import type { ${dataSetTypeName}, ${itemTypeName} } from './types';
 
-const TypedDataViews = DataViews as <TItem extends object>(
+const TypedDataViews = DataViews as unknown as <TItem extends object>(
 \tprops: DataViewsConfig<TItem>,
 ) => ReturnType<typeof DataViews>;
 

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-admin-view.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-admin-view.ts
@@ -74,6 +74,11 @@ function readPackageManifestVersion(packageJsonPath: string): string | undefined
 	}
 }
 
+function detectJsonIndent(source: string): string | number {
+	const indentMatch = /\n([ \t]+)"/u.exec(source);
+	return indentMatch?.[1] ?? 2;
+}
+
 function resolvePackageVersionRange(
 	packageName: string,
 	fallback: string,
@@ -224,7 +229,10 @@ function buildAdminViewConfigSource(
 	const camelName = toCamelCase(adminViewSlug);
 	const itemTypeName = `${pascalName}AdminViewItem`;
 	const dataViewsName = `${camelName}AdminDataViews`;
-	const secondaryFieldSource = restResource
+	const defaultViewFields = restResource
+		? "['title', 'content', 'updatedAt']"
+		: "['title', 'status', 'updatedAt']";
+	const contextualFieldSource = restResource
 		? `\t\tcontent: {
 \t\t\tlabel: __( 'Content', ${quoteTsString(textDomain)} ),
 \t\t\tschema: { type: 'string' },
@@ -232,6 +240,18 @@ function buildAdminViewConfigSource(
 		: `\t\towner: {
 \t\t\tlabel: __( 'Owner', ${quoteTsString(textDomain)} ),
 \t\t\tschema: { type: 'string' },
+\t\t},
+\t\tstatus: {
+\t\t\tfilterBy: { operators: ['isAny', 'isNone'] },
+\t\t\tlabel: __( 'Status', ${quoteTsString(textDomain)} ),
+\t\t\tschema: {
+\t\t\t\tenum: ['draft', 'published'],
+\t\t\t\tenumLabels: {
+\t\t\t\t\tdraft: __( 'Draft', ${quoteTsString(textDomain)} ),
+\t\t\t\t\tpublished: __( 'Published', ${quoteTsString(textDomain)} ),
+\t\t\t\t},
+\t\t\t\ttype: 'string',
+\t\t\t},
 \t\t},`;
 
 	return `import { defineDataViews } from '@wp-typia/dataviews';
@@ -245,7 +265,7 @@ export const ${dataViewsName} = defineDataViews<${itemTypeName}>({
 \tsearchLabel: __( 'Search records', ${quoteTsString(textDomain)} ),
 \ttitleField: 'title',
 \tdefaultView: {
-\t\tfields: ['title', 'status', 'updatedAt'],
+\t\tfields: ${defaultViewFields},
 \t\tpage: 1,
 \t\tperPage: 10,
 \t\tsort: {
@@ -262,19 +282,7 @@ export const ${dataViewsName} = defineDataViews<${itemTypeName}>({
 \t\t\treadOnly: true,
 \t\t\tschema: { type: 'integer' },
 \t\t},
-${secondaryFieldSource}
-\t\tstatus: {
-\t\t\tfilterBy: { operators: ['isAny', 'isNone'] },
-\t\t\tlabel: __( 'Status', ${quoteTsString(textDomain)} ),
-\t\t\tschema: {
-\t\t\t\tenum: ['draft', 'published'],
-\t\t\t\tenumLabels: {
-\t\t\t\t\tdraft: __( 'Draft', ${quoteTsString(textDomain)} ),
-\t\t\t\t\tpublished: __( 'Published', ${quoteTsString(textDomain)} ),
-\t\t\t\t},
-\t\t\t\ttype: 'string',
-\t\t\t},
-\t\t},
+${contextualFieldSource}
 \t\ttitle: {
 \t\t\tenableGlobalSearch: true,
 \t\t\tenableSorting: true,
@@ -354,8 +362,10 @@ export async function ${fetchName}(
 \tconst query = ${dataViewsName}.toQueryArgs<${queryTypeName}>(view, {
 \t\tperPageParam: 'perPage',
 \t});
-\tconst page = query.page ?? 1;
-\tconst perPage = query.perPage ?? view.perPage ?? 10;
+\tconst requestedPage = query.page ?? 1;
+\tconst page = requestedPage > 0 ? requestedPage : 1;
+\tconst requestedPerPage = query.perPage ?? view.perPage ?? 10;
+\tconst perPage = requestedPerPage > 0 ? requestedPerPage : 10;
 \tconst filteredItems = STARTER_ITEMS.filter((item) =>
 \t\tmatchesSearch(item, query.search),
 \t);
@@ -753,7 +763,7 @@ async function ensureAdminViewPackageDependencies(workspace: WorkspaceProject): 
 
 		packageJson.dependencies = nextDependencies;
 		packageJson.devDependencies = nextDevDependencies;
-		return `${JSON.stringify(packageJson, null, 2)}\n`;
+		return `${JSON.stringify(packageJson, null, detectJsonIndent(source))}\n`;
 	});
 }
 

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace.ts
@@ -177,6 +177,13 @@ async function writeVariationRegistry(
 }
 
 /**
+ * Re-export the DataViews admin screen scaffold workflow from the focused
+ * admin-view runtime helper module.
+ */
+export {
+	runAddAdminViewCommand,
+} from "./cli-add-workspace-admin-view.js";
+/**
  * Re-export focused workspace asset scaffold commands from the companion
  * `cli-add-workspace-assets` module.
  */

--- a/packages/wp-typia-project-tools/src/runtime/cli-add.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add.ts
@@ -23,6 +23,7 @@ export {
 	seedWorkspaceMigrationProject,
 } from "./cli-add-block.js";
 export {
+	runAddAdminViewCommand,
 	runAddBindingSourceCommand,
 	runAddAbilityCommand,
 	runAddAiFeatureCommand,

--- a/packages/wp-typia-project-tools/src/runtime/cli-core.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-core.ts
@@ -48,6 +48,7 @@ export {
 	EDITOR_PLUGIN_SLOT_IDS,
 	formatAddHelpText,
 	getWorkspaceBlockSelectOptions,
+	runAddAdminViewCommand,
 	runAddAbilityCommand,
 	runAddBindingSourceCommand,
 	runAddAiFeatureCommand,

--- a/packages/wp-typia-project-tools/src/runtime/cli-core.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-core.ts
@@ -8,6 +8,7 @@
  * Import `formatAddHelpText`, `runAddBlockCommand`,
  * `runAddVariationCommand`, `runAddPatternCommand`,
  * `runAddBindingSourceCommand`, `runAddHookedBlockCommand`,
+ * `runAddAdminViewCommand` for DataViews-backed admin screen scaffolds,
  * `runAddAbilityCommand` for typed workflow ability scaffolds,
  * and `HOOKED_BLOCK_POSITION_IDS`,
  * `getWorkspaceBlockSelectOptions`, and `seedWorkspaceMigrationProject` for

--- a/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace.ts
@@ -805,7 +805,7 @@ function checkWorkspaceAdminViewConfig(
 	adminView: WorkspaceInventory["adminViews"][number],
 	inventory: WorkspaceInventory,
 ): DoctorCheck {
-	if (!adminView.source) {
+	if (adminView.source === undefined) {
 		return createDoctorCheck(
 			`Admin view config ${adminView.slug}`,
 			"pass",
@@ -813,7 +813,8 @@ function checkWorkspaceAdminViewConfig(
 		);
 	}
 
-	const sourceMatch = /^rest-resource:([a-z][a-z0-9-]*)$/u.exec(adminView.source);
+	const source = adminView.source.trim();
+	const sourceMatch = /^rest-resource:([a-z][a-z0-9-]*)$/u.exec(source);
 	const restResourceSlug = sourceMatch?.[1];
 	const restResource = restResourceSlug
 		? inventory.restResources.find((entry) => entry.slug === restResourceSlug)
@@ -824,7 +825,7 @@ function checkWorkspaceAdminViewConfig(
 		`Admin view config ${adminView.slug}`,
 		isValid ? "pass" : "fail",
 		isValid
-			? `Admin view source ${adminView.source} is list-capable`
+			? `Admin view source ${source} is list-capable`
 			: "Admin view source must use rest-resource:<slug> and reference a list-capable REST resource",
 	);
 }

--- a/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace.ts
@@ -35,6 +35,10 @@ const WORKSPACE_ABILITY_GLOB = "/inc/abilities/*.php";
 const WORKSPACE_ABILITY_EDITOR_SCRIPT = "build/abilities/index.js";
 const WORKSPACE_ABILITY_EDITOR_ASSET = "build/abilities/index.asset.php";
 const WORKSPACE_AI_FEATURE_GLOB = "/inc/ai-features/*.php";
+const WORKSPACE_ADMIN_VIEW_GLOB = "/inc/admin-views/*.php";
+const WORKSPACE_ADMIN_VIEW_SCRIPT = "build/admin-views/index.js";
+const WORKSPACE_ADMIN_VIEW_ASSET = "build/admin-views/index.asset.php";
+const WORKSPACE_ADMIN_VIEW_STYLE = "build/admin-views/style-index.css";
 const WORKSPACE_EDITOR_PLUGIN_EDITOR_SCRIPT = "build/editor-plugins/index.js";
 const WORKSPACE_EDITOR_PLUGIN_EDITOR_ASSET = "build/editor-plugins/index.asset.php";
 const WORKSPACE_EDITOR_PLUGIN_EDITOR_STYLE = "build/editor-plugins/style-index.css";
@@ -779,6 +783,162 @@ function checkWorkspaceEditorPluginIndex(
 	);
 }
 
+function getWorkspaceAdminViewRequiredFiles(
+	adminView: WorkspaceInventory["adminViews"][number],
+): string[] {
+	const adminViewDir = path.join("src", "admin-views", adminView.slug);
+
+	return Array.from(
+		new Set([
+			adminView.file,
+			adminView.phpFile,
+			path.join(adminViewDir, "Screen.tsx"),
+			path.join(adminViewDir, "config.ts"),
+			path.join(adminViewDir, "data.ts"),
+			path.join(adminViewDir, "style.scss"),
+			path.join(adminViewDir, "types.ts"),
+		]),
+	);
+}
+
+function checkWorkspaceAdminViewConfig(
+	adminView: WorkspaceInventory["adminViews"][number],
+	inventory: WorkspaceInventory,
+): DoctorCheck {
+	if (!adminView.source) {
+		return createDoctorCheck(
+			`Admin view config ${adminView.slug}`,
+			"pass",
+			"Admin view uses a replaceable local fetcher",
+		);
+	}
+
+	const sourceMatch = /^rest-resource:([a-z][a-z0-9-]*)$/u.exec(adminView.source);
+	const restResourceSlug = sourceMatch?.[1];
+	const restResource = restResourceSlug
+		? inventory.restResources.find((entry) => entry.slug === restResourceSlug)
+		: undefined;
+	const isValid = Boolean(restResource?.methods.includes("list"));
+
+	return createDoctorCheck(
+		`Admin view config ${adminView.slug}`,
+		isValid ? "pass" : "fail",
+		isValid
+			? `Admin view source ${adminView.source} is list-capable`
+			: "Admin view source must use rest-resource:<slug> and reference a list-capable REST resource",
+	);
+}
+
+function checkWorkspaceAdminViewBootstrap(
+	projectDir: string,
+	packageName: string,
+	phpPrefix: string,
+): DoctorCheck {
+	const packageBaseName = packageName.split("/").pop() ?? packageName;
+	const bootstrapPath = path.join(projectDir, `${packageBaseName}.php`);
+	if (!fs.existsSync(bootstrapPath)) {
+		return createDoctorCheck(
+			"Admin view bootstrap",
+			"fail",
+			`Missing ${path.basename(bootstrapPath)}`,
+		);
+	}
+
+	const source = fs.readFileSync(bootstrapPath, "utf8");
+	const loadFunctionName = `${phpPrefix}_load_admin_views`;
+	const loadHook = `add_action( 'plugins_loaded', '${loadFunctionName}' );`;
+	const hasLoaderHook = source.includes(loadHook);
+	const hasServerGlob = source.includes(WORKSPACE_ADMIN_VIEW_GLOB);
+
+	return createDoctorCheck(
+		"Admin view bootstrap",
+		hasLoaderHook && hasServerGlob ? "pass" : "fail",
+		hasLoaderHook && hasServerGlob
+			? "Admin view PHP loader hook is present"
+			: "Missing admin view PHP require glob or plugins_loaded hook",
+	);
+}
+
+function checkWorkspaceAdminViewIndex(
+	projectDir: string,
+	adminViews: WorkspaceInventory["adminViews"],
+): DoctorCheck {
+	const indexRelativePath = [
+		path.join("src", "admin-views", "index.ts"),
+		path.join("src", "admin-views", "index.js"),
+	].find((relativePath) => fs.existsSync(path.join(projectDir, relativePath)));
+
+	if (!indexRelativePath) {
+		return createDoctorCheck(
+			"Admin views index",
+			"fail",
+			"Missing src/admin-views/index.ts or src/admin-views/index.js",
+		);
+	}
+
+	const indexPath = path.join(projectDir, indexRelativePath);
+	const source = fs.readFileSync(indexPath, "utf8");
+	const missingImports = adminViews.filter((adminView) => {
+		const importPattern = new RegExp(
+			`['"\`]\\./${escapeRegex(adminView.slug)}(?:/[^'"\`]*)?['"\`]`,
+			"u",
+		);
+		return !importPattern.test(source);
+	});
+
+	return createDoctorCheck(
+		"Admin views index",
+		missingImports.length === 0 ? "pass" : "fail",
+		missingImports.length === 0
+			? "Admin view registrations are aggregated"
+			: `Missing admin view imports for: ${missingImports
+					.map((entry) => entry.slug)
+					.join(", ")}`,
+	);
+}
+
+function checkWorkspaceAdminViewPhp(
+	projectDir: string,
+	adminView: WorkspaceInventory["adminViews"][number],
+): DoctorCheck {
+	const phpPath = path.join(projectDir, adminView.phpFile);
+	if (!fs.existsSync(phpPath)) {
+		return createDoctorCheck(
+			`Admin view PHP ${adminView.slug}`,
+			"fail",
+			`Missing ${adminView.phpFile}`,
+		);
+	}
+
+	const source = fs.readFileSync(phpPath, "utf8");
+	const hasAdminMenu = source.includes("add_submenu_page");
+	const hasAdminEnqueue = source.includes("admin_enqueue_scripts");
+	const hasScript = source.includes(WORKSPACE_ADMIN_VIEW_SCRIPT);
+	const hasAsset = source.includes(WORKSPACE_ADMIN_VIEW_ASSET);
+	const hasStyle = source.includes(WORKSPACE_ADMIN_VIEW_STYLE);
+	const hasComponentsStyleDependency = source.includes("'wp-components'");
+
+	return createDoctorCheck(
+		`Admin view PHP ${adminView.slug}`,
+		hasAdminMenu &&
+			hasAdminEnqueue &&
+			hasScript &&
+			hasAsset &&
+			hasStyle &&
+			hasComponentsStyleDependency
+			? "pass"
+			: "fail",
+		hasAdminMenu &&
+			hasAdminEnqueue &&
+			hasScript &&
+			hasAsset &&
+			hasStyle &&
+			hasComponentsStyleDependency
+			? "Admin menu, script, style, and wp-components style dependency are wired"
+			: "Missing admin menu, enqueue hook, build/admin-views asset reference, or wp-components style dependency",
+	);
+}
+
 function checkVariationEntrypoint(projectDir: string, blockSlug: string): DoctorCheck {
 	const entryPath = path.join(projectDir, "src", "blocks", blockSlug, "index.tsx");
 	if (!fs.existsSync(entryPath)) {
@@ -918,7 +1078,7 @@ export function getWorkspaceDoctorChecks(cwd: string): DoctorCheck[] {
 			createDoctorCheck(
 				"Workspace inventory",
 				"pass",
-				`${inventory.blocks.length} block(s), ${inventory.variations.length} variation(s), ${inventory.patterns.length} pattern(s), ${inventory.bindingSources.length} binding source(s), ${inventory.restResources.length} REST resource(s), ${inventory.abilities.length} ability scaffold(s), ${inventory.aiFeatures.length} AI feature(s), ${inventory.editorPlugins.length} editor plugin(s)`,
+				`${inventory.blocks.length} block(s), ${inventory.variations.length} variation(s), ${inventory.patterns.length} pattern(s), ${inventory.bindingSources.length} binding source(s), ${inventory.restResources.length} REST resource(s), ${inventory.abilities.length} ability scaffold(s), ${inventory.aiFeatures.length} AI feature(s), ${inventory.editorPlugins.length} editor plugin(s), ${inventory.adminViews.length} admin view(s)`,
 			),
 		);
 
@@ -1073,6 +1233,30 @@ export function getWorkspaceDoctorChecks(cwd: string): DoctorCheck[] {
 				),
 			);
 			checks.push(checkWorkspaceEditorPluginConfig(editorPlugin));
+		}
+
+		if (inventory.adminViews.length > 0) {
+			checks.push(
+				checkWorkspaceAdminViewBootstrap(
+					workspace.projectDir,
+					workspace.packageName,
+					workspace.workspace.phpPrefix,
+				),
+			);
+			checks.push(
+				checkWorkspaceAdminViewIndex(workspace.projectDir, inventory.adminViews),
+			);
+		}
+		for (const adminView of inventory.adminViews) {
+			checks.push(checkWorkspaceAdminViewConfig(adminView, inventory));
+			checks.push(
+				checkExistingFiles(
+					workspace.projectDir,
+					`Admin view ${adminView.slug}`,
+					getWorkspaceAdminViewRequiredFiles(adminView),
+				),
+			);
+			checks.push(checkWorkspaceAdminViewPhp(workspace.projectDir, adminView));
 		}
 
 		const migrationWorkspaceCheck = checkMigrationWorkspaceHint(

--- a/packages/wp-typia-project-tools/src/runtime/cli-help.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-help.ts
@@ -19,6 +19,7 @@ export function formatHelpText(): string {
   wp-typia create <project-dir> [--template compound] [--external-layer-source <./path|github:owner/repo/path[#ref]|npm-package>] [--external-layer-id <layer-id>] [--inner-blocks-preset <freeform|ordered|horizontal|locked-structure>] [--alternate-render-targets <email,mjml,plain-text>] [--data-storage <post-meta|custom-table>] [--persistence-policy <authenticated|public>] [--namespace <value>] [--text-domain <value>] [--php-prefix <value>] [--with-migration-ui] [--with-wp-env] [--with-test-preset] [--yes] [--dry-run] [--no-install] [--package-manager <id>]
   wp-typia <project-dir> [create flags...]
   wp-typia init [project-dir]
+  wp-typia add admin-view <name> [--source <rest-resource:slug>]
   wp-typia add block <name> --template <basic|interactivity|persistence|compound> [--external-layer-source <./path|github:owner/repo/path[#ref]|npm-package>] [--external-layer-id <layer-id>] [--inner-blocks-preset <freeform|ordered|horizontal|locked-structure>] [--alternate-render-targets <email,mjml,plain-text>] [--data-storage <post-meta|custom-table>] [--persistence-policy <authenticated|public>]
   wp-typia add variation <name> --block <block-slug>
   wp-typia add pattern <name>
@@ -46,6 +47,7 @@ Notes:
   \`wp-typia <project-dir>\` remains a backward-compatible alias to \`create\` when \`<project-dir>\` is the only positional argument.
   \`wp-typia init\` is a preview-only retrofit planner for existing projects. It does not write files yet.
   Use \`--template workspace\` as shorthand for \`@wp-typia/create-workspace-template\`, the official empty workspace scaffold behind \`wp-typia add ...\`.
+  \`add admin-view\` scaffolds an opt-in DataViews-powered WordPress admin screen under \`src/admin-views/\`; pass \`--source rest-resource:<slug>\` to reuse a list-capable REST resource.
   \`query-loop\` is create-only. Use \`wp-typia create <project-dir> --template query-loop\`; \`wp-typia add block\` accepts only basic, interactivity, persistence, and compound families.
   \`add variation\` uses an existing workspace block from \`scripts/block-config.ts\`.
   \`add pattern\` scaffolds a namespaced PHP pattern shell under \`src/patterns/\`.

--- a/packages/wp-typia-project-tools/src/runtime/index.ts
+++ b/packages/wp-typia-project-tools/src/runtime/index.ts
@@ -181,6 +181,7 @@ export {
 	HOOKED_BLOCK_POSITION_IDS,
 	EDITOR_PLUGIN_SLOT_IDS,
 	isCliDiagnosticError,
+	runAddAdminViewCommand,
 	runAddAbilityCommand,
 	runAddAiFeatureCommand,
 	runAddBindingSourceCommand,

--- a/packages/wp-typia-project-tools/src/runtime/index.ts
+++ b/packages/wp-typia-project-tools/src/runtime/index.ts
@@ -7,6 +7,7 @@
  * and workspace-aware helpers such as `getWorkspaceBlockSelectOptions`,
  * `runAddBlockCommand`, `runAddVariationCommand`, `runAddPatternCommand`,
  * `runAddBindingSourceCommand`, `runAddEditorPluginCommand`,
+ * `runAddAdminViewCommand`,
  * `runAddHookedBlockCommand`,
  * `HOOKED_BLOCK_POSITION_IDS`, and `runDoctor`.
  */

--- a/packages/wp-typia-project-tools/src/runtime/workspace-inventory.ts
+++ b/packages/wp-typia-project-tools/src/runtime/workspace-inventory.ts
@@ -93,6 +93,21 @@ export interface WorkspaceAiFeatureInventoryEntry {
 }
 
 /**
+ * DataViews admin-screen entry parsed from `scripts/block-config.ts`.
+ *
+ * @property file Relative path to the generated admin view shared entry file.
+ * @property phpFile Relative path to the generated WordPress admin page glue.
+ * @property slug Normalized admin view slug.
+ * @property source Optional source locator such as `rest-resource:products`.
+ */
+export interface WorkspaceAdminViewInventoryEntry {
+	file: string;
+	phpFile: string;
+	slug: string;
+	source?: string;
+}
+
+/**
  * Editor-plugin entry parsed from `scripts/block-config.ts`.
  *
  * @property file Relative path to the generated editor plugin entry file.
@@ -106,12 +121,14 @@ export interface WorkspaceEditorPluginInventoryEntry {
 }
 
 export interface WorkspaceInventory {
+	adminViews: WorkspaceAdminViewInventoryEntry[];
 	bindingSources: WorkspaceBindingSourceInventoryEntry[];
 	blockConfigPath: string;
 	blocks: WorkspaceBlockInventoryEntry[];
 	abilities: WorkspaceAbilityInventoryEntry[];
 	aiFeatures: WorkspaceAiFeatureInventoryEntry[];
 	hasAbilitiesSection: boolean;
+	hasAdminViewsSection: boolean;
 	hasBindingSourcesSection: boolean;
 	hasAiFeaturesSection: boolean;
 	hasEditorPluginsSection: boolean;
@@ -132,6 +149,7 @@ export const BINDING_SOURCE_CONFIG_ENTRY_MARKER = "\t// wp-typia add binding-sou
 export const REST_RESOURCE_CONFIG_ENTRY_MARKER = "\t// wp-typia add rest-resource entries";
 export const ABILITY_CONFIG_ENTRY_MARKER = "\t// wp-typia add ability entries";
 export const AI_FEATURE_CONFIG_ENTRY_MARKER = "\t// wp-typia add ai-feature entries";
+export const ADMIN_VIEW_CONFIG_ENTRY_MARKER = "\t// wp-typia add admin-view entries";
 /**
  * Marker used to append generated editor-plugin entries into `EDITOR_PLUGINS`.
  */
@@ -268,6 +286,23 @@ const AI_FEATURES_CONST_SECTION = `
 
 export const AI_FEATURES: WorkspaceAiFeatureConfig[] = [
 \t// wp-typia add ai-feature entries
+];
+`;
+
+const ADMIN_VIEWS_INTERFACE_SECTION = `
+
+export interface WorkspaceAdminViewConfig {
+\tfile: string;
+\tphpFile: string;
+\tslug: string;
+\tsource?: string;
+}
+`;
+
+const ADMIN_VIEWS_CONST_SECTION = `
+
+export const ADMIN_VIEWS: WorkspaceAdminViewConfig[] = [
+\t// wp-typia add admin-view entries
 ];
 `;
 
@@ -662,6 +697,25 @@ function parseEditorPluginEntries(
 	});
 }
 
+function parseAdminViewEntries(
+	arrayLiteral: ts.ArrayLiteralExpression,
+): WorkspaceAdminViewInventoryEntry[] {
+	return arrayLiteral.elements.map((element, elementIndex) => {
+		if (!ts.isObjectLiteralExpression(element)) {
+			throw new Error(
+				`ADMIN_VIEWS[${elementIndex}] must be an object literal in scripts/block-config.ts.`,
+			);
+		}
+
+		return {
+			file: getRequiredStringProperty("ADMIN_VIEWS", elementIndex, element, "file"),
+			phpFile: getRequiredStringProperty("ADMIN_VIEWS", elementIndex, element, "phpFile"),
+			slug: getRequiredStringProperty("ADMIN_VIEWS", elementIndex, element, "slug"),
+			source: getOptionalStringProperty("ADMIN_VIEWS", elementIndex, element, "source"),
+		};
+	});
+}
+
 /**
  * Parse workspace inventory entries from the source of `scripts/block-config.ts`.
  *
@@ -687,6 +741,7 @@ export function parseWorkspaceInventorySource(source: string): Omit<WorkspaceInv
 	const restResourceArray = findExportedArrayLiteral(sourceFile, "REST_RESOURCES");
 	const abilityArray = findExportedArrayLiteral(sourceFile, "ABILITIES");
 	const aiFeatureArray = findExportedArrayLiteral(sourceFile, "AI_FEATURES");
+	const adminViewArray = findExportedArrayLiteral(sourceFile, "ADMIN_VIEWS");
 	const editorPluginArray = findExportedArrayLiteral(sourceFile, "EDITOR_PLUGINS");
 	if (variationArray.found && !variationArray.array) {
 		throw new Error("scripts/block-config.ts must export VARIATIONS as an array literal.");
@@ -706,18 +761,23 @@ export function parseWorkspaceInventorySource(source: string): Omit<WorkspaceInv
 	if (aiFeatureArray.found && !aiFeatureArray.array) {
 		throw new Error("scripts/block-config.ts must export AI_FEATURES as an array literal.");
 	}
+	if (adminViewArray.found && !adminViewArray.array) {
+		throw new Error("scripts/block-config.ts must export ADMIN_VIEWS as an array literal.");
+	}
 	if (editorPluginArray.found && !editorPluginArray.array) {
 		throw new Error("scripts/block-config.ts must export EDITOR_PLUGINS as an array literal.");
 	}
 
 	return {
 		abilities: abilityArray.array ? parseAbilityEntries(abilityArray.array) : [],
+		adminViews: adminViewArray.array ? parseAdminViewEntries(adminViewArray.array) : [],
 		aiFeatures: aiFeatureArray.array ? parseAiFeatureEntries(aiFeatureArray.array) : [],
 		bindingSources: bindingSourceArray.array
 			? parseBindingSourceEntries(bindingSourceArray.array)
 			: [],
 		blocks: parseBlockEntries(blockArray.array),
 		hasAbilitiesSection: abilityArray.found,
+		hasAdminViewsSection: adminViewArray.found,
 		hasAiFeaturesSection: aiFeatureArray.found,
 		hasBindingSourcesSection: bindingSourceArray.found,
 		hasEditorPluginsSection: editorPluginArray.found,
@@ -830,6 +890,12 @@ function ensureWorkspaceInventorySections(source: string): string {
 	if (!/export\s+const\s+AI_FEATURES\b/u.test(nextSource)) {
 		nextSource += AI_FEATURES_CONST_SECTION;
 	}
+	if (!/export\s+interface\s+WorkspaceAdminViewConfig\b/u.test(nextSource)) {
+		nextSource += ADMIN_VIEWS_INTERFACE_SECTION;
+	}
+	if (!/export\s+const\s+ADMIN_VIEWS\b/u.test(nextSource)) {
+		nextSource += ADMIN_VIEWS_CONST_SECTION;
+	}
 	if (!/export\s+interface\s+WorkspaceEditorPluginConfig\b/u.test(nextSource)) {
 		nextSource += EDITOR_PLUGINS_INTERFACE_SECTION;
 	}
@@ -917,6 +983,7 @@ export function updateWorkspaceInventorySource(
 		blockEntries = [],
 		bindingSourceEntries = [],
 		abilityEntries = [],
+		adminViewEntries = [],
 		aiFeatureEntries = [],
 		editorPluginEntries = [],
 		patternEntries = [],
@@ -925,6 +992,7 @@ export function updateWorkspaceInventorySource(
 		transformSource,
 	}: {
 		abilityEntries?: string[];
+		adminViewEntries?: string[];
 		aiFeatureEntries?: string[];
 		blockEntries?: string[];
 		bindingSourceEntries?: string[];
@@ -961,6 +1029,11 @@ export function updateWorkspaceInventorySource(
 		nextSource,
 		AI_FEATURE_CONFIG_ENTRY_MARKER,
 		aiFeatureEntries,
+	);
+	nextSource = appendEntriesAtMarker(
+		nextSource,
+		ADMIN_VIEW_CONFIG_ENTRY_MARKER,
+		adminViewEntries,
 	);
 	nextSource = ensureInterfaceField(
 		nextSource,

--- a/packages/wp-typia-project-tools/tests/cli-add-workspace-boundaries.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-add-workspace-boundaries.test.ts
@@ -61,6 +61,9 @@ test("cli-add-workspace delegates asset, rest-resource, ai-feature, and admin-vi
 	expect(addWorkspaceSource).not.toContain("function buildRestResourceTypesSource(");
 	expect(addWorkspaceSource).not.toContain("async function ensureRestResourceBootstrapAnchors(");
 	expect(addWorkspaceSource).not.toContain("async function ensureAdminViewBootstrapAnchors(");
+	expect(addWorkspaceSource).not.toMatch(
+		/export\s*\{[^}]*ensureAdminViewBootstrapAnchors[^}]*\}/u,
+	);
 	expect(addWorkspaceSource).not.toContain("export async function runAddAdminViewCommand(");
 	expect(addWorkspaceSource).not.toContain("export async function runAddAiFeatureCommand(");
 	expect(addWorkspaceSource).not.toContain("export async function runAddPatternCommand(");

--- a/packages/wp-typia-project-tools/tests/cli-add-workspace-boundaries.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-add-workspace-boundaries.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 
 const runtimeRoot = path.join(import.meta.dir, "..", "src", "runtime");
 
-test("cli-add-workspace delegates asset, rest-resource, and ai-feature workflows to focused helpers", () => {
+test("cli-add-workspace delegates asset, rest-resource, ai-feature, and admin-view workflows to focused helpers", () => {
 	const addWorkspaceSource = fs.readFileSync(
 		path.join(runtimeRoot, "cli-add-workspace.ts"),
 		"utf8",
@@ -37,11 +37,17 @@ test("cli-add-workspace delegates asset, rest-resource, and ai-feature workflows
 		path.join(runtimeRoot, "cli-add-workspace-ai-source-emitters.ts"),
 		"utf8",
 	);
+	const adminViewSource = fs.readFileSync(
+		path.join(runtimeRoot, "cli-add-workspace-admin-view.ts"),
+		"utf8",
+	);
 
+	expect(addWorkspaceSource).toContain('from "./cli-add-workspace-admin-view.js"');
 	expect(addWorkspaceSource).toContain('from "./cli-add-workspace-assets.js"');
 	expect(addWorkspaceSource).toContain('from "./cli-add-workspace-rest.js"');
 	expect(addWorkspaceSource).toContain('from "./cli-add-workspace-ai.js"');
 	expect(addWorkspaceSource).toContain("runAddAiFeatureCommand");
+	expect(addWorkspaceSource).toContain("runAddAdminViewCommand");
 	expect(addWorkspaceSource).toContain("runAddBindingSourceCommand");
 	expect(addWorkspaceSource).toContain("runAddEditorPluginCommand");
 	expect(addWorkspaceSource).toContain("runAddPatternCommand");
@@ -54,6 +60,8 @@ test("cli-add-workspace delegates asset, rest-resource, and ai-feature workflows
 	expect(addWorkspaceSource).not.toContain("async function ensureEditorPluginBootstrapAnchors(");
 	expect(addWorkspaceSource).not.toContain("function buildRestResourceTypesSource(");
 	expect(addWorkspaceSource).not.toContain("async function ensureRestResourceBootstrapAnchors(");
+	expect(addWorkspaceSource).not.toContain("async function ensureAdminViewBootstrapAnchors(");
+	expect(addWorkspaceSource).not.toContain("export async function runAddAdminViewCommand(");
 	expect(addWorkspaceSource).not.toContain("export async function runAddAiFeatureCommand(");
 	expect(addWorkspaceSource).not.toContain("export async function runAddPatternCommand(");
 	expect(addWorkspaceSource).not.toContain("export async function runAddBindingSourceCommand(");
@@ -87,4 +95,7 @@ test("cli-add-workspace delegates asset, rest-resource, and ai-feature workflows
 	expect(aiSourceEmittersSource).toContain("function buildAiFeatureDataSource(");
 	expect(aiAnchorsSource).toContain("async function ensureAiFeatureBootstrapAnchors(");
 	expect(aiAnchorsSource).toContain("async function ensureAiFeatureSyncRestAnchors(");
+	expect(adminViewSource).toContain("function buildAdminViewScreenSource(");
+	expect(adminViewSource).toContain("async function ensureAdminViewBootstrapAnchors(");
+	expect(adminViewSource).toContain("export async function runAddAdminViewCommand(");
 });

--- a/packages/wp-typia-project-tools/tests/cli-entry.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-entry.test.ts
@@ -777,6 +777,8 @@ test("formatHelpText keeps migration UI flags out of external template usage", (
   expect(helpText).toContain("WP_TYPIA_ASCII=1 forces ASCII status markers");
   expect(helpText).toContain("non-empty NO_COLOR requests ASCII-safe markers");
   expect(helpText).toContain("`query-loop` is create-only.");
+  expect(helpText).toContain("wp-typia add admin-view <name>");
+  expect(helpText).toContain("src/admin-views/");
   expect(helpText).toContain("wp-typia add ai-feature <name>");
   expect(helpText).toContain(
     "wp-typia add ai-feature <name> [--namespace <vendor/v1>]"

--- a/packages/wp-typia-project-tools/tests/helpers/scaffold-test-workspace.ts
+++ b/packages/wp-typia-project-tools/tests/helpers/scaffold-test-workspace.ts
@@ -30,6 +30,7 @@ const workspacePackagePaths = {
 		"..",
 		"wp-typia-block-types",
 	),
+	"@wp-typia/dataviews": path.resolve(packageRoot, "..", "wp-typia-dataviews"),
 	"@wp-typia/project-tools": packageRoot,
 	"@wp-typia/rest": path.resolve(packageRoot, "..", "wp-typia-rest"),
 } as const;

--- a/packages/wp-typia-project-tools/tests/workspace-add.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-add.test.ts
@@ -511,6 +511,7 @@ test("canonical CLI can add a variation to an official workspace template", asyn
     )?.status
   ).toBe("pass");
 
+  linkWorkspaceNodeModules(targetDir);
   runCli("npm", ["run", "build"], { cwd: targetDir });
 }, 60_000);
 
@@ -2597,6 +2598,171 @@ test("canonical CLI can add a plugin-level REST resource to an official workspac
   typecheckGeneratedProject(targetDir);
 }, 30_000);
 
+test("canonical CLI can add a DataViews admin screen with a REST resource source", async () => {
+  const targetDir = path.join(tempRoot, "demo-workspace-add-admin-view");
+
+  await scaffoldProject({
+    projectDir: targetDir,
+    templateId: workspaceTemplatePackageManifest.name,
+    packageManager: "npm",
+    noInstall: true,
+    answers: {
+      author: "Test Runner",
+      description: "Demo workspace add admin view",
+      namespace: "demo-space",
+      phpPrefix: "demo_space",
+      slug: "demo-workspace-add-admin-view",
+      textDomain: "demo-space",
+      title: "Demo Workspace Add Admin View",
+    },
+  });
+
+  linkWorkspaceNodeModules(targetDir);
+
+  runCli(
+    "node",
+    [
+      entryPath,
+      "add",
+      "rest-resource",
+      "snapshots",
+      "--namespace",
+      "demo-space/v1",
+      "--methods",
+      "list,read",
+    ],
+    {
+      cwd: targetDir,
+    }
+  );
+  runCli(
+    "node",
+    [
+      entryPath,
+      "add",
+      "admin-view",
+      "snapshots",
+      "--source",
+      "rest-resource:snapshots",
+    ],
+    {
+      cwd: targetDir,
+    }
+  );
+
+  const packageJson = JSON.parse(
+    fs.readFileSync(path.join(targetDir, "package.json"), "utf8")
+  ) as {
+    dependencies?: Record<string, string>;
+    devDependencies?: Record<string, string>;
+  };
+  const blockConfigSource = fs.readFileSync(
+    path.join(targetDir, "scripts", "block-config.ts"),
+    "utf8"
+  );
+  const bootstrapSource = fs.readFileSync(
+    path.join(targetDir, "demo-workspace-add-admin-view.php"),
+    "utf8"
+  );
+  const adminViewsIndexSource = fs.readFileSync(
+    path.join(targetDir, "src", "admin-views", "index.ts"),
+    "utf8"
+  );
+  const entrySource = fs.readFileSync(
+    path.join(targetDir, "src", "admin-views", "snapshots", "index.tsx"),
+    "utf8"
+  );
+  const screenSource = fs.readFileSync(
+    path.join(targetDir, "src", "admin-views", "snapshots", "Screen.tsx"),
+    "utf8"
+  );
+  const dataSource = fs.readFileSync(
+    path.join(targetDir, "src", "admin-views", "snapshots", "data.ts"),
+    "utf8"
+  );
+  const configSource = fs.readFileSync(
+    path.join(targetDir, "src", "admin-views", "snapshots", "config.ts"),
+    "utf8"
+  );
+  const phpSource = fs.readFileSync(
+    path.join(targetDir, "inc", "admin-views", "snapshots.php"),
+    "utf8"
+  );
+
+  expect(packageJson.devDependencies?.["@wp-typia/dataviews"]).toBeTruthy();
+  expect(packageJson.dependencies?.["@wordpress/dataviews"]).toBeTruthy();
+  expect(blockConfigSource).toContain('slug: "snapshots"');
+  expect(blockConfigSource).toContain('source: "rest-resource:snapshots"');
+  expect(blockConfigSource).toContain(
+    'file: "src/admin-views/snapshots/index.tsx"'
+  );
+  expect(blockConfigSource).toContain(
+    'phpFile: "inc/admin-views/snapshots.php"'
+  );
+  expect(bootstrapSource).toContain("inc/admin-views/*.php");
+  expect(adminViewsIndexSource).toContain("import './snapshots';");
+  expect(entrySource).toContain("@wordpress/dataviews/build-style/style.css");
+  expect(entrySource).toContain("createRoot");
+  expect(screenSource).toContain("TypedDataViews");
+  expect(screenSource).toContain("isLoading");
+  expect(screenSource).toContain("paginationInfo");
+  expect(dataSource).toContain("listResource");
+  expect(dataSource).toContain("perPageParam: 'perPage'");
+  expect(dataSource).toContain("paginationInfo");
+  expect(configSource).toContain("defineDataViews<SnapshotsAdminViewItem>");
+  expect(configSource).toContain("content");
+  expect(configSource).not.toContain("owner");
+  expect(phpSource).toContain("add_submenu_page");
+  expect(phpSource).toContain("admin_enqueue_scripts");
+  expect(phpSource).toContain("build/admin-views/index.js");
+  expect(phpSource).toContain("build/admin-views/style-index.css");
+  expect(phpSource).toContain("'wp-components'");
+
+  const doctorOutput = runCli("node", [entryPath, "doctor", "--format", "json"], {
+    cwd: targetDir,
+  });
+  const doctorChecks = parseJsonObjectFromOutput<{
+    checks: Array<{ detail: string; label: string; status: string }>;
+  }>(doctorOutput);
+  expect(
+    doctorChecks.checks.find((check) => check.label === "Admin view bootstrap")
+      ?.status
+  ).toBe("pass");
+  expect(
+    doctorChecks.checks.find((check) => check.label === "Admin views index")
+      ?.status
+  ).toBe("pass");
+  expect(
+    doctorChecks.checks.find(
+      (check) => check.label === "Admin view config snapshots"
+    )?.status
+  ).toBe("pass");
+  expect(
+    doctorChecks.checks.find((check) => check.label === "Admin view snapshots")
+      ?.status
+  ).toBe("pass");
+  expect(
+    doctorChecks.checks.find((check) => check.label === "Admin view PHP snapshots")
+      ?.status
+  ).toBe("pass");
+
+  linkWorkspaceNodeModules(targetDir);
+  runCli("npm", ["run", "build"], { cwd: targetDir });
+  expect(
+    fs.existsSync(path.join(targetDir, "build", "admin-views", "index.js"))
+  ).toBe(true);
+  expect(
+    fs.existsSync(
+      path.join(targetDir, "build", "admin-views", "index.asset.php")
+    )
+  ).toBe(true);
+  expect(
+    fs.existsSync(
+      path.join(targetDir, "build", "admin-views", "style-index.css")
+    )
+  ).toBe(true);
+}, 40_000);
+
 test("rest resource workflow repairs legacy sync-rest scripts before writing workspace resources", async () => {
   const targetDir = path.join(
     tempRoot,
@@ -3505,7 +3671,7 @@ test("editor plugin workflow repairs legacy workspace build config hooks", async
     fs
       .readFileSync(buildScriptPath, "utf8")
       .replace(
-        `[\n\t\t'src/bindings/index.ts',\n\t\t'src/bindings/index.js',\n\t\t'src/editor-plugins/index.ts',\n\t\t'src/editor-plugins/index.js',\n\t]`,
+        `[\n\t\t'src/bindings/index.ts',\n\t\t'src/bindings/index.js',\n\t\t'src/editor-plugins/index.ts',\n\t\t'src/editor-plugins/index.js',\n\t\t'src/admin-views/index.ts',\n\t\t'src/admin-views/index.js',\n\t]`,
         "[ 'src/bindings/index.ts', 'src/bindings/index.js' ]"
       ),
     "utf8"
@@ -3515,7 +3681,7 @@ test("editor plugin workflow repairs legacy workspace build config hooks", async
     fs
       .readFileSync(webpackConfigPath, "utf8")
       .replace(
-        `\tfor ( const [ entryName, candidates ] of [\n\t\t[\n\t\t\t'bindings/index',\n\t\t\t[ 'src/bindings/index.ts', 'src/bindings/index.js' ],\n\t\t],\n\t\t[\n\t\t\t'editor-plugins/index',\n\t\t\t[ 'src/editor-plugins/index.ts', 'src/editor-plugins/index.js' ],\n\t\t],\n\t] ) {\n\t\tfor ( const relativePath of candidates ) {\n\t\t\tconst entryPath = path.resolve( process.cwd(), relativePath );\n\t\t\tif ( ! fs.existsSync( entryPath ) ) {\n\t\t\t\tcontinue;\n\t\t\t}\n\n\t\t\tentries.push( [ entryName, entryPath ] );\n\t\t\tbreak;\n\t\t}\n\t}`,
+        `\tfor ( const [ entryName, candidates ] of [\n\t\t[\n\t\t\t'bindings/index',\n\t\t\t[ 'src/bindings/index.ts', 'src/bindings/index.js' ],\n\t\t],\n\t\t[\n\t\t\t'editor-plugins/index',\n\t\t\t[ 'src/editor-plugins/index.ts', 'src/editor-plugins/index.js' ],\n\t\t],\n\t\t[\n\t\t\t'admin-views/index',\n\t\t\t[ 'src/admin-views/index.ts', 'src/admin-views/index.js' ],\n\t\t],\n\t] ) {\n\t\tfor ( const relativePath of candidates ) {\n\t\t\tconst entryPath = path.resolve( process.cwd(), relativePath );\n\t\t\tif ( ! fs.existsSync( entryPath ) ) {\n\t\t\t\tcontinue;\n\t\t\t}\n\n\t\t\tentries.push( [ entryName, entryPath ] );\n\t\t\tbreak;\n\t\t}\n\t}`,
         `\tfor ( const relativePath of [ 'src/bindings/index.ts', 'src/bindings/index.js' ] ) {\n\t\tconst entryPath = path.resolve( process.cwd(), relativePath );\n\t\tif ( ! fs.existsSync( entryPath ) ) {\n\t\t\tcontinue;\n\t\t}\n\n\t\tentries.push( [ 'bindings/index', entryPath ] );\n\t\tbreak;\n\t}`
       ),
     "utf8"
@@ -3573,7 +3739,7 @@ test("editor plugin workflow repairs formatted legacy workspace build config hoo
     fs
       .readFileSync(buildScriptPath, "utf8")
       .replace(
-        `[\n\t\t'src/bindings/index.ts',\n\t\t'src/bindings/index.js',\n\t\t'src/editor-plugins/index.ts',\n\t\t'src/editor-plugins/index.js',\n\t]`,
+        `[\n\t\t'src/bindings/index.ts',\n\t\t'src/bindings/index.js',\n\t\t'src/editor-plugins/index.ts',\n\t\t'src/editor-plugins/index.js',\n\t\t'src/admin-views/index.ts',\n\t\t'src/admin-views/index.js',\n\t]`,
         `[\n      \"src/bindings/index.ts\",\n      \"src/bindings/index.js\",\n    ]`
       ),
     "utf8"
@@ -3583,7 +3749,7 @@ test("editor plugin workflow repairs formatted legacy workspace build config hoo
     fs
       .readFileSync(webpackConfigPath, "utf8")
       .replace(
-        `\tfor ( const [ entryName, candidates ] of [\n\t\t[\n\t\t\t'bindings/index',\n\t\t\t[ 'src/bindings/index.ts', 'src/bindings/index.js' ],\n\t\t],\n\t\t[\n\t\t\t'editor-plugins/index',\n\t\t\t[ 'src/editor-plugins/index.ts', 'src/editor-plugins/index.js' ],\n\t\t],\n\t] ) {\n\t\tfor ( const relativePath of candidates ) {\n\t\t\tconst entryPath = path.resolve( process.cwd(), relativePath );\n\t\t\tif ( ! fs.existsSync( entryPath ) ) {\n\t\t\t\tcontinue;\n\t\t\t}\n\n\t\t\tentries.push( [ entryName, entryPath ] );\n\t\t\tbreak;\n\t\t}\n\t}`,
+        `\tfor ( const [ entryName, candidates ] of [\n\t\t[\n\t\t\t'bindings/index',\n\t\t\t[ 'src/bindings/index.ts', 'src/bindings/index.js' ],\n\t\t],\n\t\t[\n\t\t\t'editor-plugins/index',\n\t\t\t[ 'src/editor-plugins/index.ts', 'src/editor-plugins/index.js' ],\n\t\t],\n\t\t[\n\t\t\t'admin-views/index',\n\t\t\t[ 'src/admin-views/index.ts', 'src/admin-views/index.js' ],\n\t\t],\n\t] ) {\n\t\tfor ( const relativePath of candidates ) {\n\t\t\tconst entryPath = path.resolve( process.cwd(), relativePath );\n\t\t\tif ( ! fs.existsSync( entryPath ) ) {\n\t\t\t\tcontinue;\n\t\t\t}\n\n\t\t\tentries.push( [ entryName, entryPath ] );\n\t\t\tbreak;\n\t\t}\n\t}`,
         `\tfor ( const relativePath of [\n\t\t\"src/bindings/index.ts\",\n\t\t\"src/bindings/index.js\",\n\t] ) {\n\t\tconst entryPath = path.resolve( process.cwd(), relativePath );\n\t\tif ( ! fs.existsSync( entryPath ) ) {\n\t\t\tcontinue;\n\t\t}\n\n\t\tentries.push( [ \"bindings/index\", entryPath ] );\n\t\tbreak;\n\t}`
       ),
     "utf8"
@@ -3752,7 +3918,7 @@ test("editor plugin workflow accepts existing js shared entry hooks", async () =
     fs
       .readFileSync(buildScriptPath, "utf8")
       .replace(
-        `[\n\t\t'src/bindings/index.ts',\n\t\t'src/bindings/index.js',\n\t\t'src/editor-plugins/index.ts',\n\t\t'src/editor-plugins/index.js',\n\t]`,
+        `[\n\t\t'src/bindings/index.ts',\n\t\t'src/bindings/index.js',\n\t\t'src/editor-plugins/index.ts',\n\t\t'src/editor-plugins/index.js',\n\t\t'src/admin-views/index.ts',\n\t\t'src/admin-views/index.js',\n\t]`,
         `[\n\t\t'src/bindings/index.ts',\n\t\t'src/bindings/index.js',\n\t\t'src/editor-plugins/index.js',\n\t]`
       ),
     "utf8"

--- a/packages/wp-typia-project-tools/tests/workspace-add.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-add.test.ts
@@ -86,6 +86,20 @@ function writeLegacyCompoundValidatorFixture(
   );
 }
 
+function replaceFixtureSource(
+  source: string,
+  searchValue: string | RegExp,
+  replaceValue: string,
+  label: string
+): string {
+  const nextSource = source.replace(searchValue, replaceValue);
+  if (nextSource === source) {
+    throw new Error(`Expected fixture rewrite to update ${label}.`);
+  }
+
+  return nextSource;
+}
+
 describe("@wp-typia/project-tools workspace add", () => {
   const tempRoot = createScaffoldTempRoot("wp-typia-workspace-add-");
 
@@ -2789,22 +2803,22 @@ test("admin view workflow accepts formatted shared webpack entries", async () =>
   const webpackConfigPath = path.join(targetDir, "webpack.config.js");
   fs.writeFileSync(
     buildScriptPath,
-    fs
-      .readFileSync(buildScriptPath, "utf8")
-      .replace(
-        `[\n\t\t'src/bindings/index.ts',\n\t\t'src/bindings/index.js',\n\t\t'src/editor-plugins/index.ts',\n\t\t'src/editor-plugins/index.js',\n\t\t'src/admin-views/index.ts',\n\t\t'src/admin-views/index.js',\n\t]`,
-        `[\n      \"src/bindings/index.ts\",\n      \"src/bindings/index.js\",\n      \"src/editor-plugins/index.ts\",\n      \"src/editor-plugins/index.js\"\n    ]`
-      ),
+    replaceFixtureSource(
+      fs.readFileSync(buildScriptPath, "utf8"),
+      `[\n\t\t'src/bindings/index.ts',\n\t\t'src/bindings/index.js',\n\t\t'src/editor-plugins/index.ts',\n\t\t'src/editor-plugins/index.js',\n\t\t'src/admin-views/index.ts',\n\t\t'src/admin-views/index.js',\n\t]`,
+      `[\n      \"src/bindings/index.ts\",\n      \"src/bindings/index.js\",\n      \"src/editor-plugins/index.ts\",\n      \"src/editor-plugins/index.js\"\n    ]`,
+      "formatted admin view build entries"
+    ),
     "utf8"
   );
   fs.writeFileSync(
     webpackConfigPath,
-    fs
-      .readFileSync(webpackConfigPath, "utf8")
-      .replace(
-        `\tfor ( const [ entryName, candidates ] of [\n\t\t[\n\t\t\t'bindings/index',\n\t\t\t[ 'src/bindings/index.ts', 'src/bindings/index.js' ],\n\t\t],\n\t\t[\n\t\t\t'editor-plugins/index',\n\t\t\t[ 'src/editor-plugins/index.ts', 'src/editor-plugins/index.js' ],\n\t\t],\n\t\t[\n\t\t\t'admin-views/index',\n\t\t\t[ 'src/admin-views/index.ts', 'src/admin-views/index.js' ],\n\t\t],\n\t] ) {\n\t\tfor ( const relativePath of candidates ) {\n\t\t\tconst entryPath = path.resolve( process.cwd(), relativePath );\n\t\t\tif ( ! fs.existsSync( entryPath ) ) {\n\t\t\t\tcontinue;\n\t\t\t}\n\n\t\t\tentries.push( [ entryName, entryPath ] );\n\t\t\tbreak;\n\t\t}\n\t}`,
-        `\tfor ( const [ entryName, candidates ] of [\n\t\t[\n\t\t\t\"bindings/index\",\n\t\t\t[\n\t\t\t\t\"src/bindings/index.ts\",\n\t\t\t\t\"src/bindings/index.js\",\n\t\t\t],\n\t\t],\n\t\t[ \"editor-plugins/index\", [\n\t\t\t\"src/editor-plugins/index.ts\",\n\t\t\t\"src/editor-plugins/index.js\",\n\t\t] ],\n\t] ) {\n\t\tfor ( const relativePath of candidates ) {\n\t\t\tconst entryPath = path.resolve( process.cwd(), relativePath );\n\t\t\tif ( ! fs.existsSync( entryPath ) ) {\n\t\t\t\tcontinue;\n\t\t\t}\n\n\t\t\tentries.push( [ entryName, entryPath ] );\n\t\t\tbreak;\n\t\t}\n\t}`
-      ),
+    replaceFixtureSource(
+      fs.readFileSync(webpackConfigPath, "utf8"),
+      `\tfor ( const [ entryName, candidates ] of [\n\t\t[\n\t\t\t'bindings/index',\n\t\t\t[ 'src/bindings/index.ts', 'src/bindings/index.js' ],\n\t\t],\n\t\t[\n\t\t\t'editor-plugins/index',\n\t\t\t[ 'src/editor-plugins/index.ts', 'src/editor-plugins/index.js' ],\n\t\t],\n\t\t[\n\t\t\t'admin-views/index',\n\t\t\t[ 'src/admin-views/index.ts', 'src/admin-views/index.js' ],\n\t\t],\n\t] ) {\n\t\tfor ( const relativePath of candidates ) {\n\t\t\tconst entryPath = path.resolve( process.cwd(), relativePath );\n\t\t\tif ( ! fs.existsSync( entryPath ) ) {\n\t\t\t\tcontinue;\n\t\t\t}\n\n\t\t\tentries.push( [ entryName, entryPath ] );\n\t\t\tbreak;\n\t\t}\n\t}`,
+      `\tfor ( const [ entryName, candidates ] of [\n\t\t[\n\t\t\t\"bindings/index\",\n\t\t\t[\n\t\t\t\t\"src/bindings/index.ts\",\n\t\t\t\t\"src/bindings/index.js\",\n\t\t\t],\n\t\t],\n\t\t[ \"editor-plugins/index\", [\n\t\t\t\"src/editor-plugins/index.ts\",\n\t\t\t\"src/editor-plugins/index.js\",\n\t\t] ],\n\t] ) {\n\t\tfor ( const relativePath of candidates ) {\n\t\t\tconst entryPath = path.resolve( process.cwd(), relativePath );\n\t\t\tif ( ! fs.existsSync( entryPath ) ) {\n\t\t\t\tcontinue;\n\t\t\t}\n\n\t\t\tentries.push( [ entryName, entryPath ] );\n\t\t\tbreak;\n\t\t}\n\t}`,
+      "formatted admin view webpack entries"
+    ),
     "utf8"
   );
 
@@ -3725,22 +3739,22 @@ test("editor plugin workflow repairs legacy workspace build config hooks", async
   const webpackConfigPath = path.join(targetDir, "webpack.config.js");
   fs.writeFileSync(
     buildScriptPath,
-    fs
-      .readFileSync(buildScriptPath, "utf8")
-      .replace(
-        `[\n\t\t'src/bindings/index.ts',\n\t\t'src/bindings/index.js',\n\t\t'src/editor-plugins/index.ts',\n\t\t'src/editor-plugins/index.js',\n\t\t'src/admin-views/index.ts',\n\t\t'src/admin-views/index.js',\n\t]`,
-        "[ 'src/bindings/index.ts', 'src/bindings/index.js' ]"
-      ),
+    replaceFixtureSource(
+      fs.readFileSync(buildScriptPath, "utf8"),
+      `[\n\t\t'src/bindings/index.ts',\n\t\t'src/bindings/index.js',\n\t\t'src/editor-plugins/index.ts',\n\t\t'src/editor-plugins/index.js',\n\t\t'src/admin-views/index.ts',\n\t\t'src/admin-views/index.js',\n\t]`,
+      "[ 'src/bindings/index.ts', 'src/bindings/index.js' ]",
+      "legacy editor plugin build entries"
+    ),
     "utf8"
   );
   fs.writeFileSync(
     webpackConfigPath,
-    fs
-      .readFileSync(webpackConfigPath, "utf8")
-      .replace(
-        `\tfor ( const [ entryName, candidates ] of [\n\t\t[\n\t\t\t'bindings/index',\n\t\t\t[ 'src/bindings/index.ts', 'src/bindings/index.js' ],\n\t\t],\n\t\t[\n\t\t\t'editor-plugins/index',\n\t\t\t[ 'src/editor-plugins/index.ts', 'src/editor-plugins/index.js' ],\n\t\t],\n\t\t[\n\t\t\t'admin-views/index',\n\t\t\t[ 'src/admin-views/index.ts', 'src/admin-views/index.js' ],\n\t\t],\n\t] ) {\n\t\tfor ( const relativePath of candidates ) {\n\t\t\tconst entryPath = path.resolve( process.cwd(), relativePath );\n\t\t\tif ( ! fs.existsSync( entryPath ) ) {\n\t\t\t\tcontinue;\n\t\t\t}\n\n\t\t\tentries.push( [ entryName, entryPath ] );\n\t\t\tbreak;\n\t\t}\n\t}`,
-        `\tfor ( const relativePath of [ 'src/bindings/index.ts', 'src/bindings/index.js' ] ) {\n\t\tconst entryPath = path.resolve( process.cwd(), relativePath );\n\t\tif ( ! fs.existsSync( entryPath ) ) {\n\t\t\tcontinue;\n\t\t}\n\n\t\tentries.push( [ 'bindings/index', entryPath ] );\n\t\tbreak;\n\t}`
-      ),
+    replaceFixtureSource(
+      fs.readFileSync(webpackConfigPath, "utf8"),
+      `\tfor ( const [ entryName, candidates ] of [\n\t\t[\n\t\t\t'bindings/index',\n\t\t\t[ 'src/bindings/index.ts', 'src/bindings/index.js' ],\n\t\t],\n\t\t[\n\t\t\t'editor-plugins/index',\n\t\t\t[ 'src/editor-plugins/index.ts', 'src/editor-plugins/index.js' ],\n\t\t],\n\t\t[\n\t\t\t'admin-views/index',\n\t\t\t[ 'src/admin-views/index.ts', 'src/admin-views/index.js' ],\n\t\t],\n\t] ) {\n\t\tfor ( const relativePath of candidates ) {\n\t\t\tconst entryPath = path.resolve( process.cwd(), relativePath );\n\t\t\tif ( ! fs.existsSync( entryPath ) ) {\n\t\t\t\tcontinue;\n\t\t\t}\n\n\t\t\tentries.push( [ entryName, entryPath ] );\n\t\t\tbreak;\n\t\t}\n\t}`,
+      `\tfor ( const relativePath of [ 'src/bindings/index.ts', 'src/bindings/index.js' ] ) {\n\t\tconst entryPath = path.resolve( process.cwd(), relativePath );\n\t\tif ( ! fs.existsSync( entryPath ) ) {\n\t\t\tcontinue;\n\t\t}\n\n\t\tentries.push( [ 'bindings/index', entryPath ] );\n\t\tbreak;\n\t}`,
+      "legacy editor plugin webpack entries"
+    ),
     "utf8"
   );
 
@@ -3793,22 +3807,22 @@ test("editor plugin workflow repairs formatted legacy workspace build config hoo
   const webpackConfigPath = path.join(targetDir, "webpack.config.js");
   fs.writeFileSync(
     buildScriptPath,
-    fs
-      .readFileSync(buildScriptPath, "utf8")
-      .replace(
-        `[\n\t\t'src/bindings/index.ts',\n\t\t'src/bindings/index.js',\n\t\t'src/editor-plugins/index.ts',\n\t\t'src/editor-plugins/index.js',\n\t\t'src/admin-views/index.ts',\n\t\t'src/admin-views/index.js',\n\t]`,
-        `[\n      \"src/bindings/index.ts\",\n      \"src/bindings/index.js\",\n    ]`
-      ),
+    replaceFixtureSource(
+      fs.readFileSync(buildScriptPath, "utf8"),
+      `[\n\t\t'src/bindings/index.ts',\n\t\t'src/bindings/index.js',\n\t\t'src/editor-plugins/index.ts',\n\t\t'src/editor-plugins/index.js',\n\t\t'src/admin-views/index.ts',\n\t\t'src/admin-views/index.js',\n\t]`,
+      `[\n      \"src/bindings/index.ts\",\n      \"src/bindings/index.js\",\n    ]`,
+      "formatted legacy editor plugin build entries"
+    ),
     "utf8"
   );
   fs.writeFileSync(
     webpackConfigPath,
-    fs
-      .readFileSync(webpackConfigPath, "utf8")
-      .replace(
-        `\tfor ( const [ entryName, candidates ] of [\n\t\t[\n\t\t\t'bindings/index',\n\t\t\t[ 'src/bindings/index.ts', 'src/bindings/index.js' ],\n\t\t],\n\t\t[\n\t\t\t'editor-plugins/index',\n\t\t\t[ 'src/editor-plugins/index.ts', 'src/editor-plugins/index.js' ],\n\t\t],\n\t\t[\n\t\t\t'admin-views/index',\n\t\t\t[ 'src/admin-views/index.ts', 'src/admin-views/index.js' ],\n\t\t],\n\t] ) {\n\t\tfor ( const relativePath of candidates ) {\n\t\t\tconst entryPath = path.resolve( process.cwd(), relativePath );\n\t\t\tif ( ! fs.existsSync( entryPath ) ) {\n\t\t\t\tcontinue;\n\t\t\t}\n\n\t\t\tentries.push( [ entryName, entryPath ] );\n\t\t\tbreak;\n\t\t}\n\t}`,
-        `\tfor ( const relativePath of [\n\t\t\"src/bindings/index.ts\",\n\t\t\"src/bindings/index.js\",\n\t] ) {\n\t\tconst entryPath = path.resolve( process.cwd(), relativePath );\n\t\tif ( ! fs.existsSync( entryPath ) ) {\n\t\t\tcontinue;\n\t\t}\n\n\t\tentries.push( [ \"bindings/index\", entryPath ] );\n\t\tbreak;\n\t}`
-      ),
+    replaceFixtureSource(
+      fs.readFileSync(webpackConfigPath, "utf8"),
+      `\tfor ( const [ entryName, candidates ] of [\n\t\t[\n\t\t\t'bindings/index',\n\t\t\t[ 'src/bindings/index.ts', 'src/bindings/index.js' ],\n\t\t],\n\t\t[\n\t\t\t'editor-plugins/index',\n\t\t\t[ 'src/editor-plugins/index.ts', 'src/editor-plugins/index.js' ],\n\t\t],\n\t\t[\n\t\t\t'admin-views/index',\n\t\t\t[ 'src/admin-views/index.ts', 'src/admin-views/index.js' ],\n\t\t],\n\t] ) {\n\t\tfor ( const relativePath of candidates ) {\n\t\t\tconst entryPath = path.resolve( process.cwd(), relativePath );\n\t\t\tif ( ! fs.existsSync( entryPath ) ) {\n\t\t\t\tcontinue;\n\t\t\t}\n\n\t\t\tentries.push( [ entryName, entryPath ] );\n\t\t\tbreak;\n\t\t}\n\t}`,
+      `\tfor ( const relativePath of [\n\t\t\"src/bindings/index.ts\",\n\t\t\"src/bindings/index.js\",\n\t] ) {\n\t\tconst entryPath = path.resolve( process.cwd(), relativePath );\n\t\tif ( ! fs.existsSync( entryPath ) ) {\n\t\t\tcontinue;\n\t\t}\n\n\t\tentries.push( [ \"bindings/index\", entryPath ] );\n\t\tbreak;\n\t}`,
+      "formatted legacy editor plugin webpack entries"
+    ),
     "utf8"
   );
 
@@ -3972,12 +3986,12 @@ test("editor plugin workflow accepts existing js shared entry hooks", async () =
   fs.writeFileSync(path.join(editorPluginsDir, "index.js"), "", "utf8");
   fs.writeFileSync(
     buildScriptPath,
-    fs
-      .readFileSync(buildScriptPath, "utf8")
-      .replace(
-        `[\n\t\t'src/bindings/index.ts',\n\t\t'src/bindings/index.js',\n\t\t'src/editor-plugins/index.ts',\n\t\t'src/editor-plugins/index.js',\n\t\t'src/admin-views/index.ts',\n\t\t'src/admin-views/index.js',\n\t]`,
-        `[\n\t\t'src/bindings/index.ts',\n\t\t'src/bindings/index.js',\n\t\t'src/editor-plugins/index.js',\n\t]`
-      ),
+    replaceFixtureSource(
+      fs.readFileSync(buildScriptPath, "utf8"),
+      `[\n\t\t'src/bindings/index.ts',\n\t\t'src/bindings/index.js',\n\t\t'src/editor-plugins/index.ts',\n\t\t'src/editor-plugins/index.js',\n\t\t'src/admin-views/index.ts',\n\t\t'src/admin-views/index.js',\n\t]`,
+      `[\n\t\t'src/bindings/index.ts',\n\t\t'src/bindings/index.js',\n\t\t'src/editor-plugins/index.js',\n\t]`,
+      "editor plugin js shared entry hooks"
+    ),
     "utf8"
   );
 

--- a/packages/wp-typia-project-tools/tests/workspace-add.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-add.test.ts
@@ -2793,7 +2793,7 @@ test("admin view workflow accepts formatted shared webpack entries", async () =>
       .readFileSync(buildScriptPath, "utf8")
       .replace(
         `[\n\t\t'src/bindings/index.ts',\n\t\t'src/bindings/index.js',\n\t\t'src/editor-plugins/index.ts',\n\t\t'src/editor-plugins/index.js',\n\t\t'src/admin-views/index.ts',\n\t\t'src/admin-views/index.js',\n\t]`,
-        `[\n\t\t'src/bindings/index.ts',\n\t\t'src/bindings/index.js',\n\t\t'src/editor-plugins/index.ts',\n\t\t'src/editor-plugins/index.js',\n\t]`
+        `[\n      \"src/bindings/index.ts\",\n      \"src/bindings/index.js\",\n      \"src/editor-plugins/index.ts\",\n      \"src/editor-plugins/index.js\"\n    ]`
       ),
     "utf8"
   );

--- a/packages/wp-typia-project-tools/tests/workspace-add.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-add.test.ts
@@ -2763,6 +2763,63 @@ test("canonical CLI can add a DataViews admin screen with a REST resource source
   ).toBe(true);
 }, 40_000);
 
+test("admin view workflow accepts formatted shared webpack entries", async () => {
+  const targetDir = path.join(
+    tempRoot,
+    "demo-workspace-add-admin-view-formatted-webpack"
+  );
+
+  await scaffoldProject({
+    projectDir: targetDir,
+    templateId: workspaceTemplatePackageManifest.name,
+    packageManager: "npm",
+    noInstall: true,
+    answers: {
+      author: "Test Runner",
+      description: "Demo workspace add admin view formatted webpack",
+      namespace: "demo-space",
+      phpPrefix: "demo_space",
+      slug: "demo-workspace-add-admin-view-formatted-webpack",
+      textDomain: "demo-space",
+      title: "Demo Workspace Add Admin View Formatted Webpack",
+    },
+  });
+
+  const buildScriptPath = path.join(targetDir, "scripts", "build-workspace.mjs");
+  const webpackConfigPath = path.join(targetDir, "webpack.config.js");
+  fs.writeFileSync(
+    buildScriptPath,
+    fs
+      .readFileSync(buildScriptPath, "utf8")
+      .replace(
+        `[\n\t\t'src/bindings/index.ts',\n\t\t'src/bindings/index.js',\n\t\t'src/editor-plugins/index.ts',\n\t\t'src/editor-plugins/index.js',\n\t\t'src/admin-views/index.ts',\n\t\t'src/admin-views/index.js',\n\t]`,
+        `[\n\t\t'src/bindings/index.ts',\n\t\t'src/bindings/index.js',\n\t\t'src/editor-plugins/index.ts',\n\t\t'src/editor-plugins/index.js',\n\t]`
+      ),
+    "utf8"
+  );
+  fs.writeFileSync(
+    webpackConfigPath,
+    fs
+      .readFileSync(webpackConfigPath, "utf8")
+      .replace(
+        `\tfor ( const [ entryName, candidates ] of [\n\t\t[\n\t\t\t'bindings/index',\n\t\t\t[ 'src/bindings/index.ts', 'src/bindings/index.js' ],\n\t\t],\n\t\t[\n\t\t\t'editor-plugins/index',\n\t\t\t[ 'src/editor-plugins/index.ts', 'src/editor-plugins/index.js' ],\n\t\t],\n\t\t[\n\t\t\t'admin-views/index',\n\t\t\t[ 'src/admin-views/index.ts', 'src/admin-views/index.js' ],\n\t\t],\n\t] ) {\n\t\tfor ( const relativePath of candidates ) {\n\t\t\tconst entryPath = path.resolve( process.cwd(), relativePath );\n\t\t\tif ( ! fs.existsSync( entryPath ) ) {\n\t\t\t\tcontinue;\n\t\t\t}\n\n\t\t\tentries.push( [ entryName, entryPath ] );\n\t\t\tbreak;\n\t\t}\n\t}`,
+        `\tfor ( const [ entryName, candidates ] of [\n\t\t[\n\t\t\t\"bindings/index\",\n\t\t\t[\n\t\t\t\t\"src/bindings/index.ts\",\n\t\t\t\t\"src/bindings/index.js\",\n\t\t\t],\n\t\t],\n\t\t[ \"editor-plugins/index\", [\n\t\t\t\"src/editor-plugins/index.ts\",\n\t\t\t\"src/editor-plugins/index.js\",\n\t\t] ],\n\t] ) {\n\t\tfor ( const relativePath of candidates ) {\n\t\t\tconst entryPath = path.resolve( process.cwd(), relativePath );\n\t\t\tif ( ! fs.existsSync( entryPath ) ) {\n\t\t\t\tcontinue;\n\t\t\t}\n\n\t\t\tentries.push( [ entryName, entryPath ] );\n\t\t\tbreak;\n\t\t}\n\t}`
+      ),
+    "utf8"
+  );
+
+  runCli("node", [entryPath, "add", "admin-view", "reports"], {
+    cwd: targetDir,
+  });
+
+  expect(fs.readFileSync(buildScriptPath, "utf8")).toContain(
+    "'src/admin-views/index.ts'"
+  );
+  expect(fs.readFileSync(webpackConfigPath, "utf8")).toContain(
+    "'admin-views/index'"
+  );
+}, 30_000);
+
 test("rest resource workflow repairs legacy sync-rest scripts before writing workspace resources", async () => {
   const targetDir = path.join(
     tempRoot,

--- a/packages/wp-typia-project-tools/tests/workspace-add.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-add.test.ts
@@ -2722,10 +2722,20 @@ test("canonical CLI can add a DataViews admin screen with a REST resource source
   expect(screenSource).toContain("paginationInfo");
   expect(dataSource).toContain("listResource");
   expect(dataSource).toContain("perPageParam: 'perPage'");
+  expect(dataSource).toContain("searchParam: false");
+  expect(dataSource).toContain('from "../../rest/snapshots/api"');
+  expect(dataSource).toContain('from "../../rest/snapshots/api-types"');
+  expect(dataSource).not.toContain("search: query.search");
+  expect(dataSource).toContain("if (!result.isValid || !result.data)");
+  expect(dataSource).toContain("const response = result.data");
   expect(dataSource).toContain("paginationInfo");
   expect(configSource).toContain("defineDataViews<SnapshotsAdminViewItem>");
-  expect(configSource).toContain("content");
+  expect(configSource).toContain("fields: ['id']");
+  expect(configSource).toContain("search: false");
+  expect(configSource).not.toContain("content");
   expect(configSource).not.toContain("owner");
+  expect(configSource).not.toContain("titleField: 'title'");
+  expect(configSource).not.toContain("updatedAt");
   expect(phpSource).toContain("add_submenu_page");
   expect(phpSource).toContain("admin_enqueue_scripts");
   expect(phpSource).toContain("build/admin-views/index.js");
@@ -2775,7 +2785,8 @@ test("canonical CLI can add a DataViews admin screen with a REST resource source
       path.join(targetDir, "build", "admin-views", "style-index.css")
     )
   ).toBe(true);
-}, 40_000);
+  typecheckGeneratedProject(targetDir);
+}, 60_000);
 
 test("admin view workflow accepts formatted shared webpack entries", async () => {
   const targetDir = path.join(

--- a/packages/wp-typia/bin/routing-metadata.generated.js
+++ b/packages/wp-typia/bin/routing-metadata.generated.js
@@ -32,6 +32,7 @@ export const longValueOptions = Object.freeze([
   "--query-post-type",
   "--seed",
   "--slot",
+  "--source",
   "--template",
   "--text-domain",
   "--to-migration-version",

--- a/packages/wp-typia/src/add-kind-registry.ts
+++ b/packages/wp-typia/src/add-kind-registry.ts
@@ -1,4 +1,5 @@
 export const ADD_KIND_IDS = [
+  'admin-view',
   'block',
   'variation',
   'pattern',
@@ -13,6 +14,7 @@ export type AddKindId = (typeof ADD_KIND_IDS)[number];
 export type AddFieldName =
   | 'kind'
   | 'name'
+  | 'source'
   | 'template'
   | 'block'
   | 'anchor'
@@ -64,6 +66,23 @@ export function isAddPersistenceTemplate(template?: string): boolean {
 }
 
 export const ADD_KIND_REGISTRY = {
+  'admin-view': {
+    completion: {
+      nextSteps: (values) => [
+        `Review src/admin-views/${values.adminViewSlug}/ and inc/admin-views/${values.adminViewSlug}.php.`,
+        'Run your workspace build or dev command to verify the generated DataViews admin screen.',
+      ],
+      summaryLines: (values, projectDir) => [
+        `Admin view: ${values.adminViewSlug}`,
+        ...(values.source ? [`Source: ${values.source}`] : []),
+        `Project directory: ${projectDir}`,
+      ],
+      title: 'Added DataViews admin screen',
+    },
+    description: 'Add an opt-in DataViews-powered admin screen',
+    nameLabel: 'Admin view name',
+    visibleFieldNames: () => ['kind', 'name', 'source'],
+  },
   'binding-source': {
     completion: {
       nextSteps: (values) => [

--- a/packages/wp-typia/src/command-option-metadata.ts
+++ b/packages/wp-typia/src/command-option-metadata.ts
@@ -177,6 +177,10 @@ export const ADD_OPTION_METADATA = {
 		description: "Document editor shell slot for editor-plugin workflows.",
 		type: "string",
 	},
+	source: {
+		description: "Optional data source locator for admin-view workflows, such as rest-resource:products.",
+		type: "string",
+	},
 	template: {
 		description: "Built-in block family for the new block.",
 		type: "string",

--- a/packages/wp-typia/src/runtime-bridge.ts
+++ b/packages/wp-typia/src/runtime-bridge.ts
@@ -102,6 +102,9 @@ const loadMigrationsRuntime = () =>
   import('@wp-typia/project-tools/migrations');
 
 type AddRuntime = Awaited<ReturnType<typeof loadCliAddRuntime>>;
+type AddAdminViewResult = Awaited<
+  ReturnType<AddRuntime['runAddAdminViewCommand']>
+>;
 type AddAbilityResult = Awaited<ReturnType<AddRuntime['runAddAbilityCommand']>>;
 type AddBindingSourceResult = Awaited<
   ReturnType<AddRuntime['runAddBindingSourceCommand']>
@@ -244,6 +247,31 @@ const ADD_KIND_EXECUTION_REGISTRY: Record<
     context: AddKindHandlerContext,
   ) => Promise<AlternateBufferCompletionPayload | void>
 > = {
+  'admin-view': async (context) => {
+    const name = requireAddKindName(
+      context,
+      '`wp-typia add admin-view` requires <name>. Usage: wp-typia add admin-view <name> [--source <rest-resource:slug>].',
+    );
+    const source = readOptionalStringFlag(context.flags, 'source');
+
+    return runRegisteredAddKind<AddAdminViewResult>(context, {
+      buildCompletion: (result) =>
+        buildAddCompletionPayload({
+          kind: 'admin-view',
+          projectDir: result.projectDir,
+          values: {
+            adminViewSlug: result.adminViewSlug,
+            ...(result.source ? { source: result.source } : {}),
+          },
+        }),
+      execute: (targetCwd) =>
+        context.addRuntime.runAddAdminViewCommand({
+          adminViewName: name,
+          cwd: targetCwd,
+          source,
+        }),
+    });
+  },
   ability: async (context) => {
     const name = requireAddKindName(
       context,

--- a/packages/wp-typia/src/ui/add-flow-model.ts
+++ b/packages/wp-typia/src/ui/add-flow-model.ts
@@ -34,6 +34,7 @@ export const addFlowSchema = z.object({
   'persistence-policy': z.string().optional(),
   position: z.string().optional(),
   slot: z.string().optional(),
+  source: z.string().optional(),
   template: z.string().optional(),
 });
 
@@ -52,6 +53,7 @@ const ADD_FIELD_HEIGHTS: Record<AddFieldName, number> = {
   'persistence-policy': FIRST_PARTY_SELECT_FIELD_BODY_HEIGHT,
   position: FIRST_PARTY_SELECT_FIELD_BODY_HEIGHT,
   slot: FIRST_PARTY_SELECT_FIELD_BODY_HEIGHT,
+  source: FIRST_PARTY_TEXT_FIELD_BODY_HEIGHT,
   template: FIRST_PARTY_SELECT_FIELD_BODY_HEIGHT,
 };
 

--- a/packages/wp-typia/src/ui/add-flow.tsx
+++ b/packages/wp-typia/src/ui/add-flow.tsx
@@ -201,6 +201,17 @@ function AddFlowFields({
             options: templateOptions,
           })
         : null,
+      visibleFields.has('source')
+        ? createElement(FirstPartyTextField, {
+            ...getWrappedFieldNeighbors(orderedVisibleFields, 'source'),
+            description:
+              'Optional data source locator, for example rest-resource:products',
+            key: 'source',
+            label: 'Data source',
+            name: 'source',
+            placeholder: 'rest-resource:products',
+          })
+        : null,
       visibleFields.has('alternate-render-targets')
         ? createElement(FirstPartyTextField, {
             ...getWrappedFieldNeighbors(

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -362,6 +362,7 @@ describe('wp-typia package', () => {
     expect(addHelpOutput).toContain('--external-layer-source');
     expect(addHelpOutput).toContain('--external-layer-id');
     expect(addHelpOutput).toContain('--alternate-render-targets');
+    expect(addHelpOutput).toContain('admin-view');
     expect(addHelpOutput).toContain('ability, ai-feature');
     expect(addHelpOutput).toContain('editor-plugin');
   });
@@ -1522,9 +1523,10 @@ describe('wp-typia package', () => {
 
     expect(result.status).toBe(1);
     expect(result.stdout).toContain('Usage:');
+    expect(result.stdout).toContain('wp-typia add admin-view <name>');
     expect(result.stdout).toContain('wp-typia add block <name>');
     expect(result.stderr).toContain(
-      '`wp-typia add` requires <kind>. Usage: wp-typia add <block|variation|pattern|binding-source|rest-resource|ability|ai-feature|editor-plugin|hooked-block> ...',
+      '`wp-typia add` requires <kind>. Usage: wp-typia add <admin-view|block|variation|pattern|binding-source|rest-resource|ability|ai-feature|editor-plugin|hooked-block> ...',
     );
   });
 
@@ -1538,6 +1540,9 @@ describe('wp-typia package', () => {
     try {
       await expect(runNodeCli(['add'])).rejects.toThrow('wp-typia add failed');
       expect(capturedStdout.join('\n')).toContain('Usage:');
+      expect(capturedStdout.join('\n')).toContain(
+        'wp-typia add admin-view <name>',
+      );
       expect(capturedStdout.join('\n')).toContain('wp-typia add block <name>');
       expect(capturedStdout.join('\n')).toContain(
         'wp-typia add ability <name>',

--- a/packages/wp-typia/tests/tui-interaction-models.test.ts
+++ b/packages/wp-typia/tests/tui-interaction-models.test.ts
@@ -21,6 +21,11 @@ describe("first-party TUI interaction models", () => {
 	});
 
 	test("add flow keeps visible field ordering stable across kind switches", () => {
+		expect(getVisibleAddFieldNames({ kind: "admin-view" })).toEqual([
+			"kind",
+			"name",
+			"source",
+		]);
 		expect(getVisibleAddFieldNames({ kind: "block", template: "basic" })).toEqual([
 			"kind",
 			"name",
@@ -127,6 +132,22 @@ describe("first-party TUI interaction models", () => {
 			block: "counter-card",
 			kind: "variation",
 			name: "hero-card",
+		});
+
+		expect(
+			sanitizeAddSubmitValues({
+				anchor: "",
+				block: "",
+				kind: "admin-view",
+				name: "reports",
+				position: "",
+				source: " rest-resource:reports ",
+				template: "persistence",
+			}),
+		).toEqual({
+			kind: "admin-view",
+			name: "reports",
+			source: "rest-resource:reports",
 		});
 
 		expect(


### PR DESCRIPTION
## Summary
- add `wp-typia add admin-view <name>` with optional `--source rest-resource:<slug>` wiring
- scaffold typed DataViews admin screens, PHP admin menu/enqueue hooks, explicit replaceable data fetchers, loading and paginationInfo handling
- teach workspace inventory/doctor/templates/docs/tests about the opt-in admin-view workflow

## Tests
- `bun test packages/wp-typia-project-tools/tests/cli-add-workspace-boundaries.test.ts packages/wp-typia-project-tools/tests/dataviews-opt-in-policy.test.ts`
- `bun run --cwd packages/wp-typia-project-tools build`
- `bun run --cwd packages/wp-typia build`
- `bun test packages/wp-typia-project-tools/tests/workspace-add.test.ts --test-name-pattern "DataViews admin"`
- `bun test packages/wp-typia/tests/cli-package.test.ts --test-name-pattern "missing add|help"`
- `bun test packages/wp-typia-project-tools/tests/cli-entry.test.ts --test-name-pattern "migration UI"`
- `bun test packages/wp-typia-project-tools/tests/workspace-doctor.test.ts --test-name-pattern "Workspace inventory|editor plugin"`
- `git diff --check`
- `bun run format:check`
- `bun run --cwd packages/wp-typia-project-tools test:workspace`

Closes #602

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `wp-typia add admin-view <name>` to scaffold opt-in DataViews-powered WordPress admin screens.
  * Supports optional `--source <rest-resource:slug>` to wire a generated view to an existing REST resource.
  * Generated admin views are registered under the WordPress Tools menu and build into shared assets.

* **Documentation**
  * New guide explaining how to generate, configure, and prefer custom UI vs DataViews.

* **Tests**
  * End-to-end and unit tests added/updated for the admin-view workflow and CLI help.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->