### PR TITLE
feat(scaffold): make editor plugins slot-aware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -348,7 +348,7 @@ jobs:
             package_manager: npm
             project_name: smoke-workspace-add-editor-plugin-npm
             add_editor_plugin_name: document-tools
-            add_editor_plugin_slot: PluginSidebar
+            add_editor_plugin_slot: sidebar
           - runtime: node
             template: '@wp-typia/create-workspace-template'
             package_manager: npm

--- a/.sampo/changesets/editor-plugin-slot-aware-workflow.md
+++ b/.sampo/changesets/editor-plugin-slot-aware-workflow.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Made editor-plugin scaffolding slot-aware with canonical `sidebar` and `document-setting-panel` surfaces, while preserving `PluginSidebar` as a legacy alias.

--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ wp-typia add block counter-card --template basic
 wp-typia add block faq-stack --template compound --persistence-policy public --data-storage custom-table
 wp-typia add binding-source hero-data
 wp-typia add rest-resource snapshots --namespace my-plugin/v1 --methods list,read,create
+wp-typia add editor-plugin review-workflow --slot sidebar
+wp-typia add editor-plugin seo-notes --slot document-setting-panel
 wp-typia add hooked-block counter-card --anchor core/post-content --position after
 ```
 

--- a/apps/docs/src/content/docs/reference/cli.md
+++ b/apps/docs/src/content/docs/reference/cli.md
@@ -83,28 +83,29 @@ wp-typia add hooked-block <block-slug> --anchor core/post-content --position aft
 
 Common flags:
 
-| Flag                                                             | Description                                                                                        |
-| ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `--template <basic \| interactivity \| persistence \| compound>` | Built-in block family for `add block`.                                                             |
-| `--dry-run`                                                      | Preview workspace file updates and completion guidance.                                            |
-| `--block <block-slug>`                                           | Target block for variation workflows.                                                              |
-| `--anchor <block-name>`                                          | Anchor block for hooked-block workflows.                                                           |
-| `--position <before \| after \| firstChild \| lastChild>`        | Hook position for hooked blocks.                                                                   |
-| `--slot <sidebar \| document-setting-panel>`                     | Editor shell slot for editor-plugin scaffolds; `PluginSidebar` remains accepted as a legacy alias. |
-| `--namespace <vendor/v1>`                                        | REST namespace for REST resource and AI feature workflows.                                         |
-| `--methods <method[,method...]>`                                 | REST methods for REST resource workflows.                                                          |
-| `--external-layer-source <source>`                               | Compose an external layer package on top of a built-in block template.                             |
-| `--external-layer-id <id>`                                       | Select a specific external layer.                                                                  |
-| `--inner-blocks-preset <id>`                                     | Select a compound `InnerBlocks` preset.                                                            |
-| `--alternate-render-targets <list>`                              | Add alternate render targets for persistence-capable dynamic scaffolds.                            |
-| `--data-storage <post-meta \| custom-table>`                     | Select persistence storage.                                                                        |
-| `--persistence-policy <authenticated \| public>`                 | Select persistence write policy.                                                                   |
+| Flag                                                             | Description                                                                                                                     |
+| ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `--template <basic \| interactivity \| persistence \| compound>` | Built-in block family for `add block`.                                                                                          |
+| `--dry-run`                                                      | Preview workspace file updates and completion guidance.                                                                         |
+| `--block <block-slug>`                                           | Target block for variation workflows.                                                                                           |
+| `--anchor <block-name>`                                          | Anchor block for hooked-block workflows.                                                                                        |
+| `--position <before \| after \| firstChild \| lastChild>`        | Hook position for hooked blocks.                                                                                                |
+| `--slot <sidebar \| document-setting-panel>`                     | Editor shell slot for editor-plugin scaffolds; legacy aliases `PluginSidebar` and `PluginDocumentSettingPanel` remain accepted. |
+| `--namespace <vendor/v1>`                                        | REST namespace for REST resource and AI feature workflows.                                                                      |
+| `--methods <method[,method...]>`                                 | REST methods for REST resource workflows.                                                                                       |
+| `--external-layer-source <source>`                               | Compose an external layer package on top of a built-in block template.                                                          |
+| `--external-layer-id <id>`                                       | Select a specific external layer.                                                                                               |
+| `--inner-blocks-preset <id>`                                     | Select a compound `InnerBlocks` preset.                                                                                         |
+| `--alternate-render-targets <list>`                              | Add alternate render targets for persistence-capable dynamic scaffolds.                                                         |
+| `--data-storage <post-meta \| custom-table>`                     | Select persistence storage.                                                                                                     |
+| `--persistence-policy <authenticated \| public>`                 | Select persistence write policy.                                                                                                |
 
 Editor plugin scaffolds are slot-aware. The default `sidebar` slot generates a
 `PluginSidebar` shell with a matching more-menu entry, while
 `document-setting-panel` generates a `PluginDocumentSettingPanel` surface inside
 the document settings sidebar. Existing automation that still passes
-`PluginSidebar` continues to resolve to `sidebar`.
+`PluginSidebar` or `PluginDocumentSettingPanel` continues to resolve to the
+matching canonical slot.
 
 ## `init`
 

--- a/apps/docs/src/content/docs/reference/cli.md
+++ b/apps/docs/src/content/docs/reference/cli.md
@@ -76,28 +76,35 @@ wp-typia add binding-source <name>
 wp-typia add rest-resource <name> --namespace <vendor/v1> --methods GET,POST
 wp-typia add ability <name>
 wp-typia add ai-feature <name> --namespace <vendor/v1>
-wp-typia add editor-plugin <name> --slot PluginSidebar
+wp-typia add editor-plugin <name> --slot sidebar
+wp-typia add editor-plugin seo-notes --slot document-setting-panel
 wp-typia add hooked-block <block-slug> --anchor core/post-content --position after
 ```
 
 Common flags:
 
-| Flag                                                             | Description                                                             |
-| ---------------------------------------------------------------- | ----------------------------------------------------------------------- |
-| `--template <basic \| interactivity \| persistence \| compound>` | Built-in block family for `add block`.                                  |
-| `--dry-run`                                                      | Preview workspace file updates and completion guidance.                 |
-| `--block <block-slug>`                                           | Target block for variation workflows.                                   |
-| `--anchor <block-name>`                                          | Anchor block for hooked-block workflows.                                |
-| `--position <before \| after \| firstChild \| lastChild>`        | Hook position for hooked blocks.                                        |
-| `--slot <PluginSidebar>`                                         | Editor shell slot for editor-plugin scaffolds.                          |
-| `--namespace <vendor/v1>`                                        | REST namespace for REST resource and AI feature workflows.              |
-| `--methods <method[,method...]>`                                 | REST methods for REST resource workflows.                               |
-| `--external-layer-source <source>`                               | Compose an external layer package on top of a built-in block template.  |
-| `--external-layer-id <id>`                                       | Select a specific external layer.                                       |
-| `--inner-blocks-preset <id>`                                     | Select a compound `InnerBlocks` preset.                                 |
-| `--alternate-render-targets <list>`                              | Add alternate render targets for persistence-capable dynamic scaffolds. |
-| `--data-storage <post-meta \| custom-table>`                     | Select persistence storage.                                             |
-| `--persistence-policy <authenticated \| public>`                 | Select persistence write policy.                                        |
+| Flag                                                             | Description                                                                                        |
+| ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `--template <basic \| interactivity \| persistence \| compound>` | Built-in block family for `add block`.                                                             |
+| `--dry-run`                                                      | Preview workspace file updates and completion guidance.                                            |
+| `--block <block-slug>`                                           | Target block for variation workflows.                                                              |
+| `--anchor <block-name>`                                          | Anchor block for hooked-block workflows.                                                           |
+| `--position <before \| after \| firstChild \| lastChild>`        | Hook position for hooked blocks.                                                                   |
+| `--slot <sidebar \| document-setting-panel>`                     | Editor shell slot for editor-plugin scaffolds; `PluginSidebar` remains accepted as a legacy alias. |
+| `--namespace <vendor/v1>`                                        | REST namespace for REST resource and AI feature workflows.                                         |
+| `--methods <method[,method...]>`                                 | REST methods for REST resource workflows.                                                          |
+| `--external-layer-source <source>`                               | Compose an external layer package on top of a built-in block template.                             |
+| `--external-layer-id <id>`                                       | Select a specific external layer.                                                                  |
+| `--inner-blocks-preset <id>`                                     | Select a compound `InnerBlocks` preset.                                                            |
+| `--alternate-render-targets <list>`                              | Add alternate render targets for persistence-capable dynamic scaffolds.                            |
+| `--data-storage <post-meta \| custom-table>`                     | Select persistence storage.                                                                        |
+| `--persistence-policy <authenticated \| public>`                 | Select persistence write policy.                                                                   |
+
+Editor plugin scaffolds are slot-aware. The default `sidebar` slot generates a
+`PluginSidebar` shell with a matching more-menu entry, while
+`document-setting-panel` generates a `PluginDocumentSettingPanel` surface inside
+the document settings sidebar. Existing automation that still passes
+`PluginSidebar` continues to resolve to `sidebar`.
 
 ## `init`
 

--- a/packages/create-workspace-template/README.md
+++ b/packages/create-workspace-template/README.md
@@ -13,5 +13,7 @@ The generated project starts with an empty `src/blocks/*` workspace shell and is
 ```bash
 wp-typia add block my-block --template basic
 wp-typia add binding-source hero-data
+wp-typia add editor-plugin review-workflow --slot sidebar
+wp-typia add editor-plugin seo-notes --slot document-setting-panel
 wp-typia add hooked-block my-block --anchor core/post-content --position after
 ```

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-shared.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-shared.ts
@@ -65,6 +65,21 @@ export const EDITOR_PLUGIN_SLOT_ALIASES = {
 	sidebar: "sidebar",
 } as const satisfies Record<string, EditorPluginSlotId>;
 
+export function resolveEditorPluginSlotAlias(
+	slot: string,
+): EditorPluginSlotId | undefined {
+	const trimmed = slot.trim();
+	if (
+		!Object.prototype.hasOwnProperty.call(EDITOR_PLUGIN_SLOT_ALIASES, trimmed)
+	) {
+		return undefined;
+	}
+
+	return EDITOR_PLUGIN_SLOT_ALIASES[
+		trimmed as keyof typeof EDITOR_PLUGIN_SLOT_ALIASES
+	];
+}
+
 /**
  * Supported built-in block families accepted by `wp-typia add block --template`.
  */
@@ -388,8 +403,7 @@ export function assertValidHookAnchor(anchorBlockName: string): string {
  * @throws {Error} When the slot is not supported by the workspace scaffold.
  */
 export function assertValidEditorPluginSlot(slot = "sidebar"): EditorPluginSlotId {
-	const trimmed = slot.trim();
-	const alias = EDITOR_PLUGIN_SLOT_ALIASES[trimmed as keyof typeof EDITOR_PLUGIN_SLOT_ALIASES];
+	const alias = resolveEditorPluginSlotAlias(slot);
 	if (alias) {
 		return alias;
 	}
@@ -688,5 +702,5 @@ Notes:
   \`add ability\` scaffolds typed workflow abilities under \`src/abilities/\` and server registration under \`inc/abilities/\`.
   \`add ai-feature\` scaffolds server-owned AI feature endpoints under \`src/ai-features/\` and PHP route glue under \`inc/ai-features/\`.
   \`add hooked-block\` patches an existing workspace block's \`block.json\` \`blockHooks\` metadata.
-  \`add editor-plugin\` scaffolds a document-level editor extension under \`src/editor-plugins/\`; \`PluginSidebar\` remains accepted as a legacy alias for \`sidebar\`.`;
+  \`add editor-plugin\` scaffolds a document-level editor extension under \`src/editor-plugins/\`; legacy aliases \`PluginSidebar\` and \`PluginDocumentSettingPanel\` resolve to \`sidebar\` and \`document-setting-panel\`.`;
 }

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-shared.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-shared.ts
@@ -53,10 +53,17 @@ export const REST_RESOURCE_METHOD_IDS = [
 export type RestResourceMethodId = (typeof REST_RESOURCE_METHOD_IDS)[number];
 
 /**
- * Supported editor-plugin shell slots accepted by `wp-typia add editor-plugin --slot`.
+ * Supported editor-plugin shell surfaces accepted by
+ * `wp-typia add editor-plugin --slot`.
  */
-export const EDITOR_PLUGIN_SLOT_IDS = ["PluginSidebar"] as const;
+export const EDITOR_PLUGIN_SLOT_IDS = ["sidebar", "document-setting-panel"] as const;
 export type EditorPluginSlotId = (typeof EDITOR_PLUGIN_SLOT_IDS)[number];
+export const EDITOR_PLUGIN_SLOT_ALIASES = {
+	PluginDocumentSettingPanel: "document-setting-panel",
+	PluginSidebar: "sidebar",
+	"document-setting-panel": "document-setting-panel",
+	sidebar: "sidebar",
+} as const satisfies Record<string, EditorPluginSlotId>;
 
 /**
  * Supported built-in block families accepted by `wp-typia add block --template`.
@@ -145,7 +152,7 @@ export interface RunAddHookedBlockCommandOptions {
  * Defaults to `process.cwd()`.
  * @property editorPluginName Human-entered editor plugin name that will be
  * normalized into the generated slug.
- * @property slot Optional editor shell slot. Defaults to `PluginSidebar`.
+ * @property slot Optional editor shell slot. Defaults to `sidebar`.
  */
 export interface RunAddEditorPluginCommandOptions {
 	cwd?: string;
@@ -376,17 +383,19 @@ export function assertValidHookAnchor(anchorBlockName: string): string {
 /**
  * Validate and normalize the editor plugin shell slot.
  *
- * @param slot Optional shell slot. Defaults to `PluginSidebar`.
+ * @param slot Optional shell slot. Defaults to `sidebar`.
  * @returns The canonical editor plugin slot id.
  * @throws {Error} When the slot is not supported by the workspace scaffold.
  */
-export function assertValidEditorPluginSlot(slot = "PluginSidebar"): EditorPluginSlotId {
-	if ((EDITOR_PLUGIN_SLOT_IDS as readonly string[]).includes(slot)) {
-		return slot as EditorPluginSlotId;
+export function assertValidEditorPluginSlot(slot = "sidebar"): EditorPluginSlotId {
+	const trimmed = slot.trim();
+	const alias = EDITOR_PLUGIN_SLOT_ALIASES[trimmed as keyof typeof EDITOR_PLUGIN_SLOT_ALIASES];
+	if (alias) {
+		return alias;
 	}
 
 	throw new Error(
-		`Editor plugin slot must be one of: ${EDITOR_PLUGIN_SLOT_IDS.join(", ")}.`,
+		`Editor plugin slot must be one of: ${EDITOR_PLUGIN_SLOT_IDS.join(", ")}. Legacy aliases: PluginSidebar, PluginDocumentSettingPanel.`,
 	);
 }
 
@@ -679,5 +688,5 @@ Notes:
   \`add ability\` scaffolds typed workflow abilities under \`src/abilities/\` and server registration under \`inc/abilities/\`.
   \`add ai-feature\` scaffolds server-owned AI feature endpoints under \`src/ai-features/\` and PHP route glue under \`inc/ai-features/\`.
   \`add hooked-block\` patches an existing workspace block's \`block.json\` \`blockHooks\` metadata.
-  \`add editor-plugin\` scaffolds a document-level editor extension under \`src/editor-plugins/\`.`;
+  \`add editor-plugin\` scaffolds a document-level editor extension under \`src/editor-plugins/\`; \`PluginSidebar\` remains accepted as a legacy alias for \`sidebar\`.`;
 }

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-assets.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-assets.ts
@@ -205,7 +205,7 @@ registerBlockBindingsSource( {
 }
 
 function buildEditorPluginTypesSource(editorPluginSlug: string): string {
-	const typeName = `${toPascalCase(editorPluginSlug)}SidebarModel`;
+	const typeName = `${toPascalCase(editorPluginSlug)}EditorPluginModel`;
 
 	return `export interface ${typeName} {
 \tprimaryActionLabel: string;
@@ -218,9 +218,9 @@ function buildEditorPluginDataSource(
 	editorPluginSlug: string,
 	slot: string,
 ): string {
-	const typeName = `${toPascalCase(editorPluginSlug)}SidebarModel`;
+	const typeName = `${toPascalCase(editorPluginSlug)}EditorPluginModel`;
 	const pluginTitle = toTitleCase(editorPluginSlug);
-	const modelFactoryName = `get${toPascalCase(editorPluginSlug)}SidebarModel`;
+	const modelFactoryName = `get${toPascalCase(editorPluginSlug)}EditorPluginModel`;
 	const enabledFactoryName = `is${toPascalCase(editorPluginSlug)}Enabled`;
 
 	return `import type { ${typeName} } from './types';
@@ -228,13 +228,13 @@ function buildEditorPluginDataSource(
 export const EDITOR_PLUGIN_SLOT = ${quoteTsString(slot)} as const;
 export const REQUIRED_CAPABILITY = 'edit_posts' as const;
 
-const DEFAULT_SIDEBAR_MODEL: ${typeName} = {
+const DEFAULT_EDITOR_PLUGIN_MODEL: ${typeName} = {
 \tprimaryActionLabel: ${quoteTsString(`Review ${pluginTitle}`)},
 \tsummary: ${quoteTsString(`Replace this summary with your ${pluginTitle} workflow state.`)},
 };
 
 export function ${modelFactoryName}(): ${typeName} {
-\treturn DEFAULT_SIDEBAR_MODEL;
+\treturn DEFAULT_EDITOR_PLUGIN_MODEL;
 }
 
 export function ${enabledFactoryName}(): boolean {
@@ -243,14 +243,57 @@ export function ${enabledFactoryName}(): boolean {
 `;
 }
 
-function buildEditorPluginSidebarSource(
+function buildEditorPluginSurfaceSource(
 	editorPluginSlug: string,
+	slot: string,
 	textDomain: string,
 ): string {
 	const pascalName = toPascalCase(editorPluginSlug);
-	const modelFactoryName = `get${pascalName}SidebarModel`;
+	const modelFactoryName = `get${pascalName}EditorPluginModel`;
 	const enabledFactoryName = `is${pascalName}Enabled`;
-	const componentName = `${pascalName}Sidebar`;
+	const componentName = `${pascalName}Surface`;
+
+	if (slot === "document-setting-panel") {
+		return `import { Button } from '@wordpress/components';
+import { PluginDocumentSettingPanel } from '@wordpress/editor';
+import { __ } from '@wordpress/i18n';
+
+import { ${modelFactoryName}, ${enabledFactoryName} } from './data';
+import './style.scss';
+
+export interface ${componentName}Props {
+\tsurfaceName: string;
+\ttitle: string;
+}
+
+export function ${componentName}( {
+\tsurfaceName,
+\ttitle,
+}: ${componentName}Props ) {
+\tif ( ! ${enabledFactoryName}() ) {
+\t\treturn null;
+\t}
+
+\tconst editorPluginModel = ${modelFactoryName}();
+
+\treturn (
+\t\t<PluginDocumentSettingPanel
+\t\t\tclassName="wp-typia-editor-plugin-shell"
+\t\t\tname={ surfaceName }
+\t\t\ttitle={ title }
+\t\t>
+\t\t\t<p>{ editorPluginModel.summary }</p>
+\t\t\t<Button variant="secondary">
+\t\t\t\t{ editorPluginModel.primaryActionLabel }
+\t\t\t</Button>
+\t\t\t<p className="wp-typia-editor-plugin-shell__hint">
+\t\t\t\t{ __( 'Use data.ts to add post type, capability, or editor context guards before showing this panel.', ${quoteTsString(textDomain)} ) }
+\t\t\t</p>
+\t\t</PluginDocumentSettingPanel>
+\t);
+}
+`;
+	}
 
 	return `import { Button, PanelBody } from '@wordpress/components';
 import { PluginSidebar, PluginSidebarMoreMenuItem } from '@wordpress/editor';
@@ -260,34 +303,34 @@ import { ${modelFactoryName}, ${enabledFactoryName} } from './data';
 import './style.scss';
 
 export interface ${componentName}Props {
-\tpluginName: string;
+\tsurfaceName: string;
 \ttitle: string;
 }
 
 export function ${componentName}( {
-\tpluginName,
+\tsurfaceName,
 \ttitle,
 }: ${componentName}Props ) {
 \tif ( ! ${enabledFactoryName}() ) {
 \t\treturn null;
 \t}
 
-\tconst sidebarModel = ${modelFactoryName}();
+\tconst editorPluginModel = ${modelFactoryName}();
 
 \treturn (
 \t\t<>
-\t\t\t<PluginSidebarMoreMenuItem target={ pluginName }>
+\t\t\t<PluginSidebarMoreMenuItem target={ surfaceName }>
 \t\t\t\t{ title }
 \t\t\t</PluginSidebarMoreMenuItem>
-\t\t\t<PluginSidebar name={ pluginName } title={ title }>
+\t\t\t<PluginSidebar name={ surfaceName } title={ title }>
 \t\t\t\t<div className="wp-typia-editor-plugin-shell">
 \t\t\t\t\t<PanelBody
 \t\t\t\t\t\tinitialOpen
 \t\t\t\t\t\ttitle={ __( 'Document workflow', ${quoteTsString(textDomain)} ) }
 \t\t\t\t\t>
-\t\t\t\t\t\t<p>{ sidebarModel.summary }</p>
+\t\t\t\t\t\t<p>{ editorPluginModel.summary }</p>
 \t\t\t\t\t\t<Button variant="secondary">
-\t\t\t\t\t\t\t{ sidebarModel.primaryActionLabel }
+\t\t\t\t\t\t\t{ editorPluginModel.primaryActionLabel }
 \t\t\t\t\t\t</Button>
 \t\t\t\t\t</PanelBody>
 \t\t\t\t</div>
@@ -304,24 +347,26 @@ function buildEditorPluginEntrySource(
 	textDomain: string,
 ): string {
 	const pascalName = toPascalCase(editorPluginSlug);
-	const componentName = `${pascalName}Sidebar`;
+	const componentName = `${pascalName}Surface`;
 	const pluginName = `${namespace}-${editorPluginSlug}`;
+	const surfaceName = `${pluginName}-surface`;
 	const pluginTitle = toTitleCase(editorPluginSlug);
 
 	return `import { registerPlugin } from '@wordpress/plugins';
 import { __ } from '@wordpress/i18n';
 
 import { REQUIRED_CAPABILITY } from './data';
-import { ${componentName} } from './Sidebar';
+import { ${componentName} } from './Surface';
 
 const EDITOR_PLUGIN_NAME = ${quoteTsString(pluginName)};
+const EDITOR_PLUGIN_SURFACE_NAME = ${quoteTsString(surfaceName)};
 const EDITOR_PLUGIN_TITLE = __( ${quoteTsString(pluginTitle)}, ${quoteTsString(textDomain)} );
 
 registerPlugin( EDITOR_PLUGIN_NAME, {
 \ticon: 'admin-generic',
 \trender: () => (
 \t\t<${componentName}
-\t\t\tpluginName={ EDITOR_PLUGIN_NAME }
+\t\t\tsurfaceName={ EDITOR_PLUGIN_SURFACE_NAME }
 \t\t\ttitle={ EDITOR_PLUGIN_TITLE }
 \t\t/>
 \t),
@@ -338,6 +383,11 @@ function buildEditorPluginStyleSource(): string {
 
 .wp-typia-editor-plugin-shell p {
 \tmargin: 0 0 12px;
+}
+
+.wp-typia-editor-plugin-shell__hint {
+\tcolor: #757575;
+\tfont-size: 12px;
 }
 `;
 }
@@ -759,7 +809,7 @@ async function writeEditorPluginRegistry(
  * Defaults to `process.cwd()`.
  * @param options.editorPluginName Human-entered editor-plugin name that will be
  * normalized and validated before files are written.
- * @param options.slot Optional editor plugin shell slot. Defaults to `PluginSidebar`.
+ * @param options.slot Optional editor plugin shell slot. Defaults to `sidebar`.
  * @returns A promise that resolves with the normalized `editorPluginSlug`, chosen
  * `slot`, and owning `projectDir` after the scaffold files and inventory entry
  * are written successfully.
@@ -779,7 +829,7 @@ export async function runAddEditorPluginCommand({
 	const editorPluginSlug = assertValidGeneratedSlug(
 		"Editor plugin name",
 		normalizeBlockSlug(editorPluginName),
-		"wp-typia add editor-plugin <name> [--slot <PluginSidebar>]",
+		"wp-typia add editor-plugin <name> [--slot <sidebar|document-setting-panel>]",
 	);
 	const resolvedSlot = assertValidEditorPluginSlot(slot);
 
@@ -798,7 +848,7 @@ export async function runAddEditorPluginCommand({
 		editorPluginSlug,
 	);
 	const entryFilePath = path.join(editorPluginDir, "index.tsx");
-	const sidebarFilePath = path.join(editorPluginDir, "Sidebar.tsx");
+	const surfaceFilePath = path.join(editorPluginDir, "Surface.tsx");
 	const dataFilePath = path.join(editorPluginDir, "data.ts");
 	const typesFilePath = path.join(editorPluginDir, "types.ts");
 	const styleFilePath = path.join(editorPluginDir, "style.scss");
@@ -829,9 +879,10 @@ export async function runAddEditorPluginCommand({
 			"utf8",
 		);
 		await fsp.writeFile(
-			sidebarFilePath,
-			buildEditorPluginSidebarSource(
+			surfaceFilePath,
+			buildEditorPluginSurfaceSource(
 				editorPluginSlug,
+				resolvedSlot,
 				workspace.workspace.textDomain,
 			),
 			"utf8",

--- a/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace.ts
@@ -4,10 +4,10 @@ import path from "node:path";
 import { parseScaffoldBlockMetadata } from "@wp-typia/block-runtime/blocks";
 
 import {
-	EDITOR_PLUGIN_SLOT_ALIASES,
 	EDITOR_PLUGIN_SLOT_IDS,
 	REST_RESOURCE_METHOD_IDS,
 	REST_RESOURCE_NAMESPACE_PATTERN,
+	resolveEditorPluginSlotAlias,
 } from "./cli-add-shared.js";
 import {
 	HOOKED_BLOCK_ANCHOR_PATTERN,
@@ -706,10 +706,7 @@ function getWorkspaceEditorPluginRequiredFiles(
 function checkWorkspaceEditorPluginConfig(
 	editorPlugin: WorkspaceInventory["editorPlugins"][number],
 ): DoctorCheck {
-	const normalizedSlot =
-		EDITOR_PLUGIN_SLOT_ALIASES[
-			editorPlugin.slot as keyof typeof EDITOR_PLUGIN_SLOT_ALIASES
-		];
+	const normalizedSlot = resolveEditorPluginSlotAlias(editorPlugin.slot);
 	const isValidSlot = Boolean(normalizedSlot);
 
 	return createDoctorCheck(

--- a/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { parseScaffoldBlockMetadata } from "@wp-typia/block-runtime/blocks";
 
 import {
+	EDITOR_PLUGIN_SLOT_ALIASES,
 	EDITOR_PLUGIN_SLOT_IDS,
 	REST_RESOURCE_METHOD_IDS,
 	REST_RESOURCE_NAMESPACE_PATTERN,
@@ -686,11 +687,15 @@ function getWorkspaceEditorPluginRequiredFiles(
 	editorPlugin: WorkspaceInventory["editorPlugins"][number],
 ): string[] {
 	const editorPluginDir = path.join("src", "editor-plugins", editorPlugin.slug);
+	const surfaceFile =
+		editorPlugin.slot === "PluginSidebar"
+			? path.join(editorPluginDir, "Sidebar.tsx")
+			: path.join(editorPluginDir, "Surface.tsx");
 
 	return Array.from(
 		new Set([
 			editorPlugin.file,
-			path.join(editorPluginDir, "Sidebar.tsx"),
+			surfaceFile,
 			path.join(editorPluginDir, "data.ts"),
 			path.join(editorPluginDir, "types.ts"),
 			path.join(editorPluginDir, "style.scss"),
@@ -701,15 +706,18 @@ function getWorkspaceEditorPluginRequiredFiles(
 function checkWorkspaceEditorPluginConfig(
 	editorPlugin: WorkspaceInventory["editorPlugins"][number],
 ): DoctorCheck {
-	const validSlots = new Set<string>(EDITOR_PLUGIN_SLOT_IDS);
-	const isValidSlot = validSlots.has(editorPlugin.slot);
+	const normalizedSlot =
+		EDITOR_PLUGIN_SLOT_ALIASES[
+			editorPlugin.slot as keyof typeof EDITOR_PLUGIN_SLOT_ALIASES
+		];
+	const isValidSlot = Boolean(normalizedSlot);
 
 	return createDoctorCheck(
 		`Editor plugin config ${editorPlugin.slug}`,
 		isValidSlot ? "pass" : "fail",
 		isValidSlot
-			? `Editor plugin slot ${editorPlugin.slot} is supported`
-			: `Unsupported editor plugin slot "${editorPlugin.slot}". Expected one of: ${EDITOR_PLUGIN_SLOT_IDS.join(", ")}`,
+			? `Editor plugin slot ${editorPlugin.slot} is supported as ${normalizedSlot}`
+			: `Unsupported editor plugin slot "${editorPlugin.slot}". Expected one of: ${EDITOR_PLUGIN_SLOT_IDS.join(", ")} or legacy aliases PluginSidebar, PluginDocumentSettingPanel.`,
 	);
 }
 

--- a/packages/wp-typia-project-tools/src/runtime/cli-help.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-help.ts
@@ -55,7 +55,7 @@ Notes:
   \`add rest-resource\` scaffolds plugin-level TypeScript REST contracts under \`src/rest/\` and PHP route glue under \`inc/rest/\`.
   \`add ability\` scaffolds typed workflow abilities under \`src/abilities/\` and server registration under \`inc/abilities/\`.
   \`add ai-feature\` scaffolds server-owned AI feature endpoints under \`src/ai-features/\` and PHP route glue under \`inc/ai-features/\`.
-  \`add editor-plugin\` scaffolds a document-level editor extension under \`src/editor-plugins/\`; \`PluginSidebar\` remains accepted as a legacy alias for \`sidebar\`.
+  \`add editor-plugin\` scaffolds a document-level editor extension under \`src/editor-plugins/\`; legacy aliases \`PluginSidebar\` and \`PluginDocumentSettingPanel\` resolve to \`sidebar\` and \`document-setting-panel\`.
   \`add hooked-block\` patches an existing workspace block's \`block.json\` \`blockHooks\` metadata.
   \`wp-typia doctor\` always checks environment readiness and reports when it only ran environment-level diagnostics; official workspace roots also get inventory and source-tree drift checks.
   \`wp-typia init\` previews the minimum sync/doctor/migration adoption layer for supported existing layouts before a future write mode exists.

--- a/packages/wp-typia-project-tools/src/runtime/cli-help.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-help.ts
@@ -27,7 +27,7 @@ export function formatHelpText(): string {
   wp-typia add rest-resource <name> [--namespace <vendor/v1>] [--methods <method[,method...]>]
   wp-typia add ability <name>
   wp-typia add ai-feature <name> [--namespace <vendor/v1>]
-  wp-typia add editor-plugin <name> [--slot <PluginSidebar>]
+  wp-typia add editor-plugin <name> [--slot <sidebar|document-setting-panel>]
   wp-typia add hooked-block <block-slug> --anchor <anchor-block-name> --position <before|after|firstChild|lastChild>
   wp-typia migrate <init|snapshot|diff|scaffold|verify|doctor|fixtures|fuzz> [...]
   wp-typia templates list
@@ -55,7 +55,7 @@ Notes:
   \`add rest-resource\` scaffolds plugin-level TypeScript REST contracts under \`src/rest/\` and PHP route glue under \`inc/rest/\`.
   \`add ability\` scaffolds typed workflow abilities under \`src/abilities/\` and server registration under \`inc/abilities/\`.
   \`add ai-feature\` scaffolds server-owned AI feature endpoints under \`src/ai-features/\` and PHP route glue under \`inc/ai-features/\`.
-  \`add editor-plugin\` scaffolds a document-level editor extension under \`src/editor-plugins/\`.
+  \`add editor-plugin\` scaffolds a document-level editor extension under \`src/editor-plugins/\`; \`PluginSidebar\` remains accepted as a legacy alias for \`sidebar\`.
   \`add hooked-block\` patches an existing workspace block's \`block.json\` \`blockHooks\` metadata.
   \`wp-typia doctor\` always checks environment readiness and reports when it only ran environment-level diagnostics; official workspace roots also get inventory and source-tree drift checks.
   \`wp-typia init\` previews the minimum sync/doctor/migration adoption layer for supported existing layouts before a future write mode exists.

--- a/packages/wp-typia-project-tools/tests/cli-entry.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-entry.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { cleanupScaffoldTempRoot, createBlockExternalFixturePath, createBlockSubsetFixturePath, createScaffoldTempRoot, entryPath, getCommandErrorMessage, runCapturedCli, runCli, scaffoldOfficialWorkspace, templateLayerAmbiguousFixturePath, templateLayerFixturePath } from "./helpers/scaffold-test-harness.js";
 import { CLI_DIAGNOSTIC_CODES, createCliCommandError, createCliDiagnosticCodeError, serializeCliDiagnosticError } from "../src/runtime/cli-diagnostics.js";
 import { formatHelpText, getDoctorChecks, getNextSteps, getOptionalOnboarding, runScaffoldFlow } from "../src/runtime/cli-core.js";
+import { assertValidEditorPluginSlot } from "../src/runtime/cli-add-shared.js";
 import { collectScaffoldAnswers } from "../src/runtime/scaffold.js";
 import { getQuickStartWorkflowNote } from "../src/runtime/scaffold-onboarding.js";
 
@@ -70,6 +71,16 @@ test("CLI diagnostics preserve explicit throw-site codes without message inferen
 
   expect(diagnostic.code).toBe("missing-argument");
   expect(diagnostic.message).toContain("Opaque scaffold preflight failure.");
+});
+
+test("editor plugin slot validation rejects inherited object keys", () => {
+  expect(assertValidEditorPluginSlot("PluginSidebar")).toBe("sidebar");
+  expect(assertValidEditorPluginSlot("PluginDocumentSettingPanel")).toBe(
+    "document-setting-panel"
+  );
+  expect(() => assertValidEditorPluginSlot("toString")).toThrow(
+    "Editor plugin slot must be one of:"
+  );
 });
 
 test("runScaffoldFlow defaults persistence scaffolds to custom-table and authenticated in non-interactive mode", async () => {

--- a/packages/wp-typia-project-tools/tests/cli-entry.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-entry.test.ts
@@ -785,7 +785,7 @@ test("formatHelpText keeps migration UI flags out of external template usage", (
   );
   expect(helpText).toContain("wp-typia add editor-plugin <name>");
   expect(helpText).toContain(
-    "wp-typia add editor-plugin <name> [--slot <PluginSidebar>]"
+    "wp-typia add editor-plugin <name> [--slot <sidebar|document-setting-panel>]"
   );
   expect(helpText).toContain("wp-typia add rest-resource <name>");
   expect(helpText).toContain("--methods <method[,method...]>");

--- a/packages/wp-typia-project-tools/tests/workspace-add.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-add.test.ts
@@ -3649,8 +3649,8 @@ test("canonical CLI can add an editor plugin to an official workspace template",
     path.join(targetDir, "src", "editor-plugins", "document-tools", "index.tsx"),
     "utf8"
   );
-  const sidebarSource = fs.readFileSync(
-    path.join(targetDir, "src", "editor-plugins", "document-tools", "Sidebar.tsx"),
+  const surfaceSource = fs.readFileSync(
+    path.join(targetDir, "src", "editor-plugins", "document-tools", "Surface.tsx"),
     "utf8"
   );
   const dataSource = fs.readFileSync(
@@ -3659,7 +3659,7 @@ test("canonical CLI can add an editor plugin to an official workspace template",
   );
 
   expect(blockConfigSource).toContain('slug: "document-tools"');
-  expect(blockConfigSource).toContain('slot: "PluginSidebar"');
+  expect(blockConfigSource).toContain('slot: "sidebar"');
   expect(blockConfigSource).toContain(
     'file: "src/editor-plugins/document-tools/index.tsx"'
   );
@@ -3671,9 +3671,11 @@ test("canonical CLI can add an editor plugin to an official workspace template",
   expect(editorPluginsIndexSource).toContain("import './document-tools';");
   expect(entrySource).toContain("registerPlugin");
   expect(entrySource).toContain("demo-space-document-tools");
-  expect(sidebarSource).toContain("PluginSidebar");
-  expect(sidebarSource).toContain("PluginSidebarMoreMenuItem");
-  expect(dataSource).toContain('EDITOR_PLUGIN_SLOT = "PluginSidebar"');
+  expect(entrySource).toContain("Surface");
+  expect(surfaceSource).toContain("PluginSidebar");
+  expect(surfaceSource).toContain("PluginSidebarMoreMenuItem");
+  expect(dataSource).toContain('EDITOR_PLUGIN_SLOT = "sidebar"');
+  expect(dataSource).toContain("getDocumentToolsEditorPluginModel");
   expect(dataSource).toContain("isDocumentToolsEnabled");
 
   const doctorOutput = runCli("node", [entryPath, "doctor", "--format", "json"], {
@@ -3720,6 +3722,87 @@ test("canonical CLI can add an editor plugin to an official workspace template",
   expect(
     fs.existsSync(path.join(targetDir, "build", "blocks-manifest.php"))
   ).toBe(true);
+}, 30_000);
+
+test("canonical CLI can add a document settings panel editor plugin", async () => {
+  const targetDir = path.join(
+    tempRoot,
+    "demo-workspace-add-editor-plugin-document-panel"
+  );
+
+  await scaffoldProject({
+    projectDir: targetDir,
+    templateId: workspaceTemplatePackageManifest.name,
+    packageManager: "npm",
+    noInstall: true,
+    answers: {
+      author: "Test Runner",
+      description: "Demo workspace add editor plugin document panel",
+      namespace: "demo-space",
+      phpPrefix: "demo_space",
+      slug: "demo-workspace-add-editor-plugin-document-panel",
+      textDomain: "demo-space",
+      title: "Demo Workspace Add Editor Plugin Document Panel",
+    },
+  });
+
+  linkWorkspaceNodeModules(targetDir);
+
+  runCli(
+    "node",
+    [
+      entryPath,
+      "add",
+      "editor-plugin",
+      "seo-notes",
+      "--slot",
+      "document-setting-panel",
+    ],
+    {
+      cwd: targetDir,
+    }
+  );
+
+  const blockConfigSource = fs.readFileSync(
+    path.join(targetDir, "scripts", "block-config.ts"),
+    "utf8"
+  );
+  const entrySource = fs.readFileSync(
+    path.join(targetDir, "src", "editor-plugins", "seo-notes", "index.tsx"),
+    "utf8"
+  );
+  const surfaceSource = fs.readFileSync(
+    path.join(targetDir, "src", "editor-plugins", "seo-notes", "Surface.tsx"),
+    "utf8"
+  );
+  const dataSource = fs.readFileSync(
+    path.join(targetDir, "src", "editor-plugins", "seo-notes", "data.ts"),
+    "utf8"
+  );
+
+  expect(blockConfigSource).toContain('slug: "seo-notes"');
+  expect(blockConfigSource).toContain('slot: "document-setting-panel"');
+  expect(entrySource).toContain("registerPlugin");
+  expect(entrySource).toContain("demo-space-seo-notes");
+  expect(surfaceSource).toContain("PluginDocumentSettingPanel");
+  expect(surfaceSource).not.toContain("PluginSidebarMoreMenuItem");
+  expect(surfaceSource).toContain("Use data.ts to add post type");
+  expect(dataSource).toContain('EDITOR_PLUGIN_SLOT = "document-setting-panel"');
+  expect(dataSource).toContain("getSeoNotesEditorPluginModel");
+
+  const doctorOutput = runCli("node", [entryPath, "doctor", "--format", "json"], {
+    cwd: targetDir,
+  });
+  const doctorChecks = parseJsonObjectFromOutput<{
+    checks: Array<{ detail: string; label: string; status: string }>;
+  }>(doctorOutput);
+  expect(
+    doctorChecks.checks.find(
+      (check) => check.label === "Editor plugin config seo-notes"
+    )?.status
+  ).toBe("pass");
+
+  typecheckGeneratedProject(targetDir);
 }, 30_000);
 
 test("editor plugin workflow repairs legacy workspace build config hooks", async () => {

--- a/packages/wp-typia/README.md
+++ b/packages/wp-typia/README.md
@@ -17,6 +17,8 @@ Extend an existing workspace with:
 - `wp-typia add rest-resource snapshots --namespace my-plugin/v1 --methods list,read,create`
 - `wp-typia add ability review-workflow`
 - `wp-typia add ai-feature brief-suggestions --namespace my-plugin/v1`
+- `wp-typia add editor-plugin review-workflow --slot sidebar`
+- `wp-typia add editor-plugin seo-notes --slot document-setting-panel`
 - `wp-typia add hooked-block counter-card --anchor core/post-content --position after`
 
 `wp-typia <project-dir>` remains available as a backward-compatible alias to

--- a/packages/wp-typia/src/add-kind-registry.ts
+++ b/packages/wp-typia/src/add-kind-registry.ts
@@ -161,7 +161,7 @@ export const ADD_KIND_REGISTRY = {
       ],
       title: 'Added editor plugin',
     },
-    description: 'Add a document-level editor extension shell',
+    description: 'Add a slot-aware document editor extension shell',
     nameLabel: 'Editor plugin name',
     visibleFieldNames: () => ['kind', 'name', 'slot'],
   },

--- a/packages/wp-typia/src/command-option-metadata.ts
+++ b/packages/wp-typia/src/command-option-metadata.ts
@@ -174,7 +174,8 @@ export const ADD_OPTION_METADATA = {
 		type: "string",
 	},
 	slot: {
-		description: "Document editor shell slot for editor-plugin workflows.",
+		description:
+			"Document editor shell slot for editor-plugin workflows (sidebar or document-setting-panel).",
 		type: "string",
 	},
 	source: {

--- a/packages/wp-typia/src/commands/add.ts
+++ b/packages/wp-typia/src/commands/add.ts
@@ -107,7 +107,7 @@ export const addCommand = defineCommand({
                 kind: (args.positional[0] as AddKindId | undefined) ?? 'block',
                 name: args.positional[1] ?? '',
                 position: initialValues.position ?? 'after',
-                slot: initialValues.slot ?? 'PluginSidebar',
+                slot: initialValues.slot ?? 'sidebar',
               },
             },
           });

--- a/packages/wp-typia/src/runtime-bridge.ts
+++ b/packages/wp-typia/src/runtime-bridge.ts
@@ -405,7 +405,7 @@ const ADD_KIND_EXECUTION_REGISTRY: Record<
   'editor-plugin': async (context) => {
     const name = requireAddKindName(
       context,
-      '`wp-typia add editor-plugin` requires <name>. Usage: wp-typia add editor-plugin <name> [--slot <PluginSidebar>].',
+      '`wp-typia add editor-plugin` requires <name>. Usage: wp-typia add editor-plugin <name> [--slot <sidebar|document-setting-panel>].',
     );
     const slot = readOptionalStringFlag(context.flags, 'slot');
 

--- a/packages/wp-typia/src/ui/add-flow.tsx
+++ b/packages/wp-typia/src/ui/add-flow.tsx
@@ -87,7 +87,8 @@ const compoundInnerBlocksPresetOptions: SelectOption[] =
   }));
 
 const EDITOR_PLUGIN_SLOT_DESCRIPTIONS: Record<string, string> = {
-  PluginSidebar: 'Register a document sidebar and more-menu entry',
+  'document-setting-panel': 'Register a document settings sidebar panel',
+  sidebar: 'Register a document sidebar and more-menu entry',
 };
 
 const editorPluginSlotOptions: SelectOption[] = EDITOR_PLUGIN_SLOT_IDS.map(

--- a/scripts/lib/generated-project-smoke-assertions.mjs
+++ b/scripts/lib/generated-project-smoke-assertions.mjs
@@ -403,7 +403,7 @@ export function assertGeneratedProjectScaffold({
 			assertWorkspaceEditorPluginArtifacts(
 				projectDir,
 				normalizeBlockSlug(addEditorPluginName),
-				addEditorPluginSlot ?? "PluginSidebar",
+				addEditorPluginSlot ?? "sidebar",
 			);
 		}
 		if (addHookedBlockSlug && addHookedBlockAnchor && addHookedBlockPosition) {

--- a/scripts/lib/generated-project-smoke-workspace-assertions.mjs
+++ b/scripts/lib/generated-project-smoke-workspace-assertions.mjs
@@ -6,6 +6,17 @@ import {
   run,
 } from "./generated-project-smoke-core.mjs";
 
+const EDITOR_PLUGIN_SMOKE_SLOT_ALIASES = new Map([
+	["PluginDocumentSettingPanel", "document-setting-panel"],
+	["PluginSidebar", "sidebar"],
+	["document-setting-panel", "document-setting-panel"],
+	["sidebar", "sidebar"],
+]);
+
+function normalizeEditorPluginSmokeSlot(slot = "sidebar") {
+	return EDITOR_PLUGIN_SMOKE_SLOT_ALIASES.get(slot) ?? slot;
+}
+
 function lintPhpArtifact(filePath) {
   if (!hasPhpBinary()) {
     return;
@@ -108,6 +119,7 @@ export function assertWorkspaceEditorPluginArtifacts(
 	editorPluginSlug,
 	slot,
 ) {
+	const normalizedSlot = normalizeEditorPluginSmokeSlot(slot);
 	const editorPluginDir = path.join(
 		projectDir,
 		"src",
@@ -115,12 +127,12 @@ export function assertWorkspaceEditorPluginArtifacts(
 		editorPluginSlug,
 	);
 	const entryPath = path.join(editorPluginDir, "index.tsx");
-	const sidebarPath = path.join(editorPluginDir, "Sidebar.tsx");
+	const surfacePath = path.join(editorPluginDir, "Surface.tsx");
 	const dataPath = path.join(editorPluginDir, "data.ts");
 	const typesPath = path.join(editorPluginDir, "types.ts");
 	const stylePath = path.join(editorPluginDir, "style.scss");
 
-	for (const filePath of [entryPath, sidebarPath, dataPath, typesPath, stylePath]) {
+	for (const filePath of [entryPath, surfacePath, dataPath, typesPath, stylePath]) {
 		if (!fs.existsSync(filePath)) {
 			throw new Error(`Expected workspace editor plugin file at ${filePath}`);
 		}
@@ -149,9 +161,26 @@ export function assertWorkspaceEditorPluginArtifacts(
 	}
 
 	const dataSource = fs.readFileSync(dataPath, "utf8");
-	if (!dataSource.includes(`EDITOR_PLUGIN_SLOT = "${slot}"`)) {
+	const surfaceSource = fs.readFileSync(surfacePath, "utf8");
+	if (!dataSource.includes(`EDITOR_PLUGIN_SLOT = "${normalizedSlot}"`)) {
 		throw new Error(
-			`Expected ${dataPath} to pin the ${slot} editor plugin slot.`,
+			`Expected ${dataPath} to pin the ${normalizedSlot} editor plugin slot.`,
+		);
+	}
+	if (
+		normalizedSlot === "document-setting-panel" &&
+		!surfaceSource.includes("PluginDocumentSettingPanel")
+	) {
+		throw new Error(
+			`Expected ${surfacePath} to render PluginDocumentSettingPanel for document-setting-panel.`,
+		);
+	}
+	if (
+		normalizedSlot === "sidebar" &&
+		!surfaceSource.includes("PluginSidebarMoreMenuItem")
+	) {
+		throw new Error(
+			`Expected ${surfacePath} to render PluginSidebarMoreMenuItem for sidebar.`,
 		);
 	}
 }

--- a/scripts/run-generated-project-smoke.mjs
+++ b/scripts/run-generated-project-smoke.mjs
@@ -304,7 +304,7 @@ function main() {
 		(template && exampleProject)
 	) {
 		throw new Error(
-			"Usage: node scripts/run-generated-project-smoke.mjs --runtime <node|bun> (--template <id> | --example-project <slug>) [--variant <name>] [--namespace <value>] [--text-domain <value>] [--php-prefix <value>] [--data-storage <post-meta|custom-table>] [--persistence-policy <authenticated|public>] [--with-migration-ui] [--add-block-name <name> --add-template <basic|interactivity|persistence|compound> [--add-data-storage <post-meta|custom-table>] [--add-persistence-policy <authenticated|public>]] [--add-variation-name <name> --add-variation-block <block-slug>] [--add-pattern-name <name>] [--add-binding-source-name <name>] [--add-editor-plugin-name <name> [--add-editor-plugin-slot <PluginSidebar>]] [--add-hooked-block-slug <block-slug> --add-hooked-block-anchor <anchor-block-name> --add-hooked-block-position <before|after|firstChild|lastChild>] --package-manager <id> --project-name <name>",
+			"Usage: node scripts/run-generated-project-smoke.mjs --runtime <node|bun> (--template <id> | --example-project <slug>) [--variant <name>] [--namespace <value>] [--text-domain <value>] [--php-prefix <value>] [--data-storage <post-meta|custom-table>] [--persistence-policy <authenticated|public>] [--with-migration-ui] [--add-block-name <name> --add-template <basic|interactivity|persistence|compound> [--add-data-storage <post-meta|custom-table>] [--add-persistence-policy <authenticated|public>]] [--add-variation-name <name> --add-variation-block <block-slug>] [--add-pattern-name <name>] [--add-binding-source-name <name>] [--add-editor-plugin-name <name> [--add-editor-plugin-slot <sidebar|document-setting-panel>]] [--add-hooked-block-slug <block-slug> --add-hooked-block-anchor <anchor-block-name> --add-hooked-block-position <before|after|firstChild|lastChild>] --package-manager <id> --project-name <name>",
 		);
 	}
 
@@ -430,7 +430,7 @@ function main() {
 		}
 
 		if (addEditorPluginName) {
-			const slotForArgs = addEditorPluginSlot ?? "PluginSidebar";
+			const slotForArgs = addEditorPluginSlot ?? "sidebar";
 			run(
 				runtime,
 				[
@@ -500,7 +500,7 @@ function main() {
 			addBlockName,
 			addEditorPluginName,
 			addEditorPluginSlot: addEditorPluginName
-				? (addEditorPluginSlot ?? "PluginSidebar")
+				? (addEditorPluginSlot ?? "sidebar")
 				: undefined,
 			addHookedBlockAnchor,
 			addHookedBlockPosition,


### PR DESCRIPTION
## Summary

- Make editor-plugin slots canonical with `sidebar` and `document-setting-panel`, while keeping `PluginSidebar` and `PluginDocumentSettingPanel` as legacy aliases.
- Generate neutral `Surface.tsx` shells that match the selected WordPress SlotFill: `PluginSidebar` plus a more-menu entry for sidebar, `PluginDocumentSettingPanel` for document settings.
- Update CLI help, README examples, docs, TUI option defaults, doctor compatibility checks, tests, and changeset.

## References

- WordPress SlotFills: https://developer.wordpress.org/block-editor/reference-guides/slotfills/
- PluginSidebar: https://developer.wordpress.org/block-editor/reference-guides/slotfills/plugin-sidebar/
- PluginDocumentSettingPanel: https://developer.wordpress.org/block-editor/reference-guides/slotfills/plugin-document-setting-panel/

## Tests

- `bun run --cwd packages/wp-typia-project-tools test:workspace`
- `bun test packages/wp-typia-project-tools/tests/cli-entry.test.ts --test-name-pattern "formatHelpText"`
- `bun test packages/wp-typia/tests/tui-interaction-models.test.ts packages/wp-typia/tests/command-option-metadata.test.ts packages/wp-typia/tests/add-command.test.ts`
- `bun test packages/wp-typia/tests/cli-package.test.ts --test-name-pattern "packs a built dist-bunli runtime"`
- `bun test packages/wp-typia/tests/cli-package.test.ts --test-name-pattern "emits structured add completion output"`
- `bun run changesets:validate`
- `bun run format:check`
- `bun run typecheck`
- `git diff --check`

Closes #592


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Editor plugins now support slot-aware scaffolding with two canonical surfaces: `sidebar` and `document-setting-panel`. Legacy `PluginSidebar` alias continues to work.

* **Documentation**
  * Updated CLI reference, README examples, and help text to document new slot names and their usage.

* **Tests**
  * Added integration tests for editor plugin slot configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->