### PR TITLE
feat(scaffold): wire binding source targets

### DIFF
--- a/.sampo/changesets/binding-source-target-workflows.md
+++ b/.sampo/changesets/binding-source-target-workflows.md
@@ -1,6 +1,6 @@
 ---
 npm/@wp-typia/project-tools: minor
-npm/@wp-typia/create-workspace-template: patch
+npm/@wp-typia/create-workspace-template: minor
 npm/wp-typia: minor
 ---
 

--- a/.sampo/changesets/binding-source-target-workflows.md
+++ b/.sampo/changesets/binding-source-target-workflows.md
@@ -1,0 +1,7 @@
+---
+npm/@wp-typia/project-tools: minor
+npm/@wp-typia/create-workspace-template: patch
+npm/wp-typia: minor
+---
+
+Elevate binding-source scaffolds with optional end-to-end block target wiring, including typed attribute updates, supported-attributes doctor checks, and CLI/docs coverage.

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ bun install
 wp-typia add block counter-card --template basic
 wp-typia add block faq-stack --template compound --persistence-policy public --data-storage custom-table
 wp-typia add binding-source hero-data
+wp-typia add binding-source hero-data --block counter-card --attribute headline
 wp-typia add rest-resource snapshots --namespace my-plugin/v1 --methods list,read,create
 wp-typia add editor-plugin review-workflow --slot sidebar
 wp-typia add editor-plugin seo-notes --slot document-setting-panel

--- a/apps/docs/src/content/docs/reference/api.md
+++ b/apps/docs/src/content/docs/reference/api.md
@@ -92,6 +92,7 @@ wp-typia add block counter-card --template basic
 wp-typia add variation hero-card --block counter-card
 wp-typia add pattern hero-layout
 wp-typia add binding-source hero-data
+wp-typia add binding-source hero-data --block counter-card --attribute headline
 wp-typia add hooked-block counter-card --anchor core/post-content --position after
 wp-typia templates list
 wp-typia templates inspect basic
@@ -119,6 +120,7 @@ wp-typia add block counter-card --template basic
 wp-typia add variation hero-card --block counter-card
 wp-typia add pattern hero-layout
 wp-typia add binding-source hero-data
+wp-typia add binding-source hero-data --block demo-space/counter-card --attribute headline
 wp-typia add hooked-block counter-card --anchor core/post-content --position after
 wp-typia add block faq-stack --template compound --persistence-policy public --data-storage custom-table
 ```
@@ -714,6 +716,7 @@ Official workspaces also support first-class variation, pattern, binding-source,
 wp-typia add variation hero-card --block counter-card
 wp-typia add pattern hero-layout
 wp-typia add binding-source hero-data
+wp-typia add binding-source hero-data --block counter-card --attribute headline
 wp-typia add ability review-workflow
 wp-typia add ai-feature brief-suggestions --namespace my-plugin/v1
 wp-typia add hooked-block counter-card --anchor core/post-content --position after
@@ -727,7 +730,11 @@ wired through the shared workspace bootstrap plus editor bundle. The generated
 starter contract keeps one field-keyed data map in each file, so the common
 follow-up is to edit `src/bindings/<name>/server.php` and
 `src/bindings/<name>/editor.ts` in parallel by replacing the default starter
-values for the fields you want to expose.
+values for the fields you want to expose. If you pass `--block` and
+`--attribute` together, the workflow also declares the target attribute in the
+generated block's `block.json`, registers the WordPress supported-attributes
+filter for that block, records the target in `scripts/block-config.ts`, and lets
+`wp-typia doctor` detect missing source/attribute wiring later.
 Workflow abilities are generated under `src/abilities/*/` plus
 `inc/abilities/*.php` and scaffold typed input/output contracts, JSON Schema
 sync, server-side Abilities API registration, and a lightweight admin/editor

--- a/apps/docs/src/content/docs/reference/cli.md
+++ b/apps/docs/src/content/docs/reference/cli.md
@@ -73,6 +73,7 @@ wp-typia add block <name> --template basic
 wp-typia add variation <name> --block <block-slug>
 wp-typia add pattern <name>
 wp-typia add binding-source <name>
+wp-typia add binding-source <name> --block <block-slug|namespace/block-slug> --attribute <attribute>
 wp-typia add rest-resource <name> --namespace <vendor/v1> --methods GET,POST
 wp-typia add ability <name>
 wp-typia add ai-feature <name> --namespace <vendor/v1>

--- a/packages/create-workspace-template/README.md
+++ b/packages/create-workspace-template/README.md
@@ -13,6 +13,7 @@ The generated project starts with an empty `src/blocks/*` workspace shell and is
 ```bash
 wp-typia add block my-block --template basic
 wp-typia add binding-source hero-data
+wp-typia add binding-source hero-data --block counter-card --attribute headline
 wp-typia add editor-plugin review-workflow --slot sidebar
 wp-typia add editor-plugin seo-notes --slot document-setting-panel
 wp-typia add hooked-block my-block --anchor core/post-content --position after

--- a/packages/create-workspace-template/README.md
+++ b/packages/create-workspace-template/README.md
@@ -13,7 +13,7 @@ The generated project starts with an empty `src/blocks/*` workspace shell and is
 ```bash
 wp-typia add block my-block --template basic
 wp-typia add binding-source hero-data
-wp-typia add binding-source hero-data --block counter-card --attribute headline
+wp-typia add binding-source hero-data --block my-block --attribute headline
 wp-typia add editor-plugin review-workflow --slot sidebar
 wp-typia add editor-plugin seo-notes --slot document-setting-panel
 wp-typia add hooked-block my-block --anchor core/post-content --position after

--- a/packages/create-workspace-template/scripts/block-config.ts.mustache
+++ b/packages/create-workspace-template/scripts/block-config.ts.mustache
@@ -21,6 +21,8 @@ export interface WorkspacePatternConfig {
 }
 
 export interface WorkspaceBindingSourceConfig {
+	attribute?: string;
+	block?: string;
 	editorFile: string;
 	serverFile: string;
 	slug: string;

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-shared.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-shared.ts
@@ -106,6 +106,8 @@ export interface RunAddPatternCommandOptions {
 }
 
 export interface RunAddBindingSourceCommandOptions {
+	attributeName?: string;
+	blockName?: string;
 	bindingSourceName: string;
 	cwd?: string;
 }
@@ -683,7 +685,7 @@ export function formatAddHelpText(): string {
   wp-typia add block <name> --template <${ADD_BLOCK_TEMPLATE_IDS.join("|")}> [--external-layer-source <./path|github:owner/repo/path[#ref]|npm-package>] [--external-layer-id <layer-id>] [--inner-blocks-preset <freeform|ordered|horizontal|locked-structure>] [--alternate-render-targets <email,mjml,plain-text>] [--data-storage <post-meta|custom-table>] [--persistence-policy <authenticated|public>] [--dry-run]
   wp-typia add variation <name> --block <block-slug> [--dry-run]
   wp-typia add pattern <name> [--dry-run]
-  wp-typia add binding-source <name> [--dry-run]
+  wp-typia add binding-source <name> [--block <block-slug|namespace/block-slug> --attribute <attribute>] [--dry-run]
   wp-typia add rest-resource <name> [--namespace <vendor/v1>] [--methods <list,read,create,update,delete>] [--dry-run]
   wp-typia add ability <name> [--dry-run]
   wp-typia add ai-feature <name> [--namespace <vendor/v1>] [--dry-run]
@@ -697,7 +699,7 @@ Notes:
   \`query-loop\` is a create-time scaffold family. Use \`wp-typia create <project-dir> --template query-loop\` instead of \`wp-typia add block\`.
   \`add variation\` targets an existing block slug from \`scripts/block-config.ts\`.
   \`add pattern\` scaffolds a namespaced PHP pattern shell under \`src/patterns/\`.
-  \`add binding-source\` scaffolds shared PHP and editor registration under \`src/bindings/\`.
+  \`add binding-source\` scaffolds shared PHP and editor registration under \`src/bindings/\`; pass \`--block\` and \`--attribute\` together to declare an end-to-end bindable attribute on an existing generated block.
   \`add rest-resource\` scaffolds plugin-level TypeScript REST contracts under \`src/rest/\` and PHP route glue under \`inc/rest/\`.
   \`add ability\` scaffolds typed workflow abilities under \`src/abilities/\` and server registration under \`inc/abilities/\`.
   \`add ai-feature\` scaffolds server-owned AI feature endpoints under \`src/ai-features/\` and PHP route glue under \`inc/ai-features/\`.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-assets.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-assets.ts
@@ -114,6 +114,11 @@ function resolveBindingTargetBlockSlug(
 			`Binding target block "${trimmed}" must use <block-slug> or <namespace/block-slug> format.`,
 		);
 	}
+	if (blockNameSegments.some((segment) => segment.trim() === "")) {
+		throw new Error(
+			`Binding target block "${trimmed}" must use <block-slug> or <namespace/block-slug> format without empty path segments.`,
+		);
+	}
 
 	const [maybeNamespace, maybeSlug] =
 		blockNameSegments.length === 2

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-assets.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-assets.ts
@@ -198,10 +198,12 @@ if ( ! function_exists( '${bindingSourceSupportedAttributesFunctionName}' ) ) {
 		: "";
 	const supportedAttributesHook = target
 		? `
-add_filter(
-\t${quotePhpString(`block_bindings_supported_attributes_${namespace}/${target.blockSlug}`)},
-\t${quotePhpString(bindingSourceSupportedAttributesFunctionName)}
-);
+if ( function_exists( '${bindingSourceSupportedAttributesFunctionName}' ) ) {
+\tadd_filter(
+\t\t${quotePhpString(`block_bindings_supported_attributes_${namespace}/${target.blockSlug}`)},
+\t\t${quotePhpString(bindingSourceSupportedAttributesFunctionName)}
+\t);
+}
 `
 		: "";
 
@@ -364,12 +366,12 @@ function getInterfaceDeclaration(
 	);
 	let declaration: ts.InterfaceDeclaration | undefined;
 
-	const visit = (node: ts.Node): void => {
+	const visit = (node: ts.Node): boolean => {
 		if (ts.isInterfaceDeclaration(node) && node.name.text === interfaceName) {
 			declaration = node;
-			return;
+			return true;
 		}
-		ts.forEachChild(node, visit);
+		return ts.forEachChild(node, (child) => (visit(child) ? true : undefined)) ?? false;
 	};
 	visit(sourceFile);
 

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-assets.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-assets.ts
@@ -3,13 +3,22 @@ import { promises as fsp } from "node:fs";
 import path from "node:path";
 
 import {
+	syncBlockMetadata,
+} from "@wp-typia/block-runtime/metadata-core";
+
+import {
 	resolveWorkspaceProject,
 	type WorkspaceProject,
 } from "./workspace-project.js";
-import { readWorkspaceInventory, appendWorkspaceInventoryEntries } from "./workspace-inventory.js";
+import {
+	readWorkspaceInventory,
+	appendWorkspaceInventoryEntries,
+	type WorkspaceInventory,
+} from "./workspace-inventory.js";
 import { toPascalCase, toTitleCase } from "./string-case.js";
 import {
 	findPhpFunctionRange,
+	escapeRegex,
 	hasPhpFunctionDefinition,
 	quotePhpString,
 	replacePhpFunctionDefinition,
@@ -24,6 +33,7 @@ import {
 	normalizeBlockSlug,
 	patchFile,
 	quoteTsString,
+	resolveWorkspaceBlock,
 	rollbackWorkspaceMutation,
 	type RunAddBindingSourceCommandOptions,
 	type RunAddEditorPluginCommandOptions,
@@ -40,6 +50,12 @@ const EDITOR_PLUGIN_EDITOR_SCRIPT = "build/editor-plugins/index.js";
 const EDITOR_PLUGIN_EDITOR_ASSET = "build/editor-plugins/index.asset.php";
 const EDITOR_PLUGIN_EDITOR_STYLE = "build/editor-plugins/style-index.css";
 const EDITOR_PLUGIN_EDITOR_STYLE_RTL = "build/editor-plugins/style-index-rtl.css";
+const BINDING_ATTRIBUTE_NAME_PATTERN = /^[A-Za-z][A-Za-z0-9_-]*$/u;
+
+type BindingTarget = {
+	attributeName: string;
+	blockSlug: string;
+};
 
 function buildPatternConfigEntry(patternSlug: string): string {
 	return [
@@ -50,14 +66,58 @@ function buildPatternConfigEntry(patternSlug: string): string {
 	].join("\n");
 }
 
-function buildBindingSourceConfigEntry(bindingSourceSlug: string): string {
+function buildBindingSourceConfigEntry(
+	bindingSourceSlug: string,
+	target?: BindingTarget,
+): string {
 	return [
 		"\t{",
+		...(target ? [`\t\tattribute: ${quoteTsString(target.attributeName)},`] : []),
+		...(target ? [`\t\tblock: ${quoteTsString(target.blockSlug)},`] : []),
 		`\t\teditorFile: ${quoteTsString(`src/bindings/${bindingSourceSlug}/editor.ts`)},`,
 		`\t\tserverFile: ${quoteTsString(`src/bindings/${bindingSourceSlug}/server.php`)},`,
 		`\t\tslug: ${quoteTsString(bindingSourceSlug)},`,
 		"\t},",
 	].join("\n");
+}
+
+function assertValidBindingAttributeName(attributeName: string): string {
+	const trimmed = attributeName.trim();
+	if (!trimmed) {
+		throw new Error(
+			"`wp-typia add binding-source` requires --attribute <attribute> to include a value when --block is provided.",
+		);
+	}
+	if (!BINDING_ATTRIBUTE_NAME_PATTERN.test(trimmed)) {
+		throw new Error(
+			`Binding attribute "${attributeName}" must start with a letter and use only letters, numbers, underscores, or hyphens.`,
+		);
+	}
+
+	return trimmed;
+}
+
+function resolveBindingTargetBlockSlug(
+	blockName: string,
+	namespace: string,
+): string {
+	const trimmed = blockName.trim();
+	if (!trimmed) {
+		throw new Error(
+			"`wp-typia add binding-source` requires --block <block-slug|namespace/block-slug> to include a value when --attribute is provided.",
+		);
+	}
+
+	const [maybeNamespace, maybeSlug] = trimmed.includes("/")
+		? trimmed.split("/", 2)
+		: [undefined, trimmed];
+	if (maybeNamespace && maybeNamespace !== namespace) {
+		throw new Error(
+			`Binding target block "${trimmed}" uses namespace "${maybeNamespace}". Expected "${namespace}".`,
+		);
+	}
+
+	return normalizeBlockSlug(maybeSlug ?? "");
 }
 
 function buildEditorPluginConfigEntry(
@@ -102,12 +162,35 @@ function buildBindingSourceServerSource(
 	phpPrefix: string,
 	namespace: string,
 	textDomain: string,
+	target?: BindingTarget,
 ): string {
 	const bindingSourceTitle = toTitleCase(bindingSourceSlug);
 	const bindingSourcePhpId = bindingSourceSlug.replace(/-/g, "_");
 	const bindingSourceValueFunctionName = `${phpPrefix}_${bindingSourcePhpId}_binding_source_values`;
 	const bindingSourceResolveFunctionName = `${phpPrefix}_${bindingSourcePhpId}_resolve_binding_source_value`;
+	const bindingSourceSupportedAttributesFunctionName = `${phpPrefix}_${bindingSourcePhpId}_supported_binding_attributes`;
 	const starterValue = `${bindingSourceTitle} starter value`;
+	const supportedAttributesSource = target
+		? `
+if ( ! function_exists( '${bindingSourceSupportedAttributesFunctionName}' ) ) {
+\tfunction ${bindingSourceSupportedAttributesFunctionName}( array $supported_attributes ) : array {
+\t\tif ( ! in_array( ${quotePhpString(target.attributeName)}, $supported_attributes, true ) ) {
+\t\t\t$supported_attributes[] = ${quotePhpString(target.attributeName)};
+\t\t}
+
+\t\treturn $supported_attributes;
+\t}
+}
+`
+		: "";
+	const supportedAttributesHook = target
+		? `
+add_filter(
+\t${quotePhpString(`block_bindings_supported_attributes_${namespace}/${target.blockSlug}`)},
+\t${quotePhpString(bindingSourceSupportedAttributesFunctionName)}
+);
+`
+		: "";
 
 	return `<?php
 if ( ! defined( 'ABSPATH' ) ) {
@@ -137,6 +220,7 @@ if ( ! function_exists( '${bindingSourceResolveFunctionName}' ) ) {
 \t\treturn is_string( $value ) ? $value : '';
 \t}
 }
+${supportedAttributesSource}
 
 register_block_bindings_source(
 \t${quotePhpString(`${namespace}/${bindingSourceSlug}`)},
@@ -145,16 +229,28 @@ register_block_bindings_source(
 \t\t'get_value_callback' => ${quotePhpString(bindingSourceResolveFunctionName)},
 \t)
 );
-`;
+${supportedAttributesHook}`;
 }
 
 function buildBindingSourceEditorSource(
 	bindingSourceSlug: string,
 	namespace: string,
 	textDomain: string,
+	target?: BindingTarget,
 ): string {
 	const bindingSourceTitle = toTitleCase(bindingSourceSlug);
 	const starterValue = `${bindingSourceTitle} starter value`;
+	const bindingSourceName = `${namespace}/${bindingSourceSlug}`;
+	const targetSource = target
+		? `
+export const BINDING_SOURCE_TARGET = {
+\tattribute: ${quoteTsString(target.attributeName)},
+\tblock: ${quoteTsString(`${namespace}/${target.blockSlug}`)},
+\tfield: ${quoteTsString(bindingSourceSlug)},
+\tsource: ${quoteTsString(bindingSourceName)},
+} as const;
+`
+		: "";
 
 	return `import { registerBlockBindingsSource } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
@@ -168,13 +264,14 @@ interface BindingSourceRegistration {
 const BINDING_SOURCE_VALUES: Record<string, string> = {
 \t${quoteTsString(bindingSourceSlug)}: ${quoteTsString(starterValue)},
 };
+${targetSource}
 
 function resolveBindingSourceValue( field: string ): string {
 \treturn BINDING_SOURCE_VALUES[ field ] ?? '';
 }
 
 registerBlockBindingsSource( {
-\tname: ${quoteTsString(`${namespace}/${bindingSourceSlug}`)},
+\tname: ${quoteTsString(bindingSourceName)},
 \tlabel: __( ${quoteTsString(bindingSourceTitle)}, ${quoteTsString(textDomain)} ),
 \tgetFieldsList() {
 \t\treturn [
@@ -202,6 +299,91 @@ registerBlockBindingsSource( {
 \t},
 } );
 `;
+}
+
+function resolveBindingTarget(
+	options: Pick<RunAddBindingSourceCommandOptions, "attributeName" | "blockName">,
+	namespace: string,
+): BindingTarget | undefined {
+	const hasBlock = options.blockName !== undefined && options.blockName.trim().length > 0;
+	const hasAttribute =
+		options.attributeName !== undefined && options.attributeName.trim().length > 0;
+	if (!hasBlock && !hasAttribute) {
+		return undefined;
+	}
+	if (!hasBlock || !hasAttribute) {
+		throw new Error(
+			"`wp-typia add binding-source` requires --block and --attribute to be provided together.",
+		);
+	}
+
+	return {
+		attributeName: assertValidBindingAttributeName(options.attributeName ?? ""),
+		blockSlug: resolveBindingTargetBlockSlug(options.blockName ?? "", namespace),
+	};
+}
+
+function formatBindingAttributeTypeMember(attributeName: string): string {
+	const propertyName = /^[A-Za-z_$][\w$]*$/u.test(attributeName)
+		? attributeName
+		: JSON.stringify(attributeName);
+	return [
+		"\t/**",
+		"\t * Starter string attribute declared for WordPress Block Bindings.",
+		"\t */",
+		`\t${propertyName}?: string;`,
+	].join("\n");
+}
+
+async function ensureBindingTargetBlockAttributeType(
+	projectDir: string,
+	block: WorkspaceInventory["blocks"][number],
+	target: BindingTarget,
+): Promise<void> {
+	if (!block.attributeTypeName) {
+		throw new Error(
+			`Workspace block "${block.slug}" must include attributeTypeName in scripts/block-config.ts before it can receive binding-source targets.`,
+		);
+	}
+
+	const typesPath = path.join(projectDir, block.typesFile);
+	const source = await fsp.readFile(typesPath, "utf8");
+	const propertyNamePattern = new RegExp(
+		`^[\\t ]*(?:${escapeRegex(target.attributeName)}|${escapeRegex(
+			JSON.stringify(target.attributeName),
+		)})\\??:`,
+		"mu",
+	);
+	let nextSource = source;
+	if (!propertyNamePattern.test(source)) {
+		const interfacePattern = new RegExp(
+			`(export\\s+interface\\s+${escapeRegex(block.attributeTypeName)}\\s*\\{\\r?\\n)([\\s\\S]*?)(\\r?\\n\\})`,
+			"u",
+		);
+		nextSource = source.replace(interfacePattern, (match, start: string, body: string, end: string) => {
+			const lineEnding = start.endsWith("\r\n") ? "\r\n" : "\n";
+			const memberSource = formatBindingAttributeTypeMember(target.attributeName)
+				.split("\n")
+				.join(lineEnding);
+			return `${start}${body}${body.endsWith(lineEnding) ? "" : lineEnding}${memberSource}${end}`;
+		});
+		if (nextSource === source) {
+			throw new Error(
+				`Unable to locate interface ${block.attributeTypeName} in ${block.typesFile}.`,
+			);
+		}
+		await fsp.writeFile(typesPath, nextSource, "utf8");
+	}
+
+	await syncBlockMetadata({
+		blockJsonFile: path.join("src", "blocks", block.slug, "block.json"),
+		jsonSchemaFile: path.join("src", "blocks", block.slug, "typia.schema.json"),
+		manifestFile: path.join("src", "blocks", block.slug, "typia.manifest.json"),
+		openApiFile: path.join("src", "blocks", block.slug, "typia.openapi.json"),
+		projectRoot: projectDir,
+		sourceTypeName: block.attributeTypeName,
+		typesFile: block.typesFile,
+	});
 }
 
 function buildEditorPluginTypesSource(editorPluginSlug: string): string {
@@ -987,32 +1169,50 @@ export async function runAddPatternCommand({
  * Add one block binding source scaffold to an official workspace project.
  *
  * @param options Command options for the binding-source scaffold workflow.
+ * @param options.attributeName Optional generated block attribute to declare as
+ * bindable. Must be provided together with `blockName`.
+ * @param options.blockName Optional generated block slug or full block name to
+ * receive the bindable attribute wiring. Must be provided together with
+ * `attributeName`.
  * @param options.bindingSourceName Human-entered binding source name that will
  * be normalized and validated before files are written.
  * @param options.cwd Working directory used to resolve the nearest official
  * workspace. Defaults to `process.cwd()`.
  * @returns A promise that resolves with the normalized `bindingSourceSlug` and
- * owning `projectDir` after the server/editor files and inventory entry have
- * been written successfully.
+ * owning `projectDir` after the server/editor files, optional target block
+ * metadata, and inventory entry have been written successfully.
  * @throws {Error} When the command is run outside an official workspace, when
- * the slug is invalid, or when a conflicting file or inventory entry exists.
+ * the slug is invalid, when a binding target is incomplete or unknown, or when
+ * a conflicting file or inventory entry exists.
  */
 export async function runAddBindingSourceCommand({
+	attributeName,
 	bindingSourceName,
+	blockName,
 	cwd = process.cwd(),
 }: RunAddBindingSourceCommandOptions): Promise<{
+	attributeName?: string;
 	bindingSourceSlug: string;
+	blockSlug?: string;
 	projectDir: string;
 }> {
 	const workspace = resolveWorkspaceProject(cwd);
 	const bindingSourceSlug = assertValidGeneratedSlug(
 		"Binding source name",
 		normalizeBlockSlug(bindingSourceName),
-		"wp-typia add binding-source <name>",
+		"wp-typia add binding-source <name> [--block <block-slug|namespace/block-slug> --attribute <attribute>]",
 	);
 
 	const inventory = readWorkspaceInventory(workspace.projectDir);
 	assertBindingSourceDoesNotExist(workspace.projectDir, bindingSourceSlug, inventory);
+	const target = resolveBindingTarget(
+		{
+			attributeName,
+			blockName,
+		},
+		workspace.workspace.namespace,
+	);
+	const targetBlock = target ? resolveWorkspaceBlock(inventory, target.blockSlug) : undefined;
 
 	const blockConfigPath = path.join(workspace.projectDir, "scripts", "block-config.ts");
 	const bootstrapPath = getWorkspaceBootstrapPath(workspace);
@@ -1020,8 +1220,26 @@ export async function runAddBindingSourceCommand({
 	const bindingSourceDir = path.join(workspace.projectDir, "src", "bindings", bindingSourceSlug);
 	const serverFilePath = path.join(bindingSourceDir, "server.php");
 	const editorFilePath = path.join(bindingSourceDir, "editor.ts");
+	const blockJsonPath = target
+		? path.join(workspace.projectDir, "src", "blocks", target.blockSlug, "block.json")
+		: undefined;
+	const targetGeneratedMetadataPaths = target
+		? [
+				path.join(workspace.projectDir, "src", "blocks", target.blockSlug, "typia.manifest.json"),
+				path.join(workspace.projectDir, "src", "blocks", target.blockSlug, "typia.openapi.json"),
+				path.join(workspace.projectDir, "src", "blocks", target.blockSlug, "typia.schema.json"),
+				path.join(workspace.projectDir, "src", "blocks", target.blockSlug, "typia-validator.php"),
+			]
+		: [];
 	const mutationSnapshot: WorkspaceMutationSnapshot = {
-		fileSources: await snapshotWorkspaceFiles([blockConfigPath, bootstrapPath, bindingsIndexPath]),
+		fileSources: await snapshotWorkspaceFiles([
+			blockConfigPath,
+			bootstrapPath,
+			bindingsIndexPath,
+			...(blockJsonPath ? [blockJsonPath] : []),
+			...(targetBlock ? [path.join(workspace.projectDir, targetBlock.typesFile)] : []),
+			...targetGeneratedMetadataPaths,
+		]),
 		snapshotDirs: [],
 		targetPaths: [bindingSourceDir],
 	};
@@ -1036,6 +1254,7 @@ export async function runAddBindingSourceCommand({
 				workspace.workspace.phpPrefix,
 				workspace.workspace.namespace,
 				workspace.workspace.textDomain,
+				target,
 			),
 			"utf8",
 		);
@@ -1045,15 +1264,20 @@ export async function runAddBindingSourceCommand({
 				bindingSourceSlug,
 				workspace.workspace.namespace,
 				workspace.workspace.textDomain,
+				target,
 			),
 			"utf8",
 		);
+		if (target && targetBlock) {
+			await ensureBindingTargetBlockAttributeType(workspace.projectDir, targetBlock, target);
+		}
 		await writeBindingSourceRegistry(workspace.projectDir, bindingSourceSlug);
 		await appendWorkspaceInventoryEntries(workspace.projectDir, {
-			bindingSourceEntries: [buildBindingSourceConfigEntry(bindingSourceSlug)],
+			bindingSourceEntries: [buildBindingSourceConfigEntry(bindingSourceSlug, target)],
 		});
 
 		return {
+			...(target ? { attributeName: target.attributeName, blockSlug: target.blockSlug } : {}),
 			bindingSourceSlug,
 			projectDir: workspace.projectDir,
 		};

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-assets.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-assets.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import {
 	syncBlockMetadata,
 } from "@wp-typia/block-runtime/metadata-core";
+import ts from "typescript";
 
 import {
 	resolveWorkspaceProject,
@@ -18,7 +19,6 @@ import {
 import { toPascalCase, toTitleCase } from "./string-case.js";
 import {
 	findPhpFunctionRange,
-	escapeRegex,
 	hasPhpFunctionDefinition,
 	quotePhpString,
 	replacePhpFunctionDefinition,
@@ -108,9 +108,17 @@ function resolveBindingTargetBlockSlug(
 		);
 	}
 
-	const [maybeNamespace, maybeSlug] = trimmed.includes("/")
-		? trimmed.split("/", 2)
-		: [undefined, trimmed];
+	const blockNameSegments = trimmed.split("/");
+	if (blockNameSegments.length > 2) {
+		throw new Error(
+			`Binding target block "${trimmed}" must use <block-slug> or <namespace/block-slug> format.`,
+		);
+	}
+
+	const [maybeNamespace, maybeSlug] =
+		blockNameSegments.length === 2
+			? blockNameSegments
+			: [undefined, blockNameSegments[0]];
 	if (maybeNamespace && maybeNamespace !== namespace) {
 		throw new Error(
 			`Binding target block "${trimmed}" uses namespace "${maybeNamespace}". Expected "${namespace}".`,
@@ -335,6 +343,78 @@ function formatBindingAttributeTypeMember(attributeName: string): string {
 	].join("\n");
 }
 
+function getInterfaceDeclaration(
+	source: string,
+	interfaceName: string,
+): {
+	declaration: ts.InterfaceDeclaration;
+	sourceFile: ts.SourceFile;
+} | undefined {
+	const sourceFile = ts.createSourceFile(
+		"types.ts",
+		source,
+		ts.ScriptTarget.Latest,
+		true,
+		ts.ScriptKind.TS,
+	);
+	let declaration: ts.InterfaceDeclaration | undefined;
+
+	const visit = (node: ts.Node): void => {
+		if (ts.isInterfaceDeclaration(node) && node.name.text === interfaceName) {
+			declaration = node;
+			return;
+		}
+		ts.forEachChild(node, visit);
+	};
+	visit(sourceFile);
+
+	return declaration ? { declaration, sourceFile } : undefined;
+}
+
+function getPropertyNameText(name: ts.PropertyName): string | undefined {
+	if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) {
+		return name.text;
+	}
+
+	return undefined;
+}
+
+function interfaceHasAttributeMember(
+	declaration: ts.InterfaceDeclaration,
+	attributeName: string,
+): boolean {
+	return declaration.members.some(
+		(member) =>
+			ts.isPropertySignature(member) &&
+			member.name !== undefined &&
+			getPropertyNameText(member.name) === attributeName,
+	);
+}
+
+function insertBindingAttributeTypeMember(
+	source: string,
+	declaration: ts.InterfaceDeclaration,
+	attributeName: string,
+): string {
+	let closeBracePosition = declaration.end - 1;
+	while (closeBracePosition > declaration.pos && source[closeBracePosition] !== "}") {
+		closeBracePosition -= 1;
+	}
+	if (source[closeBracePosition] !== "}") {
+		throw new Error("Unable to locate the target interface closing brace.");
+	}
+
+	const lineEnding = source.includes("\r\n") ? "\r\n" : "\n";
+	const beforeCloseBrace = source.slice(0, closeBracePosition);
+	const afterCloseBrace = source.slice(closeBracePosition);
+	const memberSource = formatBindingAttributeTypeMember(attributeName)
+		.split("\n")
+		.join(lineEnding);
+	const prefix = beforeCloseBrace.endsWith(lineEnding) ? "" : lineEnding;
+
+	return `${beforeCloseBrace}${prefix}${memberSource}${lineEnding}${afterCloseBrace}`;
+}
+
 async function ensureBindingTargetBlockAttributeType(
 	projectDir: string,
 	block: WorkspaceInventory["blocks"][number],
@@ -348,30 +428,20 @@ async function ensureBindingTargetBlockAttributeType(
 
 	const typesPath = path.join(projectDir, block.typesFile);
 	const source = await fsp.readFile(typesPath, "utf8");
-	const propertyNamePattern = new RegExp(
-		`^[\\t ]*(?:${escapeRegex(target.attributeName)}|${escapeRegex(
-			JSON.stringify(target.attributeName),
-		)})\\??:`,
-		"mu",
-	);
-	let nextSource = source;
-	if (!propertyNamePattern.test(source)) {
-		const interfacePattern = new RegExp(
-			`(export\\s+interface\\s+${escapeRegex(block.attributeTypeName)}\\s*\\{\\r?\\n)([\\s\\S]*?)(\\r?\\n\\})`,
-			"u",
+	const targetInterface = getInterfaceDeclaration(source, block.attributeTypeName);
+	if (!targetInterface) {
+		throw new Error(
+			`Unable to locate interface ${block.attributeTypeName} in ${block.typesFile}.`,
 		);
-		nextSource = source.replace(interfacePattern, (match, start: string, body: string, end: string) => {
-			const lineEnding = start.endsWith("\r\n") ? "\r\n" : "\n";
-			const memberSource = formatBindingAttributeTypeMember(target.attributeName)
-				.split("\n")
-				.join(lineEnding);
-			return `${start}${body}${body.endsWith(lineEnding) ? "" : lineEnding}${memberSource}${end}`;
-		});
-		if (nextSource === source) {
-			throw new Error(
-				`Unable to locate interface ${block.attributeTypeName} in ${block.typesFile}.`,
-			);
-		}
+	}
+
+	let nextSource = source;
+	if (!interfaceHasAttributeMember(targetInterface.declaration, target.attributeName)) {
+		nextSource = insertBindingAttributeTypeMember(
+			source,
+			targetInterface.declaration,
+			target.attributeName,
+		);
 		await fsp.writeFile(typesPath, nextSource, "utf8");
 	}
 

--- a/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace.ts
@@ -363,6 +363,113 @@ function checkWorkspaceBindingSourcesIndex(
 	);
 }
 
+function checkWorkspaceBindingTarget(
+	projectDir: string,
+	workspace: WorkspaceProject,
+	registeredBlockSlugs: Set<string>,
+	bindingSource: WorkspaceInventory["bindingSources"][number],
+): DoctorCheck | undefined {
+	const hasBlock = bindingSource.block !== undefined;
+	const hasAttribute = bindingSource.attribute !== undefined;
+	if (!hasBlock && !hasAttribute) {
+		return undefined;
+	}
+	if (!bindingSource.block || !bindingSource.attribute) {
+		return createDoctorCheck(
+			`Binding target ${bindingSource.slug}`,
+			"fail",
+			"Binding target entries must include both block and attribute.",
+		);
+	}
+	if (!registeredBlockSlugs.has(bindingSource.block)) {
+		return createDoctorCheck(
+			`Binding target ${bindingSource.slug}`,
+			"fail",
+			`Binding target references unknown block "${bindingSource.block}".`,
+		);
+	}
+
+	const blockJsonRelativePath = path.join(
+		"src",
+		"blocks",
+		bindingSource.block,
+		"block.json",
+	);
+	const blockJsonPath = path.join(projectDir, blockJsonRelativePath);
+	const issues: string[] = [];
+	try {
+		const blockJson = parseScaffoldBlockMetadata<Record<string, unknown> & { attributes?: unknown }>(
+			JSON.parse(fs.readFileSync(blockJsonPath, "utf8")),
+		);
+		const attributes = blockJson.attributes;
+		if (!attributes || typeof attributes !== "object" || Array.isArray(attributes)) {
+			issues.push(`${blockJsonRelativePath} must define an attributes object`);
+		} else {
+			const attributeConfig = (attributes as Record<string, unknown>)[bindingSource.attribute];
+			if (
+				!attributeConfig ||
+				typeof attributeConfig !== "object" ||
+				Array.isArray(attributeConfig)
+			) {
+				issues.push(
+					`${blockJsonRelativePath} must declare attribute "${bindingSource.attribute}"`,
+				);
+			}
+		}
+	} catch (error) {
+		issues.push(
+			error instanceof Error
+				? `Unable to read ${blockJsonRelativePath}: ${error.message}`
+				: `Unable to read ${blockJsonRelativePath}.`,
+		);
+	}
+
+	const serverPath = path.join(projectDir, bindingSource.serverFile);
+	if (fs.existsSync(serverPath)) {
+		const serverSource = fs.readFileSync(serverPath, "utf8");
+		const supportedAttributesFilter = `block_bindings_supported_attributes_${workspace.workspace.namespace}/${bindingSource.block}`;
+		if (!serverSource.includes(supportedAttributesFilter)) {
+			issues.push(
+				`${bindingSource.serverFile} must register ${supportedAttributesFilter}`,
+			);
+		}
+		if (!serverSource.includes(bindingSource.attribute)) {
+			issues.push(
+				`${bindingSource.serverFile} must expose attribute "${bindingSource.attribute}"`,
+			);
+		}
+	} else {
+		issues.push(`Missing ${bindingSource.serverFile}`);
+	}
+
+	const editorPath = path.join(projectDir, bindingSource.editorFile);
+	if (fs.existsSync(editorPath)) {
+		const editorSource = fs.readFileSync(editorPath, "utf8");
+		const blockName = `${workspace.workspace.namespace}/${bindingSource.block}`;
+		if (!editorSource.includes("BINDING_SOURCE_TARGET")) {
+			issues.push(`${bindingSource.editorFile} must export BINDING_SOURCE_TARGET`);
+		}
+		if (!editorSource.includes(`attribute: ${JSON.stringify(bindingSource.attribute)}`)) {
+			issues.push(
+				`${bindingSource.editorFile} must document target attribute "${bindingSource.attribute}"`,
+			);
+		}
+		if (!editorSource.includes(`block: ${JSON.stringify(blockName)}`)) {
+			issues.push(`${bindingSource.editorFile} must document target block "${blockName}"`);
+		}
+	} else {
+		issues.push(`Missing ${bindingSource.editorFile}`);
+	}
+
+	return createDoctorCheck(
+		`Binding target ${bindingSource.slug}`,
+		issues.length === 0 ? "pass" : "fail",
+		issues.length === 0
+			? `${bindingSource.block}.${bindingSource.attribute} is declared and supported`
+			: issues.join("; "),
+	);
+}
+
 function getWorkspaceRestResourceRequiredFiles(
 	restResource: WorkspaceInventory["restResources"][number],
 ): string[] {
@@ -1153,6 +1260,15 @@ export function getWorkspaceDoctorChecks(cwd: string): DoctorCheck[] {
 					bindingSource.editorFile,
 				]),
 			);
+			const bindingTargetCheck = checkWorkspaceBindingTarget(
+				workspace.projectDir,
+				workspace,
+				registeredBlockSlugs,
+				bindingSource,
+			);
+			if (bindingTargetCheck) {
+				checks.push(bindingTargetCheck);
+			}
 		}
 
 		if (inventory.restResources.length > 0) {

--- a/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace.ts
@@ -433,7 +433,7 @@ function checkWorkspaceBindingTarget(
 				`${bindingSource.serverFile} must register ${supportedAttributesFilter}`,
 			);
 		}
-		if (!serverSource.includes(bindingSource.attribute)) {
+		if (!new RegExp(`'${escapeRegex(bindingSource.attribute)}'`, "u").test(serverSource)) {
 			issues.push(
 				`${bindingSource.serverFile} must expose attribute "${bindingSource.attribute}"`,
 			);
@@ -446,16 +446,29 @@ function checkWorkspaceBindingTarget(
 	if (fs.existsSync(editorPath)) {
 		const editorSource = fs.readFileSync(editorPath, "utf8");
 		const blockName = `${workspace.workspace.namespace}/${bindingSource.block}`;
-		if (!editorSource.includes("BINDING_SOURCE_TARGET")) {
+		const bindingSourceTargetMatch = editorSource.match(
+			/export\s+const\s+BINDING_SOURCE_TARGET\s*=\s*\{([\s\S]*?)\}\s+as\s+const\s*;/u,
+		);
+		if (!bindingSourceTargetMatch) {
 			issues.push(`${bindingSource.editorFile} must export BINDING_SOURCE_TARGET`);
-		}
-		if (!editorSource.includes(`attribute: ${JSON.stringify(bindingSource.attribute)}`)) {
-			issues.push(
-				`${bindingSource.editorFile} must document target attribute "${bindingSource.attribute}"`,
+		} else {
+			const targetSource = bindingSourceTargetMatch[1] ?? "";
+			const attributePattern = new RegExp(
+				`\\battribute\\s*:\\s*["']${escapeRegex(bindingSource.attribute)}["']`,
+				"u",
 			);
-		}
-		if (!editorSource.includes(`block: ${JSON.stringify(blockName)}`)) {
-			issues.push(`${bindingSource.editorFile} must document target block "${blockName}"`);
+			const blockPattern = new RegExp(
+				`\\bblock\\s*:\\s*["']${escapeRegex(blockName)}["']`,
+				"u",
+			);
+			if (!attributePattern.test(targetSource)) {
+				issues.push(
+					`${bindingSource.editorFile} must document target attribute "${bindingSource.attribute}"`,
+				);
+			}
+			if (!blockPattern.test(targetSource)) {
+				issues.push(`${bindingSource.editorFile} must document target block "${blockName}"`);
+			}
 		}
 	} else {
 		issues.push(`Missing ${bindingSource.editorFile}`);

--- a/packages/wp-typia-project-tools/src/runtime/cli-help.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-help.ts
@@ -23,7 +23,7 @@ export function formatHelpText(): string {
   wp-typia add block <name> --template <basic|interactivity|persistence|compound> [--external-layer-source <./path|github:owner/repo/path[#ref]|npm-package>] [--external-layer-id <layer-id>] [--inner-blocks-preset <freeform|ordered|horizontal|locked-structure>] [--alternate-render-targets <email,mjml,plain-text>] [--data-storage <post-meta|custom-table>] [--persistence-policy <authenticated|public>]
   wp-typia add variation <name> --block <block-slug>
   wp-typia add pattern <name>
-  wp-typia add binding-source <name>
+  wp-typia add binding-source <name> [--block <block-slug|namespace/block-slug> --attribute <attribute>]
   wp-typia add rest-resource <name> [--namespace <vendor/v1>] [--methods <method[,method...]>]
   wp-typia add ability <name>
   wp-typia add ai-feature <name> [--namespace <vendor/v1>]
@@ -51,7 +51,7 @@ Notes:
   \`query-loop\` is create-only. Use \`wp-typia create <project-dir> --template query-loop\`; \`wp-typia add block\` accepts only basic, interactivity, persistence, and compound families.
   \`add variation\` uses an existing workspace block from \`scripts/block-config.ts\`.
   \`add pattern\` scaffolds a namespaced PHP pattern shell under \`src/patterns/\`.
-  \`add binding-source\` scaffolds shared PHP and editor registration under \`src/bindings/\`.
+  \`add binding-source\` scaffolds shared PHP and editor registration under \`src/bindings/\`; pass \`--block\` and \`--attribute\` together to declare a bindable generated-block attribute.
   \`add rest-resource\` scaffolds plugin-level TypeScript REST contracts under \`src/rest/\` and PHP route glue under \`inc/rest/\`.
   \`add ability\` scaffolds typed workflow abilities under \`src/abilities/\` and server registration under \`inc/abilities/\`.
   \`add ai-feature\` scaffolds server-owned AI feature endpoints under \`src/ai-features/\` and PHP route glue under \`inc/ai-features/\`.

--- a/packages/wp-typia-project-tools/src/runtime/workspace-inventory.ts
+++ b/packages/wp-typia-project-tools/src/runtime/workspace-inventory.ts
@@ -27,6 +27,8 @@ export interface WorkspacePatternInventoryEntry {
 }
 
 export interface WorkspaceBindingSourceInventoryEntry {
+	attribute?: string;
+	block?: string;
 	editorFile: string;
 	serverFile: string;
 	slug: string;
@@ -189,6 +191,8 @@ export const PATTERNS: WorkspacePatternConfig[] = [
 const BINDING_SOURCES_INTERFACE_SECTION = `
 
 export interface WorkspaceBindingSourceConfig {
+\tattribute?: string;
+\tblock?: string;
 \teditorFile: string;
 \tserverFile: string;
 \tslug: string;
@@ -512,6 +516,13 @@ function parseBindingSourceEntries(
 		}
 
 		return {
+			attribute: getOptionalStringProperty(
+				"BINDING_SOURCES",
+				elementIndex,
+				element,
+				"attribute",
+			),
+			block: getOptionalStringProperty("BINDING_SOURCES", elementIndex, element, "block"),
 			editorFile: getRequiredStringProperty("BINDING_SOURCES", elementIndex, element, "editorFile"),
 			serverFile: getRequiredStringProperty("BINDING_SOURCES", elementIndex, element, "serverFile"),
 			slug: getRequiredStringProperty("BINDING_SOURCES", elementIndex, element, "slug"),
@@ -1034,6 +1045,18 @@ export function updateWorkspaceInventorySource(
 		nextSource,
 		ADMIN_VIEW_CONFIG_ENTRY_MARKER,
 		adminViewEntries,
+	);
+	nextSource = ensureInterfaceField(
+		nextSource,
+		"WorkspaceBindingSourceConfig",
+		"attribute",
+		"\tattribute?: string;",
+	);
+	nextSource = ensureInterfaceField(
+		nextSource,
+		"WorkspaceBindingSourceConfig",
+		"block",
+		"\tblock?: string;",
 	);
 	nextSource = ensureInterfaceField(
 		nextSource,

--- a/packages/wp-typia-project-tools/tests/fixtures/create-block-external/plugin-templates/README.md
+++ b/packages/wp-typia-project-tools/tests/fixtures/create-block-external/plugin-templates/README.md
@@ -13,6 +13,6 @@ The generated project starts with an empty `src/blocks/*` workspace shell and is
 ```bash
 wp-typia add block my-block --template basic
 wp-typia add binding-source hero-data
-wp-typia add binding-source hero-data --block counter-card --attribute headline
+wp-typia add binding-source hero-data --block my-block --attribute headline
 wp-typia add hooked-block my-block --anchor core/post-content --position after
 ```

--- a/packages/wp-typia-project-tools/tests/fixtures/create-block-external/plugin-templates/README.md
+++ b/packages/wp-typia-project-tools/tests/fixtures/create-block-external/plugin-templates/README.md
@@ -13,5 +13,6 @@ The generated project starts with an empty `src/blocks/*` workspace shell and is
 ```bash
 wp-typia add block my-block --template basic
 wp-typia add binding-source hero-data
+wp-typia add binding-source hero-data --block counter-card --attribute headline
 wp-typia add hooked-block my-block --anchor core/post-content --position after
 ```

--- a/packages/wp-typia-project-tools/tests/fixtures/create-block-external/plugin-templates/README.md.mustache
+++ b/packages/wp-typia-project-tools/tests/fixtures/create-block-external/plugin-templates/README.md.mustache
@@ -27,6 +27,7 @@ Variations and patterns can also be added after the first block exists:
 wp-typia add variation hero-card --block counter-card
 wp-typia add pattern hero-layout
 wp-typia add rest-resource snapshots --namespace {{namespace}}/v1 --methods list,read,create
+wp-typia add binding-source hero-data --block counter-card --attribute headline
 ```
 
 This external template also seeds:

--- a/packages/wp-typia-project-tools/tests/fixtures/create-block-external/plugin-templates/scripts/block-config.ts.mustache
+++ b/packages/wp-typia-project-tools/tests/fixtures/create-block-external/plugin-templates/scripts/block-config.ts.mustache
@@ -21,6 +21,8 @@ export interface WorkspacePatternConfig {
 }
 
 export interface WorkspaceBindingSourceConfig {
+	attribute?: string;
+	block?: string;
 	editorFile: string;
 	serverFile: string;
 	slug: string;

--- a/packages/wp-typia-project-tools/tests/workspace-add.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-add.test.ts
@@ -773,69 +773,73 @@ test("canonical CLI can dry-run hooked-block metadata updates without rewriting 
   ).toBe(originalBlockJsonSource);
 });
 
-test("duplicate add block failures preserve existing workspace blocks", async () => {
-  const targetDir = path.join(tempRoot, "demo-workspace-add-duplicate");
+test(
+  "duplicate add block failures preserve existing workspace blocks",
+  async () => {
+    const targetDir = path.join(tempRoot, "demo-workspace-add-duplicate");
 
-  await scaffoldProject({
-    projectDir: targetDir,
-    templateId: workspaceTemplatePackageManifest.name,
-    packageManager: "npm",
-    noInstall: true,
-    answers: {
-      author: "Test Runner",
-      description: "Demo workspace add duplicate",
-      namespace: "demo-space",
-      phpPrefix: "demo_space",
-      slug: "demo-workspace-add-duplicate",
-      textDomain: "demo-space",
-      title: "Demo Workspace Add Duplicate",
-    },
-  });
+    await scaffoldProject({
+      projectDir: targetDir,
+      templateId: workspaceTemplatePackageManifest.name,
+      packageManager: "npm",
+      noInstall: true,
+      answers: {
+        author: "Test Runner",
+        description: "Demo workspace add duplicate",
+        namespace: "demo-space",
+        phpPrefix: "demo_space",
+        slug: "demo-workspace-add-duplicate",
+        textDomain: "demo-space",
+        title: "Demo Workspace Add Duplicate",
+      },
+    });
 
-  linkWorkspaceNodeModules(targetDir);
+    linkWorkspaceNodeModules(targetDir);
 
-  runCli(
-    "node",
-    [entryPath, "add", "block", "counter-card", "--template", "basic"],
-    {
-      cwd: targetDir,
-    }
-  );
-
-  const originalIndexSource = fs.readFileSync(
-    path.join(targetDir, "src", "blocks", "counter-card", "index.tsx"),
-    "utf8"
-  );
-  const originalBlockConfigSource = fs.readFileSync(
-    path.join(targetDir, "scripts", "block-config.ts"),
-    "utf8"
-  );
-
-  expect(() =>
     runCli(
       "node",
       [entryPath, "add", "block", "counter-card", "--template", "basic"],
       {
         cwd: targetDir,
       }
-    )
-  ).toThrow(
-    "A block already exists at src/blocks/counter-card. Choose a different name."
-  );
+    );
 
-  expect(
-    fs.readFileSync(
+    const originalIndexSource = fs.readFileSync(
       path.join(targetDir, "src", "blocks", "counter-card", "index.tsx"),
       "utf8"
-    )
-  ).toBe(originalIndexSource);
-  expect(
-    fs.readFileSync(
+    );
+    const originalBlockConfigSource = fs.readFileSync(
       path.join(targetDir, "scripts", "block-config.ts"),
       "utf8"
-    )
-  ).toBe(originalBlockConfigSource);
-});
+    );
+
+    expect(() =>
+      runCli(
+        "node",
+        [entryPath, "add", "block", "counter-card", "--template", "basic"],
+        {
+          cwd: targetDir,
+        }
+      )
+    ).toThrow(
+      "A block already exists at src/blocks/counter-card. Choose a different name."
+    );
+
+    expect(
+      fs.readFileSync(
+        path.join(targetDir, "src", "blocks", "counter-card", "index.tsx"),
+        "utf8"
+      )
+    ).toBe(originalIndexSource);
+    expect(
+      fs.readFileSync(
+        path.join(targetDir, "scripts", "block-config.ts"),
+        "utf8"
+      )
+    ).toBe(originalBlockConfigSource);
+  },
+  15_000
+);
 
 test("hooked-block workflow rejects unknown blocks, invalid anchors, self-hooks, invalid positions, and duplicate anchors", async () => {
   const targetDir = path.join(
@@ -2461,6 +2465,9 @@ test("canonical CLI can add an end-to-end binding source target to an existing b
   expect(blockJson.attributes.headline).toEqual({ type: "string" });
   expect(bindingServerSource).toContain(
     "block_bindings_supported_attributes_demo-space/counter-card"
+  );
+  expect(bindingServerSource).toContain(
+    "if ( function_exists( 'demo_space_hero_data_supported_binding_attributes' ) )"
   );
   expect(bindingServerSource).toContain(
     "function demo_space_hero_data_supported_binding_attributes"

--- a/packages/wp-typia-project-tools/tests/workspace-add.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-add.test.ts
@@ -2398,6 +2398,28 @@ test("canonical CLI can add an end-to-end binding source target to an existing b
       cwd: targetDir,
     }
   );
+  for (const invalidBlockName of ["/counter-card", "counter-card/"]) {
+    expect(
+      getCommandErrorMessage(() =>
+        runCli(
+          "node",
+          [
+            entryPath,
+            "add",
+            "binding-source",
+            "hero-data",
+            "--block",
+            invalidBlockName,
+            "--attribute",
+            "headline",
+          ],
+          {
+            cwd: targetDir,
+          }
+        )
+      )
+    ).toContain("must use <block-slug> or <namespace/block-slug> format");
+  }
   runCli(
     "node",
     [

--- a/packages/wp-typia-project-tools/tests/workspace-add.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-add.test.ts
@@ -610,6 +610,38 @@ test("canonical CLI can add hooked-block metadata to an official workspace block
       cwd: targetDir,
     }
   );
+  const typesPath = path.join(
+    targetDir,
+    "src",
+    "blocks",
+    "counter-card",
+    "types.ts"
+  );
+  fs.writeFileSync(
+    typesPath,
+    `interface UnrelatedBindingFixture {\n\theadline?: string;\n}\n\n${fs.readFileSync(typesPath, "utf8")}`,
+    "utf8"
+  );
+  expect(
+    getCommandErrorMessage(() =>
+      runCli(
+        "node",
+        [
+          entryPath,
+          "add",
+          "binding-source",
+          "broken-target",
+          "--block",
+          "demo-space/counter-card/extra",
+          "--attribute",
+          "headline",
+        ],
+        {
+          cwd: targetDir,
+        }
+      )
+    )
+  ).toContain("must use <block-slug> or <namespace/block-slug> format");
   runCli(
     "node",
     [

--- a/packages/wp-typia-project-tools/tests/workspace-add.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-add.test.ts
@@ -2336,6 +2336,104 @@ test("canonical CLI can add a binding source to an official workspace template",
   ).toBe(true);
 }, 30_000);
 
+test("canonical CLI can add an end-to-end binding source target to an existing block", async () => {
+  const targetDir = path.join(
+    tempRoot,
+    "demo-workspace-add-binding-source-target"
+  );
+
+  await scaffoldProject({
+    projectDir: targetDir,
+    templateId: workspaceTemplatePackageManifest.name,
+    packageManager: "npm",
+    noInstall: true,
+    answers: {
+      author: "Test Runner",
+      description: "Demo workspace add binding source target",
+      namespace: "demo-space",
+      phpPrefix: "demo_space",
+      slug: "demo-workspace-add-binding-source-target",
+      textDomain: "demo-space",
+      title: "Demo Workspace Add Binding Source Target",
+    },
+  });
+
+  linkWorkspaceNodeModules(targetDir);
+  runCli(
+    "node",
+    [entryPath, "add", "block", "counter-card", "--template", "basic"],
+    {
+      cwd: targetDir,
+    }
+  );
+  runCli(
+    "node",
+    [
+      entryPath,
+      "add",
+      "binding-source",
+      "hero-data",
+      "--block",
+      "demo-space/counter-card",
+      "--attribute",
+      "headline",
+    ],
+    {
+      cwd: targetDir,
+    }
+  );
+
+  const blockConfigSource = fs.readFileSync(
+    path.join(targetDir, "scripts", "block-config.ts"),
+    "utf8"
+  );
+  const blockJson = JSON.parse(
+    fs.readFileSync(
+      path.join(targetDir, "src", "blocks", "counter-card", "block.json"),
+      "utf8"
+    )
+  );
+  const bindingServerSource = fs.readFileSync(
+    path.join(targetDir, "src", "bindings", "hero-data", "server.php"),
+    "utf8"
+  );
+  const bindingEditorSource = fs.readFileSync(
+    path.join(targetDir, "src", "bindings", "hero-data", "editor.ts"),
+    "utf8"
+  );
+
+  expect(blockConfigSource).toContain('block: "counter-card"');
+  expect(blockConfigSource).toContain('attribute: "headline"');
+  expect(blockJson.attributes.headline).toEqual({ type: "string" });
+  expect(bindingServerSource).toContain(
+    "block_bindings_supported_attributes_demo-space/counter-card"
+  );
+  expect(bindingServerSource).toContain(
+    "function demo_space_hero_data_supported_binding_attributes"
+  );
+  expect(bindingServerSource).toContain("'headline'");
+  expect(bindingEditorSource).toContain("export const BINDING_SOURCE_TARGET");
+  expect(bindingEditorSource).toContain('block: "demo-space/counter-card"');
+  expect(bindingEditorSource).toContain('attribute: "headline"');
+
+  const doctorOutput = runCli("node", [entryPath, "doctor", "--format", "json"], {
+    cwd: targetDir,
+  });
+  const doctorChecks = parseJsonObjectFromOutput<{
+    checks: Array<{ detail: string; label: string; status: string }>;
+  }>(doctorOutput);
+  expect(
+    doctorChecks.checks.find(
+      (check) => check.label === "Binding target hero-data"
+    )?.status
+  ).toBe("pass");
+
+  runCli("npm", ["run", "build"], { cwd: targetDir });
+  expect(
+    fs.existsSync(path.join(targetDir, "build", "bindings", "index.js"))
+  ).toBe(true);
+}, 45_000);
+
 test("binding source workflow preserves existing files on duplicate failure", async () => {
   const targetDir = path.join(
     tempRoot,

--- a/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
@@ -185,6 +185,65 @@ test("binding source workflow preserves an existing src/bindings/index.js regist
   expect(bindingsIndexSource).toContain("import './news-data/editor';");
 }, 15_000);
 
+test("doctor fails when a binding source target attribute drifts from block metadata", async () => {
+  const targetDir = path.join(
+    tempRoot,
+    "demo-workspace-binding-source-target-drift"
+  );
+
+  await scaffoldOfficialWorkspace(targetDir, {
+    description: "Demo workspace binding source target drift",
+    slug: "demo-workspace-binding-source-target-drift",
+    title: "Demo Workspace Binding Source Target Drift",
+  });
+
+  linkWorkspaceNodeModules(targetDir);
+  runCli(
+    "node",
+    [entryPath, "add", "block", "counter-card", "--template", "basic"],
+    {
+      cwd: targetDir,
+    }
+  );
+  runCli(
+    "node",
+    [
+      entryPath,
+      "add",
+      "binding-source",
+      "hero-data",
+      "--block",
+      "counter-card",
+      "--attribute",
+      "headline",
+    ],
+    {
+      cwd: targetDir,
+    }
+  );
+
+  const blockJsonPath = path.join(
+    targetDir,
+    "src",
+    "blocks",
+    "counter-card",
+    "block.json"
+  );
+  const blockJson = JSON.parse(fs.readFileSync(blockJsonPath, "utf8"));
+  delete blockJson.attributes.headline;
+  fs.writeFileSync(blockJsonPath, JSON.stringify(blockJson, null, 2), "utf8");
+
+  const checks = await getDoctorChecks(targetDir);
+  const bindingTargetCheck = checks.find(
+    (check) => check.label === "Binding target hero-data"
+  );
+
+  expect(bindingTargetCheck?.status).toBe("fail");
+  expect(bindingTargetCheck?.detail).toContain(
+    'must declare attribute "headline"'
+  );
+}, 15_000);
+
 test("doctor accepts workspaces that keep editor plugin registries in src/editor-plugins/index.js", async () => {
   const targetDir = path.join(
     tempRoot,

--- a/packages/wp-typia/README.md
+++ b/packages/wp-typia/README.md
@@ -14,6 +14,7 @@ Extend an existing workspace with:
 
 - `wp-typia add block counter-card --template basic`
 - `wp-typia add binding-source hero-data`
+- `wp-typia add binding-source hero-data --block counter-card --attribute headline`
 - `wp-typia add rest-resource snapshots --namespace my-plugin/v1 --methods list,read,create`
 - `wp-typia add ability review-workflow`
 - `wp-typia add ai-feature brief-suggestions --namespace my-plugin/v1`

--- a/packages/wp-typia/bin/routing-metadata.generated.js
+++ b/packages/wp-typia/bin/routing-metadata.generated.js
@@ -10,6 +10,7 @@ export const fullRuntimeCommands = Object.freeze([
 export const longValueOptions = Object.freeze([
   "--alternate-render-targets",
   "--anchor",
+  "--attribute",
   "--block",
   "--config",
   "--current-migration-version",

--- a/packages/wp-typia/src/add-kind-registry.ts
+++ b/packages/wp-typia/src/add-kind-registry.ts
@@ -17,6 +17,7 @@ export type AddFieldName =
   | 'source'
   | 'template'
   | 'block'
+  | 'attribute'
   | 'anchor'
   | 'methods'
   | 'namespace'
@@ -87,17 +88,25 @@ export const ADD_KIND_REGISTRY = {
     completion: {
       nextSteps: (values) => [
         `Review src/bindings/${values.bindingSourceSlug}/server.php and src/bindings/${values.bindingSourceSlug}/editor.ts.`,
+        ...(values.blockSlug && values.attributeName
+          ? [
+              `Review src/blocks/${values.blockSlug}/block.json for the ${values.attributeName} bindable attribute.`,
+            ]
+          : []),
         'Run your workspace build or dev command to verify the binding source hooks and editor registration.',
       ],
       summaryLines: (values, projectDir) => [
         `Binding source: ${values.bindingSourceSlug}`,
+        ...(values.blockSlug && values.attributeName
+          ? [`Target: ${values.blockSlug}.${values.attributeName}`]
+          : []),
         `Project directory: ${projectDir}`,
       ],
       title: 'Added binding source',
     },
     description: 'Add a shared block bindings source',
     nameLabel: 'Binding source name',
-    visibleFieldNames: () => ['kind', 'name'],
+    visibleFieldNames: () => ['kind', 'name', 'block', 'attribute'],
   },
   block: {
     completion: {

--- a/packages/wp-typia/src/command-option-metadata.ts
+++ b/packages/wp-typia/src/command-option-metadata.ts
@@ -130,8 +130,12 @@ export const ADD_OPTION_METADATA = {
 		description: "Anchor block name for hooked-block workflows.",
 		type: "string",
 	},
+	attribute: {
+		description: "Target block attribute for end-to-end binding-source workflows.",
+		type: "string",
+	},
 	block: {
-		description: "Target block slug for variation workflows.",
+		description: "Target block slug for variation and end-to-end binding-source workflows.",
 		type: "string",
 	},
 	"data-storage": {

--- a/packages/wp-typia/src/runtime-bridge.ts
+++ b/packages/wp-typia/src/runtime-bridge.ts
@@ -297,8 +297,10 @@ const ADD_KIND_EXECUTION_REGISTRY: Record<
   'binding-source': async (context) => {
     const name = requireAddKindName(
       context,
-      '`wp-typia add binding-source` requires <name>. Usage: wp-typia add binding-source <name>.',
+      '`wp-typia add binding-source` requires <name>. Usage: wp-typia add binding-source <name> [--block <block-slug|namespace/block-slug> --attribute <attribute>].',
     );
+    const blockName = readOptionalStringFlag(context.flags, 'block');
+    const attributeName = readOptionalStringFlag(context.flags, 'attribute');
 
     return runRegisteredAddKind<AddBindingSourceResult>(context, {
       buildCompletion: (result) =>
@@ -306,12 +308,18 @@ const ADD_KIND_EXECUTION_REGISTRY: Record<
           kind: 'binding-source',
           projectDir: result.projectDir,
           values: {
+            ...(result.attributeName
+              ? { attributeName: result.attributeName }
+              : {}),
+            ...(result.blockSlug ? { blockSlug: result.blockSlug } : {}),
             bindingSourceSlug: result.bindingSourceSlug,
           },
         }),
       execute: (targetCwd) =>
         context.addRuntime.runAddBindingSourceCommand({
+          attributeName,
           bindingSourceName: name,
+          blockName,
           cwd: targetCwd,
         }),
     });

--- a/packages/wp-typia/src/runtime-bridge.ts
+++ b/packages/wp-typia/src/runtime-bridge.ts
@@ -301,6 +301,12 @@ const ADD_KIND_EXECUTION_REGISTRY: Record<
     );
     const blockName = readOptionalStringFlag(context.flags, 'block');
     const attributeName = readOptionalStringFlag(context.flags, 'attribute');
+    if (Boolean(blockName) !== Boolean(attributeName)) {
+      throw createCliDiagnosticCodeError(
+        CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
+        '`wp-typia add binding-source` requires --block and --attribute to be provided together.',
+      );
+    }
 
     return runRegisteredAddKind<AddBindingSourceResult>(context, {
       buildCompletion: (result) =>

--- a/packages/wp-typia/src/ui/add-flow-model.ts
+++ b/packages/wp-typia/src/ui/add-flow-model.ts
@@ -22,6 +22,7 @@ import {
 export const addFlowSchema = z.object({
   'alternate-render-targets': z.string().optional(),
   anchor: z.string().optional(),
+  attribute: z.string().optional(),
   block: z.string().optional(),
   'data-storage': z.string().optional(),
   'external-layer-id': z.string().optional(),
@@ -42,6 +43,7 @@ export type AddFlowValues = z.infer<typeof addFlowSchema>;
 
 const ADD_FIELD_HEIGHTS: Record<AddFieldName, number> = {
   anchor: FIRST_PARTY_TEXT_FIELD_BODY_HEIGHT,
+  attribute: FIRST_PARTY_TEXT_FIELD_BODY_HEIGHT,
   block: FIRST_PARTY_SELECT_FIELD_BODY_HEIGHT,
   'data-storage': FIRST_PARTY_SELECT_FIELD_BODY_HEIGHT,
   'alternate-render-targets': FIRST_PARTY_TEXT_FIELD_BODY_HEIGHT,

--- a/packages/wp-typia/src/ui/add-flow.tsx
+++ b/packages/wp-typia/src/ui/add-flow.tsx
@@ -157,7 +157,8 @@ function AddFlowFields({
   const hookedBlockNameUsesSelect =
     kind === 'hooked-block' && workspaceBlockOptions.length > 0;
   const variationBlockUsesSelect =
-    kind === 'variation' && workspaceBlockOptions.length > 0;
+    (kind === 'variation' || kind === 'binding-source') &&
+    workspaceBlockOptions.length > 0;
 
   return createElement(
     FirstPartyFormViewport,
@@ -251,6 +252,15 @@ function AddFlowFields({
             label: 'Target block',
             name: 'block' satisfies AddSelectFieldName,
             options: workspaceBlockOptions,
+          })
+        : null,
+      visibleFields.has('attribute')
+        ? createElement(FirstPartyTextField, {
+            ...getWrappedFieldNeighbors(orderedVisibleFields, 'attribute'),
+            key: 'attribute',
+            label: 'Target attribute',
+            name: 'attribute',
+            placeholder: 'headline',
           })
         : null,
       visibleFields.has('namespace')

--- a/packages/wp-typia/src/ui/add-flow.tsx
+++ b/packages/wp-typia/src/ui/add-flow.tsx
@@ -157,8 +157,7 @@ function AddFlowFields({
   const hookedBlockNameUsesSelect =
     kind === 'hooked-block' && workspaceBlockOptions.length > 0;
   const variationBlockUsesSelect =
-    (kind === 'variation' || kind === 'binding-source') &&
-    workspaceBlockOptions.length > 0;
+    kind === 'variation' && workspaceBlockOptions.length > 0;
 
   return createElement(
     FirstPartyFormViewport,

--- a/packages/wp-typia/tests/add-command.test.ts
+++ b/packages/wp-typia/tests/add-command.test.ts
@@ -37,4 +37,45 @@ describe("wp-typia add command bridge", () => {
 			fs.existsSync(path.join(projectDir, "src", "blocks", "promo-card", "block.json")),
 		).toBe(true);
 	});
+
+	test("passes binding-source target flags through the add bridge", async () => {
+		const projectDir = path.join(tempRoot, "demo-add-binding-target");
+
+		await scaffoldOfficialWorkspace(projectDir);
+		linkWorkspaceNodeModules(projectDir);
+		await executeAddCommand({
+			cwd: projectDir,
+			emitOutput: false,
+			flags: {
+				template: "basic",
+			},
+			interactive: false,
+			kind: "block",
+			name: "counter-card",
+		});
+
+		const payload = await executeAddCommand({
+			cwd: projectDir,
+			emitOutput: false,
+			flags: {
+				attribute: "headline",
+				block: "counter-card",
+			},
+			interactive: false,
+			kind: "binding-source",
+			name: "hero-data",
+		});
+
+		expect(payload?.summaryLines).toContain("Target: counter-card.headline");
+		expect(
+			fs.existsSync(path.join(projectDir, "src", "bindings", "hero-data", "server.php")),
+		).toBe(true);
+		const blockJson = JSON.parse(
+			fs.readFileSync(
+				path.join(projectDir, "src", "blocks", "counter-card", "block.json"),
+				"utf8",
+			),
+		);
+		expect(blockJson.attributes.headline).toEqual({ type: "string" });
+	});
 });

--- a/packages/wp-typia/tests/add-command.test.ts
+++ b/packages/wp-typia/tests/add-command.test.ts
@@ -38,58 +38,62 @@ describe("wp-typia add command bridge", () => {
 		).toBe(true);
 	});
 
-	test("passes binding-source target flags through the add bridge", async () => {
-		const projectDir = path.join(tempRoot, "demo-add-binding-target");
+	test(
+		"passes binding-source target flags through the add bridge",
+		async () => {
+			const projectDir = path.join(tempRoot, "demo-add-binding-target");
 
-		await scaffoldOfficialWorkspace(projectDir);
-		linkWorkspaceNodeModules(projectDir);
-		await expect(
-			executeAddCommand({
+			await scaffoldOfficialWorkspace(projectDir);
+			linkWorkspaceNodeModules(projectDir);
+			await expect(
+				executeAddCommand({
+					cwd: projectDir,
+					emitOutput: false,
+					flags: {
+						block: "counter-card",
+					},
+					interactive: false,
+					kind: "binding-source",
+					name: "hero-data",
+				}),
+			).rejects.toThrow(
+				"`wp-typia add binding-source` requires --block and --attribute to be provided together.",
+			);
+			await executeAddCommand({
 				cwd: projectDir,
 				emitOutput: false,
 				flags: {
+					template: "basic",
+				},
+				interactive: false,
+				kind: "block",
+				name: "counter-card",
+			});
+
+			const payload = await executeAddCommand({
+				cwd: projectDir,
+				emitOutput: false,
+				flags: {
+					attribute: "headline",
 					block: "counter-card",
 				},
 				interactive: false,
 				kind: "binding-source",
 				name: "hero-data",
-			}),
-		).rejects.toThrow(
-			"`wp-typia add binding-source` requires --block and --attribute to be provided together.",
-		);
-		await executeAddCommand({
-			cwd: projectDir,
-			emitOutput: false,
-			flags: {
-				template: "basic",
-			},
-			interactive: false,
-			kind: "block",
-			name: "counter-card",
-		});
+			});
 
-		const payload = await executeAddCommand({
-			cwd: projectDir,
-			emitOutput: false,
-			flags: {
-				attribute: "headline",
-				block: "counter-card",
-			},
-			interactive: false,
-			kind: "binding-source",
-			name: "hero-data",
-		});
-
-		expect(payload?.summaryLines).toContain("Target: counter-card.headline");
-		expect(
-			fs.existsSync(path.join(projectDir, "src", "bindings", "hero-data", "server.php")),
-		).toBe(true);
-		const blockJson = JSON.parse(
-			fs.readFileSync(
-				path.join(projectDir, "src", "blocks", "counter-card", "block.json"),
-				"utf8",
-			),
-		);
-		expect(blockJson.attributes.headline).toEqual({ type: "string" });
-	});
+			expect(payload?.summaryLines).toContain("Target: counter-card.headline");
+			expect(
+				fs.existsSync(path.join(projectDir, "src", "bindings", "hero-data", "server.php")),
+			).toBe(true);
+			const blockJson = JSON.parse(
+				fs.readFileSync(
+					path.join(projectDir, "src", "blocks", "counter-card", "block.json"),
+					"utf8",
+				),
+			);
+			expect(blockJson.attributes.headline).toEqual({ type: "string" });
+		},
+		15_000,
+	);
 });

--- a/packages/wp-typia/tests/add-command.test.ts
+++ b/packages/wp-typia/tests/add-command.test.ts
@@ -43,6 +43,20 @@ describe("wp-typia add command bridge", () => {
 
 		await scaffoldOfficialWorkspace(projectDir);
 		linkWorkspaceNodeModules(projectDir);
+		await expect(
+			executeAddCommand({
+				cwd: projectDir,
+				emitOutput: false,
+				flags: {
+					block: "counter-card",
+				},
+				interactive: false,
+				kind: "binding-source",
+				name: "hero-data",
+			}),
+		).rejects.toThrow(
+			"`wp-typia add binding-source` requires --block and --attribute to be provided together.",
+		);
 		await executeAddCommand({
 			cwd: projectDir,
 			emitOutput: false,

--- a/packages/wp-typia/tests/command-option-metadata.test.ts
+++ b/packages/wp-typia/tests/command-option-metadata.test.ts
@@ -71,6 +71,22 @@ describe("command option metadata helpers", () => {
 		expect("dry-run" in resolved).toBe(false);
 	});
 
+	test("parses binding source target flags from shared add metadata", () => {
+		const parsed = parseCommandArgvWithMetadata(
+			["binding-source", "hero-data", "--block", "counter-card", "--attribute", "headline"],
+			{
+				extraBooleanOptionNames: ["help", "version"],
+				parser: buildCommandOptionParser(GLOBAL_OPTION_METADATA, ADD_OPTION_METADATA),
+			},
+		);
+
+		expect(parsed.flags).toEqual({
+			attribute: "headline",
+			block: "counter-card",
+		});
+		expect(parsed.positionals).toEqual(["binding-source", "hero-data"]);
+	});
+
 	test("parses sync preview flags from shared metadata", () => {
 		const parsed = parseCommandArgvWithMetadata(["--dry-run", "--check"], {
 			extraBooleanOptionNames: ["help", "version"],

--- a/packages/wp-typia/tests/tui-interaction-models.test.ts
+++ b/packages/wp-typia/tests/tui-interaction-models.test.ts
@@ -158,6 +158,18 @@ describe("first-party TUI interaction models", () => {
 
 		expect(
 			sanitizeAddSubmitValues({
+				attribute: "",
+				block: "",
+				kind: "binding-source",
+				name: "hero-data",
+			}),
+		).toEqual({
+			kind: "binding-source",
+			name: "hero-data",
+		});
+
+		expect(
+			sanitizeAddSubmitValues({
 				anchor: "",
 				block: "",
 				kind: "admin-view",

--- a/packages/wp-typia/tests/tui-interaction-models.test.ts
+++ b/packages/wp-typia/tests/tui-interaction-models.test.ts
@@ -46,6 +46,12 @@ describe("first-party TUI interaction models", () => {
 			"name",
 			"block",
 		]);
+		expect(getVisibleAddFieldNames({ kind: "binding-source" })).toEqual([
+			"kind",
+			"name",
+			"block",
+			"attribute",
+		]);
 		expect(getVisibleAddFieldNames({ kind: "rest-resource" })).toEqual([
 			"kind",
 			"name",
@@ -117,6 +123,7 @@ describe("first-party TUI interaction models", () => {
 		expect(
 			sanitizeAddSubmitValues({
 				anchor: "",
+				attribute: " headline ",
 				block: "counter-card",
 				"alternate-render-targets": " email,mjml ",
 				"data-storage": "custom-table",
@@ -132,6 +139,21 @@ describe("first-party TUI interaction models", () => {
 			block: "counter-card",
 			kind: "variation",
 			name: "hero-card",
+		});
+
+		expect(
+			sanitizeAddSubmitValues({
+				attribute: " headline ",
+				block: "counter-card",
+				kind: "binding-source",
+				name: "hero-data",
+				template: "persistence",
+			}),
+		).toEqual({
+			attribute: "headline",
+			block: "counter-card",
+			kind: "binding-source",
+			name: "hero-data",
 		});
 
 		expect(

--- a/scripts/lib/typescript-runtime-policy.mjs
+++ b/scripts/lib/typescript-runtime-policy.mjs
@@ -27,8 +27,11 @@ export const TYPESCRIPT_RUNTIME_PACKAGE_POLICIES = [
 		packageDir: "packages/wp-typia-project-tools",
 		packageName: "@wp-typia/project-tools",
 		reason:
-			"workspace inventory helpers used by add/doctor/migrations and exported workspace selection flows use the TypeScript compiler API at runtime",
-		requiredTypeScriptImportFiles: ["src/runtime/workspace-inventory.ts"],
+			"workspace inventory and generated workspace asset helpers used by add/doctor/migrations and exported workspace selection flows use the TypeScript compiler API at runtime",
+		requiredTypeScriptImportFiles: [
+			"src/runtime/cli-add-workspace-assets.ts",
+			"src/runtime/workspace-inventory.ts",
+		],
 		runtimeSourceRoots: ["src/runtime"],
 		typescriptPlacement: TYPESCRIPT_DEPENDENCY_POLICY.dependency,
 	},


### PR DESCRIPTION
## Summary

- Extend `wp-typia add binding-source` with optional `--block` and `--attribute` target wiring.
- Patch the target block `types.ts` source of truth, regenerate metadata artifacts, and emit supported Block Bindings attribute filters.
- Add doctor checks for missing target block/attribute/server/editor wiring plus CLI, TUI, docs, and changeset coverage.

Closes #593.

## Verification

- `bun run --cwd packages/wp-typia-project-tools build`
- `bun run --cwd packages/wp-typia build`
- `bun test packages/wp-typia-project-tools/tests/workspace-add.test.ts --test-name-pattern "binding source"`
- `bun test packages/wp-typia-project-tools/tests/workspace-doctor.test.ts --test-name-pattern "binding source"`
- `bun test packages/wp-typia/tests/add-command.test.ts packages/wp-typia/tests/command-option-metadata.test.ts`
- `bun run --cwd packages/wp-typia-project-tools test:workspace`
- `bun run typecheck`
- `bun test packages/wp-typia/tests/tui-interaction-models.test.ts packages/wp-typia/tests/add-command.test.ts packages/wp-typia/tests/command-option-metadata.test.ts`
- `bun run format:check`
- `bun run changesets:validate`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `wp-typia add binding-source` now supports optional `--block` + `--attribute` for end-to-end bindable block attributes; add UI shows a Target attribute field and completion reports the target.

* **Documentation**
  * CLI help, READMEs, and API docs updated with block/attribute examples and workflow guidance.

* **Tests**
  * New integration and doctor tests cover target wiring, validation, and drift detection.

* **Chores**
  * Packages bumped via a changeset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->