### PR TITLE
feat(project-tools): add iframe editor doctor checks

### DIFF
--- a/.sampo/changesets/iframe-api-v3-doctor.md
+++ b/.sampo/changesets/iframe-api-v3-doctor.md
@@ -1,0 +1,8 @@
+---
+npm/@wp-typia/project-tools: minor
+npm/wp-typia: minor
+---
+
+Add non-failing `wp-typia doctor` warnings for workspace block iframe/API v3
+readiness, including block metadata, stylesheet registration, global DOM access,
+and wrapper-props checks with machine-readable diagnostic codes.

--- a/apps/docs/src/content/docs/reference/api.md
+++ b/apps/docs/src/content/docs/reference/api.md
@@ -253,15 +253,18 @@ and fuzzing commands when you want to cover every configured legacy migration ve
 every configured block target in that workspace.
 
 `wp-typia doctor` is the lightweight read-only check for environment readiness,
-workspace inventory consistency, shared conventions, and current source-tree
-artifact drift. `wp-typia migrate doctor --all` is the deep migration audit for
-migration-enabled workspaces. It validates migration target alignment,
+workspace inventory consistency, shared conventions, current source-tree
+artifact drift, and iframe/API v3 compatibility readiness for workspace blocks.
+Iframe compatibility findings are emitted as non-failing `WARN` rows with
+machine-readable codes, so CI and IDE integrations can surface them without
+blocking unrelated checks. `wp-typia migrate doctor --all` is the deep migration
+audit for migration-enabled workspaces. It validates migration target alignment,
 snapshots, generated migration artifacts, and fixture coverage.
 
 In non-interactive shells, `wp-typia create`, `add`, `migrate`, and `doctor`
 now share the same summary-first failure layout. Root `doctor` still streams
-PASS/FAIL check rows plus a final summary, while the other commands render the
-shared diagnostic block only when they fail.
+PASS/WARN/FAIL check rows plus a final summary, while the other commands render
+the shared diagnostic block only when they fail.
 
 Compatibility note: `@wp-typia/project-tools` is the canonical programmatic package, `wp-typia` is the canonical CLI package, and `@wp-typia/block-runtime/*` is the maintained generated-project runtime helper surface.
 

--- a/apps/docs/src/content/docs/reference/cli.md
+++ b/apps/docs/src/content/docs/reference/cli.md
@@ -166,6 +166,17 @@ also get inventory, source-tree drift, and shared convention checks. Use
 `--format json` for CI, IDE, and wrapper integrations that need stable
 machine-readable check results.
 
+Workspace block diagnostics also include iframe/API v3 readiness rows. `WARN`
+rows do not fail `doctor`; treat them as compatibility follow-up before relying
+on iframe-enabled Post Editor or Site Editor rendering. The static checks cover
+`block.json` `apiVersion`, block stylesheet registration, direct
+`window`/`document`/parent DOM access in editor-facing sources, and detectable
+missing `useBlockProps`/`useInnerBlocksProps` wrapper usage. JSON output exposes
+stable check-level codes such as
+`wp-typia.workspace.block.iframe.api-version`. See WordPress' [iframe editor
+migration guide](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-api-versions/block-migration-for-iframe-editor-compatibility/)
+for the platform rationale.
+
 ## `templates`
 
 Inspect scaffold templates.

--- a/apps/docs/src/content/docs/reference/cli.md
+++ b/apps/docs/src/content/docs/reference/cli.md
@@ -170,9 +170,9 @@ Workspace block diagnostics also include iframe/API v3 readiness rows. `WARN`
 rows do not fail `doctor`; treat them as compatibility follow-up before relying
 on iframe-enabled Post Editor or Site Editor rendering. The static checks cover
 `block.json` `apiVersion`, block stylesheet registration, direct
-`window`/`document`/parent DOM access in editor-facing sources, and detectable
-missing `useBlockProps`/`useInnerBlocksProps` wrapper usage. JSON output exposes
-stable check-level codes such as
+`window`/`document`/`parent`/`top` DOM access in editor-facing sources, and
+detectable missing `useBlockProps`/`useInnerBlocksProps` wrapper usage. JSON
+output exposes stable check-level codes such as
 `wp-typia.workspace.block.iframe.api-version`. See WordPress' [iframe editor
 migration guide](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-api-versions/block-migration-for-iframe-editor-compatibility/)
 for the platform rationale.

--- a/packages/wp-typia-project-tools/src/runtime/cli-diagnostics.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-diagnostics.ts
@@ -31,9 +31,10 @@ export type CliDiagnosticCodeError<TCode extends CliDiagnosticCode = CliDiagnost
 	Error & { code: TCode };
 
 type DoctorCheckLike = {
+	code?: string;
 	detail: string;
 	label: string;
-	status: "pass" | "fail";
+	status: "pass" | "fail" | "warn";
 };
 
 const DEFAULT_CLI_FAILURE_SUMMARIES: Record<string, string> = {
@@ -396,8 +397,10 @@ export function serializeCliDiagnosticError(error: unknown): {
  * Format one human-readable doctor check row.
  */
 export function formatDoctorCheckLine(check: DoctorCheckLike): string {
+	const statusLabel =
+		check.status === "pass" ? "PASS" : check.status === "warn" ? "WARN" : "FAIL";
 	return formatWrappedPrefixedLine(
-		`${check.status === "pass" ? "PASS" : "FAIL"} ${check.label}: `,
+		`${statusLabel} ${check.label}: `,
 		check.detail,
 		resolveCliWrapColumns(process.stdout.columns),
 	).join("\n");
@@ -417,9 +420,15 @@ export function getFailingDoctorChecks<TCheck extends DoctorCheckLike>(
  */
 export function formatDoctorSummaryLine(checks: readonly DoctorCheckLike[]): string {
 	const failedChecks = getFailingDoctorChecks(checks);
+	const warningCount = checks.filter((check) => check.status === "warn").length;
 	return formatWrappedPrefixedLine(
 		`${failedChecks.length === 0 ? "PASS" : "FAIL"} wp-typia doctor summary: `,
-		`${checks.length - failedChecks.length}/${checks.length} checks passed`,
+		[
+			`${checks.length - failedChecks.length - warningCount}/${checks.length} checks passed`,
+			warningCount > 0 ? `${warningCount} warning(s)` : null,
+		]
+			.filter((detail): detail is string => detail !== null)
+			.join(", "),
 		resolveCliWrapColumns(process.stdout.columns),
 	).join("\n");
 }

--- a/packages/wp-typia-project-tools/src/runtime/cli-diagnostics.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-diagnostics.ts
@@ -421,8 +421,10 @@ export function getFailingDoctorChecks<TCheck extends DoctorCheckLike>(
 export function formatDoctorSummaryLine(checks: readonly DoctorCheckLike[]): string {
 	const failedChecks = getFailingDoctorChecks(checks);
 	const warningCount = checks.filter((check) => check.status === "warn").length;
+	const summaryStatus =
+		failedChecks.length > 0 ? "FAIL" : warningCount > 0 ? "WARN" : "PASS";
 	return formatWrappedPrefixedLine(
-		`${failedChecks.length === 0 ? "PASS" : "FAIL"} wp-typia doctor summary: `,
+		`${summaryStatus} wp-typia doctor summary: `,
 		[
 			`${checks.length - failedChecks.length - warningCount}/${checks.length} checks passed`,
 			warningCount > 0 ? `${warningCount} warning(s)` : null,

--- a/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace.ts
@@ -91,7 +91,7 @@ const WORKSPACE_BLOCK_LOCAL_STYLE_FILES = [
 	"style.scss",
 ];
 const WORKSPACE_BLOCK_IFRAME_GLOBAL_DOM_PATTERN =
-	/\b(?:document|window)\b|\b(?:parent|top)\s*\./gu;
+	/\b(?:document|parent|top|window)\b/gu;
 const WORKSPACE_BLOCK_PROPS_PATTERN =
 	/\buse(?:Block|InnerBlocks)Props(?:\.save)?\s*\(/u;
 
@@ -266,14 +266,15 @@ function readWorkspaceBlockIframeMetadata(
 
 function isWorkspaceBlockEditorSource(relativePath: string): boolean {
 	const normalizedPath = normalizePathSeparators(relativePath);
+	const normalizedLowerPath = normalizedPath.toLowerCase();
 	if (
-		!WORKSPACE_BLOCK_EDITOR_SOURCE_FILE_PATTERN.test(normalizedPath) ||
-		/\.d\.[cm]?[jt]s$/u.test(normalizedPath)
+		!WORKSPACE_BLOCK_EDITOR_SOURCE_FILE_PATTERN.test(normalizedLowerPath) ||
+		/\.d\.[cm]?[jt]s$/u.test(normalizedLowerPath)
 	) {
 		return false;
 	}
 
-	const segments = normalizedPath.split("/");
+	const segments = normalizedLowerPath.split("/");
 	const fileName = segments[segments.length - 1] ?? "";
 	const baseName = fileName.replace(/\.[^.]+$/u, "");
 	if (WORKSPACE_BLOCK_EDITOR_SOURCE_BASENAMES.has(baseName)) {
@@ -283,6 +284,11 @@ function isWorkspaceBlockEditorSource(relativePath: string): boolean {
 	return segments
 		.slice(0, -1)
 		.some((segment) => WORKSPACE_BLOCK_EDITOR_SOURCE_DIRECTORIES.has(segment));
+}
+
+function isWorkspaceBlockSaveSource(relativePath: string): boolean {
+	const fileName = normalizePathSeparators(relativePath).split("/").pop() ?? "";
+	return fileName.replace(/\.[^.]+$/u, "").toLowerCase() === "save";
 }
 
 function collectWorkspaceBlockEditorSources(
@@ -583,7 +589,7 @@ function checkWorkspaceBlockIframeCompatibility(
 		return [
 			createDoctorCheck(
 				`Block iframe/API v3 ${blockSlug}`,
-				"fail",
+				"warn",
 				metadataResult.error ?? `Unable to inspect ${metadataResult.blockJsonRelativePath}`,
 				WORKSPACE_BLOCK_IFRAME_DIAGNOSTIC_CODES.API_VERSION,
 			),
@@ -603,10 +609,28 @@ function checkWorkspaceBlockIframeCompatibility(
 		hasRegisteredBlockAsset(blockJson.style) ||
 		hasRegisteredBlockAsset(blockJson.editorStyle);
 	const editorSources = collectWorkspaceBlockEditorSources(projectDir, blockSlug);
+	const editorWrapperSources = editorSources.filter(
+		(source) => !isWorkspaceBlockSaveSource(source.relativePath),
+	);
 	const globalDomAccesses = findWorkspaceBlockGlobalDomAccesses(editorSources);
 	const hasBlockPropsUsage = editorSources.some(({ source }) =>
 		hasExecutablePattern(source, WORKSPACE_BLOCK_PROPS_PATTERN),
 	);
+	const hasEditorBlockPropsUsage = editorWrapperSources.some(({ source }) =>
+		hasExecutablePattern(source, WORKSPACE_BLOCK_PROPS_PATTERN),
+	);
+	const blockWrapperStatus: DoctorCheck["status"] =
+		editorWrapperSources.length === 0 || hasEditorBlockPropsUsage ? "pass" : "warn";
+	const blockWrapperDetail =
+		editorSources.length === 0
+			? "No editor-facing block source files found; general file checks will report missing entrypoints"
+			: editorWrapperSources.length === 0
+				? "No editor wrapper source files found; general file checks will report missing entrypoints"
+				: hasEditorBlockPropsUsage
+					? "Editor-facing sources use block wrapper props"
+					: hasBlockPropsUsage
+						? "Only save-facing useBlockProps.save() usage was detected. Confirm the editor wrapper also receives useBlockProps() or useInnerBlocksProps() before relying on iframe editor rendering."
+						: "No useBlockProps(), useBlockProps.save(), or useInnerBlocksProps() usage was detected in editor-facing sources. Confirm the block wrapper receives WordPress block editor props before relying on iframe editor rendering.";
 
 	return [
 		createDoctorCheck(
@@ -637,12 +661,8 @@ function checkWorkspaceBlockIframeCompatibility(
 		),
 		createDoctorCheck(
 			`Block iframe wrapper ${blockSlug}`,
-			editorSources.length === 0 || hasBlockPropsUsage ? "pass" : "warn",
-			editorSources.length === 0
-				? "No editor-facing block source files found; general file checks will report missing entrypoints"
-				: hasBlockPropsUsage
-					? "Editor-facing sources use block wrapper props"
-					: "No useBlockProps(), useBlockProps.save(), or useInnerBlocksProps() usage was detected in editor-facing sources. Confirm the block wrapper receives WordPress block editor props before relying on iframe editor rendering.",
+			blockWrapperStatus,
+			blockWrapperDetail,
 			WORKSPACE_BLOCK_IFRAME_DIAGNOSTIC_CODES.BLOCK_PROPS,
 		),
 	];

--- a/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace.ts
@@ -91,7 +91,7 @@ const WORKSPACE_BLOCK_LOCAL_STYLE_FILES = [
 	"style.scss",
 ];
 const WORKSPACE_BLOCK_IFRAME_GLOBAL_DOM_PATTERN =
-	/\b(?:document|parent|top|window)\b/gu;
+	/\b(?:document|window)\b|\b(?:parent|top)\b(?!\s*:)/gu;
 const WORKSPACE_BLOCK_PROPS_PATTERN =
 	/\buse(?:Block|InnerBlocks)Props(?:\.save)?\s*\(/u;
 
@@ -339,6 +339,33 @@ function getSourceLineNumber(source: string, index: number): number {
 	return lineNumber;
 }
 
+function isGlobalDomAccessCandidate(
+	maskedSource: string,
+	index: number,
+	token: string,
+): boolean {
+	if (token === "document" || token === "window") {
+		return true;
+	}
+
+	const before = maskedSource.slice(0, index);
+	const after = maskedSource.slice(index + token.length);
+	const previousNonWhitespace = before.match(/\S(?=\s*$)/u)?.[0] ?? "";
+	const nextNonWhitespace = after.match(/^\s*(\S)/u)?.[1] ?? "";
+
+	if (previousNonWhitespace === "." || previousNonWhitespace === "{" || previousNonWhitespace === ",") {
+		return false;
+	}
+	if (nextNonWhitespace === ":") {
+		return false;
+	}
+	if (/\b(?:const|function|let|var)\s+$/u.test(before)) {
+		return false;
+	}
+
+	return true;
+}
+
 function findWorkspaceBlockGlobalDomAccesses(
 	sources: readonly WorkspaceBlockEditorSource[],
 ): string[] {
@@ -349,6 +376,9 @@ function findWorkspaceBlockGlobalDomAccesses(
 		for (const match of matches) {
 			const index = match.index ?? 0;
 			const matchedToken = match[0].replace(/\W+/gu, "");
+			if (!isGlobalDomAccessCandidate(maskedSource, index, matchedToken)) {
+				continue;
+			}
 			findings.push(`${relativePath}:${getSourceLineNumber(source, index)} (${matchedToken})`);
 			if (findings.length >= 5) {
 				return findings;

--- a/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace.ts
@@ -62,13 +62,46 @@ const WORKSPACE_BLOCK_TRANSFORMS_IMPORT_PATTERN =
 	/^\s*import\s*\{\s*applyWorkspaceBlockTransforms\s*\}\s*from\s*["']\.\/transforms["']\s*;?\s*$/mu;
 const WORKSPACE_BLOCK_TRANSFORMS_CALL_PATTERN =
 	/applyWorkspaceBlockTransforms\s*\(\s*registration\s*\.\s*settings\s*\)\s*;?/u;
+const WORKSPACE_BLOCK_IFRAME_COMPATIBILITY_DOC_URL =
+	"https://developer.wordpress.org/block-editor/reference-guides/block-api/block-api-versions/block-migration-for-iframe-editor-compatibility/";
+const WORKSPACE_BLOCK_IFRAME_DIAGNOSTIC_CODES = {
+	API_VERSION: "wp-typia.workspace.block.iframe.api-version",
+	BLOCK_PROPS: "wp-typia.workspace.block.iframe.block-props",
+	EDITOR_GLOBALS: "wp-typia.workspace.block.iframe.editor-globals",
+	EDITOR_STYLES: "wp-typia.workspace.block.iframe.editor-styles",
+} as const;
+const WORKSPACE_BLOCK_EDITOR_SOURCE_FILE_PATTERN = /\.[cm]?[jt]sx?$/u;
+const WORKSPACE_BLOCK_EDITOR_SOURCE_BASENAMES = new Set([
+	"edit",
+	"editor",
+	"index",
+	"save",
+]);
+const WORKSPACE_BLOCK_EDITOR_SOURCE_DIRECTORIES = new Set([
+	"components",
+	"controls",
+	"editor",
+	"inspector",
+]);
+const WORKSPACE_BLOCK_LOCAL_STYLE_FILES = [
+	"editor.css",
+	"editor.scss",
+	"index.css",
+	"style.css",
+	"style.scss",
+];
+const WORKSPACE_BLOCK_IFRAME_GLOBAL_DOM_PATTERN =
+	/\b(?:document|window)\b|\b(?:parent|top)\s*\./gu;
+const WORKSPACE_BLOCK_PROPS_PATTERN =
+	/\buse(?:Block|InnerBlocks)Props(?:\.save)?\s*\(/u;
 
 function createDoctorCheck(
 	label: string,
 	status: DoctorCheck["status"],
 	detail: string,
+	code?: string,
 ): DoctorCheck {
-	return { detail, label, status };
+	return code ? { code, detail, label, status } : { detail, label, status };
 }
 
 function createDoctorScopeCheck(
@@ -166,6 +199,157 @@ function hasUncommentedPattern(source: string, pattern: RegExp): boolean {
 
 function hasExecutablePattern(source: string, pattern: RegExp): boolean {
 	return pattern.test(maskTypeScriptCommentsAndLiterals(source));
+}
+
+type WorkspaceBlockIframeMetadata = Record<string, unknown> & {
+	apiVersion?: unknown;
+	editorStyle?: unknown;
+	style?: unknown;
+};
+
+interface WorkspaceBlockEditorSource {
+	relativePath: string;
+	source: string;
+}
+
+function normalizePathSeparators(relativePath: string): string {
+	return relativePath.split(path.sep).join("/");
+}
+
+function hasRegisteredBlockAsset(value: unknown): boolean {
+	if (typeof value === "string") {
+		return value.trim().length > 0;
+	}
+	if (Array.isArray(value)) {
+		return value.some((entry) => hasRegisteredBlockAsset(entry));
+	}
+	return false;
+}
+
+function readWorkspaceBlockIframeMetadata(
+	projectDir: string,
+	blockSlug: string,
+): {
+	blockJsonRelativePath: string;
+	document?: WorkspaceBlockIframeMetadata;
+	error?: string;
+} {
+	const blockJsonRelativePath = path.join("src", "blocks", blockSlug, "block.json");
+	const blockJsonPath = path.join(projectDir, blockJsonRelativePath);
+
+	if (!fs.existsSync(blockJsonPath)) {
+		return {
+			blockJsonRelativePath,
+			error: `Missing ${blockJsonRelativePath}`,
+		};
+	}
+
+	try {
+		const parsed = JSON.parse(fs.readFileSync(blockJsonPath, "utf8"));
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+			return {
+				blockJsonRelativePath,
+				error: `${blockJsonRelativePath} must contain a JSON object`,
+			};
+		}
+		return {
+			blockJsonRelativePath,
+			document: parsed as WorkspaceBlockIframeMetadata,
+		};
+	} catch (error) {
+		return {
+			blockJsonRelativePath,
+			error: error instanceof Error ? error.message : String(error),
+		};
+	}
+}
+
+function isWorkspaceBlockEditorSource(relativePath: string): boolean {
+	const normalizedPath = normalizePathSeparators(relativePath);
+	if (
+		!WORKSPACE_BLOCK_EDITOR_SOURCE_FILE_PATTERN.test(normalizedPath) ||
+		/\.d\.[cm]?[jt]s$/u.test(normalizedPath)
+	) {
+		return false;
+	}
+
+	const segments = normalizedPath.split("/");
+	const fileName = segments[segments.length - 1] ?? "";
+	const baseName = fileName.replace(/\.[^.]+$/u, "");
+	if (WORKSPACE_BLOCK_EDITOR_SOURCE_BASENAMES.has(baseName)) {
+		return true;
+	}
+
+	return segments
+		.slice(0, -1)
+		.some((segment) => WORKSPACE_BLOCK_EDITOR_SOURCE_DIRECTORIES.has(segment));
+}
+
+function collectWorkspaceBlockEditorSources(
+	projectDir: string,
+	blockSlug: string,
+): WorkspaceBlockEditorSource[] {
+	const blockDir = path.join(projectDir, "src", "blocks", blockSlug);
+	if (!fs.existsSync(blockDir)) {
+		return [];
+	}
+
+	const sources: WorkspaceBlockEditorSource[] = [];
+	const visitDirectory = (directory: string) => {
+		for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+			const entryPath = path.join(directory, entry.name);
+			if (entry.isDirectory()) {
+				visitDirectory(entryPath);
+				continue;
+			}
+			if (!entry.isFile()) {
+				continue;
+			}
+
+			const relativePath = normalizePathSeparators(path.relative(projectDir, entryPath));
+			const blockRelativePath = path.relative(blockDir, entryPath);
+			if (!isWorkspaceBlockEditorSource(blockRelativePath)) {
+				continue;
+			}
+
+			sources.push({
+				relativePath,
+				source: fs.readFileSync(entryPath, "utf8"),
+			});
+		}
+	};
+
+	visitDirectory(blockDir);
+	return sources;
+}
+
+function getSourceLineNumber(source: string, index: number): number {
+	let lineNumber = 1;
+	for (let cursor = 0; cursor < index; cursor += 1) {
+		if (source[cursor] === "\n") {
+			lineNumber += 1;
+		}
+	}
+	return lineNumber;
+}
+
+function findWorkspaceBlockGlobalDomAccesses(
+	sources: readonly WorkspaceBlockEditorSource[],
+): string[] {
+	const findings: string[] = [];
+	for (const { relativePath, source } of sources) {
+		const maskedSource = maskTypeScriptCommentsAndLiterals(source);
+		const matches = maskedSource.matchAll(WORKSPACE_BLOCK_IFRAME_GLOBAL_DOM_PATTERN);
+		for (const match of matches) {
+			const index = match.index ?? 0;
+			const matchedToken = match[0].replace(/\W+/gu, "");
+			findings.push(`${relativePath}:${getSourceLineNumber(source, index)} (${matchedToken})`);
+			if (findings.length >= 5) {
+				return findings;
+			}
+		}
+	}
+	return findings;
 }
 
 function getWorkspaceBootstrapRelativePath(packageName: string): string {
@@ -388,6 +572,80 @@ function checkWorkspaceBlockCollectionImport(
 			? "Shared block collection import is present"
 			: `Missing a shared collection import like ${WORKSPACE_COLLECTION_IMPORT_LINE}`,
 	);
+}
+
+function checkWorkspaceBlockIframeCompatibility(
+	projectDir: string,
+	blockSlug: string,
+): DoctorCheck[] {
+	const metadataResult = readWorkspaceBlockIframeMetadata(projectDir, blockSlug);
+	if (!metadataResult.document) {
+		return [
+			createDoctorCheck(
+				`Block iframe/API v3 ${blockSlug}`,
+				"fail",
+				metadataResult.error ?? `Unable to inspect ${metadataResult.blockJsonRelativePath}`,
+				WORKSPACE_BLOCK_IFRAME_DIAGNOSTIC_CODES.API_VERSION,
+			),
+		];
+	}
+
+	const blockJson = metadataResult.document;
+	const apiVersion =
+		typeof blockJson.apiVersion === "number" && Number.isFinite(blockJson.apiVersion)
+			? blockJson.apiVersion
+			: null;
+	const blockDir = path.join(projectDir, "src", "blocks", blockSlug);
+	const localStyleFiles = WORKSPACE_BLOCK_LOCAL_STYLE_FILES.filter((fileName) =>
+		fs.existsSync(path.join(blockDir, fileName)),
+	).map((fileName) => normalizePathSeparators(path.join("src", "blocks", blockSlug, fileName)));
+	const hasRegisteredEditorStyles =
+		hasRegisteredBlockAsset(blockJson.style) ||
+		hasRegisteredBlockAsset(blockJson.editorStyle);
+	const editorSources = collectWorkspaceBlockEditorSources(projectDir, blockSlug);
+	const globalDomAccesses = findWorkspaceBlockGlobalDomAccesses(editorSources);
+	const hasBlockPropsUsage = editorSources.some(({ source }) =>
+		hasExecutablePattern(source, WORKSPACE_BLOCK_PROPS_PATTERN),
+	);
+
+	return [
+		createDoctorCheck(
+			`Block iframe API version ${blockSlug}`,
+			apiVersion !== null && apiVersion >= 3 ? "pass" : "warn",
+			apiVersion !== null && apiVersion >= 3
+				? "block.json declares apiVersion 3 for iframe editor readiness"
+				: `Set ${metadataResult.blockJsonRelativePath} apiVersion to 3 after testing the block in iframe-enabled Post Editor and Site Editor contexts. WordPress recommends API v3 for iframe editor compatibility. See ${WORKSPACE_BLOCK_IFRAME_COMPATIBILITY_DOC_URL}`,
+			WORKSPACE_BLOCK_IFRAME_DIAGNOSTIC_CODES.API_VERSION,
+		),
+		createDoctorCheck(
+			`Block iframe styles ${blockSlug}`,
+			localStyleFiles.length === 0 || hasRegisteredEditorStyles ? "pass" : "warn",
+			localStyleFiles.length === 0
+				? "No local block stylesheet source files found to register"
+				: hasRegisteredEditorStyles
+					? "block.json registers block styles for iframe editor loading"
+					: `Found stylesheet source files (${localStyleFiles.join(", ")}) but block.json does not declare style or editorStyle. Register block content styles so iframe editors do not depend on parent admin styles.`,
+			WORKSPACE_BLOCK_IFRAME_DIAGNOSTIC_CODES.EDITOR_STYLES,
+		),
+		createDoctorCheck(
+			`Block iframe globals ${blockSlug}`,
+			globalDomAccesses.length === 0 ? "pass" : "warn",
+			globalDomAccesses.length === 0
+				? "No direct window/document/parent DOM access detected in editor-facing block sources"
+				: `Direct global DOM access detected at ${globalDomAccesses.join(", ")}. Prefer element.ownerDocument/defaultView via refs or useRefEffect for iframe editor content.`,
+			WORKSPACE_BLOCK_IFRAME_DIAGNOSTIC_CODES.EDITOR_GLOBALS,
+		),
+		createDoctorCheck(
+			`Block iframe wrapper ${blockSlug}`,
+			editorSources.length === 0 || hasBlockPropsUsage ? "pass" : "warn",
+			editorSources.length === 0
+				? "No editor-facing block source files found; general file checks will report missing entrypoints"
+				: hasBlockPropsUsage
+					? "Editor-facing sources use block wrapper props"
+					: "No useBlockProps(), useBlockProps.save(), or useInnerBlocksProps() usage was detected in editor-facing sources. Confirm the block wrapper receives WordPress block editor props before relying on iframe editor rendering.",
+			WORKSPACE_BLOCK_IFRAME_DIAGNOSTIC_CODES.BLOCK_PROPS,
+		),
+	];
 }
 
 function checkWorkspacePatternBootstrap(projectDir: string, packageName: string): DoctorCheck {
@@ -1391,6 +1649,7 @@ export function getWorkspaceDoctorChecks(cwd: string): DoctorCheck[] {
 			checks.push(checkWorkspaceBlockMetadata(workspace.projectDir, workspace, block));
 			checks.push(checkWorkspaceBlockHooks(workspace.projectDir, block.slug));
 			checks.push(checkWorkspaceBlockCollectionImport(workspace.projectDir, block.slug));
+			checks.push(...checkWorkspaceBlockIframeCompatibility(workspace.projectDir, block.slug));
 		}
 
 		const registeredBlockSlugs = new Set(inventory.blocks.map((block) => block.slug));

--- a/packages/wp-typia-project-tools/src/runtime/cli-doctor.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-doctor.ts
@@ -11,12 +11,14 @@ import { getWorkspaceDoctorChecks } from "./cli-doctor-workspace.js";
  * One doctor check rendered by the CLI diagnostics flow.
  */
 export interface DoctorCheck {
+	/** Stable machine-readable diagnostic id for structured integrations. */
+	code?: string;
 	/** Human-readable status detail rendered next to the label. */
 	detail: string;
 	/** Short label for the dependency, directory, or template check. */
 	label: string;
-	/** Final pass/fail status for this diagnostic row. */
-	status: "pass" | "fail";
+	/** Final pass/fail/warn status for this diagnostic row. */
+	status: "pass" | "fail" | "warn";
 }
 
 interface RunDoctorOptions {

--- a/packages/wp-typia-project-tools/src/runtime/cli-help.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-help.ts
@@ -61,7 +61,7 @@ Notes:
   \`add ai-feature\` scaffolds server-owned AI feature endpoints under \`src/ai-features/\` and PHP route glue under \`inc/ai-features/\`.
   \`add editor-plugin\` scaffolds a document-level editor extension under \`src/editor-plugins/\`; legacy aliases \`PluginSidebar\` and \`PluginDocumentSettingPanel\` resolve to \`sidebar\` and \`document-setting-panel\`.
   \`add hooked-block\` patches an existing workspace block's \`block.json\` \`blockHooks\` metadata.
-  \`wp-typia doctor\` always checks environment readiness and reports when it only ran environment-level diagnostics; official workspace roots also get inventory and source-tree drift checks.
+  \`wp-typia doctor\` always checks environment readiness and reports when it only ran environment-level diagnostics; official workspace roots also get inventory, source-tree drift, and iframe/API v3 compatibility checks.
   \`wp-typia init\` previews the minimum sync/doctor/migration adoption layer for supported existing layouts before a future write mode exists.
   \`wp-typia migrate doctor --all\` checks migration target alignment, snapshots, fixtures, and generated migration artifacts.
   \`migrate\` is the canonical migration command; \`migrations\` is no longer supported.`;

--- a/packages/wp-typia-project-tools/src/runtime/cli-help.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-help.ts
@@ -61,7 +61,7 @@ Notes:
   \`add ai-feature\` scaffolds server-owned AI feature endpoints under \`src/ai-features/\` and PHP route glue under \`inc/ai-features/\`.
   \`add editor-plugin\` scaffolds a document-level editor extension under \`src/editor-plugins/\`; legacy aliases \`PluginSidebar\` and \`PluginDocumentSettingPanel\` resolve to \`sidebar\` and \`document-setting-panel\`.
   \`add hooked-block\` patches an existing workspace block's \`block.json\` \`blockHooks\` metadata.
-  \`wp-typia doctor\` always checks environment readiness and reports when it only ran environment-level diagnostics; official workspace roots also get inventory, source-tree drift, and iframe/API v3 compatibility checks.
+  \`wp-typia doctor\` always checks environment readiness and reports when it only ran environment-level diagnostics; official workspace roots also get inventory, source-tree drift, shared convention checks, and iframe/API v3 compatibility checks.
   \`wp-typia init\` previews the minimum sync/doctor/migration adoption layer for supported existing layouts before a future write mode exists.
   \`wp-typia migrate doctor --all\` checks migration target alignment, snapshots, fixtures, and generated migration artifacts.
   \`migrate\` is the canonical migration command; \`migrations\` is no longer supported.`;

--- a/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
@@ -132,7 +132,7 @@ test("doctor reports iframe/API v3 compatibility warnings without failing", asyn
     editPath,
     `${fs
       .readFileSync(editPath, "utf8")
-      .replace(/\buseBlockProps\b/gu, "usePlainBlockProps")}\ndocument.body.classList.contains('wp-admin');\n`,
+      .replace(/\buseBlockProps\b/gu, "usePlainBlockProps")}\nconst iframeLayout = { parent: [], top: 0 };\ndocument.body.classList.contains('wp-admin');\n`,
     "utf8"
   );
   const humanOutput = runCli("node", [entryPath, "doctor"], {
@@ -158,6 +158,12 @@ test("doctor reports iframe/API v3 compatibility warnings without failing", asyn
   );
   expect(getCheck("wp-typia.workspace.block.iframe.editor-globals")?.detail).toContain(
     "edit.tsx"
+  );
+  expect(getCheck("wp-typia.workspace.block.iframe.editor-globals")?.detail).not.toContain(
+    "(parent)"
+  );
+  expect(getCheck("wp-typia.workspace.block.iframe.editor-globals")?.detail).not.toContain(
+    "(top)"
   );
   expect(getCheck("wp-typia.workspace.block.iframe.editor-globals")?.status).toBe(
     "warn"

--- a/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
@@ -98,6 +98,82 @@ test("doctor reports workspace discovery failures before workspace checks", asyn
   );
 });
 
+test("doctor reports iframe/API v3 compatibility warnings without failing", async () => {
+  const targetDir = path.join(
+    tempRoot,
+    "demo-workspace-iframe-compatibility-warnings"
+  );
+
+  await scaffoldOfficialWorkspace(targetDir, {
+    description: "Demo workspace iframe compatibility warnings",
+    slug: "demo-workspace-iframe-compatibility-warnings",
+    title: "Demo Workspace Iframe Compatibility Warnings",
+  });
+
+  linkWorkspaceNodeModules(targetDir);
+  runCli(
+    "node",
+    [entryPath, "add", "block", "counter-card", "--template", "basic"],
+    {
+      cwd: targetDir,
+    }
+  );
+
+  const blockDir = path.join(targetDir, "src", "blocks", "counter-card");
+  const blockJsonPath = path.join(blockDir, "block.json");
+  const blockJson = JSON.parse(fs.readFileSync(blockJsonPath, "utf8"));
+  blockJson.apiVersion = 2;
+  delete blockJson.style;
+  delete blockJson.editorStyle;
+  fs.writeFileSync(blockJsonPath, JSON.stringify(blockJson, null, 2), "utf8");
+
+  const editPath = path.join(blockDir, "edit.tsx");
+  fs.writeFileSync(
+    editPath,
+    `${fs
+      .readFileSync(editPath, "utf8")
+      .replace(/\buseBlockProps\b/gu, "usePlainBlockProps")}\ndocument.body.classList.contains('wp-admin');\n`,
+    "utf8"
+  );
+  const savePath = path.join(blockDir, "save.tsx");
+  fs.writeFileSync(
+    savePath,
+    fs.readFileSync(savePath, "utf8").replace(/\buseBlockProps\b/gu, "usePlainBlockProps"),
+    "utf8"
+  );
+
+  const humanOutput = runCli("node", [entryPath, "doctor"], {
+    cwd: targetDir,
+  });
+  expect(humanOutput).toContain("WARN Block iframe API version counter-card");
+  expect(humanOutput).toContain("PASS wp-typia doctor summary:");
+
+  const doctorOutput = runCli("node", [entryPath, "doctor", "--format", "json"], {
+    cwd: targetDir,
+  });
+  const doctorChecks = parseJsonObjectFromOutput<{
+    checks: Array<{ code?: string; detail: string; label: string; status: string }>;
+  }>(doctorOutput);
+  const getCheck = (code: string) =>
+    doctorChecks.checks.find((check) => check.code === code);
+
+  expect(getCheck("wp-typia.workspace.block.iframe.api-version")?.status).toBe(
+    "warn"
+  );
+  expect(getCheck("wp-typia.workspace.block.iframe.editor-styles")?.status).toBe(
+    "warn"
+  );
+  expect(getCheck("wp-typia.workspace.block.iframe.editor-globals")?.detail).toContain(
+    "edit.tsx"
+  );
+  expect(getCheck("wp-typia.workspace.block.iframe.editor-globals")?.status).toBe(
+    "warn"
+  );
+  expect(getCheck("wp-typia.workspace.block.iframe.block-props")?.status).toBe(
+    "warn"
+  );
+}, 15_000);
+
 test("doctor accepts workspaces that keep binding registries in src/bindings/index.js", async () => {
   const targetDir = path.join(
     tempRoot,

--- a/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
@@ -135,18 +135,11 @@ test("doctor reports iframe/API v3 compatibility warnings without failing", asyn
       .replace(/\buseBlockProps\b/gu, "usePlainBlockProps")}\ndocument.body.classList.contains('wp-admin');\n`,
     "utf8"
   );
-  const savePath = path.join(blockDir, "save.tsx");
-  fs.writeFileSync(
-    savePath,
-    fs.readFileSync(savePath, "utf8").replace(/\buseBlockProps\b/gu, "usePlainBlockProps"),
-    "utf8"
-  );
-
   const humanOutput = runCli("node", [entryPath, "doctor"], {
     cwd: targetDir,
   });
   expect(humanOutput).toContain("WARN Block iframe API version counter-card");
-  expect(humanOutput).toContain("PASS wp-typia doctor summary:");
+  expect(humanOutput).toContain("WARN wp-typia doctor summary:");
 
   const doctorOutput = runCli("node", [entryPath, "doctor", "--format", "json"], {
     cwd: targetDir,
@@ -168,6 +161,9 @@ test("doctor reports iframe/API v3 compatibility warnings without failing", asyn
   );
   expect(getCheck("wp-typia.workspace.block.iframe.editor-globals")?.status).toBe(
     "warn"
+  );
+  expect(getCheck("wp-typia.workspace.block.iframe.block-props")?.detail).toContain(
+    "Only save-facing"
   );
   expect(getCheck("wp-typia.workspace.block.iframe.block-props")?.status).toBe(
     "warn"

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -301,7 +301,7 @@ function renderDoctorHelp() {
     '',
     ...NODE_FALLBACK_RUNTIME_SUMMARY_LINES,
     '',
-    'Runs read-only environment readiness checks. Official wp-typia workspace roots also get inventory, source-tree drift, and shared convention checks.',
+    'Runs read-only environment readiness checks. Official wp-typia workspace roots also get inventory, source-tree drift, iframe/API v3 compatibility, and shared convention checks.',
     '',
     'Supported flags:',
     ...formatNodeFallbackOptionHelp(DOCTOR_OPTION_METADATA),


### PR DESCRIPTION
## Summary
- add non-failing WARN doctor status and check-level diagnostic codes
- report workspace block iframe/API v3 readiness for apiVersion, registered styles, global DOM access, and wrapper props usage
- document how to interpret iframe/API v3 warnings using the WordPress migration guide

Closes #595

## Verification
- bun run --cwd packages/wp-typia-project-tools test:workspace
- bun run format:check
- bun run changesets:validate
- bun run typecheck

Reference: https://developer.wordpress.org/block-editor/reference-guides/block-api/block-api-versions/block-migration-for-iframe-editor-compatibility/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `wp-typia doctor` now performs iframe/API v3 compatibility checks for workspace blocks.
  * Introduced "warn" diagnostic status for non-failing checks with machine-readable diagnostic codes.
  * Validates block metadata, stylesheet registration, global DOM access patterns, and wrapper-props usage.

* **Documentation**
  * Updated reference docs to describe iframe/API v3 compatibility diagnostics and expanded doctor command output format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->