### PR TITLE
feat(cli): expand diagnostic code coverage

### DIFF
--- a/.sampo/changesets/cli-diagnostic-coverage.md
+++ b/.sampo/changesets/cli-diagnostic-coverage.md
@@ -1,0 +1,8 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Document the supported CLI diagnostic code contract, export recovery metadata
+for machine-readable integrations, and tighten representative structured failure
+coverage across create, add, sync, init, and doctor flows.

--- a/apps/docs/src/content/docs/reference/cli.md
+++ b/apps/docs/src/content/docs/reference/cli.md
@@ -27,6 +27,44 @@ shell `completions` require Bun 1.3.11+ or the standalone release binary.
 Status markers honor `WP_TYPIA_ASCII=1`, `WP_TYPIA_ASCII=0`, and `NO_COLOR` in
 the same way as generated project onboarding output.
 
+## Machine-readable diagnostics
+
+Commands that support `--format json` emit stable failure envelopes for CI, IDE,
+and wrapper integrations. The `error.code` field is the integration contract;
+human-readable `message`, `summary`, and `detailLines` can change as guidance
+improves.
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "missing-argument",
+    "command": "create",
+    "kind": "command-execution",
+    "tag": "CommandExecutionError"
+  }
+}
+```
+
+Known throw sites attach an explicit diagnostic code. Message-based inference is
+kept only as a compatibility fallback for legacy or untyped errors.
+
+| Code                         | Typical cause                                            | Recovery                                                                |
+| ---------------------------- | -------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `command-execution`          | The command failed after preflight checks completed.     | Read the detail lines and rerun after fixing the underlying tool error. |
+| `configuration-missing`      | Required wp-typia configuration is missing.              | Add the missing config section or rerun the scaffold/init setup.        |
+| `dependencies-not-installed` | Project or workspace dependencies are not installed.     | Run the reported package-manager install command from the project root. |
+| `doctor-check-failed`        | One or more doctor checks failed.                        | Fix the failed doctor rows, then rerun `wp-typia doctor`.               |
+| `invalid-argument`           | An argument value is present but unsupported or invalid. | Correct the argument value using command help and the detail lines.     |
+| `invalid-command`            | The command or subcommand is not supported.              | Run `wp-typia --help` and switch to a listed command/subcommand.        |
+| `missing-argument`           | A required positional argument or flag value is missing. | Provide the missing value shown in the detail lines.                    |
+| `missing-build-artifact`     | The CLI package layout is missing bundled artifacts.     | Reinstall the package/binary or rebuild the workspace.                  |
+| `outside-project-root`       | The command ran outside a generated project/workspace.   | `cd` into the scaffolded root or rerun the scaffold/init flow.          |
+| `template-source-timeout`    | External template resolution timed out.                  | Retry with a reachable source, local path, or cached package.           |
+| `template-source-too-large`  | External template content exceeded the safety limit.     | Reduce the package size or use a smaller template layer.                |
+| `unknown-template`           | The requested template id is not registered.             | Run `wp-typia templates list` and use one of the listed ids.            |
+| `unsupported-command`        | The current runtime cannot execute that command surface. | Install Bun 1.3.11+ or use the standalone wp-typia binary if required.  |
+
 ## `create`
 
 Scaffold a new project.

--- a/packages/wp-typia-project-tools/src/runtime/cli-core.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-core.ts
@@ -17,7 +17,8 @@
  * `runAddRestResourceCommand` for plugin-level REST resource scaffolds,
  * `getDoctorChecks`, `runDoctor`, and `DoctorCheck` for diagnostics,
  * `createCliCommandError`, `createCliDiagnosticCodeError`,
- * `CLI_DIAGNOSTIC_CODES`, and `formatCliDiagnosticError` for shared
+ * `CLI_DIAGNOSTIC_CODES`, `CLI_DIAGNOSTIC_CODE_METADATA`,
+ * `getCliDiagnosticCodeMetadata`, and `formatCliDiagnosticError` for shared
  * non-interactive failure rendering and explicit diagnostic-code ownership,
  * `formatHelpText` for top-level CLI usage output, scaffold helpers such as
  * `createReadlinePrompt`, `getNextSteps`, `getOptionalOnboarding`,
@@ -32,10 +33,12 @@ export {
 	createCliCommandError,
 	createCliDiagnosticCodeError,
 	CliDiagnosticError,
+	CLI_DIAGNOSTIC_CODE_METADATA,
 	CLI_DIAGNOSTIC_CODES,
 	formatCliDiagnosticError,
 	formatDoctorCheckLine,
 	formatDoctorSummaryLine,
+	getCliDiagnosticCodeMetadata,
 	getDoctorFailureDetailLines,
 	getFailingDoctorChecks,
 	isCliDiagnosticError,

--- a/packages/wp-typia-project-tools/src/runtime/cli-diagnostics.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-diagnostics.ts
@@ -27,6 +27,79 @@ export const CLI_DIAGNOSTIC_CODES = {
 export type CliDiagnosticCode =
 	(typeof CLI_DIAGNOSTIC_CODES)[keyof typeof CLI_DIAGNOSTIC_CODES];
 
+export interface CliDiagnosticCodeMetadata {
+	cause: string;
+	recovery: string;
+}
+
+export const CLI_DIAGNOSTIC_CODE_METADATA = {
+	[CLI_DIAGNOSTIC_CODES.COMMAND_EXECUTION]: {
+		cause: "The command failed after argument parsing and preflight checks completed.",
+		recovery:
+			"Read the detail lines for the underlying tool failure, rerun with the same command once corrected, and report the full JSON envelope if the recovery is unclear.",
+	},
+	[CLI_DIAGNOSTIC_CODES.CONFIGURATION_MISSING]: {
+		cause: "A command needs configuration that is not present in the current project.",
+		recovery:
+			"Add the missing wp-typia config section or rerun the scaffold/init flow that creates the expected configuration.",
+	},
+	[CLI_DIAGNOSTIC_CODES.DEPENDENCIES_NOT_INSTALLED]: {
+		cause: "Generated project or workspace dependencies are missing from the local install.",
+		recovery:
+			"Run the package-manager install command from the reported project root, then rerun the wp-typia command.",
+	},
+	[CLI_DIAGNOSTIC_CODES.DOCTOR_CHECK_FAILED]: {
+		cause: "One or more doctor checks reported a failing environment or workspace row.",
+		recovery:
+			"Inspect the failed check labels and details, fix the reported drift or missing prerequisite, then rerun `wp-typia doctor`.",
+	},
+	[CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT]: {
+		cause: "An argument was present but did not match the supported value, shape, or project state.",
+		recovery:
+			"Correct the argument value using command help or the detail lines, then rerun the command.",
+	},
+	[CLI_DIAGNOSTIC_CODES.INVALID_COMMAND]: {
+		cause: "The command or subcommand is not part of the supported wp-typia command tree.",
+		recovery:
+			"Run `wp-typia --help` or the relevant command help and switch to a supported command/subcommand.",
+	},
+	[CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT]: {
+		cause: "A required positional argument or flag value was omitted.",
+		recovery:
+			"Provide the missing argument or flag value shown in the detail lines, then rerun the command.",
+	},
+	[CLI_DIAGNOSTIC_CODES.MISSING_BUILD_ARTIFACT]: {
+		cause: "The published or standalone CLI layout is missing bundled build artifacts.",
+		recovery:
+			"Reinstall the package or standalone binary, or rebuild the workspace before invoking the command again.",
+	},
+	[CLI_DIAGNOSTIC_CODES.OUTSIDE_PROJECT_ROOT]: {
+		cause: "The command was run outside a generated wp-typia project or official workspace root.",
+		recovery:
+			"Change into the scaffolded project/workspace root, or rerun the scaffold/init workflow that creates the expected root files.",
+	},
+	[CLI_DIAGNOSTIC_CODES.TEMPLATE_SOURCE_TIMEOUT]: {
+		cause: "External template resolution did not complete within the allowed time.",
+		recovery:
+			"Retry with a reachable template source, use a local path, or cache the template package before rerunning.",
+	},
+	[CLI_DIAGNOSTIC_CODES.TEMPLATE_SOURCE_TOO_LARGE]: {
+		cause: "External template content exceeded the safety size limit.",
+		recovery:
+			"Reduce the template package size or point wp-typia at a smaller official template layer.",
+	},
+	[CLI_DIAGNOSTIC_CODES.UNKNOWN_TEMPLATE]: {
+		cause: "The requested scaffold template or add-block template id is not registered.",
+		recovery:
+			"Run `wp-typia templates list` and rerun with one of the listed template ids.",
+	},
+	[CLI_DIAGNOSTIC_CODES.UNSUPPORTED_COMMAND]: {
+		cause: "The requested command exists conceptually but is not supported by the current runtime surface.",
+		recovery:
+			"Install Bun 1.3.11+ or use the standalone wp-typia binary when the detail lines say the Bun-powered runtime is required.",
+	},
+} satisfies Record<CliDiagnosticCode, CliDiagnosticCodeMetadata>;
+
 export type CliDiagnosticCodeError<TCode extends CliDiagnosticCode = CliDiagnosticCode> =
 	Error & { code: TCode };
 
@@ -215,6 +288,12 @@ function readCliDiagnosticCode(error: unknown): CliDiagnosticCode | null {
 	}
 
 	return null;
+}
+
+export function getCliDiagnosticCodeMetadata(
+	code: CliDiagnosticCode,
+): CliDiagnosticCodeMetadata {
+	return CLI_DIAGNOSTIC_CODE_METADATA[code];
 }
 
 /**

--- a/packages/wp-typia-project-tools/src/runtime/cli-diagnostics.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-diagnostics.ts
@@ -27,11 +27,19 @@ export const CLI_DIAGNOSTIC_CODES = {
 export type CliDiagnosticCode =
 	(typeof CLI_DIAGNOSTIC_CODES)[keyof typeof CLI_DIAGNOSTIC_CODES];
 
+/**
+ * Human-readable guidance attached to one stable CLI diagnostic code.
+ */
 export interface CliDiagnosticCodeMetadata {
+	/** Why this diagnostic code is emitted. */
 	cause: string;
+	/** The recommended recovery path for users and automation. */
 	recovery: string;
 }
 
+/**
+ * Stable cause and recovery metadata for every supported CLI diagnostic code.
+ */
 export const CLI_DIAGNOSTIC_CODE_METADATA = {
 	[CLI_DIAGNOSTIC_CODES.COMMAND_EXECUTION]: {
 		cause: "The command failed after argument parsing and preflight checks completed.",
@@ -290,6 +298,9 @@ function readCliDiagnosticCode(error: unknown): CliDiagnosticCode | null {
 	return null;
 }
 
+/**
+ * Look up cause and recovery guidance for a stable CLI diagnostic code.
+ */
 export function getCliDiagnosticCodeMetadata(
 	code: CliDiagnosticCode,
 ): CliDiagnosticCodeMetadata {

--- a/packages/wp-typia-project-tools/src/runtime/cli-doctor.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-doctor.ts
@@ -1,4 +1,5 @@
 import {
+	CLI_DIAGNOSTIC_CODES,
 	createCliCommandError,
 	formatDoctorCheckLine,
 	formatDoctorSummaryLine,
@@ -72,6 +73,7 @@ export async function runDoctor(
 	const failureDetailLines = getDoctorFailureDetailLines(checks);
 	if (failureDetailLines.length > 0) {
 		throw createCliCommandError({
+			code: CLI_DIAGNOSTIC_CODES.DOCTOR_CHECK_FAILED,
 			command: "doctor",
 			detailLines: failureDetailLines,
 			summary: "One or more doctor checks failed.",

--- a/packages/wp-typia-project-tools/src/runtime/cli-init.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-init.ts
@@ -1,6 +1,10 @@
 import fs from "node:fs";
 import path from "node:path";
 
+import {
+	CLI_DIAGNOSTIC_CODES,
+	createCliDiagnosticCodeError,
+} from "./cli-diagnostics.js";
 import { discoverMigrationInitLayout } from "./migration-project.js";
 import {
 	formatAddDevDependenciesCommand,
@@ -109,7 +113,15 @@ function readProjectPackageJson(projectDir: string): ProjectPackageJson | null {
 		return null;
 	}
 
-	return JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as ProjectPackageJson;
+	try {
+		return JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as ProjectPackageJson;
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		throw createCliDiagnosticCodeError(
+			CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
+			`Unable to parse ${packageJsonPath}: ${message}`,
+		);
+	}
 }
 
 function inferInitPackageManager(

--- a/packages/wp-typia-project-tools/src/runtime/cli-init.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-init.ts
@@ -113,13 +113,15 @@ function readProjectPackageJson(projectDir: string): ProjectPackageJson | null {
 		return null;
 	}
 
+	const source = fs.readFileSync(packageJsonPath, "utf8");
 	try {
-		return JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as ProjectPackageJson;
+		return JSON.parse(source) as ProjectPackageJson;
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
 		throw createCliDiagnosticCodeError(
 			CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
 			`Unable to parse ${packageJsonPath}: ${message}`,
+			error instanceof Error ? { cause: error } : undefined,
 		);
 	}
 }

--- a/packages/wp-typia-project-tools/tests/cli-entry.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-entry.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as http from "node:http";
 import * as path from "node:path";
 import { cleanupScaffoldTempRoot, createBlockExternalFixturePath, createBlockSubsetFixturePath, createScaffoldTempRoot, entryPath, getCommandErrorMessage, runCapturedCli, runCli, scaffoldOfficialWorkspace, templateLayerAmbiguousFixturePath, templateLayerFixturePath } from "./helpers/scaffold-test-harness.js";
-import { CLI_DIAGNOSTIC_CODES, createCliCommandError, createCliDiagnosticCodeError, serializeCliDiagnosticError } from "../src/runtime/cli-diagnostics.js";
+import { CLI_DIAGNOSTIC_CODE_METADATA, CLI_DIAGNOSTIC_CODES, createCliCommandError, createCliDiagnosticCodeError, getCliDiagnosticCodeMetadata, serializeCliDiagnosticError } from "../src/runtime/cli-diagnostics.js";
 import { formatHelpText, getDoctorChecks, getNextSteps, getOptionalOnboarding, runScaffoldFlow } from "../src/runtime/cli-core.js";
 import { assertValidEditorPluginSlot } from "../src/runtime/cli-add-shared.js";
 import { collectScaffoldAnswers } from "../src/runtime/scaffold.js";
@@ -47,6 +47,88 @@ describe("@wp-typia/project-tools scaffold CLI flow", () => {
     };
   }
 
+  type StructuredCliFailurePayload = {
+    error: {
+      code: string;
+      command?: string;
+      detailLines?: string[];
+      kind: string;
+      message: string;
+      name: string;
+      summary?: string;
+      tag: string;
+    };
+    ok: false;
+  };
+
+  function parseStructuredCliFailure(output: string): StructuredCliFailurePayload {
+    for (let startIndex = output.indexOf("{"); startIndex !== -1; startIndex = output.indexOf("{", startIndex + 1)) {
+      let depth = 0;
+      let escaped = false;
+      let inString = false;
+
+      for (let index = startIndex; index < output.length; index += 1) {
+        const character = output[index];
+
+        if (escaped) {
+          escaped = false;
+          continue;
+        }
+        if (character === "\\") {
+          escaped = true;
+          continue;
+        }
+        if (character === "\"") {
+          inString = !inString;
+          continue;
+        }
+        if (inString) {
+          continue;
+        }
+        if (character === "{") {
+          depth += 1;
+          continue;
+        }
+        if (character !== "}") {
+          continue;
+        }
+
+        depth -= 1;
+        if (depth !== 0) {
+          continue;
+        }
+
+        try {
+          const parsed = JSON.parse(
+            output.slice(startIndex, index + 1)
+          ) as StructuredCliFailurePayload;
+          if (parsed.ok === false && typeof parsed.error?.code === "string") {
+            return parsed;
+          }
+        } catch {}
+
+        break;
+      }
+    }
+
+    throw new Error(`Expected a structured CLI failure payload in output: ${output}`);
+  }
+
+  function readStructuredCliFailure(
+    command: "bun" | "node",
+    args: string[],
+    options: Parameters<typeof runCli>[2] = {}
+  ): StructuredCliFailurePayload {
+    const output = getCommandErrorMessage(() =>
+      runCli(command, args, {
+        stdio: "pipe",
+        ...options,
+      })
+    );
+
+    return parseStructuredCliFailure(output);
+  }
+
 test("CLI diagnostics do not classify unknown template variants as missing templates", () => {
   const diagnostic = serializeCliDiagnosticError(
     createCliCommandError({
@@ -71,6 +153,103 @@ test("CLI diagnostics preserve explicit throw-site codes without message inferen
 
   expect(diagnostic.code).toBe("missing-argument");
   expect(diagnostic.message).toContain("Opaque scaffold preflight failure.");
+});
+
+test("CLI diagnostic metadata covers every stable code", () => {
+  const codes = Object.values(CLI_DIAGNOSTIC_CODES).sort();
+
+  expect(Object.keys(CLI_DIAGNOSTIC_CODE_METADATA).sort()).toEqual(codes);
+  for (const code of codes) {
+    const metadata = getCliDiagnosticCodeMetadata(code);
+    expect(metadata.cause.length).toBeGreaterThan(0);
+    expect(metadata.recovery.length).toBeGreaterThan(0);
+  }
+});
+
+test("node and bun entries keep structured diagnostic envelopes stable", () => {
+  for (const command of ["node", "bun"] as const) {
+    const payload = readStructuredCliFailure(command, [
+      entryPath,
+      "create",
+      "--format",
+      "json",
+    ]);
+
+    expect(payload.ok).toBe(false);
+    expect(payload.error.code).toBe("missing-argument");
+    expect(payload.error.command).toBe("create");
+    expect(payload.error.kind).toBe("command-execution");
+    expect(payload.error.name).toBe("CliDiagnosticError");
+    expect(payload.error.summary).toBe(
+      "Unable to complete the requested create workflow."
+    );
+    expect(payload.error.tag).toBe("CommandExecutionError");
+    expect(payload.error.detailLines).toContain(
+      "`wp-typia create` requires <project-dir>."
+    );
+  }
+});
+
+test("structured diagnostic codes cover representative CLI command failures", () => {
+  expect(
+    readStructuredCliFailure("node", [
+      entryPath,
+      "create",
+      "--format",
+      "json",
+    ]).error.code
+  ).toBe("missing-argument");
+
+  expect(
+    readStructuredCliFailure("node", [
+      entryPath,
+      "add",
+      "block",
+      "--format",
+      "json",
+    ]).error.code
+  ).toBe("missing-argument");
+
+  expect(
+    readStructuredCliFailure("node", [
+      entryPath,
+      "sync",
+      "legacy",
+      "--format",
+      "json",
+    ]).error.code
+  ).toBe("invalid-command");
+
+  const invalidInitDir = path.join(tempRoot, "invalid-init-package-json");
+  fs.mkdirSync(invalidInitDir, { recursive: true });
+  fs.writeFileSync(path.join(invalidInitDir, "package.json"), "{", "utf8");
+  expect(
+    readStructuredCliFailure(
+      "node",
+      [entryPath, "init", "--format", "json"],
+      {
+        cwd: invalidInitDir,
+      }
+    ).error.code
+  ).toBe("invalid-argument");
+
+  const unwritableDoctorDir = path.join(tempRoot, "doctor-unwritable-cwd");
+  fs.mkdirSync(unwritableDoctorDir, { recursive: true });
+  fs.chmodSync(unwritableDoctorDir, 0o555);
+  try {
+    const output = getCommandErrorMessage(() =>
+      runCli("node", [entryPath, "doctor", "--format", "json"], {
+        cwd: unwritableDoctorDir,
+        stdio: "pipe",
+      })
+    );
+
+    expect(output).toContain('"code": "doctor-check-failed"');
+    expect(output).toContain('"kind": "command-execution"');
+    expect(output).toContain('"tag": "CommandExecutionError"');
+  } finally {
+    fs.chmodSync(unwritableDoctorDir, 0o755);
+  }
 });
 
 test("editor plugin slot validation rejects inherited object keys", () => {

--- a/packages/wp-typia-project-tools/tests/cli-entry.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-entry.test.ts
@@ -237,16 +237,17 @@ test("structured diagnostic codes cover representative CLI command failures", ()
   fs.mkdirSync(unwritableDoctorDir, { recursive: true });
   fs.chmodSync(unwritableDoctorDir, 0o555);
   try {
-    const output = getCommandErrorMessage(() =>
-      runCli("node", [entryPath, "doctor", "--format", "json"], {
+    const payload = readStructuredCliFailure(
+      "node",
+      [entryPath, "doctor", "--format", "json"],
+      {
         cwd: unwritableDoctorDir,
-        stdio: "pipe",
-      })
+      }
     );
 
-    expect(output).toContain('"code": "doctor-check-failed"');
-    expect(output).toContain('"kind": "command-execution"');
-    expect(output).toContain('"tag": "CommandExecutionError"');
+    expect(payload.error.code).toBe("doctor-check-failed");
+    expect(payload.error.kind).toBe("command-execution");
+    expect(payload.error.tag).toBe("CommandExecutionError");
   } finally {
     fs.chmodSync(unwritableDoctorDir, 0o755);
   }

--- a/packages/wp-typia/src/commands/create.ts
+++ b/packages/wp-typia/src/commands/create.ts
@@ -1,6 +1,7 @@
 import { createElement } from "react";
 
 import { defineCommand } from "@bunli/core";
+import { CLI_DIAGNOSTIC_CODES } from "@wp-typia/project-tools/cli-diagnostics";
 
 import {
 	buildCommandOptions,
@@ -44,6 +45,7 @@ export const createCommand = defineCommand({
 		const projectDir = args.positional[0];
 		if (!projectDir) {
 			emitCliDiagnosticFailure(args, {
+				code: CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
 				command: "create",
 				detailLines: [
 					"`wp-typia create` requires <project-dir>.",

--- a/packages/wp-typia/src/config.ts
+++ b/packages/wp-typia/src/config.ts
@@ -3,6 +3,10 @@ import os from "node:os";
 import path from "node:path";
 
 import { isPlainObject as isRecord } from "@wp-typia/api-client/runtime-primitives";
+import {
+	CLI_DIAGNOSTIC_CODES,
+	createCliDiagnosticCodeError,
+} from "@wp-typia/project-tools/cli-diagnostics";
 
 export type WpTypiaSchemaSource = {
 	namespace: string;
@@ -86,7 +90,12 @@ async function readJsonFile(filePath: string): Promise<JsonRecord | null> {
 		) {
 			return null;
 		}
-		throw error;
+		const message = error instanceof Error ? error.message : String(error);
+		throw createCliDiagnosticCodeError(
+			CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
+			`Unable to parse ${filePath}: ${message}`,
+			error instanceof Error ? { cause: error } : undefined,
+		);
 	}
 }
 

--- a/packages/wp-typia/src/config.ts
+++ b/packages/wp-typia/src/config.ts
@@ -77,10 +77,9 @@ function deepMerge<T extends JsonRecord>(base: T, incoming: JsonRecord): T {
 }
 
 async function readJsonFile(filePath: string): Promise<JsonRecord | null> {
+	let source: string;
 	try {
-		const source = await fs.readFile(filePath, "utf8");
-		const parsed = JSON.parse(source);
-		return isRecord(parsed) ? parsed : null;
+		source = await fs.readFile(filePath, "utf8");
 	} catch (error) {
 		if (
 			typeof error === "object" &&
@@ -90,6 +89,13 @@ async function readJsonFile(filePath: string): Promise<JsonRecord | null> {
 		) {
 			return null;
 		}
+		throw error;
+	}
+
+	try {
+		const parsed = JSON.parse(source);
+		return isRecord(parsed) ? parsed : null;
+	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
 		throw createCliDiagnosticCodeError(
 			CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -410,6 +410,7 @@ async function renderDoctorJson(): Promise<void> {
   );
   if (checks.some((check) => check.status === 'fail')) {
     throw createCliCommandError({
+      code: CLI_DIAGNOSTIC_CODES.DOCTOR_CHECK_FAILED,
       command: 'doctor',
       detailLines: getDoctorFailureDetailLines(checks),
       summary: 'One or more doctor checks failed.',


### PR DESCRIPTION
## Summary
- export CLI diagnostic code recovery metadata as a stable integration contract
- document machine-readable diagnostic envelopes and recovery guidance
- add explicit diagnostic codes for create, doctor, init/config parse failures and representative structured failure coverage

## Verification
- bun run --cwd packages/wp-typia-project-tools build
- bun run --cwd packages/wp-typia build
- bun test packages/wp-typia-project-tools/tests/cli-entry.test.ts
- bun run format:check
- bun run typecheck
- bun run changesets:validate
- bun run lint:repo

Closes #596

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stable, machine-readable error codes for CLI commands in JSON output mode
  * Introduced diagnostic metadata mapping error codes to cause and recovery information

* **Documentation**
  * Added comprehensive error code reference with descriptions and remediation guidance

* **Improvements**
  * Enhanced error handling with structured diagnostic codes across CLI operations (`create`, `doctor`, `init`)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->