### PR TITLE
feat(project-tools): cache external template sources

### DIFF
--- a/.sampo/changesets/external-template-source-cache.md
+++ b/.sampo/changesets/external-template-source-cache.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Cache guarded remote external template sources across repeated scaffold runs and document the cache bypass/directory environment overrides.

--- a/README.md
+++ b/README.md
@@ -229,8 +229,8 @@ Remote template metadata, tarball downloads, and executable config loading now
 run behind bounded timeout and size guards so malformed or hostile template
 sources fail more directly instead of blocking the CLI indefinitely.
 Remote npm templates with registry integrity metadata and GitHub templates with
-resolvable remote revisions are cached under the local OS temp cache so repeated
-scaffolds can reuse the same unpacked source. Set
+resolvable remote revisions are cached under a private per-user local temp cache
+so repeated scaffolds can reuse the same unpacked source. Set
 `WP_TYPIA_EXTERNAL_TEMPLATE_CACHE=0` to force a refresh, or
 `WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR=/path/to/cache` to place the cache in a
 project- or CI-managed directory.

--- a/README.md
+++ b/README.md
@@ -228,6 +228,12 @@ External template configs execute trusted JavaScript (`index.js` / `index.cjs` /
 Remote template metadata, tarball downloads, and executable config loading now
 run behind bounded timeout and size guards so malformed or hostile template
 sources fail more directly instead of blocking the CLI indefinitely.
+Remote npm templates with registry integrity metadata and GitHub templates with
+resolvable remote revisions are cached under the local OS temp cache so repeated
+scaffolds can reuse the same unpacked source. Set
+`WP_TYPIA_EXTERNAL_TEMPLATE_CACHE=0` to force a refresh, or
+`WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR=/path/to/cache` to place the cache in a
+project- or CI-managed directory.
 
 Remote template examples:
 

--- a/apps/docs/src/content/docs/reference/api.md
+++ b/apps/docs/src/content/docs/reference/api.md
@@ -163,10 +163,10 @@ Remote metadata fetches, tarball downloads, and executable config loading now
 run behind bounded timeout and size guards so malformed or hostile sources fail
 directly instead of hanging the CLI indefinitely.
 Remote npm templates with registry integrity metadata and GitHub templates with
-resolvable remote revisions are cached locally after those guards pass. Use
-`WP_TYPIA_EXTERNAL_TEMPLATE_CACHE=0` when you need a forced refresh, or set
-`WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR` to move the cache into a CI-controlled
-directory.
+resolvable remote revisions are cached in a private per-user local directory
+after those guards pass. Use `WP_TYPIA_EXTERNAL_TEMPLATE_CACHE=0` when you need
+a forced refresh, or set `WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR` to move the
+cache into a CI-controlled directory.
 
 That remote-template support is still seed-oriented. Reusable external layer
 packages on top of the built-in shared scaffold graph are now implemented

--- a/apps/docs/src/content/docs/reference/api.md
+++ b/apps/docs/src/content/docs/reference/api.md
@@ -162,6 +162,11 @@ Security note: external template configs are trusted JavaScript and are executed
 Remote metadata fetches, tarball downloads, and executable config loading now
 run behind bounded timeout and size guards so malformed or hostile sources fail
 directly instead of hanging the CLI indefinitely.
+Remote npm templates with registry integrity metadata and GitHub templates with
+resolvable remote revisions are cached locally after those guards pass. Use
+`WP_TYPIA_EXTERNAL_TEMPLATE_CACHE=0` when you need a forced refresh, or set
+`WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR` to move the cache into a CI-controlled
+directory.
 
 That remote-template support is still seed-oriented. Reusable external layer
 packages on top of the built-in shared scaffold graph are now implemented

--- a/apps/docs/src/content/docs/reference/cli.md
+++ b/apps/docs/src/content/docs/reference/cli.md
@@ -102,6 +102,19 @@ Common flags:
 The positional alias `wp-typia <project-dir>` remains available only for
 unambiguous create invocations with a single local project directory.
 
+### External template cache
+
+Remote template resolution keeps the existing timeout, size, and symlink guards.
+After those guards pass, npm templates with registry `integrity` or `shasum`
+metadata and GitHub templates with a resolvable remote revision are cached under
+the local OS temp cache. Cache keys include the source locator plus the resolved
+npm tarball integrity or GitHub revision so repeated scaffolds reuse only the
+same source.
+
+Set `WP_TYPIA_EXTERNAL_TEMPLATE_CACHE=0` to bypass the cache for a forced
+refresh. Set `WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR=/path/to/cache` to place the
+cache in a project- or CI-managed directory.
+
 ## `add`
 
 Extend an official wp-typia workspace from the workspace root.

--- a/apps/docs/src/content/docs/reference/cli.md
+++ b/apps/docs/src/content/docs/reference/cli.md
@@ -107,9 +107,9 @@ unambiguous create invocations with a single local project directory.
 Remote template resolution keeps the existing timeout, size, and symlink guards.
 After those guards pass, npm templates with registry `integrity` or `shasum`
 metadata and GitHub templates with a resolvable remote revision are cached under
-the local OS temp cache. Cache keys include the source locator plus the resolved
-npm tarball integrity or GitHub revision so repeated scaffolds reuse only the
-same source.
+a private per-user local temp cache. Cache keys include the source locator plus
+the resolved npm tarball integrity or GitHub revision so repeated scaffolds
+reuse only the same source.
 
 Set `WP_TYPIA_EXTERNAL_TEMPLATE_CACHE=0` to bypass the cache for a forced
 refresh. Set `WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR=/path/to/cache` to place the

--- a/packages/wp-typia-project-tools/src/runtime/template-source-cache.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-cache.ts
@@ -24,6 +24,15 @@ export interface ExternalTemplateCacheResolution {
   sourceDir: string
 }
 
+/**
+ * Checks whether remote external template source caching is enabled.
+ *
+ * Caching is enabled by default. Set `WP_TYPIA_EXTERNAL_TEMPLATE_CACHE` to
+ * `0`, `false`, `no`, or `off` to force uncached resolution.
+ *
+ * @param env Environment object to inspect, defaulting to `process.env`.
+ * @returns Whether external template source cache reads and writes are enabled.
+ */
 export function isExternalTemplateCacheEnabled(
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
@@ -35,6 +44,16 @@ export function isExternalTemplateCacheEnabled(
   return !DISABLED_CACHE_VALUES.has(rawValue.trim().toLowerCase())
 }
 
+/**
+ * Resolves the external template source cache root directory.
+ *
+ * `WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR` overrides the location. Without an
+ * override, wp-typia uses a `wp-typia-template-source-cache` directory inside
+ * the operating system temp directory.
+ *
+ * @param env Environment object to inspect, defaulting to `process.env`.
+ * @returns Absolute cache root directory path.
+ */
 export function getExternalTemplateCacheRoot(
   env: NodeJS.ProcessEnv = process.env,
 ): string {
@@ -46,6 +65,12 @@ export function getExternalTemplateCacheRoot(
   return path.join(os.tmpdir(), 'wp-typia-template-source-cache')
 }
 
+/**
+ * Creates a deterministic cache key from source identity and integrity parts.
+ *
+ * @param keyParts Ordered values that identify one cached template source.
+ * @returns SHA-256 hex digest of the JSON-serialized key parts.
+ */
 export function createExternalTemplateCacheKey(
   keyParts: readonly string[],
 ): string {
@@ -95,6 +120,17 @@ async function isReusableCacheEntry(
   return (await pathExists(markerPath)) && (await pathExists(sourceDir))
 }
 
+/**
+ * Resolves or populates a cached external template source directory.
+ *
+ * Returns `null` when caching is disabled. Cache misses populate a temporary
+ * directory first and then atomically move it into place; concurrent writers
+ * that lose the race reuse the completed marker/source pair.
+ *
+ * @param descriptor Namespace, key parts, and metadata for the cache entry.
+ * @param populateSourceDir Callback that writes the guarded source on a miss.
+ * @returns Cache resolution details, or `null` when caching is disabled.
+ */
 export async function resolveExternalTemplateSourceCache(
   descriptor: ExternalTemplateCacheDescriptor,
   populateSourceDir: (sourceDir: string) => Promise<void>,

--- a/packages/wp-typia-project-tools/src/runtime/template-source-cache.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-cache.ts
@@ -155,6 +155,15 @@ async function pathExists(filePath: string): Promise<boolean> {
   }
 }
 
+async function isDirectoryPath(directory: string): Promise<boolean> {
+  try {
+    const stats = await fsp.lstat(directory)
+    return stats.isDirectory() && !stats.isSymbolicLink()
+  } catch {
+    return false
+  }
+}
+
 function getNodeErrorCode(error: unknown): string {
   return typeof error === 'object' && error !== null && 'code' in error
     ? String((error as { code: unknown }).code)
@@ -319,7 +328,7 @@ async function isReusableCacheEntry(
   return (
     (await isPrivateCacheDirectory(entryDir)) &&
     (await pathExists(markerPath)) &&
-    (await pathExists(sourceDir))
+    (await isDirectoryPath(sourceDir))
   )
 }
 
@@ -409,6 +418,9 @@ export async function resolveExternalTemplateSourceCache(
   } catch (error) {
     await removeTemporaryCacheEntry(temporaryEntryDir)
     if (populateFailed) {
+      if (CACHE_UNAVAILABLE_ERROR_CODES.has(getNodeErrorCode(error))) {
+        return null
+      }
       throw error
     }
 

--- a/packages/wp-typia-project-tools/src/runtime/template-source-cache.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-cache.ts
@@ -4,21 +4,49 @@ import { promises as fsp } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 
+/**
+ * Environment variable that disables external template cache reads and writes.
+ *
+ * Set to `0`, `false`, `no`, or `off` to bypass the cache.
+ */
 export const EXTERNAL_TEMPLATE_CACHE_ENV = 'WP_TYPIA_EXTERNAL_TEMPLATE_CACHE'
+
+/**
+ * Environment variable that overrides the external template cache root.
+ */
 export const EXTERNAL_TEMPLATE_CACHE_DIR_ENV =
   'WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR'
 
+/**
+ * Marker file written after a cache entry is fully populated.
+ */
 const CACHE_MARKER_FILE = 'wp-typia-template-cache.json'
+
+/**
+ * Normalized environment values that disable the cache.
+ */
 const DISABLED_CACHE_VALUES = new Set(['0', 'false', 'no', 'off'])
 
+/**
+ * Serializable metadata recorded in the cache marker for diagnostics.
+ */
 type ExternalTemplateCacheMetadata = Record<string, string | null>
 
+/**
+ * Describes a deterministic external template cache entry.
+ *
+ * `namespace` scopes independent cache families, `keyParts` identify the exact
+ * source/integrity tuple, and `metadata` is persisted to the marker file.
+ */
 export interface ExternalTemplateCacheDescriptor {
   keyParts: readonly string[]
   metadata: ExternalTemplateCacheMetadata
   namespace: string
 }
 
+/**
+ * Result returned when a cache entry is reused or populated.
+ */
 export interface ExternalTemplateCacheResolution {
   cacheHit: boolean
   sourceDir: string

--- a/packages/wp-typia-project-tools/src/runtime/template-source-cache.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-cache.ts
@@ -107,6 +107,21 @@ export interface ExternalTemplateCacheResolution {
 }
 
 /**
+ * Metadata-only lookup descriptor for finding an existing reusable cache entry.
+ */
+export interface ExternalTemplateCacheLookupDescriptor {
+  /**
+   * Metadata fields that must match the sanitized marker metadata.
+   */
+  metadata: ExternalTemplateCacheMetadata
+
+  /**
+   * Cache family scope, stored as a single safe directory segment.
+   */
+  namespace: string
+}
+
+/**
  * Checks whether remote external template source caching is enabled.
  *
  * Caching is enabled by default. Set `WP_TYPIA_EXTERNAL_TEMPLATE_CACHE` to
@@ -244,8 +259,20 @@ async function ensurePrivateCacheDirectory(directory: string): Promise<boolean> 
       mode: PRIVATE_CACHE_DIRECTORY_MODE,
       recursive: true,
     })
+    const stats = await fsp.lstat(directory)
+    if (!stats.isDirectory() || stats.isSymbolicLink()) {
+      return false
+    }
+
+    const currentUid = getCurrentUid()
+    if (currentUid !== null && stats.uid !== currentUid) {
+      return false
+    }
+
     if (process.platform !== 'win32') {
-      await fsp.chmod(directory, PRIVATE_CACHE_DIRECTORY_MODE)
+      if ((stats.mode & 0o077) !== 0) {
+        await fsp.chmod(directory, PRIVATE_CACHE_DIRECTORY_MODE)
+      }
     }
     return isPrivateCacheDirectory(directory)
   } catch {
@@ -348,6 +375,132 @@ async function isReusableCacheEntry(
     (await pathExists(markerPath)) &&
     (await isDirectoryPath(sourceDir))
   )
+}
+
+function parseCacheMarkerMetadata(
+  markerText: string,
+): { createdAtMs: number; metadata: ExternalTemplateCacheMetadata } | null {
+  let marker: unknown
+  try {
+    marker = JSON.parse(markerText)
+  } catch {
+    return null
+  }
+  if (typeof marker !== 'object' || marker === null || Array.isArray(marker)) {
+    return null
+  }
+
+  const rawMetadata = (marker as { metadata?: unknown }).metadata
+  if (
+    typeof rawMetadata !== 'object' ||
+    rawMetadata === null ||
+    Array.isArray(rawMetadata)
+  ) {
+    return null
+  }
+
+  const metadata: ExternalTemplateCacheMetadata = {}
+  for (const [key, value] of Object.entries(rawMetadata)) {
+    if (typeof value !== 'string' && value !== null) {
+      return null
+    }
+    metadata[key] = value
+  }
+
+  const rawCreatedAt = (marker as { createdAt?: unknown }).createdAt
+  const createdAtMs =
+    typeof rawCreatedAt === 'string' ? Date.parse(rawCreatedAt) : 0
+
+  return {
+    createdAtMs: Number.isFinite(createdAtMs) ? createdAtMs : 0,
+    metadata,
+  }
+}
+
+function cacheMetadataMatches(
+  actual: ExternalTemplateCacheMetadata,
+  expected: ExternalTemplateCacheMetadata,
+): boolean {
+  return Object.entries(expected).every(([key, value]) => actual[key] === value)
+}
+
+/**
+ * Finds a reusable cache entry whose marker metadata includes the expected fields.
+ *
+ * This lookup is intended for resilient fallbacks where a caller cannot compute
+ * the exact deterministic key but can safely reuse a previously validated local
+ * cache entry for the same source identity.
+ *
+ * @param descriptor Cache namespace and marker metadata fields to match.
+ * @returns Existing cache resolution details, or `null` when no safe entry exists.
+ */
+export async function findReusableExternalTemplateSourceCache(
+  descriptor: ExternalTemplateCacheLookupDescriptor,
+): Promise<ExternalTemplateCacheResolution | null> {
+  if (!isExternalTemplateCacheEnabled()) {
+    return null
+  }
+
+  const cacheRoot = getExternalTemplateCacheRoot()
+  const namespaceDir = resolveCacheNamespaceDir(
+    cacheRoot,
+    descriptor.namespace,
+  )
+  if (!namespaceDir) {
+    return null
+  }
+  if (
+    !(await isPrivateCacheDirectory(cacheRoot)) ||
+    !(await isPrivateCacheDirectory(namespaceDir))
+  ) {
+    return null
+  }
+
+  let entries: fs.Dirent[]
+  try {
+    entries = await fsp.readdir(namespaceDir, { withFileTypes: true })
+  } catch {
+    return null
+  }
+
+  let bestEntry: { createdAtMs: number; sourceDir: string } | null = null
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue
+    }
+
+    const entryDir = path.join(namespaceDir, entry.name)
+    const markerPath = path.join(entryDir, CACHE_MARKER_FILE)
+    const sourceDir = path.join(entryDir, 'source')
+    if (!(await isReusableCacheEntry(entryDir, markerPath, sourceDir))) {
+      continue
+    }
+
+    let markerText: string
+    try {
+      markerText = await fsp.readFile(markerPath, 'utf8')
+    } catch {
+      continue
+    }
+
+    const marker = parseCacheMarkerMetadata(markerText)
+    if (!marker || !cacheMetadataMatches(marker.metadata, descriptor.metadata)) {
+      continue
+    }
+    if (!bestEntry || marker.createdAtMs > bestEntry.createdAtMs) {
+      bestEntry = {
+        createdAtMs: marker.createdAtMs,
+        sourceDir,
+      }
+    }
+  }
+
+  return bestEntry
+    ? {
+        cacheHit: true,
+        sourceDir: bestEntry.sourceDir,
+      }
+    : null
 }
 
 /**

--- a/packages/wp-typia-project-tools/src/runtime/template-source-cache.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-cache.ts
@@ -23,9 +23,19 @@ export const EXTERNAL_TEMPLATE_CACHE_DIR_ENV =
 const CACHE_MARKER_FILE = 'wp-typia-template-cache.json'
 
 /**
+ * Private directory mode used for cache roots and entries on POSIX platforms.
+ */
+const PRIVATE_CACHE_DIRECTORY_MODE = 0o700
+
+/**
  * Normalized environment values that disable the cache.
  */
 const DISABLED_CACHE_VALUES = new Set(['0', 'false', 'no', 'off'])
+
+/**
+ * Metadata fields that may contain credentialed or signed URLs.
+ */
+const URL_LIKE_METADATA_KEY = /(url|uri|registry|tarball)/iu
 
 /**
  * Serializable metadata recorded in the cache marker for diagnostics.
@@ -76,8 +86,8 @@ export function isExternalTemplateCacheEnabled(
  * Resolves the external template source cache root directory.
  *
  * `WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR` overrides the location. Without an
- * override, wp-typia uses a `wp-typia-template-source-cache` directory inside
- * the operating system temp directory.
+ * override, wp-typia uses a per-user `wp-typia-template-source-cache-*`
+ * directory inside the operating system temp directory.
  *
  * @param env Environment object to inspect, defaulting to `process.env`.
  * @returns Absolute cache root directory path.
@@ -90,7 +100,10 @@ export function getExternalTemplateCacheRoot(
     return path.resolve(configuredCacheDir)
   }
 
-  return path.join(os.tmpdir(), 'wp-typia-template-source-cache')
+  return path.join(
+    os.tmpdir(),
+    `wp-typia-template-source-cache-${getCurrentUserCacheSegment()}`,
+  )
 }
 
 /**
@@ -116,24 +129,109 @@ async function pathExists(filePath: string): Promise<boolean> {
   }
 }
 
+function getCurrentUserCacheSegment(): string {
+  if (typeof process.getuid === 'function') {
+    return String(process.getuid())
+  }
+
+  try {
+    const safeUsername = os
+      .userInfo()
+      .username.trim()
+      .replace(/[^A-Za-z0-9._-]+/gu, '-')
+    return safeUsername.length > 0 ? safeUsername : 'user'
+  } catch {
+    return 'user'
+  }
+}
+
+function getCurrentUid(): number | null {
+  return typeof process.getuid === 'function' ? process.getuid() : null
+}
+
+async function isPrivateCacheDirectory(directory: string): Promise<boolean> {
+  try {
+    const stats = await fsp.lstat(directory)
+    if (!stats.isDirectory() || stats.isSymbolicLink()) {
+      return false
+    }
+
+    const currentUid = getCurrentUid()
+    if (currentUid !== null && stats.uid !== currentUid) {
+      return false
+    }
+
+    if (process.platform !== 'win32' && (stats.mode & 0o077) !== 0) {
+      return false
+    }
+
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function ensurePrivateCacheDirectory(directory: string): Promise<boolean> {
+  try {
+    await fsp.mkdir(directory, {
+      mode: PRIVATE_CACHE_DIRECTORY_MODE,
+      recursive: true,
+    })
+    if (process.platform !== 'win32') {
+      await fsp.chmod(directory, PRIVATE_CACHE_DIRECTORY_MODE)
+    }
+    return isPrivateCacheDirectory(directory)
+  } catch {
+    return false
+  }
+}
+
+function sanitizeCacheMetadataValue(key: string, value: string): string {
+  if (!URL_LIKE_METADATA_KEY.test(key)) {
+    return value
+  }
+
+  try {
+    const url = new URL(value)
+    url.username = ''
+    url.password = ''
+    url.search = ''
+    url.hash = ''
+    return url.toString()
+  } catch {
+    return value
+  }
+}
+
+function sanitizeCacheMetadata(
+  metadata: ExternalTemplateCacheMetadata,
+): ExternalTemplateCacheMetadata {
+  return Object.fromEntries(
+    Object.entries(metadata).map(([key, value]) => [
+      key,
+      value === null ? null : sanitizeCacheMetadataValue(key, value),
+    ]),
+  )
+}
+
 function getCacheEntryPaths(
   descriptor: ExternalTemplateCacheDescriptor,
 ): {
   cacheKey: string
+  cacheRoot: string
   entryDir: string
   markerPath: string
   namespaceDir: string
   sourceDir: string
 } {
   const cacheKey = createExternalTemplateCacheKey(descriptor.keyParts)
-  const namespaceDir = path.join(
-    getExternalTemplateCacheRoot(),
-    descriptor.namespace,
-  )
+  const cacheRoot = getExternalTemplateCacheRoot()
+  const namespaceDir = path.join(cacheRoot, descriptor.namespace)
   const entryDir = path.join(namespaceDir, cacheKey)
 
   return {
     cacheKey,
+    cacheRoot,
     entryDir,
     markerPath: path.join(entryDir, CACHE_MARKER_FILE),
     namespaceDir,
@@ -142,10 +240,15 @@ function getCacheEntryPaths(
 }
 
 async function isReusableCacheEntry(
+  entryDir: string,
   markerPath: string,
   sourceDir: string,
 ): Promise<boolean> {
-  return (await pathExists(markerPath)) && (await pathExists(sourceDir))
+  return (
+    (await isPrivateCacheDirectory(entryDir)) &&
+    (await pathExists(markerPath)) &&
+    (await pathExists(sourceDir))
+  )
 }
 
 /**
@@ -167,16 +270,21 @@ export async function resolveExternalTemplateSourceCache(
     return null
   }
 
-  const { cacheKey, entryDir, markerPath, namespaceDir, sourceDir } =
+  const { cacheKey, cacheRoot, entryDir, markerPath, namespaceDir, sourceDir } =
     getCacheEntryPaths(descriptor)
-  if (await isReusableCacheEntry(markerPath, sourceDir)) {
+  if (
+    !(await ensurePrivateCacheDirectory(cacheRoot)) ||
+    !(await ensurePrivateCacheDirectory(namespaceDir))
+  ) {
+    return null
+  }
+
+  if (await isReusableCacheEntry(entryDir, markerPath, sourceDir)) {
     return {
       cacheHit: true,
       sourceDir,
     }
   }
-
-  await fsp.mkdir(namespaceDir, { recursive: true })
 
   const temporaryEntryDir = path.join(
     namespaceDir,
@@ -187,7 +295,13 @@ export async function resolveExternalTemplateSourceCache(
   const temporarySourceDir = path.join(temporaryEntryDir, 'source')
 
   try {
-    await fsp.mkdir(temporarySourceDir, { recursive: true })
+    await fsp.mkdir(temporarySourceDir, {
+      mode: PRIVATE_CACHE_DIRECTORY_MODE,
+      recursive: true,
+    })
+    if (process.platform !== 'win32') {
+      await fsp.chmod(temporaryEntryDir, PRIVATE_CACHE_DIRECTORY_MODE)
+    }
     await populateSourceDir(temporarySourceDir)
     await fsp.writeFile(
       path.join(temporaryEntryDir, CACHE_MARKER_FILE),
@@ -195,8 +309,7 @@ export async function resolveExternalTemplateSourceCache(
         {
           createdAt: new Date().toISOString(),
           key: cacheKey,
-          keyParts: descriptor.keyParts,
-          metadata: descriptor.metadata,
+          metadata: sanitizeCacheMetadata(descriptor.metadata),
           namespace: descriptor.namespace,
         },
         null,
@@ -218,7 +331,7 @@ export async function resolveExternalTemplateSourceCache(
         : ''
     if (
       (errorCode === 'EEXIST' || errorCode === 'ENOTEMPTY') &&
-      (await isReusableCacheEntry(markerPath, sourceDir))
+      (await isReusableCacheEntry(entryDir, markerPath, sourceDir))
     ) {
       return {
         cacheHit: true,

--- a/packages/wp-typia-project-tools/src/runtime/template-source-cache.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-cache.ts
@@ -149,9 +149,6 @@ export async function resolveExternalTemplateSourceCache(
   }
 
   await fsp.mkdir(namespaceDir, { recursive: true })
-  if (await pathExists(entryDir)) {
-    await fsp.rm(entryDir, { force: true, recursive: true })
-  }
 
   const temporaryEntryDir = path.join(
     namespaceDir,
@@ -199,6 +196,9 @@ export async function resolveExternalTemplateSourceCache(
         cacheHit: true,
         sourceDir,
       }
+    }
+    if (errorCode === 'EEXIST' || errorCode === 'ENOTEMPTY') {
+      return null
     }
     throw error
   }

--- a/packages/wp-typia-project-tools/src/runtime/template-source-cache.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-cache.ts
@@ -1,0 +1,169 @@
+import { createHash } from 'node:crypto'
+import fs from 'node:fs'
+import { promises as fsp } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+export const EXTERNAL_TEMPLATE_CACHE_ENV = 'WP_TYPIA_EXTERNAL_TEMPLATE_CACHE'
+export const EXTERNAL_TEMPLATE_CACHE_DIR_ENV =
+  'WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR'
+
+const CACHE_MARKER_FILE = 'wp-typia-template-cache.json'
+const DISABLED_CACHE_VALUES = new Set(['0', 'false', 'no', 'off'])
+
+type ExternalTemplateCacheMetadata = Record<string, string | null>
+
+export interface ExternalTemplateCacheDescriptor {
+  keyParts: readonly string[]
+  metadata: ExternalTemplateCacheMetadata
+  namespace: string
+}
+
+export interface ExternalTemplateCacheResolution {
+  cacheHit: boolean
+  sourceDir: string
+}
+
+export function isExternalTemplateCacheEnabled(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  const rawValue = env[EXTERNAL_TEMPLATE_CACHE_ENV]
+  if (rawValue === undefined) {
+    return true
+  }
+
+  return !DISABLED_CACHE_VALUES.has(rawValue.trim().toLowerCase())
+}
+
+export function getExternalTemplateCacheRoot(
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const configuredCacheDir = env[EXTERNAL_TEMPLATE_CACHE_DIR_ENV]?.trim()
+  if (configuredCacheDir) {
+    return path.resolve(configuredCacheDir)
+  }
+
+  return path.join(os.tmpdir(), 'wp-typia-template-source-cache')
+}
+
+export function createExternalTemplateCacheKey(
+  keyParts: readonly string[],
+): string {
+  return createHash('sha256')
+    .update(JSON.stringify(keyParts))
+    .digest('hex')
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await fsp.access(filePath, fs.constants.F_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function getCacheEntryPaths(
+  descriptor: ExternalTemplateCacheDescriptor,
+): {
+  cacheKey: string
+  entryDir: string
+  markerPath: string
+  namespaceDir: string
+  sourceDir: string
+} {
+  const cacheKey = createExternalTemplateCacheKey(descriptor.keyParts)
+  const namespaceDir = path.join(
+    getExternalTemplateCacheRoot(),
+    descriptor.namespace,
+  )
+  const entryDir = path.join(namespaceDir, cacheKey)
+
+  return {
+    cacheKey,
+    entryDir,
+    markerPath: path.join(entryDir, CACHE_MARKER_FILE),
+    namespaceDir,
+    sourceDir: path.join(entryDir, 'source'),
+  }
+}
+
+async function isReusableCacheEntry(
+  markerPath: string,
+  sourceDir: string,
+): Promise<boolean> {
+  return (await pathExists(markerPath)) && (await pathExists(sourceDir))
+}
+
+export async function resolveExternalTemplateSourceCache(
+  descriptor: ExternalTemplateCacheDescriptor,
+  populateSourceDir: (sourceDir: string) => Promise<void>,
+): Promise<ExternalTemplateCacheResolution | null> {
+  if (!isExternalTemplateCacheEnabled()) {
+    return null
+  }
+
+  const { cacheKey, entryDir, markerPath, namespaceDir, sourceDir } =
+    getCacheEntryPaths(descriptor)
+  if (await isReusableCacheEntry(markerPath, sourceDir)) {
+    return {
+      cacheHit: true,
+      sourceDir,
+    }
+  }
+
+  await fsp.mkdir(namespaceDir, { recursive: true })
+  if (await pathExists(entryDir)) {
+    await fsp.rm(entryDir, { force: true, recursive: true })
+  }
+
+  const temporaryEntryDir = path.join(
+    namespaceDir,
+    `.tmp-${cacheKey}-${process.pid}-${Date.now()}-${Math.random()
+      .toString(16)
+      .slice(2)}`,
+  )
+  const temporarySourceDir = path.join(temporaryEntryDir, 'source')
+
+  try {
+    await fsp.mkdir(temporarySourceDir, { recursive: true })
+    await populateSourceDir(temporarySourceDir)
+    await fsp.writeFile(
+      path.join(temporaryEntryDir, CACHE_MARKER_FILE),
+      `${JSON.stringify(
+        {
+          createdAt: new Date().toISOString(),
+          key: cacheKey,
+          keyParts: descriptor.keyParts,
+          metadata: descriptor.metadata,
+          namespace: descriptor.namespace,
+        },
+        null,
+        2,
+      )}\n`,
+      'utf8',
+    )
+    await fsp.rename(temporaryEntryDir, entryDir)
+
+    return {
+      cacheHit: false,
+      sourceDir,
+    }
+  } catch (error) {
+    await fsp.rm(temporaryEntryDir, { force: true, recursive: true })
+    const errorCode =
+      typeof error === 'object' && error !== null && 'code' in error
+        ? String((error as { code: unknown }).code)
+        : ''
+    if (
+      (errorCode === 'EEXIST' || errorCode === 'ENOTEMPTY') &&
+      (await isReusableCacheEntry(markerPath, sourceDir))
+    ) {
+      return {
+        cacheHit: true,
+        sourceDir,
+      }
+    }
+    throw error
+  }
+}

--- a/packages/wp-typia-project-tools/src/runtime/template-source-cache.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-cache.ts
@@ -33,6 +33,22 @@ const PRIVATE_CACHE_DIRECTORY_MODE = 0o700
 const DISABLED_CACHE_VALUES = new Set(['0', 'false', 'no', 'off'])
 
 /**
+ * Filesystem errors that mean another writer published the same cache entry.
+ */
+const CACHE_PUBLISH_RACE_ERROR_CODES = new Set(['EEXIST', 'ENOTEMPTY'])
+
+/**
+ * Filesystem errors that make the optional cache unavailable.
+ */
+const CACHE_UNAVAILABLE_ERROR_CODES = new Set([
+  'EACCES',
+  'ENOSPC',
+  'ENOTDIR',
+  'EPERM',
+  'EROFS',
+])
+
+/**
  * Metadata fields that may contain credentialed or signed URLs.
  */
 const URL_LIKE_METADATA_KEY = /(url|uri|registry|tarball)/iu
@@ -126,6 +142,20 @@ async function pathExists(filePath: string): Promise<boolean> {
     return true
   } catch {
     return false
+  }
+}
+
+function getNodeErrorCode(error: unknown): string {
+  return typeof error === 'object' && error !== null && 'code' in error
+    ? String((error as { code: unknown }).code)
+    : ''
+}
+
+async function removeTemporaryCacheEntry(entryDir: string): Promise<void> {
+  try {
+    await fsp.rm(entryDir, { force: true, recursive: true })
+  } catch {
+    // Cache cleanup is best-effort; the caller can still continue uncached.
   }
 }
 
@@ -293,6 +323,7 @@ export async function resolveExternalTemplateSourceCache(
       .slice(2)}`,
   )
   const temporarySourceDir = path.join(temporaryEntryDir, 'source')
+  let populateFailed = false
 
   try {
     await fsp.mkdir(temporarySourceDir, {
@@ -302,7 +333,12 @@ export async function resolveExternalTemplateSourceCache(
     if (process.platform !== 'win32') {
       await fsp.chmod(temporaryEntryDir, PRIVATE_CACHE_DIRECTORY_MODE)
     }
-    await populateSourceDir(temporarySourceDir)
+    try {
+      await populateSourceDir(temporarySourceDir)
+    } catch (error) {
+      populateFailed = true
+      throw error
+    }
     await fsp.writeFile(
       path.join(temporaryEntryDir, CACHE_MARKER_FILE),
       `${JSON.stringify(
@@ -324,13 +360,14 @@ export async function resolveExternalTemplateSourceCache(
       sourceDir,
     }
   } catch (error) {
-    await fsp.rm(temporaryEntryDir, { force: true, recursive: true })
-    const errorCode =
-      typeof error === 'object' && error !== null && 'code' in error
-        ? String((error as { code: unknown }).code)
-        : ''
+    await removeTemporaryCacheEntry(temporaryEntryDir)
+    if (populateFailed) {
+      throw error
+    }
+
+    const errorCode = getNodeErrorCode(error)
     if (
-      (errorCode === 'EEXIST' || errorCode === 'ENOTEMPTY') &&
+      CACHE_PUBLISH_RACE_ERROR_CODES.has(errorCode) &&
       (await isReusableCacheEntry(entryDir, markerPath, sourceDir))
     ) {
       return {
@@ -338,7 +375,10 @@ export async function resolveExternalTemplateSourceCache(
         sourceDir,
       }
     }
-    if (errorCode === 'EEXIST' || errorCode === 'ENOTEMPTY') {
+    if (
+      CACHE_PUBLISH_RACE_ERROR_CODES.has(errorCode) ||
+      CACHE_UNAVAILABLE_ERROR_CODES.has(errorCode)
+    ) {
       return null
     }
     throw error

--- a/packages/wp-typia-project-tools/src/runtime/template-source-cache.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-cache.ts
@@ -28,6 +28,11 @@ const CACHE_MARKER_FILE = 'wp-typia-template-cache.json'
 const PRIVATE_CACHE_DIRECTORY_MODE = 0o700
 
 /**
+ * Marker value used when URL-like metadata cannot be safely normalized.
+ */
+const REDACTED_CACHE_METADATA_VALUE = '[redacted]'
+
+/**
  * Normalized environment values that disable the cache.
  */
 const DISABLED_CACHE_VALUES = new Set(['0', 'false', 'no', 'off'])
@@ -52,6 +57,11 @@ const CACHE_UNAVAILABLE_ERROR_CODES = new Set([
  * Metadata fields that may contain credentialed or signed URLs.
  */
 const URL_LIKE_METADATA_KEY = /(url|uri|registry|tarball)/iu
+
+/**
+ * Cache namespaces must stay within one path segment under the cache root.
+ */
+const SAFE_CACHE_NAMESPACE_SEGMENT = /^[A-Za-z0-9_.-]+$/u
 
 /**
  * Serializable metadata recorded in the cache marker for diagnostics.
@@ -229,7 +239,7 @@ function sanitizeCacheMetadataValue(key: string, value: string): string {
     url.hash = ''
     return url.toString()
   } catch {
-    return value
+    return REDACTED_CACHE_METADATA_VALUE
   }
 }
 
@@ -244,6 +254,31 @@ function sanitizeCacheMetadata(
   )
 }
 
+function resolveCacheNamespaceDir(
+  cacheRoot: string,
+  namespace: string,
+): string | null {
+  if (
+    namespace === '.' ||
+    namespace === '..' ||
+    !SAFE_CACHE_NAMESPACE_SEGMENT.test(namespace)
+  ) {
+    return null
+  }
+
+  const namespaceDir = path.join(cacheRoot, namespace)
+  const relativeNamespaceDir = path.relative(cacheRoot, namespaceDir)
+  if (
+    relativeNamespaceDir.length === 0 ||
+    relativeNamespaceDir.startsWith('..') ||
+    path.isAbsolute(relativeNamespaceDir)
+  ) {
+    return null
+  }
+
+  return namespaceDir
+}
+
 function getCacheEntryPaths(
   descriptor: ExternalTemplateCacheDescriptor,
 ): {
@@ -253,10 +288,17 @@ function getCacheEntryPaths(
   markerPath: string
   namespaceDir: string
   sourceDir: string
-} {
+} | null {
   const cacheKey = createExternalTemplateCacheKey(descriptor.keyParts)
   const cacheRoot = getExternalTemplateCacheRoot()
-  const namespaceDir = path.join(cacheRoot, descriptor.namespace)
+  const namespaceDir = resolveCacheNamespaceDir(
+    cacheRoot,
+    descriptor.namespace,
+  )
+  if (!namespaceDir) {
+    return null
+  }
+
   const entryDir = path.join(namespaceDir, cacheKey)
 
   return {
@@ -300,8 +342,13 @@ export async function resolveExternalTemplateSourceCache(
     return null
   }
 
+  const cacheEntryPaths = getCacheEntryPaths(descriptor)
+  if (!cacheEntryPaths) {
+    return null
+  }
+
   const { cacheKey, cacheRoot, entryDir, markerPath, namespaceDir, sourceDir } =
-    getCacheEntryPaths(descriptor)
+    cacheEntryPaths
   if (
     !(await ensurePrivateCacheDirectory(cacheRoot)) ||
     !(await ensurePrivateCacheDirectory(namespaceDir))

--- a/packages/wp-typia-project-tools/src/runtime/template-source-cache.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-cache.ts
@@ -75,8 +75,19 @@ type ExternalTemplateCacheMetadata = Record<string, string | null>
  * source/integrity tuple, and `metadata` is persisted to the marker file.
  */
 export interface ExternalTemplateCacheDescriptor {
+  /**
+   * Ordered values that deterministically identify one cached template source.
+   */
   keyParts: readonly string[]
+
+  /**
+   * Diagnostic values persisted to the cache marker after sanitization.
+   */
   metadata: ExternalTemplateCacheMetadata
+
+  /**
+   * Cache family scope, stored as a single safe directory segment.
+   */
   namespace: string
 }
 
@@ -84,7 +95,14 @@ export interface ExternalTemplateCacheDescriptor {
  * Result returned when a cache entry is reused or populated.
  */
 export interface ExternalTemplateCacheResolution {
+  /**
+   * Whether the returned source directory came from an existing cache entry.
+   */
   cacheHit: boolean
+
+  /**
+   * Populated or reused template source directory.
+   */
   sourceDir: string
 }
 

--- a/packages/wp-typia-project-tools/src/runtime/template-source-seeds.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-seeds.ts
@@ -550,6 +550,54 @@ function getGitHubTemplateRevisionPatterns(
   return [ref, `refs/heads/${ref}`, `refs/tags/${ref}`, `refs/tags/${ref}^{}`]
 }
 
+type GitHubTemplateResolvedRevision = {
+  resolvedRef: string
+  revision: string
+}
+
+function pickGitHubTemplateCacheRevision(
+  locator: GitHubTemplateLocator,
+  revisions: readonly GitHubTemplateResolvedRevision[],
+): string | null {
+  const ref = locator.ref ?? 'HEAD'
+  if (!locator.ref) {
+    return revisions[0]?.revision ?? null
+  }
+  if (!ref.startsWith('refs/')) {
+    const branchRevision = revisions.find(
+      (entry) => entry.resolvedRef === `refs/heads/${ref}`,
+    )
+    if (branchRevision) {
+      return branchRevision.revision
+    }
+
+    const peeledTagRevision = revisions.find(
+      (entry) => entry.resolvedRef === `refs/tags/${ref}^{}`,
+    )
+    if (peeledTagRevision) {
+      return peeledTagRevision.revision
+    }
+
+    const tagRevision = revisions.find(
+      (entry) => entry.resolvedRef === `refs/tags/${ref}`,
+    )
+    if (tagRevision) {
+      return tagRevision.revision
+    }
+  }
+  if (ref.startsWith('refs/tags/')) {
+    const peeledRevision = revisions.find(
+      (entry) => entry.resolvedRef === `${ref}^{}`,
+    )
+    if (peeledRevision) {
+      return peeledRevision.revision
+    }
+  }
+
+  const exactRevision = revisions.find((entry) => entry.resolvedRef === ref)
+  return (exactRevision ?? revisions[0])?.revision ?? null
+}
+
 /**
  * Resolves a GitHub template ref to a stable revision for cache keying.
  *
@@ -585,18 +633,10 @@ function resolveGitHubTemplateCacheRevision(
       }
     })
     .filter(
-      (
-        entry,
-      ): entry is {
-        resolvedRef: string
-        revision: string
-      } => entry !== null,
+      (entry): entry is GitHubTemplateResolvedRevision => entry !== null,
     )
 
-  const peeledRevision = revisions.find((entry) =>
-    entry.resolvedRef.endsWith('^{}'),
-  )
-  return (peeledRevision ?? revisions[0])?.revision ?? null
+  return pickGitHubTemplateCacheRevision(locator, revisions)
 }
 
 async function resolveGitHubTemplateSource(

--- a/packages/wp-typia-project-tools/src/runtime/template-source-seeds.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-seeds.ts
@@ -375,13 +375,19 @@ export async function assertNoSymlinks(sourceDir: string): Promise<void> {
 function runGitTemplateCommand(
   args: readonly string[],
   label: string,
+  options: { captureOutput?: boolean } = {},
 ): ReturnType<typeof spawnSync> {
   const timeoutMs = getExternalTemplateTimeoutMs()
-  const result = spawnSync('git', args, {
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'pipe'],
-    timeout: timeoutMs,
-  })
+  const result = options.captureOutput
+    ? spawnSync('git', args, {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+        timeout: timeoutMs,
+      })
+    : spawnSync('git', args, {
+        stdio: 'ignore',
+        timeout: timeoutMs,
+      })
   if (result.error) {
     const errorCode =
       typeof result.error === 'object' &&
@@ -447,6 +453,7 @@ function resolveGitHubTemplateCacheRevision(
   const result = runGitTemplateCommand(
     ['ls-remote', getGitHubTemplateRepositoryUrl(locator), ref],
     `checking GitHub template revision ${locator.owner}/${locator.repo}`,
+    { captureOutput: true },
   )
   if (result.status !== 0 || typeof result.stdout !== 'string') {
     return null
@@ -457,7 +464,7 @@ function resolveGitHubTemplateCacheRevision(
     .map((line) => line.trim().split(/\s+/u)[0])
     .filter((revision) => /^[0-9a-f]{40}$/iu.test(revision))
 
-  return revisions.length > 0 ? revisions[revisions.length - 1] : null
+  return revisions.length > 0 ? revisions[0] : null
 }
 
 async function resolveGitHubTemplateSource(

--- a/packages/wp-typia-project-tools/src/runtime/template-source-seeds.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-seeds.ts
@@ -497,6 +497,12 @@ function pinGitHubTemplateCacheRevision(
   }
 }
 
+/**
+ * Resolves a GitHub template ref to a stable revision for cache keying.
+ *
+ * @param locator GitHub template locator containing owner, repo, and optional ref.
+ * @returns A commit-like SHA from `git ls-remote`, or `null` when unavailable.
+ */
 function resolveGitHubTemplateCacheRevision(
   locator: GitHubTemplateLocator,
 ): string | null {
@@ -512,10 +518,29 @@ function resolveGitHubTemplateCacheRevision(
 
   const revisions = result.stdout
     .split('\n')
-    .map((line) => line.trim().split(/\s+/u)[0])
-    .filter((revision) => /^[0-9a-f]{40}$/iu.test(revision))
+    .map((line) => {
+      const [revision, resolvedRef] = line.trim().split(/\s+/u)
+      if (!/^[0-9a-f]{40}$/iu.test(revision) || !resolvedRef) {
+        return null
+      }
+      return {
+        resolvedRef,
+        revision: revision.toLowerCase(),
+      }
+    })
+    .filter(
+      (
+        entry,
+      ): entry is {
+        resolvedRef: string
+        revision: string
+      } => entry !== null,
+    )
 
-  return revisions.length > 0 ? revisions[0] : null
+  const peeledRevision = revisions.find((entry) =>
+    entry.resolvedRef.endsWith('^{}'),
+  )
+  return (peeledRevision ?? revisions[0])?.revision ?? null
 }
 
 async function resolveGitHubTemplateSource(
@@ -558,6 +583,8 @@ async function resolveGitHubTemplateSource(
             checkoutDir,
             resolvedCacheRevision,
           )
+          const sourceDir = resolveGitHubTemplateDirectory(checkoutDir, locator)
+          await assertNoSymlinks(sourceDir)
         },
       )
       if (cachedSource) {

--- a/packages/wp-typia-project-tools/src/runtime/template-source-seeds.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-seeds.ts
@@ -17,6 +17,7 @@ import {
   readJsonResponseWithLimit,
 } from './external-template-guards.js'
 import {
+  findReusableExternalTemplateSourceCache,
   isExternalTemplateCacheEnabled,
   resolveExternalTemplateSourceCache,
 } from './template-source-cache.js'
@@ -555,6 +556,11 @@ type GitHubTemplateResolvedRevision = {
   revision: string
 }
 
+type GitHubTemplateCacheRevisionResolution = {
+  lookupUnavailable: boolean
+  revision: string | null
+}
+
 function pickGitHubTemplateCacheRevision(
   locator: GitHubTemplateLocator,
   revisions: readonly GitHubTemplateResolvedRevision[],
@@ -602,11 +608,11 @@ function pickGitHubTemplateCacheRevision(
  * Resolves a GitHub template ref to a stable revision for cache keying.
  *
  * @param locator GitHub template locator containing owner, repo, and optional ref.
- * @returns A commit-like SHA from `git ls-remote`, or `null` when unavailable.
+ * @returns Revision lookup result, including whether `git ls-remote` was unavailable.
  */
 function resolveGitHubTemplateCacheRevision(
   locator: GitHubTemplateLocator,
-): string | null {
+): GitHubTemplateCacheRevisionResolution {
   const result = runGitTemplateCommand(
     [
       'ls-remote',
@@ -617,7 +623,10 @@ function resolveGitHubTemplateCacheRevision(
     { captureOutput: true },
   )
   if (result.status !== 0 || typeof result.stdout !== 'string') {
-    return null
+    return {
+      lookupUnavailable: true,
+      revision: null,
+    }
   }
 
   const revisions = result.stdout
@@ -636,18 +645,67 @@ function resolveGitHubTemplateCacheRevision(
       (entry): entry is GitHubTemplateResolvedRevision => entry !== null,
     )
 
-  return pickGitHubTemplateCacheRevision(locator, revisions)
+  return {
+    lookupUnavailable: false,
+    revision: pickGitHubTemplateCacheRevision(locator, revisions),
+  }
+}
+
+function getGitHubTemplateCacheMetadata(
+  locator: GitHubTemplateLocator,
+  revision?: string,
+): Record<string, string | null> {
+  return {
+    ...(revision ? { revision } : {}),
+    owner: locator.owner,
+    ref: locator.ref,
+    repo: locator.repo,
+    sourcePath: locator.sourcePath,
+  }
+}
+
+async function reuseGitHubTemplateCacheByMetadata(
+  locator: GitHubTemplateLocator,
+): Promise<SeedSource | null> {
+  const cachedSource = await findReusableExternalTemplateSourceCache({
+    metadata: getGitHubTemplateCacheMetadata(locator),
+    namespace: 'github',
+  })
+  if (!cachedSource) {
+    return null
+  }
+
+  const sourceDir = resolveGitHubTemplateDirectory(
+    cachedSource.sourceDir,
+    locator,
+  )
+  await assertNoSymlinks(sourceDir)
+  return {
+    blockDir: sourceDir,
+    rootDir: sourceDir,
+  }
 }
 
 async function resolveGitHubTemplateSource(
   locator: GitHubTemplateLocator,
 ): Promise<SeedSource> {
+  const cacheEnabled = isExternalTemplateCacheEnabled()
+  let cacheRevisionLookupUnavailable = false
   let cacheRevision: string | null = null
-  if (isExternalTemplateCacheEnabled()) {
+  if (cacheEnabled) {
     try {
-      cacheRevision = resolveGitHubTemplateCacheRevision(locator)
+      const resolvedRevision = resolveGitHubTemplateCacheRevision(locator)
+      cacheRevision = resolvedRevision.revision
+      cacheRevisionLookupUnavailable = resolvedRevision.lookupUnavailable
     } catch {
       cacheRevision = null
+      cacheRevisionLookupUnavailable = true
+    }
+  }
+  if (cacheEnabled && !cacheRevision && cacheRevisionLookupUnavailable) {
+    const cachedSource = await reuseGitHubTemplateCacheByMetadata(locator)
+    if (cachedSource) {
+      return cachedSource
     }
   }
   if (cacheRevision) {
@@ -663,24 +721,21 @@ async function resolveGitHubTemplateSource(
             locator.ref ?? '',
             resolvedCacheRevision,
           ],
-          metadata: {
-            owner: locator.owner,
-            ref: locator.ref,
-            repo: locator.repo,
-            revision: resolvedCacheRevision,
-            sourcePath: locator.sourcePath,
-          },
+          metadata: getGitHubTemplateCacheMetadata(
+            locator,
+            resolvedCacheRevision,
+          ),
           namespace: 'github',
         },
         async (checkoutDir) => {
           cloneGitHubTemplateSource(locator, checkoutDir)
+          const sourceDir = resolveGitHubTemplateDirectory(checkoutDir, locator)
+          await assertNoSymlinks(sourceDir)
           pinGitHubTemplateCacheRevision(
             locator,
             checkoutDir,
             resolvedCacheRevision,
           )
-          const sourceDir = resolveGitHubTemplateDirectory(checkoutDir, locator)
-          await assertNoSymlinks(sourceDir)
         },
       )
       if (cachedSource) {

--- a/packages/wp-typia-project-tools/src/runtime/template-source-seeds.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-seeds.ts
@@ -60,6 +60,19 @@ function readOptionalDistString(
   return typeof value === 'string' && value.length > 0 ? value : null
 }
 
+function normalizeNpmRegistryCacheKey(registryBase: string): string {
+  try {
+    const url = new URL(registryBase)
+    url.username = ''
+    url.password = ''
+    url.search = ''
+    url.hash = ''
+    return url.toString().replace(/\/$/u, '')
+  } catch {
+    return registryBase
+  }
+}
+
 async function downloadNpmTemplateTarball(
   locator: NpmTemplateLocator,
   resolvedVersion: string,
@@ -191,15 +204,15 @@ async function fetchNpmTemplateSource(
   )
   const tarballShasum = readOptionalDistString(versionMetadata.dist, 'shasum')
   if (tarballIntegrity || tarballShasum) {
+    const registryCacheKey = normalizeNpmRegistryCacheKey(registryBase)
     const cachedSource = await resolveExternalTemplateSourceCache(
       {
         keyParts: [
           'npm',
-          registryBase,
+          registryCacheKey,
           locator.name,
           locator.raw,
           resolvedVersion,
-          tarballUrl,
           tarballIntegrity ?? '',
           tarballShasum ?? '',
         ],

--- a/packages/wp-typia-project-tools/src/runtime/template-source-seeds.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-seeds.ts
@@ -17,6 +17,10 @@ import {
   readJsonResponseWithLimit,
 } from './external-template-guards.js'
 import {
+  isExternalTemplateCacheEnabled,
+  resolveExternalTemplateSourceCache,
+} from './template-source-cache.js'
+import {
   CLI_DIAGNOSTIC_CODES,
   createCliDiagnosticCodeError,
 } from './cli-diagnostics.js'
@@ -46,6 +50,47 @@ function getUnknownNpmTemplateMessage(templateId: string): string {
     'Run `wp-typia templates list` to inspect available templates.',
     'If you meant an npm template package, verify the package name and configured npm registry.',
   ].join(' ')
+}
+
+function readOptionalDistString(
+  dist: Record<string, unknown>,
+  key: string,
+): string | null {
+  const value = dist[key]
+  return typeof value === 'string' && value.length > 0 ? value : null
+}
+
+async function downloadNpmTemplateTarball(
+  locator: NpmTemplateLocator,
+  resolvedVersion: string,
+  tarballUrl: string,
+  unpackDir: string,
+): Promise<void> {
+  const tarballResponse = await fetchWithExternalTemplateTimeout(tarballUrl, {
+    label: `downloading npm template tarball for ${locator.raw}@${resolvedVersion}`,
+  })
+  if (!tarballResponse.ok) {
+    throw new Error(
+      `Failed to download npm template tarball for ${locator.raw}: ${tarballResponse.status}`,
+    )
+  }
+
+  const tarballPath = path.join(path.dirname(unpackDir), 'template.tgz')
+  await fsp.mkdir(unpackDir, { recursive: true })
+  await fsp.writeFile(
+    tarballPath,
+    await readBufferResponseWithLimit(tarballResponse, {
+      label: `npm template tarball for ${locator.raw}@${resolvedVersion}`,
+      maxBytes: getExternalTemplateTarballMaxBytes(),
+    }),
+  )
+  await extractTarball({
+    cwd: unpackDir,
+    file: tarballPath,
+    strip: 1,
+  })
+  await fsp.rm(tarballPath, { force: true })
+  await assertNoSymlinks(unpackDir)
 }
 
 function selectRegistryVersion(
@@ -140,36 +185,64 @@ async function fetchNpmTemplateSource(
     )
   }
 
+  const tarballIntegrity = readOptionalDistString(
+    versionMetadata.dist,
+    'integrity',
+  )
+  const tarballShasum = readOptionalDistString(versionMetadata.dist, 'shasum')
+  if (tarballIntegrity || tarballShasum) {
+    const cachedSource = await resolveExternalTemplateSourceCache(
+      {
+        keyParts: [
+          'npm',
+          registryBase,
+          locator.name,
+          locator.raw,
+          resolvedVersion,
+          tarballUrl,
+          tarballIntegrity ?? '',
+          tarballShasum ?? '',
+        ],
+        metadata: {
+          integrity: tarballIntegrity,
+          package: locator.name,
+          raw: locator.raw,
+          registry: registryBase,
+          shasum: tarballShasum,
+          tarball: tarballUrl,
+          version: resolvedVersion,
+        },
+        namespace: 'npm',
+      },
+      (unpackDir) =>
+        downloadNpmTemplateTarball(
+          locator,
+          resolvedVersion,
+          tarballUrl,
+          unpackDir,
+        ),
+    )
+    if (cachedSource) {
+      await assertNoSymlinks(cachedSource.sourceDir)
+      return {
+        blockDir: cachedSource.sourceDir,
+        rootDir: cachedSource.sourceDir,
+      }
+    }
+  }
+
   const { path: tempRoot, cleanup } = await createManagedTempRoot(
     'wp-typia-template-source-',
   )
 
   try {
-    const tarballResponse = await fetchWithExternalTemplateTimeout(tarballUrl, {
-      label: `downloading npm template tarball for ${locator.raw}@${resolvedVersion}`,
-    })
-    if (!tarballResponse.ok) {
-      throw new Error(
-        `Failed to download npm template tarball for ${locator.raw}: ${tarballResponse.status}`,
-      )
-    }
-
-    const tarballPath = path.join(tempRoot, 'template.tgz')
     const unpackDir = path.join(tempRoot, 'source')
-    await fsp.mkdir(unpackDir, { recursive: true })
-    await fsp.writeFile(
-      tarballPath,
-      await readBufferResponseWithLimit(tarballResponse, {
-        label: `npm template tarball for ${locator.raw}@${resolvedVersion}`,
-        maxBytes: getExternalTemplateTarballMaxBytes(),
-      }),
+    await downloadNpmTemplateTarball(
+      locator,
+      resolvedVersion,
+      tarballUrl,
+      unpackDir,
     )
-    await extractTarball({
-      cwd: unpackDir,
-      file: tarballPath,
-      strip: 1,
-    })
-    await assertNoSymlinks(unpackDir)
 
     return {
       blockDir: unpackDir,
@@ -299,73 +372,150 @@ export async function assertNoSymlinks(sourceDir: string): Promise<void> {
   }
 }
 
+function runGitTemplateCommand(
+  args: readonly string[],
+  label: string,
+): ReturnType<typeof spawnSync> {
+  const timeoutMs = getExternalTemplateTimeoutMs()
+  const result = spawnSync('git', args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: timeoutMs,
+  })
+  if (result.error) {
+    const errorCode =
+      typeof result.error === 'object' &&
+      result.error !== null &&
+      'code' in result.error
+        ? String((result.error as { code: unknown }).code)
+        : ''
+    if (errorCode === 'ETIMEDOUT') {
+      throw createExternalTemplateTimeoutError(label, timeoutMs)
+    }
+    throw result.error
+  }
+  if (result.signal === 'SIGTERM' || result.signal === 'SIGKILL') {
+    throw createExternalTemplateTimeoutError(label, timeoutMs)
+  }
+
+  return result
+}
+
+function getGitHubTemplateRepositoryUrl(locator: GitHubTemplateLocator): string {
+  return `https://github.com/${locator.owner}/${locator.repo}.git`
+}
+
+function resolveGitHubTemplateDirectory(
+  checkoutDir: string,
+  locator: GitHubTemplateLocator,
+): string {
+  const sourceDir = path.resolve(checkoutDir, locator.sourcePath)
+  const relativeSourceDir = path.relative(checkoutDir, sourceDir)
+  if (relativeSourceDir.startsWith('..') || path.isAbsolute(relativeSourceDir)) {
+    throw new Error('GitHub template path must stay within the cloned repository.')
+  }
+  if (!fs.existsSync(sourceDir)) {
+    throw new Error(`GitHub template path does not exist: ${locator.sourcePath}`)
+  }
+  return sourceDir
+}
+
+function cloneGitHubTemplateSource(
+  locator: GitHubTemplateLocator,
+  checkoutDir: string,
+): void {
+  const args = ['clone', '--depth', '1']
+  if (locator.ref) {
+    args.push('--branch', locator.ref)
+  }
+  args.push(getGitHubTemplateRepositoryUrl(locator), checkoutDir)
+  const cloneResult = runGitTemplateCommand(
+    args,
+    `cloning GitHub template ${locator.owner}/${locator.repo}`,
+  )
+  if (cloneResult.status !== 0) {
+    throw new Error(
+      `Failed to clone GitHub template source ${locator.owner}/${locator.repo}.`,
+    )
+  }
+}
+
+function resolveGitHubTemplateCacheRevision(
+  locator: GitHubTemplateLocator,
+): string | null {
+  const ref = locator.ref ?? 'HEAD'
+  const result = runGitTemplateCommand(
+    ['ls-remote', getGitHubTemplateRepositoryUrl(locator), ref],
+    `checking GitHub template revision ${locator.owner}/${locator.repo}`,
+  )
+  if (result.status !== 0 || typeof result.stdout !== 'string') {
+    return null
+  }
+
+  const revisions = result.stdout
+    .split('\n')
+    .map((line) => line.trim().split(/\s+/u)[0])
+    .filter((revision) => /^[0-9a-f]{40}$/iu.test(revision))
+
+  return revisions.length > 0 ? revisions[revisions.length - 1] : null
+}
+
 async function resolveGitHubTemplateSource(
   locator: GitHubTemplateLocator,
 ): Promise<SeedSource> {
+  let cacheRevision: string | null = null
+  if (isExternalTemplateCacheEnabled()) {
+    try {
+      cacheRevision = resolveGitHubTemplateCacheRevision(locator)
+    } catch {
+      cacheRevision = null
+    }
+  }
+  if (cacheRevision) {
+    const cachedSource = await resolveExternalTemplateSourceCache(
+      {
+        keyParts: [
+          'github',
+          locator.owner,
+          locator.repo,
+          locator.sourcePath,
+          locator.ref ?? '',
+          cacheRevision,
+        ],
+        metadata: {
+          owner: locator.owner,
+          ref: locator.ref,
+          repo: locator.repo,
+          revision: cacheRevision,
+          sourcePath: locator.sourcePath,
+        },
+        namespace: 'github',
+      },
+      async (checkoutDir) => {
+        cloneGitHubTemplateSource(locator, checkoutDir)
+      },
+    )
+    if (cachedSource) {
+      const sourceDir = resolveGitHubTemplateDirectory(
+        cachedSource.sourceDir,
+        locator,
+      )
+      await assertNoSymlinks(sourceDir)
+      return {
+        blockDir: sourceDir,
+        rootDir: sourceDir,
+      }
+    }
+  }
+
   const { path: remoteRoot, cleanup } = await createManagedTempRoot(
     'wp-typia-template-source-',
   )
   const checkoutDir = path.join(remoteRoot, 'source')
 
   try {
-    const args = ['clone', '--depth', '1']
-    if (locator.ref) {
-      args.push('--branch', locator.ref)
-    }
-    args.push(
-      `https://github.com/${locator.owner}/${locator.repo}.git`,
-      checkoutDir,
-    )
-    const cloneTimeoutMs = getExternalTemplateTimeoutMs()
-    const cloneResult = spawnSync('git', args, {
-      stdio: 'ignore',
-      timeout: cloneTimeoutMs,
-    })
-    if (cloneResult.error) {
-      const errorCode =
-        typeof cloneResult.error === 'object' &&
-        cloneResult.error !== null &&
-        'code' in cloneResult.error
-          ? String((cloneResult.error as { code: unknown }).code)
-          : ''
-      if (errorCode === 'ETIMEDOUT') {
-        throw createExternalTemplateTimeoutError(
-          `cloning GitHub template ${locator.owner}/${locator.repo}`,
-          cloneTimeoutMs,
-        )
-      }
-      throw cloneResult.error
-    }
-    if (
-      cloneResult.signal === 'SIGTERM' ||
-      cloneResult.signal === 'SIGKILL'
-    ) {
-      throw createExternalTemplateTimeoutError(
-        `cloning GitHub template ${locator.owner}/${locator.repo}`,
-        cloneTimeoutMs,
-      )
-    }
-    if (cloneResult.status !== 0) {
-      throw new Error(
-        `Failed to clone GitHub template source ${locator.owner}/${locator.repo}.`,
-      )
-    }
-
-    const sourceDir = path.resolve(checkoutDir, locator.sourcePath)
-    const relativeSourceDir = path.relative(checkoutDir, sourceDir)
-    if (
-      relativeSourceDir.startsWith('..') ||
-      path.isAbsolute(relativeSourceDir)
-    ) {
-      throw new Error(
-        'GitHub template path must stay within the cloned repository.',
-      )
-    }
-    if (!fs.existsSync(sourceDir)) {
-      throw new Error(
-        `GitHub template path does not exist: ${locator.sourcePath}`,
-      )
-    }
+    cloneGitHubTemplateSource(locator, checkoutDir)
+    const sourceDir = resolveGitHubTemplateDirectory(checkoutDir, locator)
     await assertNoSymlinks(sourceDir)
 
     return {

--- a/packages/wp-typia-project-tools/src/runtime/template-source-seeds.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-seeds.ts
@@ -44,6 +44,33 @@ const USER_FACING_TEMPLATE_IDS = [
   OFFICIAL_WORKSPACE_TEMPLATE_ALIAS,
 ] as const
 
+const GITHUB_TEMPLATE_CACHE_REVISION_RACE_CODE =
+  'github-template-cache-revision-race'
+
+type GitHubTemplateCacheRevisionRaceError = Error & {
+  code: typeof GITHUB_TEMPLATE_CACHE_REVISION_RACE_CODE
+}
+
+function createGitHubTemplateCacheRevisionRaceError(
+  message: string,
+): GitHubTemplateCacheRevisionRaceError {
+  const error = new Error(message) as GitHubTemplateCacheRevisionRaceError
+  error.code = GITHUB_TEMPLATE_CACHE_REVISION_RACE_CODE
+  return error
+}
+
+function isGitHubTemplateCacheRevisionRaceError(
+  error: unknown,
+): error is GitHubTemplateCacheRevisionRaceError {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as { code: unknown }).code ===
+      GITHUB_TEMPLATE_CACHE_REVISION_RACE_CODE
+  )
+}
+
 function getUnknownNpmTemplateMessage(templateId: string): string {
   return [
     `Unknown template "${templateId}". Expected one of: ${USER_FACING_TEMPLATE_IDS.join(', ')}.`,
@@ -488,7 +515,7 @@ function pinGitHubTemplateCacheRevision(
     `fetching GitHub template revision ${locator.owner}/${locator.repo}`,
   )
   if (fetchResult.status !== 0) {
-    throw new Error(
+    throw createGitHubTemplateCacheRevisionRaceError(
       `Failed to fetch GitHub template revision ${cacheRevision} for ${locator.owner}/${locator.repo}.`,
     )
   }
@@ -498,13 +525,13 @@ function pinGitHubTemplateCacheRevision(
     `checking out GitHub template revision ${locator.owner}/${locator.repo}`,
   )
   if (checkoutResult.status !== 0) {
-    throw new Error(
+    throw createGitHubTemplateCacheRevisionRaceError(
       `Failed to check out GitHub template revision ${cacheRevision} for ${locator.owner}/${locator.repo}.`,
     )
   }
 
   if (readGitHubTemplateHeadRevision(checkoutDir) !== normalizedCacheRevision) {
-    throw new Error(
+    throw createGitHubTemplateCacheRevisionRaceError(
       `GitHub template checkout did not match resolved revision ${cacheRevision} for ${locator.owner}/${locator.repo}.`,
     )
   }
@@ -611,7 +638,10 @@ async function resolveGitHubTemplateSource(
           rootDir: sourceDir,
         }
       }
-    } catch {
+    } catch (error) {
+      if (!isGitHubTemplateCacheRevisionRaceError(error)) {
+        throw error
+      }
       // Fall back to the existing uncached clone path if revision pinning races.
     }
   }

--- a/packages/wp-typia-project-tools/src/runtime/template-source-seeds.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-seeds.ts
@@ -537,6 +537,19 @@ function pinGitHubTemplateCacheRevision(
   }
 }
 
+function getGitHubTemplateRevisionPatterns(
+  locator: GitHubTemplateLocator,
+): string[] {
+  const ref = locator.ref ?? 'HEAD'
+  if (!locator.ref) {
+    return [ref]
+  }
+  if (ref.startsWith('refs/')) {
+    return [ref, `${ref}^{}`]
+  }
+  return [ref, `refs/heads/${ref}`, `refs/tags/${ref}`, `refs/tags/${ref}^{}`]
+}
+
 /**
  * Resolves a GitHub template ref to a stable revision for cache keying.
  *
@@ -546,9 +559,12 @@ function pinGitHubTemplateCacheRevision(
 function resolveGitHubTemplateCacheRevision(
   locator: GitHubTemplateLocator,
 ): string | null {
-  const ref = locator.ref ?? 'HEAD'
   const result = runGitTemplateCommand(
-    ['ls-remote', getGitHubTemplateRepositoryUrl(locator), ref],
+    [
+      'ls-remote',
+      getGitHubTemplateRepositoryUrl(locator),
+      ...getGitHubTemplateRevisionPatterns(locator),
+    ],
     `checking GitHub template revision ${locator.owner}/${locator.repo}`,
     { captureOutput: true },
   )

--- a/packages/wp-typia-project-tools/src/runtime/template-source-seeds.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-seeds.ts
@@ -446,6 +446,57 @@ function cloneGitHubTemplateSource(
   }
 }
 
+function readGitHubTemplateHeadRevision(checkoutDir: string): string | null {
+  const result = runGitTemplateCommand(
+    ['-C', checkoutDir, 'rev-parse', 'HEAD'],
+    'reading GitHub template checkout revision',
+    { captureOutput: true },
+  )
+  if (result.status !== 0 || typeof result.stdout !== 'string') {
+    return null
+  }
+
+  const revision = result.stdout.trim().split(/\s+/u)[0]
+  return /^[0-9a-f]{40}$/iu.test(revision) ? revision.toLowerCase() : null
+}
+
+function pinGitHubTemplateCacheRevision(
+  locator: GitHubTemplateLocator,
+  checkoutDir: string,
+  cacheRevision: string,
+): void {
+  const normalizedCacheRevision = cacheRevision.toLowerCase()
+  if (readGitHubTemplateHeadRevision(checkoutDir) === normalizedCacheRevision) {
+    return
+  }
+
+  const fetchResult = runGitTemplateCommand(
+    ['-C', checkoutDir, 'fetch', '--depth', '1', 'origin', cacheRevision],
+    `fetching GitHub template revision ${locator.owner}/${locator.repo}`,
+  )
+  if (fetchResult.status !== 0) {
+    throw new Error(
+      `Failed to fetch GitHub template revision ${cacheRevision} for ${locator.owner}/${locator.repo}.`,
+    )
+  }
+
+  const checkoutResult = runGitTemplateCommand(
+    ['-C', checkoutDir, 'checkout', '--detach', cacheRevision],
+    `checking out GitHub template revision ${locator.owner}/${locator.repo}`,
+  )
+  if (checkoutResult.status !== 0) {
+    throw new Error(
+      `Failed to check out GitHub template revision ${cacheRevision} for ${locator.owner}/${locator.repo}.`,
+    )
+  }
+
+  if (readGitHubTemplateHeadRevision(checkoutDir) !== normalizedCacheRevision) {
+    throw new Error(
+      `GitHub template checkout did not match resolved revision ${cacheRevision} for ${locator.owner}/${locator.repo}.`,
+    )
+  }
+}
+
 function resolveGitHubTemplateCacheRevision(
   locator: GitHubTemplateLocator,
 ): string | null {
@@ -479,39 +530,49 @@ async function resolveGitHubTemplateSource(
     }
   }
   if (cacheRevision) {
-    const cachedSource = await resolveExternalTemplateSourceCache(
-      {
-        keyParts: [
-          'github',
-          locator.owner,
-          locator.repo,
-          locator.sourcePath,
-          locator.ref ?? '',
-          cacheRevision,
-        ],
-        metadata: {
-          owner: locator.owner,
-          ref: locator.ref,
-          repo: locator.repo,
-          revision: cacheRevision,
-          sourcePath: locator.sourcePath,
+    const resolvedCacheRevision = cacheRevision
+    try {
+      const cachedSource = await resolveExternalTemplateSourceCache(
+        {
+          keyParts: [
+            'github',
+            locator.owner,
+            locator.repo,
+            locator.sourcePath,
+            locator.ref ?? '',
+            resolvedCacheRevision,
+          ],
+          metadata: {
+            owner: locator.owner,
+            ref: locator.ref,
+            repo: locator.repo,
+            revision: resolvedCacheRevision,
+            sourcePath: locator.sourcePath,
+          },
+          namespace: 'github',
         },
-        namespace: 'github',
-      },
-      async (checkoutDir) => {
-        cloneGitHubTemplateSource(locator, checkoutDir)
-      },
-    )
-    if (cachedSource) {
-      const sourceDir = resolveGitHubTemplateDirectory(
-        cachedSource.sourceDir,
-        locator,
+        async (checkoutDir) => {
+          cloneGitHubTemplateSource(locator, checkoutDir)
+          pinGitHubTemplateCacheRevision(
+            locator,
+            checkoutDir,
+            resolvedCacheRevision,
+          )
+        },
       )
-      await assertNoSymlinks(sourceDir)
-      return {
-        blockDir: sourceDir,
-        rootDir: sourceDir,
+      if (cachedSource) {
+        const sourceDir = resolveGitHubTemplateDirectory(
+          cachedSource.sourceDir,
+          locator,
+        )
+        await assertNoSymlinks(sourceDir)
+        return {
+          blockDir: sourceDir,
+          rootDir: sourceDir,
+        }
       }
+    } catch {
+      // Fall back to the existing uncached clone path if revision pinning races.
     }
   }
 

--- a/packages/wp-typia-project-tools/tests/template-source.test.ts
+++ b/packages/wp-typia-project-tools/tests/template-source.test.ts
@@ -47,6 +47,45 @@ describe("@wp-typia/project-tools template sources", () => {
     };
   }
 
+  function restoreEnvValue(name: string, previousValue: string | undefined): void {
+    if (previousValue === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = previousValue;
+    }
+  }
+
+  function createMinimalNpmTemplateTarball(
+    fixtureRoot: string,
+    packageName: string,
+    version: string
+  ): string {
+    const packageDir = path.join(fixtureRoot, "package");
+    const tarballPath = path.join(fixtureRoot, "template.tgz");
+
+    fs.mkdirSync(packageDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(packageDir, "package.json"),
+      JSON.stringify(
+        {
+          name: packageName,
+          version,
+        },
+        null,
+        2
+      ),
+      "utf8"
+    );
+    fs.writeFileSync(
+      path.join(packageDir, "block.json"),
+      JSON.stringify({ name: "demo/cache-template", title: "Cache Template" }),
+      "utf8"
+    );
+    execFileSync("tar", ["-czf", tarballPath, "-C", fixtureRoot, "package"]);
+
+    return tarballPath;
+  }
+
 test("getTemplateVariables rejects slugs that normalize to an empty identifier", () => {
   expect(() =>
     getTemplateVariables("basic", {
@@ -323,6 +362,187 @@ test("npm template tarballs that exceed the configured size limit fail early", a
         previousTarballLimit;
     }
     await server.close();
+  }
+});
+
+test("npm template tarballs reuse the external template cache until integrity changes", async () => {
+  const packageName = "@demo/cache-template";
+  const version = "1.0.0";
+  const npmTemplateRoot = fs.mkdtempSync(
+    path.join(tempRoot, "npm-cache-template-")
+  );
+  const registryBase = "https://registry.npmjs.org";
+  const metadataUrl = `${registryBase}/${encodeURIComponent(packageName)}`;
+  const tarballUrl = `${registryBase}/@demo/cache-template/-/cache-template-1.0.0.tgz`;
+  const tarballPath = createMinimalNpmTemplateTarball(
+    npmTemplateRoot,
+    packageName,
+    version
+  );
+  const originalFetch = globalThis.fetch;
+  const originalRegistry = process.env.NPM_CONFIG_REGISTRY;
+  const originalCache = process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE;
+  const originalCacheDir = process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR;
+  let integrity = "sha512-cache-one";
+  let shasum = "cache-one";
+  let tarballDownloads = 0;
+
+  process.env.NPM_CONFIG_REGISTRY = registryBase;
+  process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR = path.join(
+    npmTemplateRoot,
+    "cache"
+  );
+  delete process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE;
+  globalThis.fetch = (async (input) => {
+    const requestUrl =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+        ? input.href
+        : input.url;
+    if (requestUrl === metadataUrl) {
+      return new Response(
+        JSON.stringify({
+          "dist-tags": {
+            latest: version,
+          },
+          versions: {
+            [version]: {
+              dist: {
+                integrity,
+                shasum,
+                tarball: tarballUrl,
+              },
+            },
+          },
+        }),
+        {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+          },
+        }
+      );
+    }
+
+    if (requestUrl === tarballUrl) {
+      tarballDownloads += 1;
+      return new Response(fs.readFileSync(tarballPath), { status: 200 });
+    }
+
+    throw new Error(
+      `Unexpected fetch URL in npm template cache test: ${requestUrl}`
+    );
+  }) as typeof fetch;
+
+  try {
+    const locator = parseTemplateLocator("@demo/cache-template@^1.0.0");
+    const first = await resolveTemplateSeed(locator, tempRoot);
+    const second = await resolveTemplateSeed(locator, tempRoot);
+
+    expect(tarballDownloads).toBe(1);
+    expect(second.rootDir).toBe(first.rootDir);
+    expect(fs.existsSync(path.join(second.rootDir, "package.json"))).toBe(
+      true
+    );
+
+    integrity = "sha512-cache-two";
+    shasum = "cache-two";
+
+    const third = await resolveTemplateSeed(locator, tempRoot);
+    expect(tarballDownloads).toBe(2);
+    expect(third.rootDir).not.toBe(first.rootDir);
+  } finally {
+    globalThis.fetch = originalFetch;
+    restoreEnvValue("NPM_CONFIG_REGISTRY", originalRegistry);
+    restoreEnvValue("WP_TYPIA_EXTERNAL_TEMPLATE_CACHE", originalCache);
+    restoreEnvValue("WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR", originalCacheDir);
+  }
+});
+
+test("npm template cache can be bypassed with an environment override", async () => {
+  const packageName = "@demo/cache-bypass-template";
+  const version = "1.0.0";
+  const npmTemplateRoot = fs.mkdtempSync(
+    path.join(tempRoot, "npm-cache-bypass-template-")
+  );
+  const registryBase = "https://registry.npmjs.org";
+  const metadataUrl = `${registryBase}/${encodeURIComponent(packageName)}`;
+  const tarballUrl = `${registryBase}/@demo/cache-bypass-template/-/cache-bypass-template-1.0.0.tgz`;
+  const tarballPath = createMinimalNpmTemplateTarball(
+    npmTemplateRoot,
+    packageName,
+    version
+  );
+  const originalFetch = globalThis.fetch;
+  const originalRegistry = process.env.NPM_CONFIG_REGISTRY;
+  const originalCache = process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE;
+  const originalCacheDir = process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR;
+  let tarballDownloads = 0;
+
+  process.env.NPM_CONFIG_REGISTRY = registryBase;
+  process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE = "0";
+  process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR = path.join(
+    npmTemplateRoot,
+    "cache"
+  );
+  globalThis.fetch = (async (input) => {
+    const requestUrl =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+        ? input.href
+        : input.url;
+    if (requestUrl === metadataUrl) {
+      return new Response(
+        JSON.stringify({
+          "dist-tags": {
+            latest: version,
+          },
+          versions: {
+            [version]: {
+              dist: {
+                integrity: "sha512-cache-bypass",
+                shasum: "cache-bypass",
+                tarball: tarballUrl,
+              },
+            },
+          },
+        }),
+        {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+          },
+        }
+      );
+    }
+
+    if (requestUrl === tarballUrl) {
+      tarballDownloads += 1;
+      return new Response(fs.readFileSync(tarballPath), { status: 200 });
+    }
+
+    throw new Error(
+      `Unexpected fetch URL in npm template cache bypass test: ${requestUrl}`
+    );
+  }) as typeof fetch;
+
+  try {
+    const locator = parseTemplateLocator("@demo/cache-bypass-template@^1.0.0");
+    const first = await resolveTemplateSeed(locator, tempRoot);
+    const second = await resolveTemplateSeed(locator, tempRoot);
+
+    expect(tarballDownloads).toBe(2);
+    expect(second.rootDir).not.toBe(first.rootDir);
+
+    await first.cleanup?.();
+    await second.cleanup?.();
+  } finally {
+    globalThis.fetch = originalFetch;
+    restoreEnvValue("NPM_CONFIG_REGISTRY", originalRegistry);
+    restoreEnvValue("WP_TYPIA_EXTERNAL_TEMPLATE_CACHE", originalCache);
+    restoreEnvValue("WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR", originalCacheDir);
   }
 });
 

--- a/packages/wp-typia-project-tools/tests/template-source.test.ts
+++ b/packages/wp-typia-project-tools/tests/template-source.test.ts
@@ -6,6 +6,7 @@ import * as path from "node:path";
 import { blockTypesPackageVersion, cleanupScaffoldTempRoot, createBlockExternalFixturePath, createBlockSubsetFixturePath, createScaffoldTempRoot, normalizedBlockRuntimePackageVersion, packageRoot, templateLayerFixturePath, workspaceTemplatePackageManifest } from "./helpers/scaffold-test-harness.js";
 import { getTemplateVariables, scaffoldProject } from "../src/runtime/index.js";
 import { resolveTemplateId } from "../src/runtime/scaffold.js";
+import { resolveExternalTemplateSourceCache } from "../src/runtime/template-source-cache.js";
 import { copyRenderedDirectory } from "../src/runtime/template-render.js";
 import { parseGitHubTemplateLocator, parseNpmTemplateLocator, parseTemplateLocator, resolveTemplateSeed } from "../src/runtime/template-source.js";
 import { EXTERNAL_TEMPLATE_TRUST_WARNING } from "../src/runtime/template-source-external.js";
@@ -106,6 +107,83 @@ describe("@wp-typia/project-tools template sources", () => {
 
     return null;
   }
+
+test("external template cache rejects unsafe namespaces before populating", async () => {
+  const originalCache = process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE;
+  const originalCacheDir = process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR;
+  let populated = false;
+
+  process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR = path.join(
+    tempRoot,
+    "unsafe-namespace-cache"
+  );
+  delete process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE;
+
+  try {
+    const resolution = await resolveExternalTemplateSourceCache(
+      {
+        keyParts: ["unsafe"],
+        metadata: {},
+        namespace: "../escape",
+      },
+      async (sourceDir) => {
+        populated = true;
+        fs.writeFileSync(path.join(sourceDir, "package.json"), "{}", "utf8");
+      }
+    );
+
+    expect(resolution).toBeNull();
+    expect(populated).toBe(false);
+  } finally {
+    restoreEnvValue("WP_TYPIA_EXTERNAL_TEMPLATE_CACHE", originalCache);
+    restoreEnvValue("WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR", originalCacheDir);
+  }
+});
+
+test("external template cache redacts malformed URL-like metadata", async () => {
+  const originalCache = process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE;
+  const originalCacheDir = process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR;
+  const cacheDir = path.join(tempRoot, "redacted-marker-cache");
+
+  process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR = cacheDir;
+  delete process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE;
+
+  try {
+    const resolution = await resolveExternalTemplateSourceCache(
+      {
+        keyParts: ["redacted-marker"],
+        metadata: {
+          raw: "safe diagnostic",
+          registry: "https://user:pass@example.test/registry?token=secret#hash",
+          tarball: "not a valid url with secret-token",
+        },
+        namespace: "metadata",
+      },
+      async (sourceDir) => {
+        fs.writeFileSync(path.join(sourceDir, "package.json"), "{}", "utf8");
+      }
+    );
+
+    expect(resolution?.cacheHit).toBe(false);
+
+    const markerPath = findFileByName(
+      cacheDir,
+      "wp-typia-template-cache.json"
+    );
+    if (!markerPath) {
+      throw new Error("Expected a populated external template cache marker.");
+    }
+
+    const markerText = fs.readFileSync(markerPath, "utf8");
+    expect(markerText).toContain("[redacted]");
+    expect(markerText).not.toContain("secret-token");
+    expect(markerText).not.toContain("user:pass");
+    expect(markerText).not.toContain("token=secret");
+  } finally {
+    restoreEnvValue("WP_TYPIA_EXTERNAL_TEMPLATE_CACHE", originalCache);
+    restoreEnvValue("WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR", originalCacheDir);
+  }
+});
 
 test("getTemplateVariables rejects slugs that normalize to an empty identifier", () => {
   expect(() =>

--- a/packages/wp-typia-project-tools/tests/template-source.test.ts
+++ b/packages/wp-typia-project-tools/tests/template-source.test.ts
@@ -185,6 +185,119 @@ test("external template cache redacts malformed URL-like metadata", async () => 
   }
 });
 
+test("external template cache treats populate filesystem errors as misses", async () => {
+  const originalCache = process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE;
+  const originalCacheDir = process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR;
+
+  process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR = path.join(
+    tempRoot,
+    "populate-error-cache"
+  );
+  delete process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE;
+
+  try {
+    const resolution = await resolveExternalTemplateSourceCache(
+      {
+        keyParts: ["populate-error"],
+        metadata: {},
+        namespace: "npm",
+      },
+      async () => {
+        const error = new Error("cache volume full") as Error & {
+          code: string;
+        };
+        error.code = "ENOSPC";
+        throw error;
+      }
+    );
+
+    expect(resolution).toBeNull();
+  } finally {
+    restoreEnvValue("WP_TYPIA_EXTERNAL_TEMPLATE_CACHE", originalCache);
+    restoreEnvValue("WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR", originalCacheDir);
+  }
+});
+
+test("external template cache keeps source populate failures visible", async () => {
+  const originalCache = process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE;
+  const originalCacheDir = process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR;
+
+  process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR = path.join(
+    tempRoot,
+    "populate-source-error-cache"
+  );
+  delete process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE;
+
+  try {
+    await expect(
+      resolveExternalTemplateSourceCache(
+        {
+          keyParts: ["populate-source-error"],
+          metadata: {},
+          namespace: "npm",
+        },
+        async () => {
+          throw new Error("download failed");
+        }
+      )
+    ).rejects.toThrow("download failed");
+  } finally {
+    restoreEnvValue("WP_TYPIA_EXTERNAL_TEMPLATE_CACHE", originalCache);
+    restoreEnvValue("WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR", originalCacheDir);
+  }
+});
+
+test("external template cache ignores corrupted source files", async () => {
+  const originalCache = process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE;
+  const originalCacheDir = process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR;
+
+  process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR = path.join(
+    tempRoot,
+    "corrupted-source-cache"
+  );
+  delete process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE;
+
+  try {
+    const firstResolution = await resolveExternalTemplateSourceCache(
+      {
+        keyParts: ["corrupted-source"],
+        metadata: {},
+        namespace: "npm",
+      },
+      async (sourceDir) => {
+        fs.writeFileSync(path.join(sourceDir, "package.json"), "{}", "utf8");
+      }
+    );
+
+    expect(firstResolution?.cacheHit).toBe(false);
+    if (!firstResolution) {
+      throw new Error("Expected a populated external template cache entry.");
+    }
+
+    fs.rmSync(firstResolution.sourceDir, { force: true, recursive: true });
+    fs.writeFileSync(firstResolution.sourceDir, "not a directory", "utf8");
+
+    let populated = false;
+    const secondResolution = await resolveExternalTemplateSourceCache(
+      {
+        keyParts: ["corrupted-source"],
+        metadata: {},
+        namespace: "npm",
+      },
+      async (sourceDir) => {
+        populated = true;
+        fs.writeFileSync(path.join(sourceDir, "package.json"), "{}", "utf8");
+      }
+    );
+
+    expect(secondResolution).toBeNull();
+    expect(populated).toBe(true);
+  } finally {
+    restoreEnvValue("WP_TYPIA_EXTERNAL_TEMPLATE_CACHE", originalCache);
+    restoreEnvValue("WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR", originalCacheDir);
+  }
+});
+
 test("getTemplateVariables rejects slugs that normalize to an empty identifier", () => {
   expect(() =>
     getTemplateVariables("basic", {

--- a/packages/wp-typia-project-tools/tests/template-source.test.ts
+++ b/packages/wp-typia-project-tools/tests/template-source.test.ts
@@ -86,6 +86,27 @@ describe("@wp-typia/project-tools template sources", () => {
     return tarballPath;
   }
 
+  function findFileByName(rootDir: string, fileName: string): string | null {
+    if (!fs.existsSync(rootDir)) {
+      return null;
+    }
+
+    for (const entry of fs.readdirSync(rootDir, { withFileTypes: true })) {
+      const entryPath = path.join(rootDir, entry.name);
+      if (entry.isFile() && entry.name === fileName) {
+        return entryPath;
+      }
+      if (entry.isDirectory()) {
+        const nestedFilePath = findFileByName(entryPath, fileName);
+        if (nestedFilePath) {
+          return nestedFilePath;
+        }
+      }
+    }
+
+    return null;
+  }
+
 test("getTemplateVariables rejects slugs that normalize to an empty identifier", () => {
   expect(() =>
     getTemplateVariables("basic", {
@@ -371,9 +392,9 @@ test("npm template tarballs reuse the external template cache until integrity ch
   const npmTemplateRoot = fs.mkdtempSync(
     path.join(tempRoot, "npm-cache-template-")
   );
-  const registryBase = "https://registry.npmjs.org";
+  const registryBase = "https://token:secret@registry.npmjs.org";
   const metadataUrl = `${registryBase}/${encodeURIComponent(packageName)}`;
-  const tarballUrl = `${registryBase}/@demo/cache-template/-/cache-template-1.0.0.tgz`;
+  const tarballUrl = `${registryBase}/@demo/cache-template/-/cache-template-1.0.0.tgz?download-token=secret#debug`;
   const tarballPath = createMinimalNpmTemplateTarball(
     npmTemplateRoot,
     packageName,
@@ -445,6 +466,22 @@ test("npm template tarballs reuse the external template cache until integrity ch
     expect(fs.existsSync(path.join(second.rootDir, "package.json"))).toBe(
       true
     );
+
+    const cacheDir = process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR;
+    if (!cacheDir) {
+      throw new Error("Expected the template cache directory to be configured.");
+    }
+    const markerPath = findFileByName(
+      cacheDir,
+      "wp-typia-template-cache.json"
+    );
+    if (!markerPath) {
+      throw new Error("Expected a populated external template cache marker.");
+    }
+    const markerText = fs.readFileSync(markerPath, "utf8");
+    expect(markerText).not.toContain("keyParts");
+    expect(markerText).not.toContain("token:secret");
+    expect(markerText).not.toContain("download-token");
 
     integrity = "sha512-cache-two";
     shasum = "cache-two";

--- a/packages/wp-typia-project-tools/tests/template-source.test.ts
+++ b/packages/wp-typia-project-tools/tests/template-source.test.ts
@@ -6,7 +6,10 @@ import * as path from "node:path";
 import { blockTypesPackageVersion, cleanupScaffoldTempRoot, createBlockExternalFixturePath, createBlockSubsetFixturePath, createScaffoldTempRoot, normalizedBlockRuntimePackageVersion, packageRoot, templateLayerFixturePath, workspaceTemplatePackageManifest } from "./helpers/scaffold-test-harness.js";
 import { getTemplateVariables, scaffoldProject } from "../src/runtime/index.js";
 import { resolveTemplateId } from "../src/runtime/scaffold.js";
-import { resolveExternalTemplateSourceCache } from "../src/runtime/template-source-cache.js";
+import {
+  findReusableExternalTemplateSourceCache,
+  resolveExternalTemplateSourceCache,
+} from "../src/runtime/template-source-cache.js";
 import { copyRenderedDirectory } from "../src/runtime/template-render.js";
 import { parseGitHubTemplateLocator, parseNpmTemplateLocator, parseTemplateLocator, resolveTemplateSeed } from "../src/runtime/template-source.js";
 import { EXTERNAL_TEMPLATE_TRUST_WARNING } from "../src/runtime/template-source-external.js";
@@ -292,6 +295,100 @@ test("external template cache ignores corrupted source files", async () => {
 
     expect(secondResolution).toBeNull();
     expect(populated).toBe(true);
+  } finally {
+    restoreEnvValue("WP_TYPIA_EXTERNAL_TEMPLATE_CACHE", originalCache);
+    restoreEnvValue("WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR", originalCacheDir);
+  }
+});
+
+test("external template cache rejects symlinked roots without chmoding targets", async () => {
+  if (process.platform === "win32") {
+    return;
+  }
+
+  const originalCache = process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE;
+  const originalCacheDir = process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR;
+  const targetDir = path.join(tempRoot, "symlink-cache-target");
+  const symlinkDir = path.join(tempRoot, "symlink-cache-root");
+  let populated = false;
+
+  fs.mkdirSync(targetDir, { recursive: true });
+  fs.chmodSync(targetDir, 0o755);
+  fs.symlinkSync(targetDir, symlinkDir, "dir");
+  process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR = symlinkDir;
+  delete process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE;
+
+  try {
+    const resolution = await resolveExternalTemplateSourceCache(
+      {
+        keyParts: ["symlink-root"],
+        metadata: {},
+        namespace: "npm",
+      },
+      async (sourceDir) => {
+        populated = true;
+        fs.writeFileSync(path.join(sourceDir, "package.json"), "{}", "utf8");
+      }
+    );
+
+    expect(resolution).toBeNull();
+    expect(populated).toBe(false);
+    expect(fs.statSync(targetDir).mode & 0o077).not.toBe(0);
+  } finally {
+    restoreEnvValue("WP_TYPIA_EXTERNAL_TEMPLATE_CACHE", originalCache);
+    restoreEnvValue("WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR", originalCacheDir);
+  }
+});
+
+test("external template cache can find reusable entries by metadata", async () => {
+  const originalCache = process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE;
+  const originalCacheDir = process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR;
+
+  process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR = path.join(
+    tempRoot,
+    "metadata-lookup-cache"
+  );
+  delete process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE;
+
+  try {
+    const resolution = await resolveExternalTemplateSourceCache(
+      {
+        keyParts: [
+          "github",
+          "demo-owner",
+          "demo-repo",
+          "plugin",
+          "main",
+          "0123456789abcdef0123456789abcdef01234567",
+        ],
+        metadata: {
+          owner: "demo-owner",
+          ref: "main",
+          repo: "demo-repo",
+          revision: "0123456789abcdef0123456789abcdef01234567",
+          sourcePath: "plugin",
+        },
+        namespace: "github",
+      },
+      async (sourceDir) => {
+        fs.writeFileSync(path.join(sourceDir, "package.json"), "{}", "utf8");
+      }
+    );
+
+    expect(resolution?.cacheHit).toBe(false);
+
+    const lookupResolution = await findReusableExternalTemplateSourceCache({
+      metadata: {
+        owner: "demo-owner",
+        ref: "main",
+        repo: "demo-repo",
+        sourcePath: "plugin",
+      },
+      namespace: "github",
+    });
+
+    expect(lookupResolution?.cacheHit).toBe(true);
+    expect(lookupResolution?.sourceDir).toBe(resolution?.sourceDir);
   } finally {
     restoreEnvValue("WP_TYPIA_EXTERNAL_TEMPLATE_CACHE", originalCache);
     restoreEnvValue("WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR", originalCacheDir);

--- a/packages/wp-typia-project-tools/tests/template-source.test.ts
+++ b/packages/wp-typia-project-tools/tests/template-source.test.ts
@@ -394,7 +394,8 @@ test("npm template tarballs reuse the external template cache until integrity ch
   );
   const registryBase = "https://token:secret@registry.npmjs.org";
   const metadataUrl = `${registryBase}/${encodeURIComponent(packageName)}`;
-  const tarballUrl = `${registryBase}/@demo/cache-template/-/cache-template-1.0.0.tgz?download-token=secret#debug`;
+  const getTarballUrl = (): string =>
+    `${registryBase}/@demo/cache-template/-/cache-template-1.0.0.tgz?download-token=${tarballToken}#debug`;
   const tarballPath = createMinimalNpmTemplateTarball(
     npmTemplateRoot,
     packageName,
@@ -406,6 +407,7 @@ test("npm template tarballs reuse the external template cache until integrity ch
   const originalCacheDir = process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR;
   let integrity = "sha512-cache-one";
   let shasum = "cache-one";
+  let tarballToken = "cache-one";
   let tarballDownloads = 0;
 
   process.env.NPM_CONFIG_REGISTRY = registryBase;
@@ -432,7 +434,7 @@ test("npm template tarballs reuse the external template cache until integrity ch
               dist: {
                 integrity,
                 shasum,
-                tarball: tarballUrl,
+                tarball: getTarballUrl(),
               },
             },
           },
@@ -446,7 +448,7 @@ test("npm template tarballs reuse the external template cache until integrity ch
       );
     }
 
-    if (requestUrl === tarballUrl) {
+    if (requestUrl === getTarballUrl()) {
       tarballDownloads += 1;
       return new Response(fs.readFileSync(tarballPath), { status: 200 });
     }
@@ -459,6 +461,7 @@ test("npm template tarballs reuse the external template cache until integrity ch
   try {
     const locator = parseTemplateLocator("@demo/cache-template@^1.0.0");
     const first = await resolveTemplateSeed(locator, tempRoot);
+    tarballToken = "cache-two";
     const second = await resolveTemplateSeed(locator, tempRoot);
 
     expect(tarballDownloads).toBe(1);
@@ -485,6 +488,7 @@ test("npm template tarballs reuse the external template cache until integrity ch
 
     integrity = "sha512-cache-two";
     shasum = "cache-two";
+    tarballToken = "cache-three";
 
     const third = await resolveTemplateSeed(locator, tempRoot);
     expect(tarballDownloads).toBe(2);

--- a/packages/wp-typia-project-tools/tests/template-source.test.ts
+++ b/packages/wp-typia-project-tools/tests/template-source.test.ts
@@ -587,6 +587,93 @@ test("npm template cache can be bypassed with an environment override", async ()
   }
 });
 
+test("npm template cache falls back when the cache directory is unavailable", async () => {
+  const packageName = "@demo/cache-unavailable-template";
+  const version = "1.0.0";
+  const npmTemplateRoot = fs.mkdtempSync(
+    path.join(tempRoot, "npm-cache-unavailable-template-")
+  );
+  const registryBase = "https://registry.npmjs.org";
+  const metadataUrl = `${registryBase}/${encodeURIComponent(packageName)}`;
+  const tarballUrl = `${registryBase}/@demo/cache-unavailable-template/-/cache-unavailable-template-1.0.0.tgz`;
+  const tarballPath = createMinimalNpmTemplateTarball(
+    npmTemplateRoot,
+    packageName,
+    version
+  );
+  const unavailableCachePath = path.join(npmTemplateRoot, "cache-file");
+  const originalFetch = globalThis.fetch;
+  const originalRegistry = process.env.NPM_CONFIG_REGISTRY;
+  const originalCache = process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE;
+  const originalCacheDir = process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR;
+  let tarballDownloads = 0;
+
+  fs.writeFileSync(unavailableCachePath, "not a directory", "utf8");
+  process.env.NPM_CONFIG_REGISTRY = registryBase;
+  process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR = unavailableCachePath;
+  delete process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE;
+  globalThis.fetch = (async (input) => {
+    const requestUrl =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+        ? input.href
+        : input.url;
+    if (requestUrl === metadataUrl) {
+      return new Response(
+        JSON.stringify({
+          "dist-tags": {
+            latest: version,
+          },
+          versions: {
+            [version]: {
+              dist: {
+                integrity: "sha512-cache-unavailable",
+                shasum: "cache-unavailable",
+                tarball: tarballUrl,
+              },
+            },
+          },
+        }),
+        {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+          },
+        }
+      );
+    }
+
+    if (requestUrl === tarballUrl) {
+      tarballDownloads += 1;
+      return new Response(fs.readFileSync(tarballPath), { status: 200 });
+    }
+
+    throw new Error(
+      `Unexpected fetch URL in npm template unavailable cache test: ${requestUrl}`
+    );
+  }) as typeof fetch;
+
+  try {
+    const locator = parseTemplateLocator(
+      "@demo/cache-unavailable-template@^1.0.0"
+    );
+    const first = await resolveTemplateSeed(locator, tempRoot);
+    const second = await resolveTemplateSeed(locator, tempRoot);
+
+    expect(tarballDownloads).toBe(2);
+    expect(second.rootDir).not.toBe(first.rootDir);
+
+    await first.cleanup?.();
+    await second.cleanup?.();
+  } finally {
+    globalThis.fetch = originalFetch;
+    restoreEnvValue("NPM_CONFIG_REGISTRY", originalRegistry);
+    restoreEnvValue("WP_TYPIA_EXTERNAL_TEMPLATE_CACHE", originalCache);
+    restoreEnvValue("WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR", originalCacheDir);
+  }
+});
+
 test("local official external template configs honor --variant overrides", async () => {
   const targetDir = path.join(tempRoot, "demo-external-hero");
 


### PR DESCRIPTION
## Summary
- add guarded cache storage for remote external template sources
- reuse npm template tarballs when registry integrity/shasum metadata matches and allow env bypass/directory overrides
- cache GitHub template checkouts by resolvable remote revision while preserving timeout and symlink validation
- document the cache behavior and add a Sampo changeset

## Verification
- bun run --cwd packages/wp-typia-project-tools build
- bun test packages/wp-typia-project-tools/tests/template-source.test.ts --test-name-pattern "cache|size limit|registry resolver"
- bun test packages/wp-typia-project-tools/tests/template-source.test.ts
- bun run changesets:validate
- bun run format:check
- bun run typecheck
- bun run lint:repo

Closes #584

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote external templates are cached in a private per-user local temp cache to speed repeated scaffolds; cache respects integrity/revision and includes safety guardrails.

* **Configuration**
  * Disable cache with WP_TYPIA_EXTERNAL_TEMPLATE_CACHE=0 or set WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR to override cache location (useful for CI).

* **Documentation**
  * API and CLI docs updated with caching behavior and configuration details.

* **Tests**
  * Integration tests added for cache reuse, cache-bypass, corruption and unusable-cache scenarios.

* **Chore**
  * Added changeset for the patch release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->