### PR TITLE
Align add registry, dry-run contract, and template prompting

### DIFF
--- a/.sampo/changesets/add-registry-template-prompt.md
+++ b/.sampo/changesets/add-registry-template-prompt.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: minor
+npm/wp-typia: minor
+---
+
+Unify add-kind metadata and execution behind a single registry, restore the canonical add-kind ordering, and clarify interactive block-template selection while keeping non-interactive add flows defaulted to `basic`.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-shared.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-shared.ts
@@ -718,7 +718,7 @@ export function assertEditorPluginDoesNotExist(projectDir: string, editorPluginS
 export function formatAddHelpText(): string {
 	return `Usage:
   wp-typia add admin-view <name> [--source <rest-resource:slug>] [--dry-run]
-  wp-typia add block <name> --template <${ADD_BLOCK_TEMPLATE_IDS.join("|")}> [--external-layer-source <./path|github:owner/repo/path[#ref]|npm-package>] [--external-layer-id <layer-id>] [--inner-blocks-preset <freeform|ordered|horizontal|locked-structure>] [--alternate-render-targets <email,mjml,plain-text>] [--data-storage <post-meta|custom-table>] [--persistence-policy <authenticated|public>] [--dry-run]
+  wp-typia add block <name> [--template <${ADD_BLOCK_TEMPLATE_IDS.join("|")}>] [--external-layer-source <./path|github:owner/repo/path[#ref]|npm-package>] [--external-layer-id <layer-id>] [--inner-blocks-preset <freeform|ordered|horizontal|locked-structure>] [--alternate-render-targets <email,mjml,plain-text>] [--data-storage <post-meta|custom-table>] [--persistence-policy <authenticated|public>] [--dry-run]
   wp-typia add variation <name> --block <block-slug> [--dry-run]
   wp-typia add style <name> --block <block-slug> [--dry-run]
   wp-typia add transform <name> --from <namespace/block> --to <block-slug|namespace/block-slug> [--dry-run]
@@ -733,6 +733,7 @@ export function formatAddHelpText(): string {
 Notes:
   \`wp-typia add\` runs only inside official ${WORKSPACE_TEMPLATE_PACKAGE} workspaces scaffolded via \`wp-typia create <project-dir> --template workspace\`.
   Pass \`--dry-run\` to preview the workspace files that would change without writing them.
+  In interactive terminals, \`add block\` prompts for a template when \`--template\` is omitted; non-interactive runs default to \`basic\`.
   \`add admin-view\` scaffolds an opt-in DataViews-powered WordPress admin screen under \`src/admin-views/\`; pass \`--source rest-resource:<slug>\` to reuse a list-capable REST resource.
   \`query-loop\` is a create-time scaffold family. Use \`wp-typia create <project-dir> --template query-loop\` instead of \`wp-typia add block\`.
   \`add variation\` targets an existing block slug from \`scripts/block-config.ts\`.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-shared.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-shared.ts
@@ -733,7 +733,7 @@ export function formatAddHelpText(): string {
 Notes:
   \`wp-typia add\` runs only inside official ${WORKSPACE_TEMPLATE_PACKAGE} workspaces scaffolded via \`wp-typia create <project-dir> --template workspace\`.
   Pass \`--dry-run\` to preview the workspace files that would change without writing them.
-  In interactive terminals, \`add block\` prompts for a template when \`--template\` is omitted; non-interactive runs default to \`basic\`.
+  Interactive add flows let you choose a template when \`--template\` is omitted; non-interactive runs default to \`basic\`.
   \`add admin-view\` scaffolds an opt-in DataViews-powered WordPress admin screen under \`src/admin-views/\`; pass \`--source rest-resource:<slug>\` to reuse a list-capable REST resource.
   \`query-loop\` is a create-time scaffold family. Use \`wp-typia create <project-dir> --template query-loop\` instead of \`wp-typia add block\`.
   \`add variation\` targets an existing block slug from \`scripts/block-config.ts\`.

--- a/packages/wp-typia-project-tools/src/runtime/cli-help.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-help.ts
@@ -20,7 +20,7 @@ export function formatHelpText(): string {
   wp-typia <project-dir> [create flags...]
   wp-typia init [project-dir]
   wp-typia add admin-view <name> [--source <rest-resource:slug>]
-  wp-typia add block <name> --template <basic|interactivity|persistence|compound> [--external-layer-source <./path|github:owner/repo/path[#ref]|npm-package>] [--external-layer-id <layer-id>] [--inner-blocks-preset <freeform|ordered|horizontal|locked-structure>] [--alternate-render-targets <email,mjml,plain-text>] [--data-storage <post-meta|custom-table>] [--persistence-policy <authenticated|public>]
+  wp-typia add block <name> [--template <basic|interactivity|persistence|compound>] [--external-layer-source <./path|github:owner/repo/path[#ref]|npm-package>] [--external-layer-id <layer-id>] [--inner-blocks-preset <freeform|ordered|horizontal|locked-structure>] [--alternate-render-targets <email,mjml,plain-text>] [--data-storage <post-meta|custom-table>] [--persistence-policy <authenticated|public>]
   wp-typia add variation <name> --block <block-slug>
   wp-typia add style <name> --block <block-slug>
   wp-typia add transform <name> --from <namespace/block> --to <block-slug|namespace/block-slug>
@@ -49,6 +49,7 @@ Notes:
   \`wp-typia <project-dir>\` remains a backward-compatible alias to \`create\` when \`<project-dir>\` is the only positional argument.
   \`wp-typia init\` is a preview-only retrofit planner for existing projects. It does not write files yet.
   Use \`--template workspace\` as shorthand for \`@wp-typia/create-workspace-template\`, the official empty workspace scaffold behind \`wp-typia add ...\`.
+  In interactive terminals, \`wp-typia add block <name>\` prompts for a template when \`--template\` is omitted; non-interactive runs default to \`basic\`.
   \`add admin-view\` scaffolds an opt-in DataViews-powered WordPress admin screen under \`src/admin-views/\`; pass \`--source rest-resource:<slug>\` to reuse a list-capable REST resource.
   \`query-loop\` is create-only. Use \`wp-typia create <project-dir> --template query-loop\`; \`wp-typia add block\` accepts only basic, interactivity, persistence, and compound families.
   \`add variation\` uses an existing workspace block from \`scripts/block-config.ts\`.

--- a/packages/wp-typia-project-tools/src/runtime/cli-help.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-help.ts
@@ -49,7 +49,7 @@ Notes:
   \`wp-typia <project-dir>\` remains a backward-compatible alias to \`create\` when \`<project-dir>\` is the only positional argument.
   \`wp-typia init\` is a preview-only retrofit planner for existing projects. It does not write files yet.
   Use \`--template workspace\` as shorthand for \`@wp-typia/create-workspace-template\`, the official empty workspace scaffold behind \`wp-typia add ...\`.
-  In interactive terminals, \`wp-typia add block <name>\` prompts for a template when \`--template\` is omitted; non-interactive runs default to \`basic\`.
+  Interactive add flows let you choose a template when \`--template\` is omitted; non-interactive runs default to \`basic\`.
   \`add admin-view\` scaffolds an opt-in DataViews-powered WordPress admin screen under \`src/admin-views/\`; pass \`--source rest-resource:<slug>\` to reuse a list-capable REST resource.
   \`query-loop\` is create-only. Use \`wp-typia create <project-dir> --template query-loop\`; \`wp-typia add block\` accepts only basic, interactivity, persistence, and compound families.
   \`add variation\` uses an existing workspace block from \`scripts/block-config.ts\`.

--- a/packages/wp-typia/src/add-kind-registry.ts
+++ b/packages/wp-typia/src/add-kind-registry.ts
@@ -1,18 +1,21 @@
-export const ADD_KIND_IDS = [
-  'admin-view',
-  'block',
-  'variation',
-  'style',
-  'transform',
-  'pattern',
-  'binding-source',
-  'rest-resource',
-  'ability',
-  'ai-feature',
-  'editor-plugin',
-  'hooked-block',
-] as const;
-export type AddKindId = (typeof ADD_KIND_IDS)[number];
+import {
+  CLI_DIAGNOSTIC_CODES,
+  createCliDiagnosticCodeError,
+} from '@wp-typia/project-tools/cli-diagnostics';
+import type * as CliAddRuntime from '@wp-typia/project-tools/cli-add';
+import type { ReadlinePrompt } from '@wp-typia/project-tools/cli-prompt';
+
+type PrintLine = (line: string) => void;
+type AddRuntime = typeof CliAddRuntime;
+type AddKindExecutionResultBase = {
+  projectDir: string;
+};
+type ExternalLayerSelectOption = {
+  description?: string;
+  extends: string[];
+  id: string;
+};
+
 export type AddFieldName =
   | 'kind'
   | 'name'
@@ -32,6 +35,25 @@ export type AddFieldName =
   | 'data-storage'
   | 'persistence-policy';
 
+export type AddKindExecutionContext = {
+  addRuntime: AddRuntime;
+  cwd: string;
+  flags: Record<string, unknown>;
+  getOrCreatePrompt: () => Promise<ReadlinePrompt>;
+  isInteractiveSession: boolean;
+  name?: string;
+  warnLine: PrintLine;
+};
+
+export type AddKindExecutionPlan<
+  TResult extends AddKindExecutionResultBase = AddKindExecutionResultBase,
+> = {
+  execute: (cwd: string) => Promise<TResult>;
+  getValues: (result: TResult) => Record<string, string>;
+  getWarnings?: (result: TResult) => string[] | undefined;
+  warnLine?: PrintLine;
+};
+
 type AddKindRegistryEntry = {
   completion: {
     nextSteps: (values: Record<string, string>) => string[];
@@ -44,10 +66,46 @@ type AddKindRegistryEntry = {
   description: string;
   hiddenStringSubmitFields?: readonly string[];
   nameLabel: string;
+  prepareExecution: (
+    context: AddKindExecutionContext,
+  ) => Promise<AddKindExecutionPlan<any>>;
+  supportsDryRun: boolean;
+  usage: string;
   visibleFieldNames: (options: {
     template?: string;
   }) => readonly AddFieldName[];
 };
+
+type AddAdminViewResult = Awaited<
+  ReturnType<AddRuntime['runAddAdminViewCommand']>
+>;
+type AddAbilityResult = Awaited<ReturnType<AddRuntime['runAddAbilityCommand']>>;
+type AddBindingSourceResult = Awaited<
+  ReturnType<AddRuntime['runAddBindingSourceCommand']>
+>;
+type AddBlockResult = Awaited<ReturnType<AddRuntime['runAddBlockCommand']>>;
+type AddEditorPluginResult = Awaited<
+  ReturnType<AddRuntime['runAddEditorPluginCommand']>
+>;
+type AddAiFeatureResult = Awaited<
+  ReturnType<AddRuntime['runAddAiFeatureCommand']>
+>;
+type AddHookedBlockResult = Awaited<
+  ReturnType<AddRuntime['runAddHookedBlockCommand']>
+>;
+type AddPatternResult = Awaited<ReturnType<AddRuntime['runAddPatternCommand']>>;
+type AddRestResourceResult = Awaited<
+  ReturnType<AddRuntime['runAddRestResourceCommand']>
+>;
+type AddBlockStyleResult = Awaited<
+  ReturnType<AddRuntime['runAddBlockStyleCommand']>
+>;
+type AddBlockTransformResult = Awaited<
+  ReturnType<AddRuntime['runAddBlockTransformCommand']>
+>;
+type AddVariationResult = Awaited<
+  ReturnType<AddRuntime['runAddVariationCommand']>
+>;
 
 const BLOCK_VISIBLE_FIELD_ORDER = [
   'kind',
@@ -59,11 +117,58 @@ const BLOCK_VISIBLE_FIELD_ORDER = [
   'persistence-policy',
 ] as const satisfies ReadonlyArray<AddFieldName>;
 
-export function isAddKindId(value?: string): value is AddKindId {
-  return (
-    typeof value === 'string' &&
-    (ADD_KIND_IDS as readonly string[]).includes(value)
+function readOptionalStringFlag(
+  flags: Record<string, unknown>,
+  name: string,
+): string | undefined {
+  const value = flags[name];
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw createCliDiagnosticCodeError(
+      CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
+      `\`--${name}\` requires a value.`,
+    );
+  }
+  return value;
+}
+
+function requireAddKindName(
+  context: AddKindExecutionContext,
+  message: string,
+): string {
+  if (!context.name) {
+    throw createCliDiagnosticCodeError(
+      CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
+      message,
+    );
+  }
+
+  return context.name;
+}
+
+function formatExternalLayerSelectHint(
+  option: ExternalLayerSelectOption,
+): string | undefined {
+  const details = [
+    option.description,
+    option.extends.length > 0
+      ? `extends ${option.extends.join(', ')}`
+      : undefined,
+  ].filter(
+    (value): value is string => typeof value === 'string' && value.length > 0,
   );
+
+  return details.length > 0 ? details.join(' · ') : undefined;
+}
+
+function toExternalLayerPromptOptions(options: ExternalLayerSelectOption[]) {
+  return options.map((option) => ({
+    hint: formatExternalLayerSelectHint(option),
+    label: option.id,
+    value: option.id,
+  }));
 }
 
 export function isAddPersistenceTemplate(template?: string): boolean {
@@ -86,6 +191,29 @@ export const ADD_KIND_REGISTRY = {
     },
     description: 'Add an opt-in DataViews-powered admin screen',
     nameLabel: 'Admin view name',
+    async prepareExecution(context) {
+      const name = requireAddKindName(
+        context,
+        '`wp-typia add admin-view` requires <name>. Usage: wp-typia add admin-view <name> [--source <rest-resource:slug>].',
+      );
+      const source = readOptionalStringFlag(context.flags, 'source');
+
+      return {
+        execute: (cwd) =>
+          context.addRuntime.runAddAdminViewCommand({
+            adminViewName: name,
+            cwd,
+            source,
+          }),
+        getValues: (result: AddAdminViewResult) => ({
+          adminViewSlug: result.adminViewSlug,
+          ...(result.source ? { source: result.source } : {}),
+        }),
+      };
+    },
+    supportsDryRun: true,
+    usage:
+      'wp-typia add admin-view <name> [--source <rest-resource:slug>] [--dry-run]',
     visibleFieldNames: () => ['kind', 'name', 'source'],
   },
   'binding-source': {
@@ -110,6 +238,40 @@ export const ADD_KIND_REGISTRY = {
     },
     description: 'Add a shared block bindings source',
     nameLabel: 'Binding source name',
+    async prepareExecution(context) {
+      const name = requireAddKindName(
+        context,
+        '`wp-typia add binding-source` requires <name>. Usage: wp-typia add binding-source <name> [--block <block-slug|namespace/block-slug> --attribute <attribute>].',
+      );
+      const blockName = readOptionalStringFlag(context.flags, 'block');
+      const attributeName = readOptionalStringFlag(context.flags, 'attribute');
+      if (Boolean(blockName) !== Boolean(attributeName)) {
+        throw createCliDiagnosticCodeError(
+          CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
+          '`wp-typia add binding-source` requires --block and --attribute to be provided together.',
+        );
+      }
+
+      return {
+        execute: (cwd) =>
+          context.addRuntime.runAddBindingSourceCommand({
+            attributeName,
+            bindingSourceName: name,
+            blockName,
+            cwd,
+          }),
+        getValues: (result: AddBindingSourceResult) => ({
+          ...(result.attributeName
+            ? { attributeName: result.attributeName }
+            : {}),
+          ...(result.blockSlug ? { blockSlug: result.blockSlug } : {}),
+          bindingSourceSlug: result.bindingSourceSlug,
+        }),
+      };
+    },
+    supportsDryRun: true,
+    usage:
+      'wp-typia add binding-source <name> [--block <block-slug|namespace/block-slug> --attribute <attribute>] [--dry-run]',
     visibleFieldNames: () => ['kind', 'name', 'block', 'attribute'],
   },
   block: {
@@ -128,6 +290,92 @@ export const ADD_KIND_REGISTRY = {
     description: 'Add a real block slice',
     hiddenStringSubmitFields: ['external-layer-id', 'external-layer-source'],
     nameLabel: 'Block name',
+    async prepareExecution(context) {
+      const name = requireAddKindName(
+        context,
+        '`wp-typia add block` requires <name>. Usage: wp-typia add block <name> [--template <basic|interactivity|persistence|compound>]',
+      );
+      const externalLayerId = readOptionalStringFlag(
+        context.flags,
+        'external-layer-id',
+      );
+      const externalLayerSource = readOptionalStringFlag(
+        context.flags,
+        'external-layer-source',
+      );
+      const shouldPromptForLayerSelection =
+        Boolean(externalLayerSource) &&
+        !Boolean(externalLayerId) &&
+        context.isInteractiveSession;
+      const selectPrompt = shouldPromptForLayerSelection
+        ? await context.getOrCreatePrompt()
+        : undefined;
+      const alternateRenderTargets = readOptionalStringFlag(
+        context.flags,
+        'alternate-render-targets',
+      );
+      const dataStorageMode = readOptionalStringFlag(
+        context.flags,
+        'data-storage',
+      );
+      const innerBlocksPreset = readOptionalStringFlag(
+        context.flags,
+        'inner-blocks-preset',
+      );
+      const persistencePolicy = readOptionalStringFlag(
+        context.flags,
+        'persistence-policy',
+      );
+      let resolvedTemplateId = readOptionalStringFlag(
+        context.flags,
+        'template',
+      ) as CliAddRuntime.AddBlockTemplateId | undefined;
+      if (!resolvedTemplateId && context.isInteractiveSession) {
+        const templatePrompt = await context.getOrCreatePrompt();
+        resolvedTemplateId = await templatePrompt.select(
+          'Select a block template',
+          context.addRuntime.ADD_BLOCK_TEMPLATE_IDS.map((templateId) => ({
+            hint: `Scaffold the ${templateId} block family`,
+            label: templateId,
+            value: templateId,
+          })),
+          1,
+        );
+      }
+      resolvedTemplateId ??= 'basic';
+
+      return {
+        execute: (cwd) =>
+          context.addRuntime.runAddBlockCommand({
+            alternateRenderTargets,
+            blockName: name,
+            cwd,
+            dataStorageMode,
+            externalLayerId,
+            externalLayerSource,
+            innerBlocksPreset,
+            persistencePolicy,
+            selectExternalLayerId: selectPrompt
+              ? (options) =>
+                  selectPrompt.select(
+                    'Select an external layer',
+                    toExternalLayerPromptOptions(options),
+                    1,
+                  )
+              : undefined,
+            templateId: resolvedTemplateId,
+          }),
+        getValues: (result: AddBlockResult) => ({
+          blockSlugs: result.blockSlugs.join(', '),
+          templateId: result.templateId,
+        }),
+        getWarnings: (result: AddBlockResult) => result.warnings,
+        warnLine: context.warnLine,
+      };
+    },
+    supportsDryRun: true,
+    usage:
+      'wp-typia add block <name> [--template <basic|interactivity|persistence|compound>] [--external-layer-source <./path|github:owner/repo/path[#ref]|npm-package>] [--external-layer-id <layer-id>] [--inner-blocks-preset <freeform|ordered|horizontal|locked-structure>] [--alternate-render-targets <email,mjml,plain-text>] [--data-storage <post-meta|custom-table>] [--persistence-policy <authenticated|public>] [--dry-run]',
     visibleFieldNames: ({ template }) =>
       BLOCK_VISIBLE_FIELD_ORDER.filter((fieldName) => {
         if (fieldName === 'alternate-render-targets') {
@@ -159,6 +407,25 @@ export const ADD_KIND_REGISTRY = {
     },
     description: 'Add a typed server/client workflow ability scaffold',
     nameLabel: 'Ability name',
+    async prepareExecution(context) {
+      const name = requireAddKindName(
+        context,
+        '`wp-typia add ability` requires <name>. Usage: wp-typia add ability <name>.',
+      );
+
+      return {
+        execute: (cwd) =>
+          context.addRuntime.runAddAbilityCommand({
+            abilityName: name,
+            cwd,
+          }),
+        getValues: (result: AddAbilityResult) => ({
+          abilitySlug: result.abilitySlug,
+        }),
+      };
+    },
+    supportsDryRun: true,
+    usage: 'wp-typia add ability <name> [--dry-run]',
     visibleFieldNames: () => ['kind', 'name'],
   },
   'editor-plugin': {
@@ -176,6 +443,29 @@ export const ADD_KIND_REGISTRY = {
     },
     description: 'Add a slot-aware document editor extension shell',
     nameLabel: 'Editor plugin name',
+    async prepareExecution(context) {
+      const name = requireAddKindName(
+        context,
+        '`wp-typia add editor-plugin` requires <name>. Usage: wp-typia add editor-plugin <name> [--slot <sidebar|document-setting-panel>].',
+      );
+      const slot = readOptionalStringFlag(context.flags, 'slot');
+
+      return {
+        execute: (cwd) =>
+          context.addRuntime.runAddEditorPluginCommand({
+            cwd,
+            editorPluginName: name,
+            slot,
+          }),
+        getValues: (result: AddEditorPluginResult) => ({
+          editorPluginSlug: result.editorPluginSlug,
+          slot: result.slot,
+        }),
+      };
+    },
+    supportsDryRun: true,
+    usage:
+      'wp-typia add editor-plugin <name> [--slot <sidebar|document-setting-panel>] [--dry-run]',
     visibleFieldNames: () => ['kind', 'name', 'slot'],
   },
   'hooked-block': {
@@ -194,6 +484,44 @@ export const ADD_KIND_REGISTRY = {
     },
     description: 'Add block.json hook metadata to an existing block',
     nameLabel: 'Target block',
+    async prepareExecution(context) {
+      const name = requireAddKindName(
+        context,
+        '`wp-typia add hooked-block` requires <block-slug>. Usage: wp-typia add hooked-block <block-slug> --anchor <anchor-block-name> --position <before|after|firstChild|lastChild>.',
+      );
+      const anchorBlockName = readOptionalStringFlag(context.flags, 'anchor');
+      if (!anchorBlockName) {
+        throw createCliDiagnosticCodeError(
+          CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
+          '`wp-typia add hooked-block` requires --anchor <anchor-block-name>.',
+        );
+      }
+      const position = readOptionalStringFlag(context.flags, 'position');
+      if (!position) {
+        throw createCliDiagnosticCodeError(
+          CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
+          '`wp-typia add hooked-block` requires --position <before|after|firstChild|lastChild>.',
+        );
+      }
+
+      return {
+        execute: (cwd) =>
+          context.addRuntime.runAddHookedBlockCommand({
+            anchorBlockName,
+            blockName: name,
+            cwd,
+            position,
+          }),
+        getValues: (result: AddHookedBlockResult) => ({
+          anchorBlockName: result.anchorBlockName,
+          blockSlug: result.blockSlug,
+          position: result.position,
+        }),
+      };
+    },
+    supportsDryRun: true,
+    usage:
+      'wp-typia add hooked-block <block-slug> --anchor <anchor-block-name> --position <before|after|firstChild|lastChild> [--dry-run]',
     visibleFieldNames: () => ['kind', 'name', 'anchor', 'position'],
   },
   pattern: {
@@ -210,6 +538,25 @@ export const ADD_KIND_REGISTRY = {
     },
     description: 'Add a PHP block pattern shell',
     nameLabel: 'Pattern name',
+    async prepareExecution(context) {
+      const name = requireAddKindName(
+        context,
+        '`wp-typia add pattern` requires <name>. Usage: wp-typia add pattern <name>.',
+      );
+
+      return {
+        execute: (cwd) =>
+          context.addRuntime.runAddPatternCommand({
+            cwd,
+            patternName: name,
+          }),
+        getValues: (result: AddPatternResult) => ({
+          patternSlug: result.patternSlug,
+        }),
+      };
+    },
+    supportsDryRun: true,
+    usage: 'wp-typia add pattern <name> [--dry-run]',
     visibleFieldNames: () => ['kind', 'name'],
   },
   style: {
@@ -227,6 +574,34 @@ export const ADD_KIND_REGISTRY = {
     },
     description: 'Add a Block Styles registration to an existing block',
     nameLabel: 'Style name',
+    async prepareExecution(context) {
+      const name = requireAddKindName(
+        context,
+        '`wp-typia add style` requires <name>. Usage: wp-typia add style <name> --block <block-slug>.',
+      );
+      const blockSlug = readOptionalStringFlag(context.flags, 'block');
+      if (!blockSlug) {
+        throw createCliDiagnosticCodeError(
+          CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
+          '`wp-typia add style` requires --block <block-slug>.',
+        );
+      }
+
+      return {
+        execute: (cwd) =>
+          context.addRuntime.runAddBlockStyleCommand({
+            blockName: blockSlug,
+            cwd,
+            styleName: name,
+          }),
+        getValues: (result: AddBlockStyleResult) => ({
+          blockSlug: result.blockSlug,
+          styleSlug: result.styleSlug,
+        }),
+      };
+    },
+    supportsDryRun: true,
+    usage: 'wp-typia add style <name> --block <block-slug> [--dry-run]',
     visibleFieldNames: () => ['kind', 'name', 'block'],
   },
   transform: {
@@ -245,6 +620,45 @@ export const ADD_KIND_REGISTRY = {
     },
     description: 'Add a block-to-block transform into a workspace block',
     nameLabel: 'Transform name',
+    async prepareExecution(context) {
+      const name = requireAddKindName(
+        context,
+        '`wp-typia add transform` requires <name>. Usage: wp-typia add transform <name> --from <namespace/block> --to <block-slug|namespace/block-slug>.',
+      );
+      const fromBlockName = readOptionalStringFlag(context.flags, 'from');
+      if (!fromBlockName) {
+        throw createCliDiagnosticCodeError(
+          CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
+          '`wp-typia add transform` requires --from <namespace/block>.',
+        );
+      }
+      const toBlockName = readOptionalStringFlag(context.flags, 'to');
+      if (!toBlockName) {
+        throw createCliDiagnosticCodeError(
+          CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
+          '`wp-typia add transform` requires --to <block-slug|namespace/block-slug>.',
+        );
+      }
+
+      return {
+        execute: (cwd) =>
+          context.addRuntime.runAddBlockTransformCommand({
+            cwd,
+            fromBlockName,
+            toBlockName,
+            transformName: name,
+          }),
+        getValues: (result: AddBlockTransformResult) => ({
+          blockSlug: result.blockSlug,
+          fromBlockName: result.fromBlockName,
+          toBlockName: result.toBlockName,
+          transformSlug: result.transformSlug,
+        }),
+      };
+    },
+    supportsDryRun: true,
+    usage:
+      'wp-typia add transform <name> --from <namespace/block> --to <block-slug|namespace/block-slug> [--dry-run]',
     visibleFieldNames: () => ['kind', 'name', 'from', 'to'],
   },
   'rest-resource': {
@@ -263,6 +677,32 @@ export const ADD_KIND_REGISTRY = {
     },
     description: 'Add a plugin-level typed REST resource',
     nameLabel: 'REST resource name',
+    async prepareExecution(context) {
+      const name = requireAddKindName(
+        context,
+        '`wp-typia add rest-resource` requires <name>. Usage: wp-typia add rest-resource <name> [--namespace <vendor/v1>] [--methods <list,read,create>].',
+      );
+      const methods = readOptionalStringFlag(context.flags, 'methods');
+      const namespace = readOptionalStringFlag(context.flags, 'namespace');
+
+      return {
+        execute: (cwd) =>
+          context.addRuntime.runAddRestResourceCommand({
+            cwd,
+            methods,
+            namespace,
+            restResourceName: name,
+          }),
+        getValues: (result: AddRestResourceResult) => ({
+          methods: result.methods.join(', '),
+          namespace: result.namespace,
+          restResourceSlug: result.restResourceSlug,
+        }),
+      };
+    },
+    supportsDryRun: true,
+    usage:
+      'wp-typia add rest-resource <name> [--namespace <vendor/v1>] [--methods <list,read,create,update,delete>] [--dry-run]',
     visibleFieldNames: () => ['kind', 'name', 'namespace', 'methods'],
   },
   'ai-feature': {
@@ -280,6 +720,31 @@ export const ADD_KIND_REGISTRY = {
     },
     description: 'Add a server-owned WordPress AI feature endpoint',
     nameLabel: 'AI feature name',
+    async prepareExecution(context) {
+      const name = requireAddKindName(
+        context,
+        '`wp-typia add ai-feature` requires <name>. Usage: wp-typia add ai-feature <name> [--namespace <vendor/v1>].',
+      );
+      const namespace = readOptionalStringFlag(context.flags, 'namespace');
+
+      return {
+        execute: (cwd) =>
+          context.addRuntime.runAddAiFeatureCommand({
+            aiFeatureName: name,
+            cwd,
+            namespace,
+          }),
+        getValues: (result: AddAiFeatureResult) => ({
+          aiFeatureSlug: result.aiFeatureSlug,
+          namespace: result.namespace,
+        }),
+        getWarnings: (result: AddAiFeatureResult) => result.warnings,
+        warnLine: context.warnLine,
+      };
+    },
+    supportsDryRun: true,
+    usage:
+      'wp-typia add ai-feature <name> [--namespace <vendor/v1>] [--dry-run]',
     visibleFieldNames: () => ['kind', 'name', 'namespace'],
   },
   variation: {
@@ -297,9 +762,54 @@ export const ADD_KIND_REGISTRY = {
     },
     description: 'Add a variation to an existing block',
     nameLabel: 'Variation name',
+    async prepareExecution(context) {
+      const name = requireAddKindName(
+        context,
+        '`wp-typia add variation` requires <name>. Usage: wp-typia add variation <name> --block <block-slug>',
+      );
+      const blockSlug = readOptionalStringFlag(context.flags, 'block');
+      if (!blockSlug) {
+        throw createCliDiagnosticCodeError(
+          CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
+          '`wp-typia add variation` requires --block <block-slug>.',
+        );
+      }
+
+      return {
+        execute: (cwd) =>
+          context.addRuntime.runAddVariationCommand({
+            blockName: blockSlug,
+            cwd,
+            variationName: name,
+          }),
+        getValues: (result: AddVariationResult) => ({
+          blockSlug: result.blockSlug,
+          variationSlug: result.variationSlug,
+        }),
+      };
+    },
+    supportsDryRun: true,
+    usage: 'wp-typia add variation <name> --block <block-slug> [--dry-run]',
     visibleFieldNames: () => ['kind', 'name', 'block'],
   },
-} as const satisfies Record<AddKindId, AddKindRegistryEntry>;
+} as const satisfies Record<CliAddRuntime.AddKindId, AddKindRegistryEntry>;
+
+export type AddKindId = keyof typeof ADD_KIND_REGISTRY;
+export const ADD_KIND_IDS = Object.keys(ADD_KIND_REGISTRY) as AddKindId[];
+
+export function isAddKindId(value?: string): value is AddKindId {
+  return (
+    typeof value === 'string' &&
+    (ADD_KIND_IDS as readonly string[]).includes(value)
+  );
+}
+
+export async function getAddKindExecutionPlan(
+  kind: AddKindId,
+  context: AddKindExecutionContext,
+) {
+  return ADD_KIND_REGISTRY[kind].prepareExecution(context);
+}
 
 export function buildAddKindCompletionDetails(
   kind: AddKindId,
@@ -325,10 +835,22 @@ export function formatAddKindUsagePlaceholder(): string {
   return `<${ADD_KIND_IDS.join('|')}>`;
 }
 
+export function getAddKindUsage(kind: AddKindId): string {
+  return ADD_KIND_REGISTRY[kind].usage;
+}
+
+export function supportsAddKindDryRun(kind: AddKindId): boolean {
+  return ADD_KIND_REGISTRY[kind].supportsDryRun;
+}
+
 export function getAddHiddenStringSubmitFieldNames(kind?: string): string[] {
   const resolvedKind = isAddKindId(kind) ? kind : 'block';
-  const entry: AddKindRegistryEntry = ADD_KIND_REGISTRY[resolvedKind];
-  return [...(entry.hiddenStringSubmitFields ?? [])];
+  const entry = ADD_KIND_REGISTRY[resolvedKind];
+  const hiddenStringSubmitFields =
+    'hiddenStringSubmitFields' in entry
+      ? entry.hiddenStringSubmitFields
+      : undefined;
+  return [...(hiddenStringSubmitFields ?? [])];
 }
 
 export function getAddKindOptions() {

--- a/packages/wp-typia/src/add-kind-registry.ts
+++ b/packages/wp-typia/src/add-kind-registry.ts
@@ -54,7 +54,9 @@ export type AddKindExecutionPlan<
   warnLine?: PrintLine;
 };
 
-type AddKindRegistryEntry = {
+type AddKindRegistryEntry<
+  TResult extends AddKindExecutionResultBase = AddKindExecutionResultBase,
+> = {
   completion: {
     nextSteps: (values: Record<string, string>) => string[];
     summaryLines: (
@@ -68,7 +70,8 @@ type AddKindRegistryEntry = {
   nameLabel: string;
   prepareExecution: (
     context: AddKindExecutionContext,
-  ) => Promise<AddKindExecutionPlan<any>>;
+  ) => Promise<AddKindExecutionPlan<TResult>>;
+  sortOrder: number;
   supportsDryRun: boolean;
   usage: string;
   visibleFieldNames: (options: {
@@ -171,12 +174,18 @@ function toExternalLayerPromptOptions(options: ExternalLayerSelectOption[]) {
   }));
 }
 
+function defineAddKindRegistryEntry<
+  TResult extends AddKindExecutionResultBase,
+>(entry: AddKindRegistryEntry<TResult>) {
+  return entry;
+}
+
 export function isAddPersistenceTemplate(template?: string): boolean {
   return template === 'persistence' || template === 'compound';
 }
 
 export const ADD_KIND_REGISTRY = {
-  'admin-view': {
+  'admin-view': defineAddKindRegistryEntry<AddAdminViewResult>({
     completion: {
       nextSteps: (values) => [
         `Review src/admin-views/${values.adminViewSlug}/ and inc/admin-views/${values.adminViewSlug}.php.`,
@@ -211,12 +220,13 @@ export const ADD_KIND_REGISTRY = {
         }),
       };
     },
+    sortOrder: 10,
     supportsDryRun: true,
     usage:
       'wp-typia add admin-view <name> [--source <rest-resource:slug>] [--dry-run]',
     visibleFieldNames: () => ['kind', 'name', 'source'],
-  },
-  'binding-source': {
+  }),
+  'binding-source': defineAddKindRegistryEntry<AddBindingSourceResult>({
     completion: {
       nextSteps: (values) => [
         `Review src/bindings/${values.bindingSourceSlug}/server.php and src/bindings/${values.bindingSourceSlug}/editor.ts.`,
@@ -269,12 +279,13 @@ export const ADD_KIND_REGISTRY = {
         }),
       };
     },
+    sortOrder: 70,
     supportsDryRun: true,
     usage:
       'wp-typia add binding-source <name> [--block <block-slug|namespace/block-slug> --attribute <attribute>] [--dry-run]',
     visibleFieldNames: () => ['kind', 'name', 'block', 'attribute'],
-  },
-  block: {
+  }),
+  block: defineAddKindRegistryEntry<AddBlockResult>({
     completion: {
       nextSteps: () => [
         'Review the generated sources under src/blocks/ and the updated scripts/block-config.ts entry.',
@@ -373,6 +384,7 @@ export const ADD_KIND_REGISTRY = {
         warnLine: context.warnLine,
       };
     },
+    sortOrder: 20,
     supportsDryRun: true,
     usage:
       'wp-typia add block <name> [--template <basic|interactivity|persistence|compound>] [--external-layer-source <./path|github:owner/repo/path[#ref]|npm-package>] [--external-layer-id <layer-id>] [--inner-blocks-preset <freeform|ordered|horizontal|locked-structure>] [--alternate-render-targets <email,mjml,plain-text>] [--data-storage <post-meta|custom-table>] [--persistence-policy <authenticated|public>] [--dry-run]',
@@ -392,8 +404,8 @@ export const ADD_KIND_REGISTRY = {
         }
         return true;
       }),
-  },
-  ability: {
+  }),
+  ability: defineAddKindRegistryEntry<AddAbilityResult>({
     completion: {
       nextSteps: (values) => [
         `Review src/abilities/${values.abilitySlug}/ and inc/abilities/${values.abilitySlug}.php.`,
@@ -424,11 +436,12 @@ export const ADD_KIND_REGISTRY = {
         }),
       };
     },
+    sortOrder: 90,
     supportsDryRun: true,
     usage: 'wp-typia add ability <name> [--dry-run]',
     visibleFieldNames: () => ['kind', 'name'],
-  },
-  'editor-plugin': {
+  }),
+  'editor-plugin': defineAddKindRegistryEntry<AddEditorPluginResult>({
     completion: {
       nextSteps: (values) => [
         `Review src/editor-plugins/${values.editorPluginSlug}/.`,
@@ -463,12 +476,13 @@ export const ADD_KIND_REGISTRY = {
         }),
       };
     },
+    sortOrder: 120,
     supportsDryRun: true,
     usage:
       'wp-typia add editor-plugin <name> [--slot <sidebar|document-setting-panel>] [--dry-run]',
     visibleFieldNames: () => ['kind', 'name', 'slot'],
-  },
-  'hooked-block': {
+  }),
+  'hooked-block': defineAddKindRegistryEntry<AddHookedBlockResult>({
     completion: {
       nextSteps: (values) => [
         `Review src/blocks/${values.blockSlug}/block.json for the new blockHooks entry.`,
@@ -519,12 +533,13 @@ export const ADD_KIND_REGISTRY = {
         }),
       };
     },
+    sortOrder: 110,
     supportsDryRun: true,
     usage:
       'wp-typia add hooked-block <block-slug> --anchor <anchor-block-name> --position <before|after|firstChild|lastChild> [--dry-run]',
     visibleFieldNames: () => ['kind', 'name', 'anchor', 'position'],
-  },
-  pattern: {
+  }),
+  pattern: defineAddKindRegistryEntry<AddPatternResult>({
     completion: {
       nextSteps: (values) => [
         `Review src/patterns/${values.patternSlug}.php.`,
@@ -555,11 +570,12 @@ export const ADD_KIND_REGISTRY = {
         }),
       };
     },
+    sortOrder: 60,
     supportsDryRun: true,
     usage: 'wp-typia add pattern <name> [--dry-run]',
     visibleFieldNames: () => ['kind', 'name'],
-  },
-  style: {
+  }),
+  style: defineAddKindRegistryEntry<AddBlockStyleResult>({
     completion: {
       nextSteps: (values) => [
         `Review src/blocks/${values.blockSlug}/styles/${values.styleSlug}.ts.`,
@@ -600,11 +616,12 @@ export const ADD_KIND_REGISTRY = {
         }),
       };
     },
+    sortOrder: 40,
     supportsDryRun: true,
     usage: 'wp-typia add style <name> --block <block-slug> [--dry-run]',
     visibleFieldNames: () => ['kind', 'name', 'block'],
-  },
-  transform: {
+  }),
+  transform: defineAddKindRegistryEntry<AddBlockTransformResult>({
     completion: {
       nextSteps: (values) => [
         `Review src/blocks/${values.blockSlug}/transforms/${values.transformSlug}.ts.`,
@@ -656,12 +673,13 @@ export const ADD_KIND_REGISTRY = {
         }),
       };
     },
+    sortOrder: 50,
     supportsDryRun: true,
     usage:
       'wp-typia add transform <name> --from <namespace/block> --to <block-slug|namespace/block-slug> [--dry-run]',
     visibleFieldNames: () => ['kind', 'name', 'from', 'to'],
-  },
-  'rest-resource': {
+  }),
+  'rest-resource': defineAddKindRegistryEntry<AddRestResourceResult>({
     completion: {
       nextSteps: (values) => [
         `Review src/rest/${values.restResourceSlug}/ and inc/rest/${values.restResourceSlug}.php.`,
@@ -700,12 +718,13 @@ export const ADD_KIND_REGISTRY = {
         }),
       };
     },
+    sortOrder: 80,
     supportsDryRun: true,
     usage:
       'wp-typia add rest-resource <name> [--namespace <vendor/v1>] [--methods <list,read,create,update,delete>] [--dry-run]',
     visibleFieldNames: () => ['kind', 'name', 'namespace', 'methods'],
-  },
-  'ai-feature': {
+  }),
+  'ai-feature': defineAddKindRegistryEntry<AddAiFeatureResult>({
     completion: {
       nextSteps: (values) => [
         `Review src/ai-features/${values.aiFeatureSlug}/ and inc/ai-features/${values.aiFeatureSlug}.php.`,
@@ -742,12 +761,13 @@ export const ADD_KIND_REGISTRY = {
         warnLine: context.warnLine,
       };
     },
+    sortOrder: 100,
     supportsDryRun: true,
     usage:
       'wp-typia add ai-feature <name> [--namespace <vendor/v1>] [--dry-run]',
     visibleFieldNames: () => ['kind', 'name', 'namespace'],
-  },
-  variation: {
+  }),
+  variation: defineAddKindRegistryEntry<AddVariationResult>({
     completion: {
       nextSteps: (values) => [
         `Review src/blocks/${values.blockSlug}/variations/${values.variationSlug}.ts.`,
@@ -788,14 +808,21 @@ export const ADD_KIND_REGISTRY = {
         }),
       };
     },
+    sortOrder: 30,
     supportsDryRun: true,
     usage: 'wp-typia add variation <name> --block <block-slug> [--dry-run]',
     visibleFieldNames: () => ['kind', 'name', 'block'],
-  },
-} as const satisfies Record<CliAddRuntime.AddKindId, AddKindRegistryEntry>;
+  }),
+} as const satisfies Record<CliAddRuntime.AddKindId, AddKindRegistryEntry<any>>;
 
 export type AddKindId = keyof typeof ADD_KIND_REGISTRY;
-export const ADD_KIND_IDS = Object.keys(ADD_KIND_REGISTRY) as AddKindId[];
+export type AddKindExecutionPlanFor<TKey extends AddKindId> = Awaited<
+  ReturnType<(typeof ADD_KIND_REGISTRY)[TKey]['prepareExecution']>
+>;
+export const ADD_KIND_IDS = (Object.keys(ADD_KIND_REGISTRY) as AddKindId[]).sort(
+  (left, right) =>
+    ADD_KIND_REGISTRY[left].sortOrder - ADD_KIND_REGISTRY[right].sortOrder,
+);
 
 export function isAddKindId(value?: string): value is AddKindId {
   return (
@@ -804,11 +831,12 @@ export function isAddKindId(value?: string): value is AddKindId {
   );
 }
 
-export async function getAddKindExecutionPlan(
-  kind: AddKindId,
+export async function getAddKindExecutionPlan<TKey extends AddKindId>(
+  kind: TKey,
   context: AddKindExecutionContext,
-) {
-  return ADD_KIND_REGISTRY[kind].prepareExecution(context);
+): Promise<AddKindExecutionPlanFor<TKey>> {
+  return ADD_KIND_REGISTRY[kind]
+    .prepareExecution(context) as Promise<AddKindExecutionPlanFor<TKey>>;
 }
 
 export function buildAddKindCompletionDetails(

--- a/packages/wp-typia/src/command-option-metadata.ts
+++ b/packages/wp-typia/src/command-option-metadata.ts
@@ -211,7 +211,7 @@ export const ADD_OPTION_METADATA = {
   },
   template: {
     description:
-      'Optional built-in block family for the new block; interactive terminals prompt when omitted and non-interactive runs default to basic.',
+      'Optional built-in block family for the new block; interactive flows let you choose it when omitted and non-interactive runs default to basic.',
     type: 'string',
   },
   to: {

--- a/packages/wp-typia/src/command-option-metadata.ts
+++ b/packages/wp-typia/src/command-option-metadata.ts
@@ -210,7 +210,8 @@ export const ADD_OPTION_METADATA = {
     type: 'string',
   },
   template: {
-    description: 'Built-in block family for the new block.',
+    description:
+      'Optional built-in block family for the new block; interactive terminals prompt when omitted and non-interactive runs default to basic.',
     type: 'string',
   },
   to: {

--- a/packages/wp-typia/src/runtime-bridge.ts
+++ b/packages/wp-typia/src/runtime-bridge.ts
@@ -4,9 +4,12 @@ import {
   createCliDiagnosticCodeError,
 } from '@wp-typia/project-tools/cli-diagnostics';
 import {
+  type AddKindExecutionPlan,
+  type AddKindExecutionContext,
   type AddKindId,
   formatAddKindList,
   formatAddKindUsagePlaceholder,
+  getAddKindExecutionPlan,
   isAddKindId,
 } from './add-kind-registry';
 import { simulateWorkspaceAddDryRun } from './runtime-bridge-add-dry-run';
@@ -101,57 +104,6 @@ const loadWorkspaceProjectRuntime = () =>
 const loadMigrationsRuntime = () =>
   import('@wp-typia/project-tools/migrations');
 
-type AddRuntime = Awaited<ReturnType<typeof loadCliAddRuntime>>;
-type AddAdminViewResult = Awaited<
-  ReturnType<AddRuntime['runAddAdminViewCommand']>
->;
-type AddAbilityResult = Awaited<ReturnType<AddRuntime['runAddAbilityCommand']>>;
-type AddBindingSourceResult = Awaited<
-  ReturnType<AddRuntime['runAddBindingSourceCommand']>
->;
-type AddBlockResult = Awaited<ReturnType<AddRuntime['runAddBlockCommand']>>;
-type AddEditorPluginResult = Awaited<
-  ReturnType<AddRuntime['runAddEditorPluginCommand']>
->;
-type AddAiFeatureResult = Awaited<
-  ReturnType<AddRuntime['runAddAiFeatureCommand']>
->;
-type AddHookedBlockResult = Awaited<
-  ReturnType<AddRuntime['runAddHookedBlockCommand']>
->;
-type AddPatternResult = Awaited<ReturnType<AddRuntime['runAddPatternCommand']>>;
-type AddRestResourceResult = Awaited<
-  ReturnType<AddRuntime['runAddRestResourceCommand']>
->;
-type AddBlockStyleResult = Awaited<
-  ReturnType<AddRuntime['runAddBlockStyleCommand']>
->;
-type AddBlockTransformResult = Awaited<
-  ReturnType<AddRuntime['runAddBlockTransformCommand']>
->;
-type AddVariationResult = Awaited<
-  ReturnType<AddRuntime['runAddVariationCommand']>
->;
-type RegisteredAddKindPlan<TResult> = {
-  buildCompletion: (
-    result: TResult,
-  ) => ReturnType<typeof buildAddCompletionPayload>;
-  execute: (cwd: string) => Promise<TResult>;
-  warnLine?: PrintLine;
-};
-type AddKindHandlerContext = {
-  addRuntime: AddRuntime;
-  cwd: string;
-  dryRun: boolean;
-  emitOutput: boolean | undefined;
-  flags: Record<string, unknown>;
-  getOrCreatePrompt: () => Promise<ReadlinePrompt>;
-  isInteractiveSession: boolean;
-  name?: string;
-  printLine: PrintLine;
-  warnLine: PrintLine;
-};
-
 async function wrapCliCommandError(command: CliCommandId, error: unknown) {
   const { createCliCommandError } = await loadCliDiagnosticsRuntime();
   return createCliCommandError({ command, error });
@@ -170,23 +122,6 @@ function shouldWrapCliCommandError(options: {
   }
 
   return true;
-}
-
-function readOptionalStringFlag(
-  flags: Record<string, unknown>,
-  name: string,
-): string | undefined {
-  const value = flags[name];
-  if (value === undefined || value === null) {
-    return undefined;
-  }
-  if (typeof value !== 'string' || value.trim().length === 0) {
-    throw createCliDiagnosticCodeError(
-      CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
-      `\`--${name}\` requires a value.`,
-    );
-  }
-  return value;
 }
 
 function readOptionalLooseStringFlag(
@@ -217,456 +152,6 @@ function pushFlag(argv: string[], name: string, value: unknown): void {
   }
   argv.push(`--${name}`, String(value));
 }
-
-function requireAddKindName(
-  context: AddKindHandlerContext,
-  message: string,
-): string {
-  if (!context.name) {
-    throw createCliDiagnosticCodeError(
-      CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
-      message,
-    );
-  }
-
-  return context.name;
-}
-
-function runRegisteredAddKind<TResult>(
-  context: AddKindHandlerContext,
-  plan: RegisteredAddKindPlan<TResult>,
-): Promise<AlternateBufferCompletionPayload | void> {
-  return executeWorkspaceAddWithOptionalDryRun({
-    buildCompletion: plan.buildCompletion,
-    cwd: context.cwd,
-    dryRun: context.dryRun,
-    emitOutput: context.emitOutput,
-    execute: plan.execute,
-    printLine: context.printLine,
-    warnLine: plan.warnLine,
-  });
-}
-
-const ADD_KIND_EXECUTION_REGISTRY: Record<
-  AddKindId,
-  (
-    context: AddKindHandlerContext,
-  ) => Promise<AlternateBufferCompletionPayload | void>
-> = {
-  'admin-view': async (context) => {
-    const name = requireAddKindName(
-      context,
-      '`wp-typia add admin-view` requires <name>. Usage: wp-typia add admin-view <name> [--source <rest-resource:slug>].',
-    );
-    const source = readOptionalStringFlag(context.flags, 'source');
-
-    return runRegisteredAddKind<AddAdminViewResult>(context, {
-      buildCompletion: (result) =>
-        buildAddCompletionPayload({
-          kind: 'admin-view',
-          projectDir: result.projectDir,
-          values: {
-            adminViewSlug: result.adminViewSlug,
-            ...(result.source ? { source: result.source } : {}),
-          },
-        }),
-      execute: (targetCwd) =>
-        context.addRuntime.runAddAdminViewCommand({
-          adminViewName: name,
-          cwd: targetCwd,
-          source,
-        }),
-    });
-  },
-  ability: async (context) => {
-    const name = requireAddKindName(
-      context,
-      '`wp-typia add ability` requires <name>. Usage: wp-typia add ability <name>.',
-    );
-
-    return runRegisteredAddKind<AddAbilityResult>(context, {
-      buildCompletion: (result) =>
-        buildAddCompletionPayload({
-          kind: 'ability',
-          projectDir: result.projectDir,
-          values: {
-            abilitySlug: result.abilitySlug,
-          },
-        }),
-      execute: (targetCwd) =>
-        context.addRuntime.runAddAbilityCommand({
-          abilityName: name,
-          cwd: targetCwd,
-        }),
-    });
-  },
-  'binding-source': async (context) => {
-    const name = requireAddKindName(
-      context,
-      '`wp-typia add binding-source` requires <name>. Usage: wp-typia add binding-source <name> [--block <block-slug|namespace/block-slug> --attribute <attribute>].',
-    );
-    const blockName = readOptionalStringFlag(context.flags, 'block');
-    const attributeName = readOptionalStringFlag(context.flags, 'attribute');
-    if (Boolean(blockName) !== Boolean(attributeName)) {
-      throw createCliDiagnosticCodeError(
-        CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
-        '`wp-typia add binding-source` requires --block and --attribute to be provided together.',
-      );
-    }
-
-    return runRegisteredAddKind<AddBindingSourceResult>(context, {
-      buildCompletion: (result) =>
-        buildAddCompletionPayload({
-          kind: 'binding-source',
-          projectDir: result.projectDir,
-          values: {
-            ...(result.attributeName
-              ? { attributeName: result.attributeName }
-              : {}),
-            ...(result.blockSlug ? { blockSlug: result.blockSlug } : {}),
-            bindingSourceSlug: result.bindingSourceSlug,
-          },
-        }),
-      execute: (targetCwd) =>
-        context.addRuntime.runAddBindingSourceCommand({
-          attributeName,
-          bindingSourceName: name,
-          blockName,
-          cwd: targetCwd,
-        }),
-    });
-  },
-  block: async (context) => {
-    const name = requireAddKindName(
-      context,
-      '`wp-typia add block` requires <name>. Usage: wp-typia add block <name> [--template <basic|interactivity|persistence|compound>]',
-    );
-
-    if (!context.flags.template && context.isInteractiveSession) {
-      throw createCliDiagnosticCodeError(
-        CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
-        '`wp-typia add block` requires --template <basic|interactivity|persistence|compound> in interactive terminals. Non-interactive runs default to --template basic.',
-      );
-    }
-
-    const externalLayerId = readOptionalStringFlag(
-      context.flags,
-      'external-layer-id',
-    );
-    const externalLayerSource = readOptionalStringFlag(
-      context.flags,
-      'external-layer-source',
-    );
-    const shouldPromptForLayerSelection =
-      Boolean(externalLayerSource) &&
-      !Boolean(externalLayerId) &&
-      context.isInteractiveSession;
-    const selectPrompt = shouldPromptForLayerSelection
-      ? await context.getOrCreatePrompt()
-      : undefined;
-    const alternateRenderTargets = readOptionalStringFlag(
-      context.flags,
-      'alternate-render-targets',
-    );
-    const dataStorageMode = readOptionalStringFlag(
-      context.flags,
-      'data-storage',
-    );
-    const innerBlocksPreset = readOptionalStringFlag(
-      context.flags,
-      'inner-blocks-preset',
-    );
-    const persistencePolicy = readOptionalStringFlag(
-      context.flags,
-      'persistence-policy',
-    );
-    const resolvedTemplateId =
-      (readOptionalStringFlag(context.flags, 'template') as
-        | 'basic'
-        | 'interactivity'
-        | 'persistence'
-        | 'compound'
-        | undefined) ?? 'basic';
-
-    return runRegisteredAddKind<AddBlockResult>(context, {
-      buildCompletion: (result) =>
-        buildAddCompletionPayload({
-          kind: 'block',
-          projectDir: result.projectDir,
-          values: {
-            blockSlugs: result.blockSlugs.join(', '),
-            templateId: result.templateId,
-          },
-          warnings: result.warnings,
-        }),
-      execute: (targetCwd) =>
-        context.addRuntime.runAddBlockCommand({
-          alternateRenderTargets,
-          blockName: name,
-          cwd: targetCwd,
-          dataStorageMode,
-          externalLayerId,
-          externalLayerSource,
-          innerBlocksPreset,
-          persistencePolicy,
-          selectExternalLayerId: selectPrompt
-            ? (options) =>
-                selectPrompt.select(
-                  'Select an external layer',
-                  toExternalLayerPromptOptions(options),
-                  1,
-                )
-            : undefined,
-          templateId: resolvedTemplateId,
-        }),
-      warnLine: context.warnLine,
-    });
-  },
-  'editor-plugin': async (context) => {
-    const name = requireAddKindName(
-      context,
-      '`wp-typia add editor-plugin` requires <name>. Usage: wp-typia add editor-plugin <name> [--slot <sidebar|document-setting-panel>].',
-    );
-    const slot = readOptionalStringFlag(context.flags, 'slot');
-
-    return runRegisteredAddKind<AddEditorPluginResult>(context, {
-      buildCompletion: (result) =>
-        buildAddCompletionPayload({
-          kind: 'editor-plugin',
-          projectDir: result.projectDir,
-          values: {
-            editorPluginSlug: result.editorPluginSlug,
-            slot: result.slot,
-          },
-        }),
-      execute: (targetCwd) =>
-        context.addRuntime.runAddEditorPluginCommand({
-          cwd: targetCwd,
-          editorPluginName: name,
-          slot,
-        }),
-    });
-  },
-  'ai-feature': async (context) => {
-    const name = requireAddKindName(
-      context,
-      '`wp-typia add ai-feature` requires <name>. Usage: wp-typia add ai-feature <name> [--namespace <vendor/v1>].',
-    );
-    const namespace = readOptionalStringFlag(context.flags, 'namespace');
-
-    return runRegisteredAddKind<AddAiFeatureResult>(context, {
-      buildCompletion: (result) =>
-        buildAddCompletionPayload({
-          kind: 'ai-feature',
-          projectDir: result.projectDir,
-          values: {
-            aiFeatureSlug: result.aiFeatureSlug,
-            namespace: result.namespace,
-          },
-          warnings: result.warnings,
-        }),
-      execute: (targetCwd) =>
-        context.addRuntime.runAddAiFeatureCommand({
-          aiFeatureName: name,
-          cwd: targetCwd,
-          namespace,
-        }),
-    });
-  },
-  'hooked-block': async (context) => {
-    const name = requireAddKindName(
-      context,
-      '`wp-typia add hooked-block` requires <block-slug>. Usage: wp-typia add hooked-block <block-slug> --anchor <anchor-block-name> --position <before|after|firstChild|lastChild>.',
-    );
-    const anchorBlockName = readOptionalStringFlag(context.flags, 'anchor');
-    if (!anchorBlockName) {
-      throw createCliDiagnosticCodeError(
-        CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
-        '`wp-typia add hooked-block` requires --anchor <anchor-block-name>.',
-      );
-    }
-    const position = readOptionalStringFlag(context.flags, 'position');
-    if (!position) {
-      throw createCliDiagnosticCodeError(
-        CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
-        '`wp-typia add hooked-block` requires --position <before|after|firstChild|lastChild>.',
-      );
-    }
-
-    return runRegisteredAddKind<AddHookedBlockResult>(context, {
-      buildCompletion: (result) =>
-        buildAddCompletionPayload({
-          kind: 'hooked-block',
-          projectDir: result.projectDir,
-          values: {
-            anchorBlockName: result.anchorBlockName,
-            blockSlug: result.blockSlug,
-            position: result.position,
-          },
-        }),
-      execute: (targetCwd) =>
-        context.addRuntime.runAddHookedBlockCommand({
-          anchorBlockName,
-          blockName: name,
-          cwd: targetCwd,
-          position,
-        }),
-    });
-  },
-  pattern: async (context) => {
-    const name = requireAddKindName(
-      context,
-      '`wp-typia add pattern` requires <name>. Usage: wp-typia add pattern <name>.',
-    );
-
-    return runRegisteredAddKind<AddPatternResult>(context, {
-      buildCompletion: (result) =>
-        buildAddCompletionPayload({
-          kind: 'pattern',
-          projectDir: result.projectDir,
-          values: {
-            patternSlug: result.patternSlug,
-          },
-        }),
-      execute: (targetCwd) =>
-        context.addRuntime.runAddPatternCommand({
-          cwd: targetCwd,
-          patternName: name,
-        }),
-    });
-  },
-  style: async (context) => {
-    const name = requireAddKindName(
-      context,
-      '`wp-typia add style` requires <name>. Usage: wp-typia add style <name> --block <block-slug>.',
-    );
-    const blockSlug = readOptionalStringFlag(context.flags, 'block');
-    if (!blockSlug) {
-      throw createCliDiagnosticCodeError(
-        CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
-        '`wp-typia add style` requires --block <block-slug>.',
-      );
-    }
-
-    return runRegisteredAddKind<AddBlockStyleResult>(context, {
-      buildCompletion: (result) =>
-        buildAddCompletionPayload({
-          kind: 'style',
-          projectDir: result.projectDir,
-          values: {
-            blockSlug: result.blockSlug,
-            styleSlug: result.styleSlug,
-          },
-        }),
-      execute: (targetCwd) =>
-        context.addRuntime.runAddBlockStyleCommand({
-          blockName: blockSlug,
-          cwd: targetCwd,
-          styleName: name,
-        }),
-    });
-  },
-  transform: async (context) => {
-    const name = requireAddKindName(
-      context,
-      '`wp-typia add transform` requires <name>. Usage: wp-typia add transform <name> --from <namespace/block> --to <block-slug|namespace/block-slug>.',
-    );
-    const fromBlockName = readOptionalStringFlag(context.flags, 'from');
-    if (!fromBlockName) {
-      throw createCliDiagnosticCodeError(
-        CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
-        '`wp-typia add transform` requires --from <namespace/block>.',
-      );
-    }
-    const toBlockName = readOptionalStringFlag(context.flags, 'to');
-    if (!toBlockName) {
-      throw createCliDiagnosticCodeError(
-        CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
-        '`wp-typia add transform` requires --to <block-slug|namespace/block-slug>.',
-      );
-    }
-
-    return runRegisteredAddKind<AddBlockTransformResult>(context, {
-      buildCompletion: (result) =>
-        buildAddCompletionPayload({
-          kind: 'transform',
-          projectDir: result.projectDir,
-          values: {
-            blockSlug: result.blockSlug,
-            fromBlockName: result.fromBlockName,
-            toBlockName: result.toBlockName,
-            transformSlug: result.transformSlug,
-          },
-        }),
-      execute: (targetCwd) =>
-        context.addRuntime.runAddBlockTransformCommand({
-          cwd: targetCwd,
-          fromBlockName,
-          toBlockName,
-          transformName: name,
-        }),
-    });
-  },
-  'rest-resource': async (context) => {
-    const name = requireAddKindName(
-      context,
-      '`wp-typia add rest-resource` requires <name>. Usage: wp-typia add rest-resource <name> [--namespace <vendor/v1>] [--methods <list,read,create>].',
-    );
-    const methods = readOptionalStringFlag(context.flags, 'methods');
-    const namespace = readOptionalStringFlag(context.flags, 'namespace');
-
-    return runRegisteredAddKind<AddRestResourceResult>(context, {
-      buildCompletion: (result) =>
-        buildAddCompletionPayload({
-          kind: 'rest-resource',
-          projectDir: result.projectDir,
-          values: {
-            methods: result.methods.join(', '),
-            namespace: result.namespace,
-            restResourceSlug: result.restResourceSlug,
-          },
-        }),
-      execute: (targetCwd) =>
-        context.addRuntime.runAddRestResourceCommand({
-          cwd: targetCwd,
-          methods,
-          namespace,
-          restResourceName: name,
-        }),
-    });
-  },
-  variation: async (context) => {
-    const name = requireAddKindName(
-      context,
-      '`wp-typia add variation` requires <name>. Usage: wp-typia add variation <name> --block <block-slug>',
-    );
-    const blockSlug = readOptionalStringFlag(context.flags, 'block');
-    if (!blockSlug) {
-      throw createCliDiagnosticCodeError(
-        CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
-        '`wp-typia add variation` requires --block <block-slug>.',
-      );
-    }
-
-    return runRegisteredAddKind<AddVariationResult>(context, {
-      buildCompletion: (result) =>
-        buildAddCompletionPayload({
-          kind: 'variation',
-          projectDir: result.projectDir,
-          values: {
-            blockSlug: result.blockSlug,
-            variationSlug: result.variationSlug,
-          },
-        }),
-      execute: (targetCwd) =>
-        context.addRuntime.runAddVariationCommand({
-          blockName: blockSlug,
-          cwd: targetCwd,
-          variationName: name,
-        }),
-    });
-  },
-};
 
 async function executeWorkspaceAddWithOptionalDryRun<TResult>(options: {
   buildCompletion: (
@@ -707,6 +192,33 @@ async function executeWorkspaceAddWithOptionalDryRun<TResult>(options: {
       warnLine: options.warnLine,
     },
   );
+}
+
+function executePreparedAddKind(
+  kind: AddKindId,
+  context: {
+    cwd: string;
+    dryRun: boolean;
+    emitOutput: boolean | undefined;
+    printLine: PrintLine;
+  },
+  plan: AddKindExecutionPlan<any>,
+): Promise<AlternateBufferCompletionPayload | void> {
+  return executeWorkspaceAddWithOptionalDryRun({
+    buildCompletion: (result) =>
+      buildAddCompletionPayload({
+        kind,
+        projectDir: result.projectDir,
+        values: plan.getValues(result),
+        warnings: plan.getWarnings?.(result),
+      }),
+    cwd: context.cwd,
+    dryRun: context.dryRun,
+    emitOutput: context.emitOutput,
+    execute: plan.execute,
+    printLine: context.printLine,
+    warnLine: plan.warnLine,
+  });
 }
 
 const PACKAGE_MANAGER_PROMPT_OPTIONS = [
@@ -960,11 +472,9 @@ export async function executeAddCommand({
       );
     }
 
-    return await ADD_KIND_EXECUTION_REGISTRY[kind]({
+    const executionContext: AddKindExecutionContext = {
       addRuntime,
       cwd,
-      dryRun,
-      emitOutput,
       flags,
       getOrCreatePrompt: async () => {
         if (activePrompt) {
@@ -977,9 +487,20 @@ export async function executeAddCommand({
       },
       isInteractiveSession,
       name,
-      printLine,
       warnLine,
-    });
+    };
+    const plan = await getAddKindExecutionPlan(kind, executionContext);
+
+    return await executePreparedAddKind(
+      kind,
+      {
+        cwd,
+        dryRun,
+        emitOutput,
+        printLine,
+      },
+      plan,
+    );
   } catch (error) {
     if (!shouldWrapCliCommandError({ emitOutput })) {
       throw error;

--- a/packages/wp-typia/src/runtime-bridge.ts
+++ b/packages/wp-typia/src/runtime-bridge.ts
@@ -5,12 +5,14 @@ import {
 } from '@wp-typia/project-tools/cli-diagnostics';
 import {
   type AddKindExecutionPlan,
+  type AddKindExecutionPlanFor,
   type AddKindExecutionContext,
   type AddKindId,
   formatAddKindList,
   formatAddKindUsagePlaceholder,
   getAddKindExecutionPlan,
   isAddKindId,
+  supportsAddKindDryRun,
 } from './add-kind-registry';
 import { simulateWorkspaceAddDryRun } from './runtime-bridge-add-dry-run';
 import type { AlternateBufferCompletionPayload } from './ui/alternate-buffer-lifecycle';
@@ -194,8 +196,8 @@ async function executeWorkspaceAddWithOptionalDryRun<TResult>(options: {
   );
 }
 
-function executePreparedAddKind(
-  kind: AddKindId,
+function executePreparedAddKind<TKey extends AddKindId>(
+  kind: TKey,
   context: {
     cwd: string;
     dryRun: boolean;
@@ -219,6 +221,24 @@ function executePreparedAddKind(
     printLine: context.printLine,
     warnLine: plan.warnLine,
   });
+}
+
+async function executePlannedAddKind<TKey extends AddKindId>(
+  kind: TKey,
+  executionContext: AddKindExecutionContext,
+  context: {
+    cwd: string;
+    dryRun: boolean;
+    emitOutput: boolean | undefined;
+    printLine: PrintLine;
+  },
+): Promise<AlternateBufferCompletionPayload | void> {
+  const plan = await getAddKindExecutionPlan(kind, executionContext);
+  return executePreparedAddKind(
+    kind,
+    context,
+    plan as AddKindExecutionPlanFor<TKey> & AddKindExecutionPlan<any>,
+  );
 }
 
 const PACKAGE_MANAGER_PROMPT_OPTIONS = [
@@ -471,6 +491,12 @@ export async function executeAddCommand({
         `Unknown add kind "${kind}". Expected one of: ${formatAddKindList()}.`,
       );
     }
+    if (dryRun && !supportsAddKindDryRun(kind)) {
+      throw createCliDiagnosticCodeError(
+        CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
+        `\`wp-typia add ${kind}\` does not support \`--dry-run\` yet.`,
+      );
+    }
 
     const executionContext: AddKindExecutionContext = {
       addRuntime,
@@ -489,17 +515,15 @@ export async function executeAddCommand({
       name,
       warnLine,
     };
-    const plan = await getAddKindExecutionPlan(kind, executionContext);
-
-    return await executePreparedAddKind(
+    return await executePlannedAddKind(
       kind,
+      executionContext,
       {
         cwd,
         dryRun,
         emitOutput,
         printLine,
       },
-      plan,
     );
   } catch (error) {
     if (!shouldWrapCliCommandError({ emitOutput })) {

--- a/packages/wp-typia/tests/add-command.test.ts
+++ b/packages/wp-typia/tests/add-command.test.ts
@@ -238,4 +238,21 @@ describe('wp-typia add command bridge', () => {
       true,
     );
   });
+
+  test('keeps the canonical add kind order stable', () => {
+    expect(ADD_KIND_IDS).toEqual([
+      'admin-view',
+      'block',
+      'variation',
+      'style',
+      'transform',
+      'pattern',
+      'binding-source',
+      'rest-resource',
+      'ability',
+      'ai-feature',
+      'hooked-block',
+      'editor-plugin',
+    ]);
+  });
 });

--- a/packages/wp-typia/tests/add-command.test.ts
+++ b/packages/wp-typia/tests/add-command.test.ts
@@ -1,187 +1,241 @@
-import { afterAll, describe, expect, test } from "bun:test";
-import * as fs from "node:fs";
-import * as os from "node:os";
-import * as path from "node:path";
+import { afterAll, describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
-import { executeAddCommand } from "../src/runtime-bridge";
+import type { ReadlinePrompt } from '@wp-typia/project-tools/cli-prompt';
+import { ADD_KIND_IDS, supportsAddKindDryRun } from '../src/add-kind-registry';
+import { executeAddCommand } from '../src/runtime-bridge';
 import {
-	linkWorkspaceNodeModules,
-	scaffoldOfficialWorkspace,
-} from "../../wp-typia-project-tools/tests/helpers/scaffold-test-harness.js";
+  linkWorkspaceNodeModules,
+  scaffoldOfficialWorkspace,
+} from '../../wp-typia-project-tools/tests/helpers/scaffold-test-harness.js';
 
-describe("wp-typia add command bridge", () => {
-	const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "wp-typia-add-bridge-"));
+describe('wp-typia add command bridge', () => {
+  const tempRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'wp-typia-add-bridge-'),
+  );
 
-	afterAll(() => {
-		fs.rmSync(tempRoot, { force: true, recursive: true });
-	});
+  afterAll(() => {
+    fs.rmSync(tempRoot, { force: true, recursive: true });
+  });
 
-	test("defaults add block to the basic template in non-interactive runs", async () => {
-		const projectDir = path.join(tempRoot, "demo-add-basic-default");
+  test('defaults add block to the basic template in non-interactive runs', async () => {
+    const projectDir = path.join(tempRoot, 'demo-add-basic-default');
 
-		await scaffoldOfficialWorkspace(projectDir);
-		linkWorkspaceNodeModules(projectDir);
+    await scaffoldOfficialWorkspace(projectDir);
+    linkWorkspaceNodeModules(projectDir);
 
-		const payload = await executeAddCommand({
-			cwd: projectDir,
-			emitOutput: false,
-			flags: {},
-			interactive: false,
-			kind: "block",
-			name: "promo-card",
-		});
+    const payload = await executeAddCommand({
+      cwd: projectDir,
+      emitOutput: false,
+      flags: {},
+      interactive: false,
+      kind: 'block',
+      name: 'promo-card',
+    });
 
-		expect(payload?.title).toContain("Added workspace block");
-		expect(payload?.summaryLines).toContain("Template family: basic");
-		expect(
-			fs.existsSync(path.join(projectDir, "src", "blocks", "promo-card", "block.json")),
-		).toBe(true);
-	});
+    expect(payload?.title).toContain('Added workspace block');
+    expect(payload?.summaryLines).toContain('Template family: basic');
+    expect(
+      fs.existsSync(
+        path.join(projectDir, 'src', 'blocks', 'promo-card', 'block.json'),
+      ),
+    ).toBe(true);
+  });
 
-	test(
-		"passes binding-source target flags through the add bridge",
-		async () => {
-			const projectDir = path.join(tempRoot, "demo-add-binding-target");
+  test('passes binding-source target flags through the add bridge', async () => {
+    const projectDir = path.join(tempRoot, 'demo-add-binding-target');
 
-			await scaffoldOfficialWorkspace(projectDir);
-			linkWorkspaceNodeModules(projectDir);
-			await expect(
-				executeAddCommand({
-					cwd: projectDir,
-					emitOutput: false,
-					flags: {
-						block: "counter-card",
-					},
-					interactive: false,
-					kind: "binding-source",
-					name: "hero-data",
-				}),
-			).rejects.toThrow(
-				"`wp-typia add binding-source` requires --block and --attribute to be provided together.",
-			);
-			await executeAddCommand({
-				cwd: projectDir,
-				emitOutput: false,
-				flags: {
-					template: "basic",
-				},
-				interactive: false,
-				kind: "block",
-				name: "counter-card",
-			});
+    await scaffoldOfficialWorkspace(projectDir);
+    linkWorkspaceNodeModules(projectDir);
+    await expect(
+      executeAddCommand({
+        cwd: projectDir,
+        emitOutput: false,
+        flags: {
+          block: 'counter-card',
+        },
+        interactive: false,
+        kind: 'binding-source',
+        name: 'hero-data',
+      }),
+    ).rejects.toThrow(
+      '`wp-typia add binding-source` requires --block and --attribute to be provided together.',
+    );
+    await executeAddCommand({
+      cwd: projectDir,
+      emitOutput: false,
+      flags: {
+        template: 'basic',
+      },
+      interactive: false,
+      kind: 'block',
+      name: 'counter-card',
+    });
 
-			const payload = await executeAddCommand({
-				cwd: projectDir,
-				emitOutput: false,
-				flags: {
-					attribute: "headline",
-					block: "counter-card",
-				},
-				interactive: false,
-				kind: "binding-source",
-				name: "hero-data",
-			});
+    const payload = await executeAddCommand({
+      cwd: projectDir,
+      emitOutput: false,
+      flags: {
+        attribute: 'headline',
+        block: 'counter-card',
+      },
+      interactive: false,
+      kind: 'binding-source',
+      name: 'hero-data',
+    });
 
-			expect(payload?.summaryLines).toContain("Target: counter-card.headline");
-			expect(
-				fs.existsSync(path.join(projectDir, "src", "bindings", "hero-data", "server.php")),
-			).toBe(true);
-			const blockJson = JSON.parse(
-				fs.readFileSync(
-					path.join(projectDir, "src", "blocks", "counter-card", "block.json"),
-					"utf8",
-				),
-			);
-			expect(blockJson.attributes.headline).toEqual({ type: "string" });
-		},
-		15_000,
-	);
+    expect(payload?.summaryLines).toContain('Target: counter-card.headline');
+    expect(
+      fs.existsSync(
+        path.join(projectDir, 'src', 'bindings', 'hero-data', 'server.php'),
+      ),
+    ).toBe(true);
+    const blockJson = JSON.parse(
+      fs.readFileSync(
+        path.join(projectDir, 'src', 'blocks', 'counter-card', 'block.json'),
+        'utf8',
+      ),
+    );
+    expect(blockJson.attributes.headline).toEqual({ type: 'string' });
+  }, 15_000);
 
-	test(
-		"passes block style and transform flags through the add bridge",
-		async () => {
-			const projectDir = path.join(tempRoot, "demo-add-style-transform");
+  test('passes block style and transform flags through the add bridge', async () => {
+    const projectDir = path.join(tempRoot, 'demo-add-style-transform');
 
-			await scaffoldOfficialWorkspace(projectDir);
-			linkWorkspaceNodeModules(projectDir);
-			await executeAddCommand({
-				cwd: projectDir,
-				emitOutput: false,
-				flags: {
-					template: "basic",
-				},
-				interactive: false,
-				kind: "block",
-				name: "counter-card",
-			});
-			await expect(
-				executeAddCommand({
-					cwd: projectDir,
-					emitOutput: false,
-					flags: {},
-					interactive: false,
-					kind: "style",
-					name: "callout-emphasis",
-				}),
-			).rejects.toThrow("`wp-typia add style` requires --block <block-slug>.");
+    await scaffoldOfficialWorkspace(projectDir);
+    linkWorkspaceNodeModules(projectDir);
+    await executeAddCommand({
+      cwd: projectDir,
+      emitOutput: false,
+      flags: {
+        template: 'basic',
+      },
+      interactive: false,
+      kind: 'block',
+      name: 'counter-card',
+    });
+    await expect(
+      executeAddCommand({
+        cwd: projectDir,
+        emitOutput: false,
+        flags: {},
+        interactive: false,
+        kind: 'style',
+        name: 'callout-emphasis',
+      }),
+    ).rejects.toThrow('`wp-typia add style` requires --block <block-slug>.');
 
-			const stylePayload = await executeAddCommand({
-				cwd: projectDir,
-				emitOutput: false,
-				flags: {
-					block: "counter-card",
-				},
-				interactive: false,
-				kind: "style",
-				name: "callout-emphasis",
-			});
-			const transformPayload = await executeAddCommand({
-				cwd: projectDir,
-				emitOutput: false,
-				flags: {
-					from: "core/quote",
-					to: "counter-card",
-				},
-				interactive: false,
-				kind: "transform",
-				name: "quote-to-counter",
-			});
+    const stylePayload = await executeAddCommand({
+      cwd: projectDir,
+      emitOutput: false,
+      flags: {
+        block: 'counter-card',
+      },
+      interactive: false,
+      kind: 'style',
+      name: 'callout-emphasis',
+    });
+    const transformPayload = await executeAddCommand({
+      cwd: projectDir,
+      emitOutput: false,
+      flags: {
+        from: 'core/quote',
+        to: 'counter-card',
+      },
+      interactive: false,
+      kind: 'transform',
+      name: 'quote-to-counter',
+    });
 
-			expect(stylePayload?.summaryLines).toContain(
-				"Block style: callout-emphasis",
-			);
-			expect(transformPayload?.summaryLines).toContain(
-				"Block transform: quote-to-counter",
-			);
-			expect(transformPayload?.summaryLines).toContain("From: core/quote");
-			expect(transformPayload?.summaryLines).toContain(
-				"To: demo-space/counter-card",
-			);
-			expect(
-				fs.existsSync(
-					path.join(
-						projectDir,
-						"src",
-						"blocks",
-						"counter-card",
-						"styles",
-						"callout-emphasis.ts",
-					),
-				),
-			).toBe(true);
-			expect(
-				fs.existsSync(
-					path.join(
-						projectDir,
-						"src",
-						"blocks",
-						"counter-card",
-						"transforms",
-						"quote-to-counter.ts",
-					),
-				),
-			).toBe(true);
-		},
-		15_000,
-	);
+    expect(stylePayload?.summaryLines).toContain(
+      'Block style: callout-emphasis',
+    );
+    expect(transformPayload?.summaryLines).toContain(
+      'Block transform: quote-to-counter',
+    );
+    expect(transformPayload?.summaryLines).toContain('From: core/quote');
+    expect(transformPayload?.summaryLines).toContain(
+      'To: demo-space/counter-card',
+    );
+    expect(
+      fs.existsSync(
+        path.join(
+          projectDir,
+          'src',
+          'blocks',
+          'counter-card',
+          'styles',
+          'callout-emphasis.ts',
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(
+          projectDir,
+          'src',
+          'blocks',
+          'counter-card',
+          'transforms',
+          'quote-to-counter.ts',
+        ),
+      ),
+    ).toBe(true);
+  }, 15_000);
+
+  test('interactive add block can select a template when --template is omitted', async () => {
+    const projectDir = path.join(
+      tempRoot,
+      'demo-add-interactive-template-prompt',
+    );
+    const selectedPrompts: string[] = [];
+    const prompt: ReadlinePrompt = {
+      close() {},
+      async select<T extends string>(
+        message: string,
+        options: Array<{ value: T }>,
+      ) {
+        selectedPrompts.push(message);
+        expect(options.map((option) => String(option.value))).toEqual([
+          'basic',
+          'interactivity',
+          'persistence',
+          'compound',
+        ]);
+        return 'compound' as T;
+      },
+      async text() {
+        throw new Error('text() should not be called for template selection');
+      },
+    };
+
+    await scaffoldOfficialWorkspace(projectDir);
+    linkWorkspaceNodeModules(projectDir);
+
+    const payload = await executeAddCommand({
+      cwd: projectDir,
+      emitOutput: false,
+      flags: {},
+      interactive: true,
+      kind: 'block',
+      name: 'faq-stack',
+      prompt,
+    });
+
+    expect(selectedPrompts).toEqual(['Select a block template']);
+    expect(payload?.summaryLines).toContain('Template family: compound');
+    expect(
+      fs.existsSync(
+        path.join(projectDir, 'src', 'blocks', 'faq-stack', 'children.ts'),
+      ),
+    ).toBe(true);
+  });
+
+  test('every registered add kind currently advertises dry-run support', () => {
+    expect(ADD_KIND_IDS.every((kind) => supportsAddKindDryRun(kind))).toBe(
+      true,
+    );
+  });
 });

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -8,6 +8,7 @@ import {
   WP_TYPIA_NODE_FALLBACK_TOP_LEVEL_COMMAND_NAMES,
   WP_TYPIA_TOP_LEVEL_COMMAND_NAMES,
 } from '../src/command-contract';
+import { formatAddKindUsagePlaceholder } from '../src/add-kind-registry';
 import {
   hasFlagBeforeTerminator,
   parseGlobalFlags,
@@ -365,8 +366,12 @@ describe('wp-typia package', () => {
     expect(addHelpOutput).toContain('--external-layer-source');
     expect(addHelpOutput).toContain('--external-layer-id');
     expect(addHelpOutput).toContain('--alternate-render-targets');
+    expect(addHelpOutput).toContain(
+      'interactive terminals prompt when omitted and non-interactive runs default to basic',
+    );
     expect(addHelpOutput).toContain('admin-view');
-    expect(addHelpOutput).toContain('ability, ai-feature');
+    expect(addHelpOutput).toContain('ability');
+    expect(addHelpOutput).toContain('ai-feature');
     expect(addHelpOutput).toContain('editor-plugin');
   });
 
@@ -1575,11 +1580,13 @@ describe('wp-typia package', () => {
     expect(result.status).toBe(1);
     expect(result.stdout).toContain('Usage:');
     expect(result.stdout).toContain('wp-typia add admin-view <name>');
-    expect(result.stdout).toContain('wp-typia add block <name>');
+    expect(result.stdout).toContain(
+      'wp-typia add block <name> [--template <basic|interactivity|persistence|compound>]',
+    );
     expect(result.stdout).toContain('wp-typia add style <name>');
     expect(result.stdout).toContain('wp-typia add transform <name>');
     expect(result.stderr).toContain(
-      '`wp-typia add` requires <kind>. Usage: wp-typia add <admin-view|block|variation|style|transform|pattern|binding-source|rest-resource|ability|ai-feature|editor-plugin|hooked-block> ...',
+      `\`wp-typia add\` requires <kind>. Usage: wp-typia add ${formatAddKindUsagePlaceholder()} ...`,
     );
   });
 
@@ -1596,7 +1603,9 @@ describe('wp-typia package', () => {
       expect(capturedStdout.join('\n')).toContain(
         'wp-typia add admin-view <name>',
       );
-      expect(capturedStdout.join('\n')).toContain('wp-typia add block <name>');
+      expect(capturedStdout.join('\n')).toContain(
+        'wp-typia add block <name> [--template <basic|interactivity|persistence|compound>]',
+      );
       expect(capturedStdout.join('\n')).toContain(
         'wp-typia add ability <name>',
       );

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -367,7 +367,7 @@ describe('wp-typia package', () => {
     expect(addHelpOutput).toContain('--external-layer-id');
     expect(addHelpOutput).toContain('--alternate-render-targets');
     expect(addHelpOutput).toContain(
-      'interactive terminals prompt when omitted and non-interactive runs default to basic',
+      'interactive flows let you choose it when omitted and non-interactive runs default to basic',
     );
     expect(addHelpOutput).toContain('admin-view');
     expect(addHelpOutput).toContain('ability');


### PR DESCRIPTION
## Summary
- unify add kind metadata and execution behind a single `ADD_KIND_REGISTRY`
- let interactive `wp-typia add block <name>` prompt for a template when `--template` is omitted
- align add help text and Node fallback metadata with the dry-run/template behavior contract

Closes #577

## Testing
- bun run typecheck
- bun run --cwd packages/wp-typia-project-tools build
- bun run --cwd packages/wp-typia build
- bun test packages/wp-typia/tests/add-command.test.ts packages/wp-typia/tests/cli-package.test.ts
- bun test packages/wp-typia/tests/*.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Interactive template selection is now available for `wp-typia add block` when `--template` is omitted; interactive terminals prompt for selection while non-interactive runs default to "basic"
  * Dry-run support added for add commands

* **Documentation**
  * Updated help text to show `--template` as optional for `wp-typia add block`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->