### PR TITLE
Expand wp-typia init into an apply-capable retrofit workflow

### DIFF
--- a/.sampo/changesets/init-apply-retrofit-workflow.md
+++ b/.sampo/changesets/init-apply-retrofit-workflow.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: minor
+npm/wp-typia: minor
+---
+
+Add `wp-typia init --apply` for existing projects so the CLI can write the planned retrofit package.json updates and helper scripts with rollback-on-failure protection, package-manager-aware next steps, and shared init option metadata across the Bunli and Node fallback runtimes.

--- a/packages/wp-typia-project-tools/src/runtime/cli-help.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-help.ts
@@ -18,7 +18,7 @@ export function formatHelpText(): string {
   wp-typia create <project-dir> [--template persistence] [--external-layer-source <./path|github:owner/repo/path[#ref]|npm-package>] [--external-layer-id <layer-id>] [--alternate-render-targets <email,mjml,plain-text>] [--data-storage <post-meta|custom-table>] [--persistence-policy <authenticated|public>] [--namespace <value>] [--text-domain <value>] [--php-prefix <value>] [--with-migration-ui] [--with-wp-env] [--with-test-preset] [--yes] [--dry-run] [--no-install] [--package-manager <id>]
   wp-typia create <project-dir> [--template compound] [--external-layer-source <./path|github:owner/repo/path[#ref]|npm-package>] [--external-layer-id <layer-id>] [--inner-blocks-preset <freeform|ordered|horizontal|locked-structure>] [--alternate-render-targets <email,mjml,plain-text>] [--data-storage <post-meta|custom-table>] [--persistence-policy <authenticated|public>] [--namespace <value>] [--text-domain <value>] [--php-prefix <value>] [--with-migration-ui] [--with-wp-env] [--with-test-preset] [--yes] [--dry-run] [--no-install] [--package-manager <id>]
   wp-typia <project-dir> [create flags...]
-  wp-typia init [project-dir]
+  wp-typia init [project-dir] [--apply] [--package-manager <id>]
   wp-typia add admin-view <name> [--source <rest-resource:slug>]
   wp-typia add block <name> [--template <basic|interactivity|persistence|compound>] [--external-layer-source <./path|github:owner/repo/path[#ref]|npm-package>] [--external-layer-id <layer-id>] [--inner-blocks-preset <freeform|ordered|horizontal|locked-structure>] [--alternate-render-targets <email,mjml,plain-text>] [--data-storage <post-meta|custom-table>] [--persistence-policy <authenticated|public>]
   wp-typia add variation <name> --block <block-slug>
@@ -47,7 +47,7 @@ Output environment:
 Notes:
   \`wp-typia create\` is the canonical scaffold command.
   \`wp-typia <project-dir>\` remains a backward-compatible alias to \`create\` when \`<project-dir>\` is the only positional argument.
-  \`wp-typia init\` is a preview-only retrofit planner for existing projects. It does not write files yet.
+  \`wp-typia init\` previews the minimum retrofit sync surface by default; rerun with \`--apply\` to write package.json updates and generated helper scripts.
   Use \`--template workspace\` as shorthand for \`@wp-typia/create-workspace-template\`, the official empty workspace scaffold behind \`wp-typia add ...\`.
   Interactive add flows let you choose a template when \`--template\` is omitted; non-interactive runs default to \`basic\`.
   \`add admin-view\` scaffolds an opt-in DataViews-powered WordPress admin screen under \`src/admin-views/\`; pass \`--source rest-resource:<slug>\` to reuse a list-capable REST resource.
@@ -63,7 +63,7 @@ Notes:
   \`add editor-plugin\` scaffolds a document-level editor extension under \`src/editor-plugins/\`; legacy aliases \`PluginSidebar\` and \`PluginDocumentSettingPanel\` resolve to \`sidebar\` and \`document-setting-panel\`.
   \`add hooked-block\` patches an existing workspace block's \`block.json\` \`blockHooks\` metadata.
   \`wp-typia doctor\` always checks environment readiness and reports when it only ran environment-level diagnostics; official workspace roots also get inventory, source-tree drift, shared convention checks, and iframe/API v3 compatibility checks.
-  \`wp-typia init\` previews the minimum sync/doctor/migration adoption layer for supported existing layouts before a future write mode exists.
+  \`wp-typia init\` previews or applies the minimum sync/doctor/migration adoption layer for supported existing layouts; pass \`--package-manager <id>\` to pin emitted scripts and next steps.
   \`wp-typia migrate doctor --all\` checks migration target alignment, snapshots, fixtures, and generated migration artifacts.
   \`migrate\` is the canonical migration command; \`migrations\` is no longer supported.`;
 }

--- a/packages/wp-typia-project-tools/src/runtime/cli-init.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-init.ts
@@ -1,11 +1,22 @@
 import fs from "node:fs";
+import { promises as fsp } from "node:fs";
 import path from "node:path";
+
+import { analyzeSourceTypes } from "@wp-typia/block-runtime/metadata-parser";
+import ts from "typescript";
 
 import {
 	CLI_DIAGNOSTIC_CODES,
 	createCliDiagnosticCodeError,
 } from "./cli-diagnostics.js";
+import {
+	quoteTsString,
+	rollbackWorkspaceMutation,
+	snapshotWorkspaceFiles,
+	type WorkspaceMutationSnapshot,
+} from "./cli-add-shared.js";
 import { discoverMigrationInitLayout } from "./migration-project.js";
+import type { MigrationBlockConfig } from "./migration-types.js";
 import {
 	formatAddDevDependenciesCommand,
 	formatPackageExecCommand,
@@ -15,14 +26,17 @@ import {
 	type PackageManagerId,
 } from "./package-managers.js";
 import { getPackageVersions } from "./package-versions.js";
+import { toPascalCase } from "./string-case.js";
+import { updateWorkspaceInventorySource } from "./workspace-inventory.js";
 import {
 	parseWorkspacePackageManagerId,
 	tryResolveWorkspaceProject,
 	type WorkspacePackageJson,
 } from "./workspace-project.js";
 
+type InitCommandMode = "apply" | "preview-only";
 type InitPlanAction = "add" | "update";
-type InitPlanStatus = "already-initialized" | "preview";
+type InitPlanStatus = "already-initialized" | "applied" | "preview";
 type InitPlanLayoutKind =
 	| "generated-project"
 	| "multi-block"
@@ -51,12 +65,24 @@ interface InitPackageManagerFieldChange {
 }
 
 interface InitFilePlan {
+	action: InitPlanAction;
 	path: string;
 	purpose: string;
 }
 
+export interface RetrofitInitBlockTarget {
+	attributeTypeName: string;
+	blockJsonFile: string;
+	blockName: string;
+	manifestFile: string;
+	saveFile: string;
+	slug: string;
+	typesFile: string;
+}
+
 export interface RetrofitInitPlan {
-	commandMode: "preview-only";
+	blockTargets: RetrofitInitBlockTarget[];
+	commandMode: InitCommandMode;
 	detectedLayout: {
 		blockNames: string[];
 		description: string;
@@ -87,6 +113,12 @@ type ProjectPackageJson = WorkspacePackageJson & {
 
 const SUPPORTED_RETROFIT_LAYOUT_NOTE =
 	"Supported retrofit layouts currently mirror the migration bootstrap detector: `src/block.json` + `src/types.ts` + `src/save.tsx`, legacy root `block.json` + `src/types.ts` + `src/save.tsx`, or multi-block `src/blocks/*/block.json` workspaces."
+
+const RETROFIT_APPLY_PREVIEW_NOTE =
+	"If you rerun with `wp-typia init --apply`, package.json and generated helper files are snapshotted and rolled back automatically if a write fails."
+
+const RETROFIT_ROLLBACK_NOTE =
+	"Apply mode writes package.json and generated helper files with rollback-on-failure protection."
 
 const BASE_RETROFIT_SCRIPTS = {
 	sync: "tsx scripts/sync-project.ts",
@@ -153,6 +185,30 @@ function inferInitPackageManager(
 	return "npm";
 }
 
+function resolveInitPackageManager(
+	projectDir: string,
+	packageJson: ProjectPackageJson | null,
+	override?: string,
+): PackageManagerId {
+	if (!override) {
+		return inferInitPackageManager(projectDir, packageJson);
+	}
+
+	if (
+		override !== "bun" &&
+		override !== "npm" &&
+		override !== "pnpm" &&
+		override !== "yarn"
+	) {
+		throw createCliDiagnosticCodeError(
+			CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
+			`Unknown package manager "${override}". Expected one of: bun, npm, pnpm, yarn.`,
+		);
+	}
+
+	return override;
+}
+
 function getWpTypiaCliSpecifier(): string {
 	const versions = getPackageVersions();
 	return versions.wpTypiaPackageExactVersion === "0.0.0"
@@ -163,12 +219,12 @@ function getWpTypiaCliSpecifier(): string {
 function buildRequiredDevDependencyMap(): Record<string, string> {
 	const versions = getPackageVersions();
 	return {
-		"@typia/unplugin": "^12.0.1",
+		"@typia/unplugin": versions.typiaUnpluginPackageVersion,
 		"@wp-typia/block-runtime": versions.blockRuntimePackageVersion,
 		"@wp-typia/block-types": versions.blockTypesPackageVersion,
-		tsx: "^4.20.5",
-		typescript: "^5.9.2",
-		typia: "^12.0.1",
+		tsx: versions.tsxPackageVersion,
+		typescript: versions.typescriptPackageVersion,
+		typia: versions.typiaPackageVersion,
 	};
 }
 
@@ -270,8 +326,328 @@ function buildGeneratedArtifactPaths(
 	);
 }
 
+function collectNamedSourceTypeCandidates(typesSource: string): string[] {
+	const sourceFile = ts.createSourceFile(
+		"types.ts",
+		typesSource,
+		ts.ScriptTarget.Latest,
+		true,
+		ts.ScriptKind.TS,
+	);
+
+	return sourceFile.statements.flatMap((statement) => {
+		if (
+			ts.isInterfaceDeclaration(statement) ||
+			ts.isTypeAliasDeclaration(statement)
+		) {
+			return [statement.name.text];
+		}
+
+		return [];
+	});
+}
+
+function isObjectLikeSourceType(
+	projectDir: string,
+	typesFile: string,
+	sourceTypeName: string,
+): boolean {
+	try {
+		const analyzedTypes = analyzeSourceTypes(
+			{
+				projectRoot: projectDir,
+				typesFile,
+			},
+			[sourceTypeName],
+		);
+		return analyzedTypes[sourceTypeName]?.kind === "object";
+	} catch {
+		return false;
+	}
+}
+
+function inferRetrofitAttributeTypeName(
+	projectDir: string,
+	block: MigrationBlockConfig,
+): string {
+	const typesPath = path.join(projectDir, block.typesFile);
+	const typesSource = fs.readFileSync(typesPath, "utf8");
+	const blockNameSegments = block.blockName.split("/");
+	const slug = blockNameSegments[blockNameSegments.length - 1] ?? block.key;
+	const candidateNames = collectNamedSourceTypeCandidates(typesSource);
+	const validCandidates = candidateNames.filter((candidateName) =>
+		isObjectLikeSourceType(projectDir, block.typesFile, candidateName),
+	);
+	const preferredName = `${toPascalCase(slug)}Attributes`;
+
+	if (validCandidates.includes(preferredName)) {
+		return preferredName;
+	}
+
+	const attributeCandidates = validCandidates.filter((candidateName) =>
+		candidateName.endsWith("Attributes"),
+	);
+	if (attributeCandidates.length === 1) {
+		return attributeCandidates[0];
+	}
+
+	if (validCandidates.length === 1) {
+		return validCandidates[0];
+	}
+
+	if (validCandidates.length === 0) {
+		throw new Error(
+			`Unable to infer an object-like source type from ${block.typesFile}. Add one interface or type alias such as ${preferredName} before rerunning \`wp-typia init\`.`,
+		);
+	}
+
+	throw new Error(
+		`Unable to infer a unique source type from ${block.typesFile}. Candidate object-like exports: ${validCandidates.join(", ")}. Rename one to ${preferredName} or leave a single object-like attributes type before rerunning \`wp-typia init\`.`,
+	);
+}
+
+function buildRetrofitBlockTarget(
+	projectDir: string,
+	block: MigrationBlockConfig,
+): RetrofitInitBlockTarget {
+	const blockNameSegments = block.blockName.split("/");
+	const slug = blockNameSegments[blockNameSegments.length - 1] ?? block.key;
+
+	return {
+		attributeTypeName: inferRetrofitAttributeTypeName(projectDir, block),
+		blockJsonFile: block.blockJsonFile,
+		blockName: block.blockName,
+		manifestFile: block.manifestFile,
+		saveFile: block.saveFile,
+		slug,
+		typesFile: block.typesFile,
+	};
+}
+
+function buildRetrofitBlockConfigEntry(
+	target: RetrofitInitBlockTarget,
+): string {
+	return [
+		"\t{",
+		`\t\tslug: ${quoteTsString(target.slug)},`,
+		`\t\tattributeTypeName: ${quoteTsString(target.attributeTypeName)},`,
+		`\t\tblockJsonFile: ${quoteTsString(target.blockJsonFile)},`,
+		`\t\tmanifestFile: ${quoteTsString(target.manifestFile)},`,
+		`\t\ttypesFile: ${quoteTsString(target.typesFile)},`,
+		"\t},",
+	].join("\n");
+}
+
+function buildRetrofitBlockConfigSource(
+	targets: RetrofitInitBlockTarget[],
+): string {
+	const blockEntries = targets.map(buildRetrofitBlockConfigEntry).join("\n");
+	const baseSource = `export interface WorkspaceBlockConfig {
+\tattributeTypeName: string;
+\tapiTypesFile?: string;
+\tblockJsonFile?: string;
+\tmanifestFile?: string;
+\topenApiFile?: string;
+\trestManifest?: ReturnType<
+\t\ttypeof import( '@wp-typia/block-runtime/metadata-core' ).defineEndpointManifest
+\t>;
+\tslug: string;
+\ttypesFile: string;
+}
+
+export const BLOCKS: WorkspaceBlockConfig[] = [
+${blockEntries}
+];
+`;
+
+	return `${updateWorkspaceInventorySource(baseSource)}\n`;
+}
+
+function buildRetrofitSyncTypesScriptSource(): string {
+	return `/* eslint-disable no-console */
+import path from 'node:path';
+
+import { syncBlockMetadata } from '@wp-typia/block-runtime/metadata-core';
+
+import { BLOCKS } from './block-config';
+
+function parseCliOptions( argv: string[] ) {
+\tconst options = {
+\t\tcheck: false,
+\t};
+
+\tfor ( const argument of argv ) {
+\t\tif ( argument === '--check' ) {
+\t\t\toptions.check = true;
+\t\t\tcontinue;
+\t\t}
+
+\t\tthrow new Error( \`Unknown sync-types flag: \${ argument }\` );
+\t}
+
+\treturn options;
+}
+
+async function main() {
+\tconst options = parseCliOptions( process.argv.slice( 2 ) );
+
+\tif ( BLOCKS.length === 0 ) {
+\t\tconsole.log(
+\t\t\toptions.check
+\t\t\t\t? 'ℹ️ No retrofit blocks are registered yet. \`sync-types --check\` is already clean.'
+\t\t\t\t: 'ℹ️ No retrofit blocks are registered yet. Add one block target to scripts/block-config.ts before rerunning sync-types.'
+\t\t);
+\t\treturn;
+\t}
+
+\tfor ( const block of BLOCKS ) {
+\t\tconst blockDir = path.dirname( block.typesFile );
+\t\tconst blockJsonFile =
+\t\t\tblock.blockJsonFile ?? path.join( blockDir, 'block.json' );
+\t\tconst manifestFile =
+\t\t\tblock.manifestFile ?? path.join( blockDir, 'typia.manifest.json' );
+\t\tconst manifestDir = path.dirname( manifestFile );
+\t\tconst result = await syncBlockMetadata(
+\t\t\t{
+\t\t\t\tblockJsonFile,
+\t\t\t\tjsonSchemaFile: path.join( manifestDir, 'typia.schema.json' ),
+\t\t\t\tmanifestFile,
+\t\t\t\topenApiFile: path.join( manifestDir, 'typia.openapi.json' ),
+\t\t\t\tsourceTypeName: block.attributeTypeName,
+\t\t\t\ttypesFile: block.typesFile,
+\t\t\t},
+\t\t\t{
+\t\t\t\tcheck: options.check,
+\t\t\t}
+\t\t);
+\t\tfor ( const warning of result.lossyProjectionWarnings ) {
+\t\t\tconsole.warn( \`⚠️ \${ block.slug }: \${ warning }\` );
+\t\t}
+\t\tfor ( const warning of result.phpGenerationWarnings ) {
+\t\t\tconsole.warn( \`⚠️ \${ block.slug }: \${ warning }\` );
+\t\t}
+
+\t\tconsole.log(
+\t\t\toptions.check
+\t\t\t\t? \`✅ \${ block.slug }: block.json, typia.manifest.json, typia-validator.php, typia.schema.json, and typia.openapi.json are already up to date with the TypeScript types!\`
+\t\t\t\t: \`✅ \${ block.slug }: block.json, typia.manifest.json, typia-validator.php, typia.schema.json, and typia.openapi.json were generated from TypeScript types!\`
+\t\t);
+\t\tconsole.log( '📝 Generated attributes:', result.attributeNames );
+\t}
+}
+
+main().catch( ( error ) => {
+\tconsole.error( '❌ Type sync failed:', error );
+\tprocess.exit( 1 );
+} );
+`;
+}
+
+function buildRetrofitSyncProjectScriptSource(): string {
+	return `/* eslint-disable no-console */
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+interface SyncCliOptions {
+\tcheck: boolean;
+}
+
+function parseCliOptions( argv: string[] ): SyncCliOptions {
+\tconst options: SyncCliOptions = {
+\t\tcheck: false,
+\t};
+
+\tfor ( const argument of argv ) {
+\t\tif ( argument === '--check' ) {
+\t\t\toptions.check = true;
+\t\t\tcontinue;
+\t\t}
+
+\t\tthrow new Error( \`Unknown sync flag: \${ argument }\` );
+\t}
+
+\treturn options;
+}
+
+function getSyncScriptEnv() {
+\tconst binaryDirectory = path.join( process.cwd(), 'node_modules', '.bin' );
+\tconst inheritedPath =
+\t\tprocess.env.PATH ??
+\t\tprocess.env.Path ??
+\t\tObject.entries( process.env ).find(
+\t\t\t( [ key ] ) => key.toLowerCase() === 'path'
+\t\t)?.[ 1 ] ??
+\t\t'';
+\tconst nextPath = fs.existsSync( binaryDirectory )
+\t\t? \`\${ binaryDirectory }\${ path.delimiter }\${ inheritedPath }\`
+\t\t: inheritedPath;
+\tconst env: NodeJS.ProcessEnv = {
+\t\t...process.env,
+\t};
+
+\tfor ( const key of Object.keys( env ) ) {
+\t\tif ( key.toLowerCase() === 'path' ) {
+\t\t\tdelete env[ key ];
+\t\t}
+\t}
+
+\tenv.PATH = nextPath;
+
+\treturn env;
+}
+
+function runSyncScript( scriptPath: string, options: SyncCliOptions ) {
+\tconst args = [ scriptPath ];
+\tif ( options.check ) {
+\t\targs.push( '--check' );
+\t}
+
+\tconst result = spawnSync( 'tsx', args, {
+\t\tcwd: process.cwd(),
+\t\tenv: getSyncScriptEnv(),
+\t\tshell: process.platform === 'win32',
+\t\tstdio: 'inherit',
+\t} );
+
+\tif ( result.error ) {
+\t\tif ( ( result.error as NodeJS.ErrnoException ).code === 'ENOENT' ) {
+\t\t\tthrow new Error(
+\t\t\t\t'Unable to resolve \`tsx\` for project sync. Install project dependencies or rerun the command through your package manager.'
+\t\t\t);
+\t\t}
+
+\t\tthrow result.error;
+\t}
+
+\tif ( result.status !== 0 ) {
+\t\tthrow new Error( \`Sync script failed: \${ scriptPath }\` );
+\t}
+}
+
+async function main() {
+\tconst options = parseCliOptions( process.argv.slice( 2 ) );
+\tconst syncTypesScriptPath = path.join( 'scripts', 'sync-types-to-block-json.ts' );
+
+\trunSyncScript( syncTypesScriptPath, options );
+
+\tconsole.log(
+\t\toptions.check
+\t\t\t? '✅ Generated project metadata is already synchronized.'
+\t\t\t: '✅ Generated project metadata was synchronized.'
+\t);
+}
+
+main().catch( ( error ) => {
+\tconsole.error( '❌ Project sync failed:', error );
+\tprocess.exit( 1 );
+} );
+`;
+}
+
 function buildLayoutDetails(projectDir: string): {
 	blockNames: string[];
+	blockTargets: RetrofitInitBlockTarget[];
 	description: string;
 	generatedArtifacts: string[];
 	kind: InitPlanLayoutKind;
@@ -279,11 +655,33 @@ function buildLayoutDetails(projectDir: string): {
 } {
 	try {
 		const discoveredLayout = discoverMigrationInitLayout(projectDir);
+		const discoveredBlocks =
+			discoveredLayout.mode === "multi"
+				? discoveredLayout.blocks
+				: [discoveredLayout.block];
+		let blockTargets: RetrofitInitBlockTarget[];
+		try {
+			blockTargets = discoveredBlocks.map((block) =>
+				buildRetrofitBlockTarget(projectDir, block),
+			);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			return {
+				blockNames: discoveredBlocks.map((block) => block.blockName),
+				blockTargets: [],
+				description:
+					"Detected supported block files, but could not infer retrofit block-config metadata automatically yet.",
+				generatedArtifacts: [],
+				kind: "unsupported",
+				notes: [message, SUPPORTED_RETROFIT_LAYOUT_NOTE],
+			};
+		}
 		if (discoveredLayout.mode === "multi") {
 			return {
-				blockNames: discoveredLayout.blocks.map((block) => block.blockName),
-				description: `Detected a supported multi-block retrofit candidate (${discoveredLayout.blocks.length} targets).`,
-				generatedArtifacts: discoveredLayout.blocks.flatMap((block) =>
+				blockNames: discoveredBlocks.map((block) => block.blockName),
+				blockTargets,
+				description: `Detected a supported multi-block retrofit candidate (${discoveredBlocks.length} targets).`,
+				generatedArtifacts: discoveredBlocks.flatMap((block) =>
 					buildGeneratedArtifactPaths(block.blockJsonFile, block.manifestFile),
 				),
 				kind: "multi-block",
@@ -295,6 +693,7 @@ function buildLayoutDetails(projectDir: string): {
 
 		return {
 			blockNames: [discoveredLayout.block.blockName],
+			blockTargets,
 			description: "Detected a supported single-block retrofit candidate.",
 			generatedArtifacts: buildGeneratedArtifactPaths(
 				discoveredLayout.block.blockJsonFile,
@@ -312,6 +711,7 @@ function buildLayoutDetails(projectDir: string): {
 		const message = error instanceof Error ? error.message : String(error);
 		return {
 			blockNames: [],
+			blockTargets: [],
 			description: "No supported retrofit layout was auto-detected yet.",
 			generatedArtifacts: [],
 			kind: "unsupported",
@@ -335,33 +735,49 @@ function hasExistingWpTypiaProjectSurface(
 	return hasSyncSurface && hasRuntimeDeps;
 }
 
-function buildPlannedFiles(layoutKind: InitPlanLayoutKind): InitFilePlan[] {
-	const plannedFiles: InitFilePlan[] = [
+function buildPlannedFiles(
+	projectDir: string,
+	layoutKind: InitPlanLayoutKind,
+): InitFilePlan[] {
+	if (layoutKind === "unsupported") {
+		return [];
+	}
+
+	return [
 		{
+			action: fs.existsSync(path.join(projectDir, "scripts", "block-config.ts"))
+				? "update"
+				: "add",
+			path: "scripts/block-config.ts",
+			purpose:
+				"Declare the current retrofit block targets so sync-types can regenerate metadata from the existing TypeScript source of truth.",
+		},
+		{
+			action: fs.existsSync(
+				path.join(projectDir, "scripts", "sync-types-to-block-json.ts"),
+			)
+				? "update"
+				: "add",
 			path: "scripts/sync-types-to-block-json.ts",
 			purpose:
 				"Generate block.json and Typia metadata artifacts from the current TypeScript source of truth.",
 		},
 		{
+			action: fs.existsSync(path.join(projectDir, "scripts", "sync-project.ts"))
+				? "update"
+				: "add",
 			path: "scripts/sync-project.ts",
 			purpose:
 				"Provide one shared sync entrypoint that can grow into sync-rest or workspace-aware refresh steps later.",
 		},
 	];
-
-	if (layoutKind === "unsupported") {
-		plannedFiles.unshift({
-			path: "package.json",
-			purpose:
-				"Add the minimum wp-typia devDependencies and scripts once the project matches a supported retrofit layout.",
-		});
-	}
-
-	return plannedFiles;
 }
 
 function buildChangeSummary(
 	changes: Pick<RetrofitInitPlan, "generatedArtifacts" | "packageChanges" | "plannedFiles">,
+	options: {
+		includeGeneratedArtifacts: boolean;
+	},
 ): string[] {
 	const lines: string[] = [];
 
@@ -384,18 +800,22 @@ function buildChangeSummary(
 	}
 
 	for (const filePlan of changes.plannedFiles) {
-		lines.push(`file add ${filePlan.path} (${filePlan.purpose})`);
+		lines.push(`file ${filePlan.action} ${filePlan.path} (${filePlan.purpose})`);
 	}
 
-	for (const artifactPath of changes.generatedArtifacts) {
-		lines.push(`generated artifact ${artifactPath}`);
+	if (options.includeGeneratedArtifacts) {
+		for (const artifactPath of changes.generatedArtifacts) {
+			lines.push(`generated artifact ${artifactPath}`);
+		}
 	}
 
 	return lines;
 }
 
 function buildNextSteps(options: {
-	changeSummaryLines: string[];
+	commandMode: InitCommandMode;
+	dependencyChangeCount: number;
+	hasPlannedChanges: boolean;
 	layoutKind: InitPlanLayoutKind;
 	packageManager: PackageManagerId;
 }): string[] {
@@ -426,11 +846,25 @@ function buildNextSteps(options: {
 		];
 	}
 
+	if (options.commandMode === "apply") {
+		return [
+			...(options.dependencyChangeCount > 0
+				? [
+						"Install or reinstall project dependencies so the retrofit sync scripts and metadata generators are available locally.",
+						dependencyInstallCommand,
+				  ]
+				: []),
+			syncRun,
+			doctorRun,
+			`Optional migration bootstrap: ${migrationInitRun}`,
+		];
+	}
+
 	const steps = [
-		...(options.changeSummaryLines.length > 0
+		...(options.hasPlannedChanges
 			? [
-					"Apply the planned package.json changes and helper files listed below.",
-					dependencyInstallCommand,
+					"Re-run `wp-typia init --apply` to write the planned package.json changes and helper files automatically.",
+					...(options.dependencyChangeCount > 0 ? [dependencyInstallCommand] : []),
 			  ]
 			: []),
 		syncRun,
@@ -447,14 +881,228 @@ function buildRequiredDevDependencyMapEntries(): string[] {
 	);
 }
 
-export function getInitPlan(projectDir: string): RetrofitInitPlan {
+function buildRetrofitPlanSummary(options: {
+	commandMode: InitCommandMode;
+	status: InitPlanStatus;
+}): string {
+	if (options.status === "already-initialized") {
+		return options.commandMode === "apply"
+			? "This project already exposes the minimum wp-typia retrofit surface. No files were changed."
+			: "This project already exposes the minimum wp-typia retrofit surface.";
+	}
+
+	if (options.commandMode === "apply") {
+		return "Applied the minimum wp-typia retrofit surface so package.json and helper scripts are ready for the next install and sync run.";
+	}
+
+	return "This command previews the minimum wp-typia adoption layer for the current project without rewriting it into a full scaffold.";
+}
+
+function createRetrofitPlan(options: {
+	commandMode: InitCommandMode;
+	detectedLayout: {
+		blockNames: string[];
+		description: string;
+		kind: InitPlanLayoutKind;
+	};
+	blockTargets: RetrofitInitBlockTarget[];
+	generatedArtifacts: string[];
+	nextSteps?: string[];
+	notes: string[];
+	packageChanges: RetrofitInitPlan["packageChanges"];
+	packageManager: PackageManagerId;
+	plannedFiles: InitFilePlan[];
+	projectDir: string;
+	projectName: string;
+	status: InitPlanStatus;
+}): RetrofitInitPlan {
+	const includeGeneratedArtifacts = options.commandMode === "preview-only";
+	const plannedChanges = buildChangeSummary(
+		{
+			generatedArtifacts: options.generatedArtifacts,
+			packageChanges: options.packageChanges,
+			plannedFiles: options.plannedFiles,
+		},
+		{
+			includeGeneratedArtifacts,
+		},
+	);
+
+	return {
+		blockTargets: options.blockTargets,
+		commandMode: options.commandMode,
+		detectedLayout: options.detectedLayout,
+		generatedArtifacts: options.generatedArtifacts,
+		nextSteps:
+			options.nextSteps ??
+			buildNextSteps({
+				commandMode: options.commandMode,
+				dependencyChangeCount: options.packageChanges.addDevDependencies.length,
+				hasPlannedChanges: plannedChanges.length > 0,
+				layoutKind: options.detectedLayout.kind,
+				packageManager: options.packageManager,
+			}),
+		notes: options.notes,
+		packageChanges: options.packageChanges,
+		plannedFiles: options.plannedFiles,
+		packageManager: options.packageManager,
+		projectDir: options.projectDir,
+		projectName: options.projectName,
+		status: options.status,
+		summary: buildRetrofitPlanSummary({
+			commandMode: options.commandMode,
+			status: options.status,
+		}),
+	};
+}
+
+function setDependencyVersion(
+	packageJson: ProjectPackageJson,
+	name: string,
+	requiredValue: string,
+): void {
+	if (packageJson.devDependencies?.[name] !== undefined) {
+		packageJson.devDependencies[name] = requiredValue;
+		return;
+	}
+	if (packageJson.dependencies?.[name] !== undefined) {
+		packageJson.dependencies[name] = requiredValue;
+		return;
+	}
+
+	packageJson.devDependencies ??= {};
+	packageJson.devDependencies[name] = requiredValue;
+}
+
+function buildNextProjectPackageJson(options: {
+	packageChanges: RetrofitInitPlan["packageChanges"];
+	packageJson: ProjectPackageJson | null;
+	packageManager: PackageManagerId;
+	projectName: string;
+}): ProjectPackageJson {
+	const nextPackageJson: ProjectPackageJson = options.packageJson
+		? JSON.parse(JSON.stringify(options.packageJson))
+		: {
+				name: options.projectName,
+				private: true,
+		  };
+
+	nextPackageJson.devDependencies ??= {};
+	nextPackageJson.scripts ??= {};
+
+	for (const dependencyChange of options.packageChanges.addDevDependencies) {
+		setDependencyVersion(
+			nextPackageJson,
+			dependencyChange.name,
+			dependencyChange.requiredValue,
+		);
+	}
+
+	if (options.packageChanges.packageManagerField) {
+		nextPackageJson.packageManager =
+			options.packageChanges.packageManagerField.requiredValue;
+	} else if (
+		!nextPackageJson.packageManager &&
+		options.packageManager !== "npm"
+	) {
+		nextPackageJson.packageManager =
+			getPackageManager(options.packageManager).packageManagerField;
+	}
+
+	for (const scriptChange of options.packageChanges.scripts) {
+		nextPackageJson.scripts[scriptChange.name] = scriptChange.requiredValue;
+	}
+
+	return nextPackageJson;
+}
+
+function buildProjectPackageJsonSource(packageJson: ProjectPackageJson): string {
+	return `${JSON.stringify(packageJson, null, 2)}\n`;
+}
+
+function buildRetrofitHelperFiles(
+	blockTargets: RetrofitInitBlockTarget[],
+): Record<string, string> {
+	return {
+		[path.join("scripts", "block-config.ts")]:
+			buildRetrofitBlockConfigSource(blockTargets),
+		[path.join("scripts", "sync-project.ts")]:
+			buildRetrofitSyncProjectScriptSource(),
+		[path.join("scripts", "sync-types-to-block-json.ts")]:
+			buildRetrofitSyncTypesScriptSource(),
+	};
+}
+
+async function createRetrofitMutationSnapshot(
+	projectDir: string,
+	filePaths: string[],
+): Promise<WorkspaceMutationSnapshot> {
+	const scriptsDir = path.join(projectDir, "scripts");
+	const scriptsDirExisted = fs.existsSync(scriptsDir);
+	const fileSources = await snapshotWorkspaceFiles(filePaths);
+	const targetPaths = fileSources
+		.filter((entry) => entry.source === null)
+		.map((entry) => entry.filePath);
+
+	if (!scriptsDirExisted) {
+		targetPaths.push(scriptsDir);
+	}
+
+	return {
+		fileSources,
+		snapshotDirs: [],
+		targetPaths,
+	};
+}
+
+async function writeRetrofitFiles(options: {
+	blockTargets: RetrofitInitBlockTarget[];
+	packageJson: ProjectPackageJson;
+	projectDir: string;
+}): Promise<void> {
+	const helperFiles = buildRetrofitHelperFiles(options.blockTargets);
+	const scriptsDir = path.join(options.projectDir, "scripts");
+
+	await fsp.mkdir(scriptsDir, { recursive: true });
+	await fsp.writeFile(
+		path.join(options.projectDir, "package.json"),
+		buildProjectPackageJsonSource(options.packageJson),
+		"utf8",
+	);
+
+	for (const [relativePath, source] of Object.entries(helperFiles)) {
+		await fsp.writeFile(path.join(options.projectDir, relativePath), source, "utf8");
+	}
+}
+
+function buildApplyFailureError(error: unknown): Error {
+	const message = error instanceof Error ? error.message : String(error);
+	return createCliDiagnosticCodeError(
+		CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
+		`Unable to apply the retrofit init plan safely. The command restored the previous package.json/helper-file snapshot. ${message}`,
+		error instanceof Error ? { cause: error } : undefined,
+	);
+}
+
+export function getInitPlan(
+	projectDir: string,
+	options: {
+		packageManager?: string;
+	} = {},
+): RetrofitInitPlan {
 	const resolvedProjectDir = path.resolve(projectDir);
 	const packageJson = readProjectPackageJson(resolvedProjectDir);
-	const packageManager = inferInitPackageManager(resolvedProjectDir, packageJson);
+	const packageManager = resolveInitPackageManager(
+		resolvedProjectDir,
+		packageJson,
+		options.packageManager,
+	);
 	const workspace = tryResolveWorkspaceProject(resolvedProjectDir);
 
 	if (workspace) {
-		return {
+		const cliSpecifier = getWpTypiaCliSpecifier();
+		return createRetrofitPlan({
+			blockTargets: [],
 			commandMode: "preview-only",
 			detectedLayout: {
 				blockNames: [],
@@ -463,8 +1111,9 @@ export function getInitPlan(projectDir: string): RetrofitInitPlan {
 			},
 			generatedArtifacts: [],
 			nextSteps: [
-				formatPackageExecCommand(packageManager, getWpTypiaCliSpecifier(), "doctor"),
-				"Use `wp-typia add ...` to extend this workspace instead of rerunning init.",
+				"Use `wp-typia add <kind> <name>` to extend the official workspace instead of rerunning init.",
+				formatRunScript(packageManager, "sync"),
+				formatPackageExecCommand(packageManager, cliSpecifier, "doctor"),
 			],
 			notes: [
 				"The official workspace template already owns inventory, doctor, and add-command workflows.",
@@ -473,14 +1122,12 @@ export function getInitPlan(projectDir: string): RetrofitInitPlan {
 				addDevDependencies: [],
 				scripts: [],
 			},
-			plannedFiles: [],
 			packageManager,
+			plannedFiles: [],
 			projectDir: workspace.projectDir,
 			projectName: workspace.packageName,
 			status: "already-initialized",
-			summary:
-				"This directory is already an official wp-typia workspace. No retrofit bootstrap is needed.",
-		};
+		});
 	}
 
 	const projectName =
@@ -497,7 +1144,7 @@ export function getInitPlan(projectDir: string): RetrofitInitPlan {
 	const rawPlannedFiles =
 		layout.kind === "generated-project" || layout.kind === "official-workspace"
 			? []
-			: buildPlannedFiles(layout.kind);
+			: buildPlannedFiles(resolvedProjectDir, layout.kind);
 	const hasExistingSurface = hasExistingWpTypiaProjectSurface(packageJson);
 	const status: InitPlanStatus =
 		hasExistingSurface &&
@@ -522,35 +1169,19 @@ export function getInitPlan(projectDir: string): RetrofitInitPlan {
 					description: layout.description,
 					kind: layout.kind,
 			  };
-	const plan: RetrofitInitPlan = {
+
+	return createRetrofitPlan({
+		blockTargets: layout.blockTargets,
 		commandMode: "preview-only",
 		detectedLayout,
 		generatedArtifacts:
 			status === "already-initialized" && detectedLayout.kind === "generated-project"
 				? []
 				: layout.generatedArtifacts,
-		nextSteps: buildNextSteps({
-			changeSummaryLines: buildChangeSummary({
-				generatedArtifacts:
-					status === "already-initialized" &&
-					detectedLayout.kind === "generated-project"
-						? []
-						: layout.generatedArtifacts,
-				packageChanges: {
-					addDevDependencies: dependencyChanges,
-					...(packageManagerFieldChange
-						? { packageManagerField: packageManagerFieldChange }
-						: {}),
-					scripts: scriptChanges,
-				},
-				plannedFiles,
-			}),
-			layoutKind: detectedLayout.kind,
-			packageManager,
-		}),
 		notes: Array.from(
 			new Set([
 				"Preview only: `wp-typia init` does not write files yet.",
+				RETROFIT_APPLY_PREVIEW_NOTE,
 				...layout.notes,
 			]),
 		),
@@ -561,16 +1192,103 @@ export function getInitPlan(projectDir: string): RetrofitInitPlan {
 				: {}),
 			scripts: scriptChanges,
 		},
-		plannedFiles,
 		packageManager,
+		plannedFiles,
 		projectDir: resolvedProjectDir,
 		projectName,
 		status,
-		summary:
-			status === "already-initialized"
-				? "This project already exposes the minimum wp-typia retrofit surface."
-				: "This command previews the minimum wp-typia adoption layer for the current project without rewriting it into a full scaffold.",
-	};
+	});
+}
 
-	return plan;
+export async function applyInitPlan(
+	projectDir: string,
+	options: {
+		packageManager?: string;
+	} = {},
+): Promise<RetrofitInitPlan> {
+	const previewPlan = getInitPlan(projectDir, options);
+
+	if (previewPlan.detectedLayout.kind === "unsupported") {
+		throw createCliDiagnosticCodeError(
+			CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
+			"`wp-typia init --apply` requires a supported retrofit layout. Run `wp-typia init` first to inspect the preview plan and any blocking notes.",
+		);
+	}
+
+	if (previewPlan.status === "already-initialized") {
+		return createRetrofitPlan({
+			...previewPlan,
+			commandMode: "apply",
+			notes: Array.from(
+				new Set([
+					...previewPlan.notes.filter(
+						(note) =>
+							note !== "Preview only: `wp-typia init` does not write files yet." &&
+							note !== RETROFIT_APPLY_PREVIEW_NOTE,
+					),
+					RETROFIT_ROLLBACK_NOTE,
+				]),
+			),
+			status: "already-initialized",
+		});
+	}
+
+	const nextPackageJson = buildNextProjectPackageJson({
+		packageChanges: previewPlan.packageChanges,
+		packageJson: readProjectPackageJson(previewPlan.projectDir),
+		packageManager: previewPlan.packageManager,
+		projectName: previewPlan.projectName,
+	});
+	const helperFiles = buildRetrofitHelperFiles(previewPlan.blockTargets);
+	const filePaths = [
+		path.join(previewPlan.projectDir, "package.json"),
+		...Object.keys(helperFiles).map((relativePath) =>
+			path.join(previewPlan.projectDir, relativePath),
+		),
+	];
+	const mutationSnapshot = await createRetrofitMutationSnapshot(
+		previewPlan.projectDir,
+		filePaths,
+	);
+
+	try {
+		await writeRetrofitFiles({
+			blockTargets: previewPlan.blockTargets,
+			packageJson: nextPackageJson,
+			projectDir: previewPlan.projectDir,
+		});
+	} catch (error) {
+		await rollbackWorkspaceMutation(mutationSnapshot);
+		throw buildApplyFailureError(error);
+	}
+
+	return createRetrofitPlan({
+		...previewPlan,
+		commandMode: "apply",
+		notes: Array.from(
+			new Set([
+				...previewPlan.notes.filter(
+					(note) =>
+						note !== "Preview only: `wp-typia init` does not write files yet." &&
+						note !== RETROFIT_APPLY_PREVIEW_NOTE,
+				),
+				RETROFIT_ROLLBACK_NOTE,
+			]),
+		),
+		status: "applied",
+	});
+}
+
+export async function runInitCommand(options: {
+	apply?: boolean;
+	packageManager?: string;
+	projectDir: string;
+}): Promise<RetrofitInitPlan> {
+	return options.apply
+		? applyInitPlan(options.projectDir, {
+				packageManager: options.packageManager,
+		  })
+		: getInitPlan(options.projectDir, {
+				packageManager: options.packageManager,
+		  });
 }

--- a/packages/wp-typia-project-tools/src/runtime/cli-init.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-init.ts
@@ -70,6 +70,14 @@ interface InitFilePlan {
 	purpose: string;
 }
 
+/**
+ * One existing block target that `wp-typia init` can retrofit into the shared
+ * sync surface.
+ *
+ * Each path stays relative to the project root so generated helper scripts can
+ * resolve the current block metadata and TypeScript source of truth without
+ * guessing layout-specific locations.
+ */
 export interface RetrofitInitBlockTarget {
 	attributeTypeName: string;
 	blockJsonFile: string;
@@ -80,6 +88,13 @@ export interface RetrofitInitBlockTarget {
 	typesFile: string;
 }
 
+/**
+ * Preview or apply result returned by `wp-typia init`.
+ *
+ * The plan describes the detected retrofit layout, package-level mutations,
+ * helper files, next steps, and any warnings gathered while preparing or
+ * applying the minimum sync surface for an existing project.
+ */
 export interface RetrofitInitPlan {
 	blockTargets: RetrofitInitBlockTarget[];
 	commandMode: InitCommandMode;
@@ -290,8 +305,11 @@ function buildScriptChanges(
 function buildPackageManagerFieldChange(
 	packageJson: ProjectPackageJson | null,
 	packageManager: PackageManagerId,
+	options: {
+		persistExplicitOverride?: boolean;
+	} = {},
 ): InitPackageManagerFieldChange | undefined {
-	if (packageManager === "npm") {
+	if (!options.persistExplicitOverride && packageManager === "npm") {
 		return undefined;
 	}
 
@@ -352,18 +370,14 @@ function isObjectLikeSourceType(
 	typesFile: string,
 	sourceTypeName: string,
 ): boolean {
-	try {
-		const analyzedTypes = analyzeSourceTypes(
-			{
-				projectRoot: projectDir,
-				typesFile,
-			},
-			[sourceTypeName],
-		);
-		return analyzedTypes[sourceTypeName]?.kind === "object";
-	} catch {
-		return false;
-	}
+	const analyzedTypes = analyzeSourceTypes(
+		{
+			projectRoot: projectDir,
+			typesFile,
+		},
+		[sourceTypeName],
+	);
+	return analyzedTypes[sourceTypeName]?.kind === "object";
 }
 
 function inferRetrofitAttributeTypeName(
@@ -721,18 +735,24 @@ function buildLayoutDetails(projectDir: string): {
 }
 
 function hasExistingWpTypiaProjectSurface(
+	projectDir: string,
 	packageJson: ProjectPackageJson | null,
 ): boolean {
 	const scripts = packageJson?.scripts ?? {};
 	const hasSyncSurface =
 		typeof scripts.sync === "string" || typeof scripts["sync-types"] === "string";
+	const hasHelperFiles = [
+		path.join("scripts", "block-config.ts"),
+		path.join("scripts", "sync-project.ts"),
+		path.join("scripts", "sync-types-to-block-json.ts"),
+	].every((relativePath) => fs.existsSync(path.join(projectDir, relativePath)));
 	const hasRuntimeDeps =
 		typeof getExistingDependencyVersion(packageJson, "@wp-typia/block-runtime") ===
 			"string" &&
 		typeof getExistingDependencyVersion(packageJson, "@wp-typia/block-types") ===
 			"string";
 
-	return hasSyncSurface && hasRuntimeDeps;
+	return hasSyncSurface && hasHelperFiles && hasRuntimeDeps;
 }
 
 function buildPlannedFiles(
@@ -1084,6 +1104,14 @@ function buildApplyFailureError(error: unknown): Error {
 	);
 }
 
+/**
+ * Inspect one project directory and return the current retrofit init plan.
+ *
+ * @param projectDir Project root or nested path that should be analyzed.
+ * @param options Optional package-manager override used for emitted scripts and
+ * follow-up guidance.
+ * @returns The preview-only retrofit init plan for the resolved project.
+ */
 export function getInitPlan(
 	projectDir: string,
 	options: {
@@ -1100,6 +1128,12 @@ export function getInitPlan(
 	const workspace = tryResolveWorkspaceProject(resolvedProjectDir);
 
 	if (workspace) {
+		const workspacePackageJson = readProjectPackageJson(workspace.projectDir);
+		const workspacePackageManager = resolveInitPackageManager(
+			workspace.projectDir,
+			workspacePackageJson,
+			options.packageManager,
+		);
 		const cliSpecifier = getWpTypiaCliSpecifier();
 		return createRetrofitPlan({
 			blockTargets: [],
@@ -1112,8 +1146,12 @@ export function getInitPlan(
 			generatedArtifacts: [],
 			nextSteps: [
 				"Use `wp-typia add <kind> <name>` to extend the official workspace instead of rerunning init.",
-				formatRunScript(packageManager, "sync"),
-				formatPackageExecCommand(packageManager, cliSpecifier, "doctor"),
+				formatRunScript(workspacePackageManager, "sync"),
+				formatPackageExecCommand(
+					workspacePackageManager,
+					cliSpecifier,
+					"doctor",
+				),
 			],
 			notes: [
 				"The official workspace template already owns inventory, doctor, and add-command workflows.",
@@ -1122,7 +1160,7 @@ export function getInitPlan(
 				addDevDependencies: [],
 				scripts: [],
 			},
-			packageManager,
+			packageManager: workspacePackageManager,
 			plannedFiles: [],
 			projectDir: workspace.projectDir,
 			projectName: workspace.packageName,
@@ -1140,12 +1178,18 @@ export function getInitPlan(
 	const packageManagerFieldChange = buildPackageManagerFieldChange(
 		packageJson,
 		packageManager,
+		{
+			persistExplicitOverride: typeof options.packageManager === "string",
+		},
 	);
 	const rawPlannedFiles =
 		layout.kind === "generated-project" || layout.kind === "official-workspace"
 			? []
 			: buildPlannedFiles(resolvedProjectDir, layout.kind);
-	const hasExistingSurface = hasExistingWpTypiaProjectSurface(packageJson);
+	const hasExistingSurface = hasExistingWpTypiaProjectSurface(
+		resolvedProjectDir,
+		packageJson,
+	);
 	const status: InitPlanStatus =
 		hasExistingSurface &&
 		dependencyChanges.length === 0 &&
@@ -1200,6 +1244,17 @@ export function getInitPlan(
 	});
 }
 
+/**
+ * Apply the previewed retrofit init plan to disk.
+ *
+ * The command snapshots package.json and generated helper targets before
+ * writing, then rolls those files back automatically if any write fails.
+ *
+ * @param projectDir Project root that should receive the retrofit surface.
+ * @param options Optional package-manager override used for emitted scripts and
+ * follow-up guidance.
+ * @returns The applied retrofit init plan describing the persisted changes.
+ */
 export async function applyInitPlan(
 	projectDir: string,
 	options: {
@@ -1279,6 +1334,14 @@ export async function applyInitPlan(
 	});
 }
 
+/**
+ * Execute `wp-typia init` in preview or apply mode.
+ *
+ * @param options Resolved command options including the target project
+ * directory, optional package-manager override, and whether writes should be
+ * applied.
+ * @returns The previewed or applied retrofit init plan.
+ */
 export async function runInitCommand(options: {
 	apply?: boolean;
 	packageManager?: string;

--- a/packages/wp-typia-project-tools/src/runtime/package-versions.ts
+++ b/packages/wp-typia-project-tools/src/runtime/package-versions.ts
@@ -34,9 +34,7 @@ const require = createRequire(import.meta.url);
 const DEFAULT_VERSION_RANGE = "^0.0.0";
 const DEFAULT_EXACT_VERSION = "0.0.0";
 const DEFAULT_TSX_PACKAGE_VERSION = "^4.20.5";
-const DEFAULT_TYPIA_PACKAGE_VERSION = "^12.0.1";
 const DEFAULT_TYPIA_UNPLUGIN_PACKAGE_VERSION = "^12.0.1";
-const DEFAULT_TYPESCRIPT_PACKAGE_VERSION = "^5.9.2";
 
 let cachedPackageVersions:
 	| {
@@ -267,7 +265,7 @@ export function getPackageVersions(): PackageVersions {
 				monorepoManifest.devDependencies?.typia ??
 				createManifest.dependencies?.typia ??
 				readPackageManifest(installedTypiaManifestLocation)?.version,
-			DEFAULT_TYPIA_PACKAGE_VERSION,
+			DEFAULT_VERSION_RANGE,
 		),
 		typiaUnpluginPackageVersion: normalizeVersionRangeWithFallback(
 			monorepoManifest.dependencies?.["@typia/unplugin"] ??
@@ -280,7 +278,7 @@ export function getPackageVersions(): PackageVersions {
 				monorepoManifest.devDependencies?.typescript ??
 				createManifest.dependencies?.typescript ??
 				readPackageManifest(installedTypescriptManifestLocation)?.version,
-			DEFAULT_TYPESCRIPT_PACKAGE_VERSION,
+			DEFAULT_VERSION_RANGE,
 		),
 		wpTypiaPackageExactVersion: normalizeExactVersion(wpTypiaManifest.version),
 		wpTypiaPackageVersion: normalizeVersionRange(wpTypiaManifest.version),

--- a/packages/wp-typia-project-tools/src/runtime/package-versions.ts
+++ b/packages/wp-typia-project-tools/src/runtime/package-versions.ts
@@ -6,6 +6,7 @@ import { PROJECT_TOOLS_PACKAGE_ROOT } from "./template-registry.js";
 
 interface PackageManifest {
 	dependencies?: Record<string, string>;
+	devDependencies?: Record<string, string>;
 	version?: string;
 }
 
@@ -15,6 +16,10 @@ export interface PackageVersions {
 	blockTypesPackageVersion: string;
 	projectToolsPackageVersion: string;
 	restPackageVersion: string;
+	tsxPackageVersion: string;
+	typiaPackageVersion: string;
+	typiaUnpluginPackageVersion: string;
+	typescriptPackageVersion: string;
 	wpTypiaPackageExactVersion: string;
 	wpTypiaPackageVersion: string;
 }
@@ -28,6 +33,10 @@ interface PackageManifestLocation {
 const require = createRequire(import.meta.url);
 const DEFAULT_VERSION_RANGE = "^0.0.0";
 const DEFAULT_EXACT_VERSION = "0.0.0";
+const DEFAULT_TSX_PACKAGE_VERSION = "^4.20.5";
+const DEFAULT_TYPIA_PACKAGE_VERSION = "^12.0.1";
+const DEFAULT_TYPIA_UNPLUGIN_PACKAGE_VERSION = "^12.0.1";
+const DEFAULT_TYPESCRIPT_PACKAGE_VERSION = "^5.9.2";
 
 let cachedPackageVersions:
 	| {
@@ -63,6 +72,14 @@ function normalizeExactVersion(value: string | undefined): string {
 		return DEFAULT_EXACT_VERSION;
 	}
 	return trimmed.replace(/^[~^<>=]+/, "");
+}
+
+function normalizeVersionRangeWithFallback(
+	value: string | undefined,
+	fallback: string,
+): string {
+	const normalized = normalizeVersionRange(value);
+	return normalized === DEFAULT_VERSION_RANGE ? fallback : normalized;
 }
 
 function createContentFingerprint(source: string): string {
@@ -155,6 +172,9 @@ export function getPackageVersions(): PackageVersions {
 	const createManifestLocation = resolvePackageManifestLocation(
 		path.join(PROJECT_TOOLS_PACKAGE_ROOT, "package.json"),
 	);
+	const monorepoManifestLocation = resolvePackageManifestLocation(
+		path.join(PROJECT_TOOLS_PACKAGE_ROOT, "..", "..", "package.json"),
+	);
 	const blockRuntimeManifestLocation = resolvePackageManifestLocation(
 		path.join(PROJECT_TOOLS_PACKAGE_ROOT, "..", "wp-typia-block-runtime", "package.json"),
 	);
@@ -171,10 +191,19 @@ export function getPackageVersions(): PackageVersions {
 		resolveInstalledPackageManifestLocation("@wp-typia/block-types");
 	const installedRestManifestLocation =
 		resolveInstalledPackageManifestLocation("@wp-typia/rest");
+	const installedTsxManifestLocation =
+		resolveInstalledPackageManifestLocation("tsx");
+	const installedTypiaManifestLocation =
+		resolveInstalledPackageManifestLocation("typia");
+	const installedTypiaUnpluginManifestLocation =
+		resolveInstalledPackageManifestLocation("@typia/unplugin");
+	const installedTypescriptManifestLocation =
+		resolveInstalledPackageManifestLocation("typescript");
 	const installedWpTypiaManifestLocation =
 		resolveInstalledPackageManifestLocation("wp-typia");
 	const cacheKey = composePackageVersionsCacheKey([
 		createManifestLocation,
+		monorepoManifestLocation,
 		blockRuntimeManifestLocation,
 		wpTypiaManifestLocation,
 		installedProjectToolsManifestLocation,
@@ -182,6 +211,10 @@ export function getPackageVersions(): PackageVersions {
 		installedBlockRuntimeManifestLocation,
 		installedBlockTypesManifestLocation,
 		installedRestManifestLocation,
+		installedTsxManifestLocation,
+		installedTypiaManifestLocation,
+		installedTypiaUnpluginManifestLocation,
+		installedTypescriptManifestLocation,
 		installedWpTypiaManifestLocation,
 	]);
 
@@ -193,6 +226,7 @@ export function getPackageVersions(): PackageVersions {
 		readPackageManifest(createManifestLocation) ??
 		readPackageManifest(installedProjectToolsManifestLocation) ??
 		{};
+	const monorepoManifest = readPackageManifest(monorepoManifestLocation) ?? {};
 	const blockRuntimeManifest =
 		readPackageManifest(blockRuntimeManifestLocation) ??
 		readPackageManifest(installedBlockRuntimeManifestLocation) ??
@@ -221,6 +255,32 @@ export function getPackageVersions(): PackageVersions {
 		restPackageVersion: normalizeVersionRange(
 			createManifest.dependencies?.["@wp-typia/rest"] ??
 				readPackageManifest(installedRestManifestLocation)?.version,
+		),
+		tsxPackageVersion: normalizeVersionRangeWithFallback(
+			monorepoManifest.dependencies?.tsx ??
+				monorepoManifest.devDependencies?.tsx ??
+				readPackageManifest(installedTsxManifestLocation)?.version,
+			DEFAULT_TSX_PACKAGE_VERSION,
+		),
+		typiaPackageVersion: normalizeVersionRangeWithFallback(
+			monorepoManifest.dependencies?.typia ??
+				monorepoManifest.devDependencies?.typia ??
+				createManifest.dependencies?.typia ??
+				readPackageManifest(installedTypiaManifestLocation)?.version,
+			DEFAULT_TYPIA_PACKAGE_VERSION,
+		),
+		typiaUnpluginPackageVersion: normalizeVersionRangeWithFallback(
+			monorepoManifest.dependencies?.["@typia/unplugin"] ??
+				monorepoManifest.devDependencies?.["@typia/unplugin"] ??
+				readPackageManifest(installedTypiaUnpluginManifestLocation)?.version,
+			DEFAULT_TYPIA_UNPLUGIN_PACKAGE_VERSION,
+		),
+		typescriptPackageVersion: normalizeVersionRangeWithFallback(
+			monorepoManifest.dependencies?.typescript ??
+				monorepoManifest.devDependencies?.typescript ??
+				createManifest.dependencies?.typescript ??
+				readPackageManifest(installedTypescriptManifestLocation)?.version,
+			DEFAULT_TYPESCRIPT_PACKAGE_VERSION,
 		),
 		wpTypiaPackageExactVersion: normalizeExactVersion(wpTypiaManifest.version),
 		wpTypiaPackageVersion: normalizeVersionRange(wpTypiaManifest.version),

--- a/packages/wp-typia-project-tools/tests/init-command.test.ts
+++ b/packages/wp-typia-project-tools/tests/init-command.test.ts
@@ -7,6 +7,7 @@ import { getPackageVersions } from "../src/runtime/package-versions.js";
 import {
 	cleanupScaffoldTempRoot,
 	createScaffoldTempRoot,
+	scaffoldOfficialWorkspace,
 	wpTypiaPackageManifest,
 } from "./helpers/scaffold-test-harness.js";
 
@@ -165,6 +166,38 @@ describe("wp-typia init", () => {
 		);
 	});
 
+	test("persists explicit npm overrides over conflicting packageManager metadata", async () => {
+		const projectDir = path.join(tempRoot, "retrofit-explicit-npm");
+		scaffoldRetrofitProject(projectDir, {
+			interfaceName: "RetrofitExplicitNpmAttributes",
+			packageJson: {
+				packageManager: "bun@1.3.11",
+			},
+		});
+
+		const previewPlan = getInitPlan(projectDir, {
+			packageManager: "npm",
+		});
+		const appliedPlan = await applyInitPlan(projectDir, {
+			packageManager: "npm",
+		});
+		const packageJson = JSON.parse(
+			fs.readFileSync(path.join(projectDir, "package.json"), "utf8"),
+		) as {
+			packageManager?: string;
+		};
+
+		expect(previewPlan.packageChanges.packageManagerField).toEqual(
+			expect.objectContaining({
+				action: "update",
+				currentValue: "bun@1.3.11",
+				requiredValue: "npm@11.6.1",
+			}),
+		);
+		expect(appliedPlan.packageManager).toBe("npm");
+		expect(packageJson.packageManager).toBe("npm@11.6.1");
+	});
+
 	test("applies retrofit helper files and preserves legacy root block paths", async () => {
 		const projectDir = path.join(tempRoot, "retrofit-legacy-root");
 		scaffoldRetrofitProject(projectDir, {
@@ -236,10 +269,40 @@ describe("wp-typia init", () => {
 		}
 	});
 
+	test("resolves official workspace package-manager guidance from the workspace root", async () => {
+		const projectDir = path.join(tempRoot, "workspace-init-package-manager");
+		await scaffoldOfficialWorkspace(projectDir);
+		const packageJsonPath = path.join(projectDir, "package.json");
+		const packageJson = JSON.parse(
+			fs.readFileSync(packageJsonPath, "utf8"),
+		) as Record<string, unknown>;
+		fs.writeFileSync(
+			packageJsonPath,
+			`${JSON.stringify(
+				{
+					...packageJson,
+					packageManager: "bun@1.3.11",
+				},
+				null,
+				2,
+			)}\n`,
+			"utf8",
+		);
+
+		const plan = getInitPlan(path.join(projectDir, "src"));
+
+		expect(plan.projectDir).toBe(projectDir);
+		expect(plan.packageManager).toBe("bun");
+		expect(plan.nextSteps).toContain("bun run sync");
+		expect(plan.nextSteps).toContain(
+			`bunx wp-typia@${wpTypiaPackageManifest.version} doctor`,
+		);
+	});
+
 	test("reports already-initialized projects without planning redundant changes", () => {
 		const projectDir = path.join(tempRoot, "retrofit-already-initialized");
 		const versions = getPackageVersions();
-		fs.mkdirSync(projectDir, { recursive: true });
+		fs.mkdirSync(path.join(projectDir, "scripts"), { recursive: true });
 		fs.writeFileSync(
 			path.join(projectDir, "package.json"),
 			`${JSON.stringify(
@@ -263,6 +326,21 @@ describe("wp-typia init", () => {
 				null,
 				2,
 			)}\n`,
+			"utf8",
+		);
+		fs.writeFileSync(
+			path.join(projectDir, "scripts", "block-config.ts"),
+			"export const BLOCKS = [];\n",
+			"utf8",
+		);
+		fs.writeFileSync(
+			path.join(projectDir, "scripts", "sync-project.ts"),
+			"export {};\n",
+			"utf8",
+		);
+		fs.writeFileSync(
+			path.join(projectDir, "scripts", "sync-types-to-block-json.ts"),
+			"export {};\n",
 			"utf8",
 		);
 

--- a/packages/wp-typia-project-tools/tests/init-command.test.ts
+++ b/packages/wp-typia-project-tools/tests/init-command.test.ts
@@ -2,13 +2,70 @@ import { afterAll, describe, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
-import { getInitPlan } from "../src/runtime/cli-init.js";
+import { applyInitPlan, getInitPlan } from "../src/runtime/cli-init.js";
 import { getPackageVersions } from "../src/runtime/package-versions.js";
 import {
 	cleanupScaffoldTempRoot,
 	createScaffoldTempRoot,
 	wpTypiaPackageManifest,
 } from "./helpers/scaffold-test-harness.js";
+
+function scaffoldRetrofitProject(
+	projectDir: string,
+	options: {
+		blockName?: string;
+		interfaceName: string;
+		layout?: "root" | "src";
+		packageJson?: Record<string, unknown>;
+	} = {
+		interfaceName: "RetrofitInitAttributes",
+	},
+): void {
+	const blockName =
+		options.blockName ?? `create-block/${path.basename(projectDir)}`;
+	const layout = options.layout ?? "src";
+	const blockJsonPath =
+		layout === "src"
+			? path.join(projectDir, "src", "block.json")
+			: path.join(projectDir, "block.json");
+
+	fs.mkdirSync(path.join(projectDir, "src"), { recursive: true });
+	fs.writeFileSync(
+		path.join(projectDir, "package.json"),
+		`${JSON.stringify(
+			{
+				name: path.basename(projectDir),
+				private: true,
+				scripts: {},
+				...(options.packageJson ?? {}),
+			},
+			null,
+			2,
+		)}\n`,
+		"utf8",
+	);
+	fs.writeFileSync(
+		blockJsonPath,
+		`${JSON.stringify(
+			{
+				name: blockName,
+			},
+			null,
+			2,
+		)}\n`,
+		"utf8",
+	);
+	fs.writeFileSync(
+		path.join(projectDir, "src", "types.ts"),
+		`export interface ${options.interfaceName} {}\n`,
+		"utf8",
+	);
+	fs.writeFileSync(
+		path.join(projectDir, "src", "save.tsx"),
+		"export default function Save() { return null; }\n",
+		"utf8",
+	);
+}
 
 describe("wp-typia init", () => {
 	const tempRoot = createScaffoldTempRoot("wp-typia-init-plan-");
@@ -19,38 +76,36 @@ describe("wp-typia init", () => {
 
 	test("detects single-block retrofit candidates and plans the minimum sync surface", () => {
 		const projectDir = path.join(tempRoot, "retrofit-single-block");
-		fs.mkdirSync(path.join(projectDir, "src"), { recursive: true });
-		fs.writeFileSync(
-			path.join(projectDir, "package.json"),
-			JSON.stringify(
-				{
-					name: "retrofit-single-block",
-					private: true,
-					scripts: {},
-				},
-				null,
-				2,
-			),
-		);
-		fs.writeFileSync(
-			path.join(projectDir, "src", "block.json"),
-			JSON.stringify(
-				{
-					name: "create-block/retrofit-single-block",
-				},
-				null,
-				2,
-			),
-		);
-		fs.writeFileSync(path.join(projectDir, "src", "types.ts"), "export {};\n");
-		fs.writeFileSync(path.join(projectDir, "src", "save.tsx"), "export default null;\n");
+		scaffoldRetrofitProject(projectDir, {
+			interfaceName: "RetrofitSingleBlockAttributes",
+		});
 
 		const plan = getInitPlan(projectDir);
 
 		expect(plan.status).toBe("preview");
+		expect(plan.commandMode).toBe("preview-only");
 		expect(plan.detectedLayout.kind).toBe("single-block");
 		expect(plan.detectedLayout.blockNames).toEqual([
 			"create-block/retrofit-single-block",
+		]);
+		expect(plan.blockTargets).toEqual([
+			expect.objectContaining({
+				attributeTypeName: "RetrofitSingleBlockAttributes",
+				blockJsonFile: "src/block.json",
+				manifestFile: "src/typia.manifest.json",
+				slug: "retrofit-single-block",
+				typesFile: "src/types.ts",
+			}),
+		]);
+		expect(
+			plan.plannedFiles.map(({ action, path: filePath }) => ({
+				action,
+				path: filePath,
+			})),
+		).toEqual([
+			{ action: "add", path: "scripts/block-config.ts" },
+			{ action: "add", path: "scripts/sync-types-to-block-json.ts" },
+			{ action: "add", path: "scripts/sync-project.ts" },
 		]);
 		expect(plan.packageChanges.scripts.map((script) => script.name)).toEqual([
 			"sync",
@@ -63,12 +118,122 @@ describe("wp-typia init", () => {
 			),
 		).toBe(true);
 		expect(plan.generatedArtifacts).toContain("src/typia.manifest.json");
+		expect(plan.nextSteps[0]).toContain("wp-typia init --apply");
 		expect(plan.nextSteps).toContain(
 			`npx --yes wp-typia@${wpTypiaPackageManifest.version} doctor`,
 		);
 		expect(plan.notes).toContain(
 			"Preview only: `wp-typia init` does not write files yet.",
 		);
+		expect(
+			plan.notes.some((note) =>
+				note.includes("snapshotted and rolled back automatically"),
+			),
+		).toBe(true);
+	});
+
+	test("honors package-manager overrides and reports helper-file updates in the preview plan", () => {
+		const projectDir = path.join(tempRoot, "retrofit-package-manager-override");
+		scaffoldRetrofitProject(projectDir, {
+			interfaceName: "RetrofitPackageManagerAttributes",
+		});
+		fs.mkdirSync(path.join(projectDir, "scripts"), { recursive: true });
+		fs.writeFileSync(
+			path.join(projectDir, "scripts", "block-config.ts"),
+			"export const BLOCKS = [];\n",
+			"utf8",
+		);
+
+		const plan = getInitPlan(projectDir, {
+			packageManager: "pnpm",
+		});
+
+		expect(plan.packageManager).toBe("pnpm");
+		expect(
+			plan.plannedFiles.find((filePlan) => filePlan.path === "scripts/block-config.ts"),
+		).toEqual(
+			expect.objectContaining({
+				action: "update",
+			}),
+		);
+		expect(
+			plan.packageChanges.scripts.find((script) => script.name === "typecheck")
+				?.requiredValue,
+		).toBe("pnpm run sync --check && tsc --noEmit");
+		expect(plan.nextSteps).toContain(
+			`pnpm dlx wp-typia@${wpTypiaPackageManifest.version} doctor`,
+		);
+	});
+
+	test("applies retrofit helper files and preserves legacy root block paths", async () => {
+		const projectDir = path.join(tempRoot, "retrofit-legacy-root");
+		scaffoldRetrofitProject(projectDir, {
+			interfaceName: "RetrofitLegacyRootAttributes",
+			layout: "root",
+		});
+
+		const plan = await applyInitPlan(projectDir, {
+			packageManager: "pnpm",
+		});
+		const packageJson = JSON.parse(
+			fs.readFileSync(path.join(projectDir, "package.json"), "utf8"),
+		) as {
+			packageManager?: string;
+			scripts?: Record<string, string>;
+		};
+		const blockConfigSource = fs.readFileSync(
+			path.join(projectDir, "scripts", "block-config.ts"),
+			"utf8",
+		);
+
+		expect(plan.status).toBe("applied");
+		expect(plan.commandMode).toBe("apply");
+		expect(plan.packageManager).toBe("pnpm");
+		expect(plan.notes).toContain(
+			"Apply mode writes package.json and generated helper files with rollback-on-failure protection.",
+		);
+		expect(packageJson.packageManager).toBe("pnpm@8.3.1");
+		expect(packageJson.scripts?.sync).toBe("tsx scripts/sync-project.ts");
+		expect(packageJson.scripts?.typecheck).toBe(
+			"pnpm run sync --check && tsc --noEmit",
+		);
+		expect(blockConfigSource).toContain(`blockJsonFile: "block.json"`);
+		expect(blockConfigSource).toContain(`manifestFile: "typia.manifest.json"`);
+		expect(
+			fs.existsSync(path.join(projectDir, "scripts", "sync-project.ts")),
+		).toBe(true);
+		expect(
+			fs.existsSync(
+				path.join(projectDir, "scripts", "sync-types-to-block-json.ts"),
+			),
+		).toBe(true);
+	});
+
+	test("rolls back package.json changes when apply mode cannot finish writing helper files", async () => {
+		const projectDir = path.join(tempRoot, "retrofit-rollback");
+		scaffoldRetrofitProject(projectDir, {
+			interfaceName: "RetrofitRollbackAttributes",
+		});
+		const scriptsDir = path.join(projectDir, "scripts");
+		const packageJsonPath = path.join(projectDir, "package.json");
+		const originalPackageJsonSource = fs.readFileSync(packageJsonPath, "utf8");
+
+		fs.mkdirSync(scriptsDir, { recursive: true });
+		fs.chmodSync(scriptsDir, 0o555);
+
+		try {
+			await expect(applyInitPlan(projectDir)).rejects.toThrow(
+				/restored the previous package\.json\/helper-file snapshot/i,
+			);
+			expect(fs.readFileSync(packageJsonPath, "utf8")).toBe(
+				originalPackageJsonSource,
+			);
+			expect(
+				fs.existsSync(path.join(projectDir, "scripts", "block-config.ts")),
+			).toBe(false);
+		} finally {
+			fs.chmodSync(scriptsDir, 0o755);
+		}
 	});
 
 	test("reports already-initialized projects without planning redundant changes", () => {
@@ -77,7 +242,7 @@ describe("wp-typia init", () => {
 		fs.mkdirSync(projectDir, { recursive: true });
 		fs.writeFileSync(
 			path.join(projectDir, "package.json"),
-			JSON.stringify(
+			`${JSON.stringify(
 				{
 					name: "retrofit-already-initialized",
 					private: true,
@@ -87,22 +252,24 @@ describe("wp-typia init", () => {
 						typecheck: "npm run sync -- --check && tsc --noEmit",
 					},
 					devDependencies: {
-						"@typia/unplugin": "^12.0.1",
+						"@typia/unplugin": versions.typiaUnpluginPackageVersion,
 						"@wp-typia/block-runtime": versions.blockRuntimePackageVersion,
 						"@wp-typia/block-types": versions.blockTypesPackageVersion,
-						tsx: "^4.20.5",
-						typescript: "^5.9.2",
-						typia: "^12.0.1",
+						tsx: versions.tsxPackageVersion,
+						typescript: versions.typescriptPackageVersion,
+						typia: versions.typiaPackageVersion,
 					},
 				},
 				null,
 				2,
-			),
+			)}\n`,
+			"utf8",
 		);
 
 		const plan = getInitPlan(projectDir);
 
 		expect(plan.status).toBe("already-initialized");
+		expect(plan.commandMode).toBe("preview-only");
 		expect(plan.detectedLayout.kind).toBe("generated-project");
 		expect(plan.packageChanges.addDevDependencies).toEqual([]);
 		expect(plan.packageChanges.scripts).toEqual([]);

--- a/packages/wp-typia/.bunli/commands.gen.ts
+++ b/packages/wp-typia/.bunli/commands.gen.ts
@@ -46,7 +46,7 @@ const metadata: Record<GeneratedNames, GeneratedCommandMeta> = {
     },
   'init': {
       name: 'init',
-      description: 'Preview the minimum wp-typia retrofit plan for an existing project.',
+      description: 'Preview or apply the minimum wp-typia retrofit plan for an existing project.',
       path: './src/commands/init'
     },
   'mcp': {

--- a/packages/wp-typia/src/command-option-metadata.ts
+++ b/packages/wp-typia/src/command-option-metadata.ts
@@ -25,6 +25,7 @@ export type CommandOptionGroupName =
   | 'global'
   | 'create'
   | 'add'
+  | 'init'
   | 'migrate'
   | 'sync'
   | 'doctor'
@@ -222,6 +223,23 @@ export const ADD_OPTION_METADATA = {
 } as const satisfies CommandOptionMetadataMap;
 
 /**
+ * Shared `wp-typia init` option metadata used by both runtime entry paths.
+ */
+export const INIT_OPTION_METADATA = {
+  apply: {
+    argumentKind: 'flag',
+    description:
+      'Write the planned package.json updates and retrofit helper files instead of previewing only.',
+    type: 'boolean',
+  },
+  'package-manager': {
+    description: 'Package manager to use for emitted scripts and next steps.',
+    short: 'p',
+    type: 'string',
+  },
+} as const satisfies CommandOptionMetadataMap;
+
+/**
  * Shared `wp-typia migrate` option metadata used by both runtime entry paths.
  */
 export const MIGRATE_OPTION_METADATA = {
@@ -328,6 +346,7 @@ export const COMMAND_OPTION_METADATA_BY_GROUP = {
   create: CREATE_OPTION_METADATA,
   doctor: DOCTOR_OPTION_METADATA,
   global: GLOBAL_OPTION_METADATA,
+  init: INIT_OPTION_METADATA,
   migrate: MIGRATE_OPTION_METADATA,
   sync: SYNC_OPTION_METADATA,
   templates: TEMPLATES_OPTION_METADATA,

--- a/packages/wp-typia/src/command-registry.ts
+++ b/packages/wp-typia/src/command-registry.ts
@@ -17,10 +17,11 @@ export const WP_TYPIA_COMMAND_REGISTRY = [
   },
   {
     commandTree: true,
-    description: 'Preview the minimum retrofit plan for an existing project.',
+    description:
+      'Preview or apply the minimum retrofit plan for an existing project.',
     name: 'init',
     nodeFallback: true,
-    optionGroups: [],
+    optionGroups: ['init'],
     requiresBunRuntime: false,
   },
   {

--- a/packages/wp-typia/src/commands/init.ts
+++ b/packages/wp-typia/src/commands/init.ts
@@ -1,22 +1,28 @@
 import { defineCommand } from "@bunli/core";
 
 import {
-	emitCliDiagnosticFailure,
-	prefersStructuredCliOutput,
-} from "../cli-diagnostic-output";
+	buildCommandOptions,
+	INIT_OPTION_METADATA,
+} from "../command-option-metadata";
+import { emitCliDiagnosticFailure, prefersStructuredCliOutput } from "../cli-diagnostic-output";
 import { executeInitCommand } from "../runtime-bridge";
 
 export const initCommand = defineCommand({
 	defaultFormat: "toon",
 	description:
-		"Preview the minimum wp-typia retrofit plan for an existing project.",
+		"Preview or apply the minimum wp-typia retrofit plan for an existing project.",
 	handler: async (args) => {
 		const prefersStructuredOutput = prefersStructuredCliOutput(args);
 
 		try {
 			const plan = await executeInitCommand(
 				{
+					apply: Boolean(args.flags.apply),
 					cwd: args.cwd,
+					packageManager:
+						typeof args.flags["package-manager"] === "string"
+							? args.flags["package-manager"]
+							: undefined,
 					projectDir: args.positional[0] as string | undefined,
 				},
 				{ emitOutput: !prefersStructuredOutput },
@@ -32,7 +38,7 @@ export const initCommand = defineCommand({
 		}
 	},
 	name: "init",
-	options: {},
+	options: buildCommandOptions(INIT_OPTION_METADATA),
 });
 
 export default initCommand;

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -15,6 +15,7 @@ import {
   extractKnownOptionValuesFromArgv,
   formatNodeFallbackOptionHelp,
   GLOBAL_OPTION_METADATA,
+  INIT_OPTION_METADATA,
   MIGRATE_OPTION_METADATA,
   parseCommandArgvWithMetadata,
   resolveCommandOptionValues,
@@ -244,7 +245,10 @@ function renderInitHelp() {
     '',
     ...NODE_FALLBACK_RUNTIME_SUMMARY_LINES,
     '',
-    'Preview-only retrofit planner for existing WordPress block or plugin projects. No files are written yet.',
+    'Preview-by-default retrofit planner for existing WordPress block or plugin projects. Re-run with --apply to write package.json updates and helper scripts.',
+    '',
+    'Supported flags:',
+    ...formatNodeFallbackOptionHelp(INIT_OPTION_METADATA),
   ]);
 }
 
@@ -535,7 +539,12 @@ const NODE_FALLBACK_COMMAND_DISPATCHERS = {
   }: NodeFallbackDispatchContext) => {
     const plan = await executeInitCommand(
       {
+        apply: Boolean(mergedFlags.apply),
         cwd,
+        packageManager:
+          typeof mergedFlags['package-manager'] === 'string'
+            ? mergedFlags['package-manager']
+            : undefined,
         projectDir: positionals[1],
       },
       {

--- a/packages/wp-typia/src/runtime-bridge-output.ts
+++ b/packages/wp-typia/src/runtime-bridge-output.ts
@@ -339,13 +339,14 @@ export function buildCreateDryRunPayload(
 }
 
 /**
- * Builds the completion payload shown after an init preview succeeds.
+ * Builds the completion payload shown after an init preview or apply succeeds.
  *
- * @param plan Preview-only retrofit init plan for one project directory.
+ * @param plan Retrofit init plan for one project directory.
  * @returns A structured alternate-buffer completion payload.
  */
 export function buildInitCompletionPayload(
   plan: {
+    commandMode: 'apply' | 'preview-only';
     detectedLayout: {
       blockNames: string[];
       description: string;
@@ -371,18 +372,19 @@ export function buildInitCompletionPayload(
       }>;
     };
     plannedFiles: Array<{
+      action: 'add' | 'update';
       path: string;
       purpose: string;
     }>;
     packageManager: PackageManagerId;
     projectDir: string;
     projectName: string;
-    status: 'already-initialized' | 'preview';
+    status: 'already-initialized' | 'applied' | 'preview';
     summary: string;
   },
   markerOptions?: OutputMarkerOptions,
 ): AlternateBufferCompletionPayload {
-  const plannedChanges = [
+  const changeLines = [
     ...plan.packageChanges.addDevDependencies.map(
       (dependency) =>
         `devDependency ${dependency.action} ${dependency.name} -> ${dependency.requiredValue}`,
@@ -397,18 +399,49 @@ export function buildInitCompletionPayload(
         `script ${script.action} ${script.name} -> ${script.requiredValue}`,
     ),
     ...plan.plannedFiles.map(
-      (filePlan) => `file add ${filePlan.path} (${filePlan.purpose})`,
+      (filePlan) =>
+        `file ${filePlan.action} ${filePlan.path} (${filePlan.purpose})`,
     ),
-    ...plan.generatedArtifacts.map(
-      (artifactPath) => `generated artifact ${artifactPath}`,
-    ),
+    ...(plan.commandMode === 'preview-only'
+      ? plan.generatedArtifacts.map(
+          (artifactPath) => `generated artifact ${artifactPath}`,
+        )
+      : []),
   ];
+  const modeLine =
+    plan.commandMode === 'apply'
+      ? plan.status === 'already-initialized'
+        ? 'Mode: apply requested; no files were written because the retrofit surface already existed.'
+        : 'Mode: apply; package.json and retrofit helper files were written.'
+      : 'Mode: preview only; no files were written.';
+  const optionalTitle =
+    plan.commandMode === 'apply'
+      ? `Applied adoption changes (${changeLines.length}):`
+      : `Planned adoption changes (${changeLines.length}):`;
+  const title =
+    plan.status === 'already-initialized'
+      ? formatOutputMarker(
+          'success',
+          `wp-typia init: ${plan.projectName} is already initialized`,
+          markerOptions,
+        )
+      : plan.commandMode === 'apply'
+        ? formatOutputMarker(
+            'success',
+            `Applied retrofit init for ${plan.projectName}`,
+            markerOptions,
+          )
+        : formatOutputMarker(
+            'dryRun',
+            `Retrofit init plan for ${plan.projectName}`,
+            markerOptions,
+          );
 
   return {
     nextSteps: plan.nextSteps,
-    optionalLines: plannedChanges,
+    optionalLines: changeLines,
     optionalNote: plan.summary,
-    optionalTitle: `Planned adoption changes (${plannedChanges.length}):`,
+    optionalTitle,
     summaryLines: [
       `Project directory: ${plan.projectDir}`,
       `Detected layout: ${plan.detectedLayout.description}`,
@@ -416,20 +449,9 @@ export function buildInitCompletionPayload(
         ? [`Block targets: ${plan.detectedLayout.blockNames.join(', ')}`]
         : []),
       `Package manager: ${plan.packageManager}`,
-      'Mode: preview only; no files were written.',
+      modeLine,
     ],
-    title:
-      plan.status === 'already-initialized'
-        ? formatOutputMarker(
-            'success',
-            `wp-typia init: ${plan.projectName} is already initialized`,
-            markerOptions,
-          )
-        : formatOutputMarker(
-            'dryRun',
-            `Retrofit init plan for ${plan.projectName}`,
-            markerOptions,
-          ),
+    title,
     warningLines: plan.notes,
   };
 }

--- a/packages/wp-typia/src/runtime-bridge.ts
+++ b/packages/wp-typia/src/runtime-bridge.ts
@@ -76,7 +76,9 @@ type TemplatesExecutionInput = {
 };
 
 type InitExecutionInput = {
+  apply?: boolean;
   cwd: string;
+  packageManager?: string;
   projectDir?: string;
 };
 
@@ -585,7 +587,7 @@ export async function executeTemplatesCommand(
 }
 
 export async function executeInitCommand(
-  { cwd, projectDir }: InitExecutionInput,
+  { apply, cwd, packageManager, projectDir }: InitExecutionInput,
   options: {
     emitOutput?: boolean;
     printLine?: PrintLine;
@@ -593,11 +595,15 @@ export async function executeInitCommand(
   } = {},
 ) {
   try {
-    const { getInitPlan } = await loadCliInitRuntime();
+    const { runInitCommand } = await loadCliInitRuntime();
     const resolvedProjectDir = projectDir
       ? (await import('node:path')).resolve(cwd, projectDir)
       : cwd;
-    const plan = getInitPlan(resolvedProjectDir);
+    const plan = await runInitCommand({
+      apply,
+      packageManager,
+      projectDir: resolvedProjectDir,
+    });
     const completion = buildInitCompletionPayload(plan);
 
     if (options.emitOutput ?? true) {
@@ -609,6 +615,9 @@ export async function executeInitCommand(
 
     return plan;
   } catch (error) {
+    if (!shouldWrapCliCommandError({ emitOutput: options.emitOutput })) {
+      throw error;
+    }
     throw await wrapCliCommandError('init', error);
   }
 }

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -57,6 +57,10 @@ const migrateCommandSource = fs.readFileSync(
   path.join(packageRoot, 'src', 'commands', 'migrate.ts'),
   'utf8',
 );
+const initCommandSource = fs.readFileSync(
+  path.join(packageRoot, 'src', 'commands', 'init.ts'),
+  'utf8',
+);
 const templatesCommandSource = fs.readFileSync(
   path.join(packageRoot, 'src', 'commands', 'templates.ts'),
   'utf8',
@@ -362,7 +366,9 @@ describe('wp-typia package', () => {
     expect(createHelpOutput).toContain('--external-layer-id');
     expect(createHelpOutput).toContain('--alternate-render-targets');
     expect(createHelpOutput).toContain('Query Loop');
-    expect(initHelpOutput).toContain('Preview-only retrofit planner');
+    expect(initHelpOutput).toContain('Preview-by-default retrofit planner');
+    expect(initHelpOutput).toContain('--apply');
+    expect(initHelpOutput).toContain('--package-manager');
     expect(addHelpOutput).toContain('--external-layer-source');
     expect(addHelpOutput).toContain('--external-layer-id');
     expect(addHelpOutput).toContain('--alternate-render-targets');
@@ -388,6 +394,7 @@ describe('wp-typia package', () => {
       );
       const parsed = parseJsonObjectFromOutput<{
         init?: {
+          commandMode?: string;
           detectedLayout?: { kind?: string; blockNames?: string[] };
           nextSteps?: string[];
           packageChanges?: {
@@ -398,6 +405,7 @@ describe('wp-typia package', () => {
       }>(output);
 
       expect(parsed.init?.status).toBe('preview');
+      expect(parsed.init?.commandMode).toBe('preview-only');
       expect(parsed.init?.detectedLayout?.kind).toBe('single-block');
       expect(parsed.init?.detectedLayout?.blockNames).toEqual([
         'create-block/retrofit-init',
@@ -408,6 +416,80 @@ describe('wp-typia package', () => {
       expect(parsed.init?.nextSteps).toContain(
         `npx --yes wp-typia@${packageManifest.version} doctor`,
       );
+    } finally {
+      fs.rmSync(fixtureRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('applies retrofit init through the canonical bin in Node fallback JSON mode', () => {
+    const fixtureRoot = createRetrofitInitFixture();
+
+    try {
+      const output = runUtf8Command(
+        process.execPath,
+        [
+          entryPath,
+          'init',
+          '--apply',
+          '--package-manager',
+          'pnpm',
+          '--format',
+          'json',
+        ],
+        {
+          cwd: fixtureRoot,
+        },
+      );
+      const parsed = parseJsonObjectFromOutput<{
+        init?: {
+          commandMode?: string;
+          packageManager?: string;
+          plannedFiles?: Array<{ action?: string; path?: string }>;
+          status?: string;
+        };
+      }>(output);
+      const packageJson = JSON.parse(
+        fs.readFileSync(path.join(fixtureRoot, 'package.json'), 'utf8'),
+      ) as {
+        packageManager?: string;
+        scripts?: Record<string, string>;
+      };
+
+      expect(parsed.init?.status).toBe('applied');
+      expect(parsed.init?.commandMode).toBe('apply');
+      expect(parsed.init?.packageManager).toBe('pnpm');
+      expect(parsed.init?.plannedFiles).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            action: 'add',
+            path: 'scripts/block-config.ts',
+          }),
+          expect.objectContaining({
+            action: 'add',
+            path: 'scripts/sync-types-to-block-json.ts',
+          }),
+          expect.objectContaining({
+            action: 'add',
+            path: 'scripts/sync-project.ts',
+          }),
+        ]),
+      );
+      expect(packageJson.packageManager).toBe('pnpm@8.3.1');
+      expect(packageJson.scripts?.sync).toBe('tsx scripts/sync-project.ts');
+      expect(packageJson.scripts?.typecheck).toBe(
+        'pnpm run sync --check && tsc --noEmit',
+      );
+      expect(
+        fs.existsSync(path.join(fixtureRoot, 'scripts', 'block-config.ts')),
+      ).toBe(true);
+      expect(
+        fs.existsSync(
+          path.join(fixtureRoot, 'scripts', 'sync-types-to-block-json.ts'),
+        ),
+      ).toBe(true);
+      expect(
+        fs.existsSync(path.join(fixtureRoot, 'scripts', 'sync-project.ts')),
+      ).toBe(true);
     } finally {
       fs.rmSync(fixtureRoot, { force: true, recursive: true });
     }
@@ -689,6 +771,9 @@ describe('wp-typia package', () => {
     expect(addCommandSource).toContain(
       'buildCommandOptions(ADD_OPTION_METADATA)',
     );
+    expect(initCommandSource).toContain(
+      'buildCommandOptions(INIT_OPTION_METADATA)',
+    );
     expect(syncCommandSource).toContain(
       'buildCommandOptions(SYNC_OPTION_METADATA)',
     );
@@ -704,6 +789,9 @@ describe('wp-typia package', () => {
     expect(nodeCliSource).toMatch(/from ['"]\.\/command-option-metadata['"]/);
     expect(nodeCliSource).toContain(
       'formatNodeFallbackOptionHelp(CREATE_OPTION_METADATA)',
+    );
+    expect(nodeCliSource).toContain(
+      'formatNodeFallbackOptionHelp(INIT_OPTION_METADATA)',
     );
     expect(nodeCliSource).toContain(
       'formatNodeFallbackOptionHelp(ADD_OPTION_METADATA)',

--- a/packages/wp-typia/tests/command-option-metadata.test.ts
+++ b/packages/wp-typia/tests/command-option-metadata.test.ts
@@ -11,6 +11,7 @@ import {
   DOCTOR_OPTION_METADATA,
   extractKnownOptionValuesFromArgv,
   GLOBAL_OPTION_METADATA,
+  INIT_OPTION_METADATA,
   parseCommandArgvWithMetadata,
   resolveCommandOptionValues,
   SYNC_OPTION_METADATA,
@@ -142,6 +143,25 @@ describe('command option metadata helpers', () => {
       'dry-run': true,
     });
     expect(parsed.positionals).toEqual([]);
+  });
+
+  test('parses init apply/package-manager flags from shared metadata', () => {
+    const parsed = parseCommandArgvWithMetadata(
+      ['init', '--apply', '--package-manager', 'pnpm', 'demo-plugin'],
+      {
+        extraBooleanOptionNames: ['help', 'version'],
+        parser: buildCommandOptionParser(
+          GLOBAL_OPTION_METADATA,
+          INIT_OPTION_METADATA,
+        ),
+      },
+    );
+
+    expect(parsed.flags).toEqual({
+      apply: true,
+      'package-manager': 'pnpm',
+    });
+    expect(parsed.positionals).toEqual(['init', 'demo-plugin']);
   });
 
   test('parses doctor structured output flags from shared metadata', () => {

--- a/scripts/lib/typescript-runtime-policy.mjs
+++ b/scripts/lib/typescript-runtime-policy.mjs
@@ -30,6 +30,7 @@ export const TYPESCRIPT_RUNTIME_PACKAGE_POLICIES = [
 			"workspace inventory and generated workspace asset helpers used by add/doctor/migrations and exported workspace selection flows use the TypeScript compiler API at runtime",
 		requiredTypeScriptImportFiles: [
 			"src/runtime/cli-add-workspace-assets.ts",
+			"src/runtime/cli-init.ts",
 			"src/runtime/workspace-inventory.ts",
 		],
 		runtimeSourceRoots: ["src/runtime"],

--- a/tests/unit/package-versions.test.ts
+++ b/tests/unit/package-versions.test.ts
@@ -28,6 +28,10 @@ async function importPackageVersionsModule(options: {
 		blockTypesPackageVersion: string;
 		projectToolsPackageVersion: string;
 		restPackageVersion: string;
+		tsxPackageVersion: string;
+		typiaPackageVersion: string;
+		typiaUnpluginPackageVersion: string;
+		typescriptPackageVersion: string;
 		wpTypiaPackageExactVersion: string;
 		wpTypiaPackageVersion: string;
 	};
@@ -91,6 +95,10 @@ describe("package version helpers", () => {
 			blockTypesPackageVersion: "^2.3.4",
 			projectToolsPackageVersion: "^4.5.6",
 			restPackageVersion: "^3.4.5",
+			tsxPackageVersion: "^4.20.5",
+			typiaPackageVersion: "^0.0.0",
+			typiaUnpluginPackageVersion: "^12.0.1",
+			typescriptPackageVersion: "^0.0.0",
 			wpTypiaPackageExactVersion: "0.0.0",
 			wpTypiaPackageVersion: "^0.0.0",
 		});
@@ -122,6 +130,10 @@ describe("package version helpers", () => {
 			blockTypesPackageVersion: "^2.3.4",
 			projectToolsPackageVersion: "^4.5.6",
 			restPackageVersion: "^3.4.5",
+			tsxPackageVersion: "^4.20.5",
+			typiaPackageVersion: "^0.0.0",
+			typiaUnpluginPackageVersion: "^12.0.1",
+			typescriptPackageVersion: "^0.0.0",
 			wpTypiaPackageExactVersion: "0.0.0",
 			wpTypiaPackageVersion: "^0.0.0",
 		});
@@ -157,6 +169,10 @@ describe("package version helpers", () => {
 			blockTypesPackageVersion: "^0.3.0",
 			projectToolsPackageVersion: "^0.8.0",
 			restPackageVersion: "~0.4.0",
+			tsxPackageVersion: "^4.20.5",
+			typiaPackageVersion: "^0.0.0",
+			typiaUnpluginPackageVersion: "^12.0.1",
+			typescriptPackageVersion: "^0.0.0",
 			wpTypiaPackageExactVersion: "0.8.0",
 			wpTypiaPackageVersion: "^0.8.0",
 		});
@@ -211,6 +227,10 @@ describe("package version helpers", () => {
 			blockTypesPackageVersion: "^0.2.0",
 			projectToolsPackageVersion: "^0.11.0",
 			restPackageVersion: "^0.3.1",
+			tsxPackageVersion: "^4.20.5",
+			typiaPackageVersion: "^0.0.0",
+			typiaUnpluginPackageVersion: "^12.0.1",
+			typescriptPackageVersion: "^0.0.0",
 			wpTypiaPackageExactVersion: "0.0.0",
 			wpTypiaPackageVersion: "^0.0.0",
 		});
@@ -234,6 +254,10 @@ describe("package version helpers", () => {
 			blockTypesPackageVersion: "^0.0.0",
 			projectToolsPackageVersion: "^0.0.0",
 			restPackageVersion: "^0.0.0",
+			tsxPackageVersion: "^4.20.5",
+			typiaPackageVersion: "^0.0.0",
+			typiaUnpluginPackageVersion: "^12.0.1",
+			typescriptPackageVersion: "^0.0.0",
 			wpTypiaPackageExactVersion: "0.0.0",
 			wpTypiaPackageVersion: "^0.0.0",
 		});
@@ -278,6 +302,10 @@ describe("package version helpers", () => {
 			blockTypesPackageVersion: "^2.3.4",
 			projectToolsPackageVersion: "^11.22.33",
 			restPackageVersion: "^30.40.50",
+			tsxPackageVersion: "^4.20.5",
+			typiaPackageVersion: "^0.0.0",
+			typiaUnpluginPackageVersion: "^12.0.1",
+			typescriptPackageVersion: "^0.0.0",
 			wpTypiaPackageExactVersion: "0.0.0",
 			wpTypiaPackageVersion: "^0.0.0",
 		});


### PR DESCRIPTION
## Summary
- add an apply-capable retrofit init flow with rollback-protected package.json/helper-file writes and package-manager-aware guidance
- share init option metadata across the Bunli and Node fallback runtimes, including completion/help updates for --apply and --package-manager
- cover preview/apply/rollback behavior with project-tools and canonical CLI tests

Closes #575

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--apply` flag to `init` command to execute planned retrofit updates for existing projects
  * Added `--package-manager` option to override package manager selection

* **Improvements**
  * Enhanced preview output showing exact files to be added/updated
  * Implemented automatic rollback on apply failures to protect existing project state
  * Improved package version detection for dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->