### PR TITLE
[codex] fix interactive CLI runtime routing

### DIFF
--- a/.sampo/changesets/fix-interactive-cli-routing.md
+++ b/.sampo/changesets/fix-interactive-cli-routing.md
@@ -1,0 +1,7 @@
+---
+npm/wp-typia: patch
+---
+
+Route interactive `wp-typia create`, `add`, and `migrate` invocations back
+through the Bunli/OpenTUI runtime when Bun and a TTY are available, while
+preserving Node fallback behavior for CI, JSON, help, and Bun-free runs.

--- a/packages/wp-typia/bin/routing-metadata.generated.d.ts
+++ b/packages/wp-typia/bin/routing-metadata.generated.d.ts
@@ -2,5 +2,7 @@
 // Do not edit directly.
 
 export declare const fullRuntimeCommands: readonly string[];
+export declare const interactiveRuntimeCommands: readonly string[];
 export declare const longValueOptions: readonly string[];
+export declare const reservedCommands: readonly string[];
 export declare const shortValueOptions: readonly string[];

--- a/packages/wp-typia/bin/routing-metadata.generated.js
+++ b/packages/wp-typia/bin/routing-metadata.generated.js
@@ -7,6 +7,11 @@ export const fullRuntimeCommands = Object.freeze([
   'completions',
   'complete',
 ]);
+export const interactiveRuntimeCommands = Object.freeze([
+  'create',
+  'add',
+  'migrate',
+]);
 export const longValueOptions = Object.freeze([
   '--alternate-render-targets',
   '--anchor',
@@ -40,5 +45,20 @@ export const longValueOptions = Object.freeze([
   '--to',
   '--to-migration-version',
   '--variant',
+]);
+export const reservedCommands = Object.freeze([
+  'create',
+  'init',
+  'sync',
+  'add',
+  'migrate',
+  'templates',
+  'doctor',
+  'mcp',
+  'help',
+  'version',
+  'skills',
+  'completions',
+  'complete',
 ]);
 export const shortValueOptions = Object.freeze(['-c', '-p', '-t']);

--- a/packages/wp-typia/bin/runtime-routing.d.ts
+++ b/packages/wp-typia/bin/runtime-routing.d.ts
@@ -1,0 +1,34 @@
+type RuntimeRoutingValues = readonly string[] | ReadonlySet<string>;
+
+type RuntimeRoutingMetadata = {
+  longValueOptions: RuntimeRoutingValues;
+  reservedCommands: RuntimeRoutingValues;
+  shortValueOptions: RuntimeRoutingValues;
+};
+
+type RuntimeRoutingStream = {
+  isTTY?: boolean;
+};
+
+export declare function getRuntimeRoutingInvocation(
+  argv: readonly string[],
+  metadata: RuntimeRoutingMetadata,
+): {
+  command: string | undefined;
+  isSinglePositionalAlias: boolean;
+  positionals: string[];
+};
+
+export declare function shouldRouteToFullRuntime(options: {
+  argv: readonly string[];
+  fullRuntimeCommands: RuntimeRoutingValues;
+  hasBuiltRuntime: boolean;
+  hasWorkingBun: boolean;
+  interactiveRuntimeCommands: RuntimeRoutingValues;
+  longValueOptions: RuntimeRoutingValues;
+  reservedCommands: RuntimeRoutingValues;
+  shortValueOptions: RuntimeRoutingValues;
+  stdin?: RuntimeRoutingStream;
+  stdout?: RuntimeRoutingStream;
+  term?: string;
+}): boolean;

--- a/packages/wp-typia/bin/runtime-routing.js
+++ b/packages/wp-typia/bin/runtime-routing.js
@@ -5,20 +5,22 @@ function normalizeSet(values) {
 }
 
 function hasBooleanFlagBeforeTerminator(argv, longFlag, shortFlag) {
+  let matched = false;
   for (const arg of argv) {
     if (arg === '--') {
-      return false;
+      break;
     }
     if (arg === longFlag || (shortFlag && arg === shortFlag)) {
-      return true;
+      matched = true;
+      continue;
     }
     if (arg.startsWith(`${longFlag}=`)) {
       const value = arg.slice(longFlag.length + 1).toLowerCase();
-      return value !== 'false' && value !== '0' && value !== 'no';
+      matched = value !== 'false' && value !== '0' && value !== 'no';
     }
   }
 
-  return false;
+  return matched;
 }
 
 function hasLongOptionBeforeTerminator(argv, optionName) {

--- a/packages/wp-typia/bin/runtime-routing.js
+++ b/packages/wp-typia/bin/runtime-routing.js
@@ -1,0 +1,122 @@
+import { collectPositionalIndexes } from './argv-walker.js';
+
+function normalizeSet(values) {
+  return values instanceof Set ? values : new Set(values);
+}
+
+function hasBooleanFlagBeforeTerminator(argv, longFlag, shortFlag) {
+  for (const arg of argv) {
+    if (arg === '--') {
+      return false;
+    }
+    if (arg === longFlag || (shortFlag && arg === shortFlag)) {
+      return true;
+    }
+    if (arg.startsWith(`${longFlag}=`)) {
+      const value = arg.slice(longFlag.length + 1).toLowerCase();
+      return value !== 'false' && value !== '0' && value !== 'no';
+    }
+  }
+
+  return false;
+}
+
+function hasLongOptionBeforeTerminator(argv, optionName) {
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--') {
+      return false;
+    }
+    if (arg === optionName || arg.startsWith(`${optionName}=`)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function isInteractiveTerminal({ stdin, stdout, term }) {
+  return Boolean(stdin?.isTTY) && Boolean(stdout?.isTTY) && term !== 'dumb';
+}
+
+export function getRuntimeRoutingInvocation(argv, metadata) {
+  const positionalIndexes = collectPositionalIndexes(argv, metadata);
+  const positionals = positionalIndexes
+    .map((index) => argv[index])
+    .filter((value) => typeof value === 'string' && value.length > 0);
+  const command = positionals[0];
+  const reservedCommandSet = normalizeSet(metadata.reservedCommands);
+  const isSinglePositionalAlias =
+    Boolean(command) &&
+    positionals.length === 1 &&
+    !reservedCommandSet.has(command);
+
+  return {
+    command,
+    isSinglePositionalAlias,
+    positionals,
+  };
+}
+
+export function shouldRouteToFullRuntime({
+  argv,
+  fullRuntimeCommands,
+  hasBuiltRuntime,
+  hasWorkingBun,
+  interactiveRuntimeCommands,
+  longValueOptions,
+  reservedCommands,
+  shortValueOptions,
+  stdin = process.stdin,
+  stdout = process.stdout,
+  term = process.env.TERM,
+}) {
+  if (!hasWorkingBun || !hasBuiltRuntime) {
+    return false;
+  }
+
+  const fullRuntimeCommandSet = normalizeSet(fullRuntimeCommands);
+  const interactiveRuntimeCommandSet = normalizeSet(interactiveRuntimeCommands);
+  const invocation = getRuntimeRoutingInvocation(argv, {
+    longValueOptions,
+    reservedCommands,
+    shortValueOptions,
+  });
+
+  if (invocation.command && fullRuntimeCommandSet.has(invocation.command)) {
+    return true;
+  }
+
+  if (
+    !isInteractiveTerminal({
+      stdin,
+      stdout,
+      term,
+    })
+  ) {
+    return false;
+  }
+
+  if (
+    invocation.command === 'help' ||
+    invocation.command === 'version' ||
+    hasBooleanFlagBeforeTerminator(argv, '--help', '-h') ||
+    hasBooleanFlagBeforeTerminator(argv, '--version', '-v') ||
+    hasLongOptionBeforeTerminator(argv, '--format') ||
+    hasBooleanFlagBeforeTerminator(argv, '--yes', '-y')
+  ) {
+    return false;
+  }
+
+  if (
+    invocation.command &&
+    interactiveRuntimeCommandSet.has(invocation.command)
+  ) {
+    return true;
+  }
+
+  return (
+    invocation.isSinglePositionalAlias &&
+    interactiveRuntimeCommandSet.has('create')
+  );
+}

--- a/packages/wp-typia/bin/wp-typia.js
+++ b/packages/wp-typia/bin/wp-typia.js
@@ -7,10 +7,15 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import {
   fullRuntimeCommands,
+  interactiveRuntimeCommands,
   longValueOptions,
+  reservedCommands,
   shortValueOptions,
 } from './routing-metadata.generated.js';
-import { findFirstPositional } from './argv-walker.js';
+import {
+  getRuntimeRoutingInvocation,
+  shouldRouteToFullRuntime,
+} from './runtime-routing.js';
 
 const packageRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -20,7 +25,9 @@ const cliEntrypoint = path.join(packageRoot, 'dist-bunli', 'cli.js');
 const nodeCliEntrypoint = path.join(packageRoot, 'dist-bunli', 'node-cli.js');
 const bunBinary = process.env.BUN_BIN || 'bun';
 const fullRuntimeCommandSet = new Set(fullRuntimeCommands);
+const interactiveRuntimeCommandSet = new Set(interactiveRuntimeCommands);
 const longValueOptionSet = new Set(longValueOptions);
+const reservedCommandSet = new Set(reservedCommands);
 const shortValueOptionSet = new Set(shortValueOptions);
 const buildScriptEntrypoint = path.join(
   packageRoot,
@@ -69,17 +76,29 @@ function ensureBuiltRuntime() {
 }
 
 const argv = process.argv.slice(2);
-const command = findFirstPositional(argv, {
+const { command } = getRuntimeRoutingInvocation(argv, {
   longValueOptions: longValueOptionSet,
+  reservedCommands: reservedCommandSet,
   shortValueOptions: shortValueOptionSet,
 });
-const shouldUseFullRuntime = command
+const commandRequiresFullRuntime = command
   ? fullRuntimeCommandSet.has(command)
   : false;
 const hasBuiltRuntime = ensureBuiltRuntime();
 const hasWorkingBun = isWorkingBunBinary();
+const shouldUseFullRuntime = shouldRouteToFullRuntime({
+  argv,
+  fullRuntimeCommands: fullRuntimeCommandSet,
+  hasBuiltRuntime,
+  hasWorkingBun,
+  interactiveRuntimeCommands: interactiveRuntimeCommandSet,
+  longValueOptions: longValueOptionSet,
+  reservedCommands: reservedCommandSet,
+  shortValueOptions: shortValueOptionSet,
+});
 
-// Keep common help on the human-readable Node fallback even when Bun is present.
+// Keep common help and explicit non-TUI calls on the human-readable Node fallback
+// even when Bun is present.
 if (hasWorkingBun && hasBuiltRuntime && shouldUseFullRuntime) {
   const result = spawnSync(bunBinary, [cliEntrypoint, ...argv], {
     cwd: process.cwd(),
@@ -89,7 +108,7 @@ if (hasWorkingBun && hasBuiltRuntime && shouldUseFullRuntime) {
   process.exit(result.status ?? 1);
 }
 
-if (shouldUseFullRuntime) {
+if (commandRequiresFullRuntime) {
   if (!hasBuiltRuntime) {
     console.error(
       'Error: wp-typia could not locate its built CLI runtime. Reinstall the published package, or run `bun run build` when using a source checkout.',

--- a/packages/wp-typia/scripts/generate-routing-metadata.mjs
+++ b/packages/wp-typia/scripts/generate-routing-metadata.mjs
@@ -57,7 +57,9 @@ async function importTranspiledTypeScriptModule(modulePath) {
 
 function renderRoutingMetadataFiles({
   fullRuntimeCommands,
+  interactiveRuntimeCommands,
   longValueOptions,
+  reservedCommands,
   shortValueOptions,
 }) {
   const renderStringArray = (values) => {
@@ -77,8 +79,14 @@ function renderRoutingMetadataFiles({
 export const fullRuntimeCommands = Object.freeze(${renderStringArray(
     fullRuntimeCommands,
   )});
+export const interactiveRuntimeCommands = Object.freeze(${renderStringArray(
+    interactiveRuntimeCommands,
+  )});
 export const longValueOptions = Object.freeze(${renderStringArray(
     longValueOptions,
+  )});
+export const reservedCommands = Object.freeze(${renderStringArray(
+    reservedCommands,
   )});
 export const shortValueOptions = Object.freeze(${renderStringArray(
     shortValueOptions,
@@ -88,7 +96,9 @@ export const shortValueOptions = Object.freeze(${renderStringArray(
 // Do not edit directly.
 
 export declare const fullRuntimeCommands: readonly string[];
+export declare const interactiveRuntimeCommands: readonly string[];
 export declare const longValueOptions: readonly string[];
+export declare const reservedCommands: readonly string[];
 export declare const shortValueOptions: readonly string[];
 `;
 
@@ -107,7 +117,11 @@ function failCheck(pathname) {
 
 const [
   { COMMAND_ROUTING_METADATA },
-  { WP_TYPIA_BUN_REQUIRED_TOP_LEVEL_COMMAND_NAMES },
+  {
+    WP_TYPIA_BUN_REQUIRED_TOP_LEVEL_COMMAND_NAMES,
+    WP_TYPIA_INTERACTIVE_RUNTIME_TOP_LEVEL_COMMAND_NAMES,
+    WP_TYPIA_RESERVED_TOP_LEVEL_COMMAND_NAMES,
+  },
 ] = await Promise.all([
   importTranspiledTypeScriptModule(commandOptionMetadataModulePath),
   importTranspiledTypeScriptModule(commandRegistryModulePath),
@@ -117,7 +131,11 @@ const renderedFiles = renderRoutingMetadataFiles({
   fullRuntimeCommands: Array.from(
     WP_TYPIA_BUN_REQUIRED_TOP_LEVEL_COMMAND_NAMES,
   ),
+  interactiveRuntimeCommands: Array.from(
+    WP_TYPIA_INTERACTIVE_RUNTIME_TOP_LEVEL_COMMAND_NAMES,
+  ),
   longValueOptions: COMMAND_ROUTING_METADATA.longValueOptions,
+  reservedCommands: Array.from(WP_TYPIA_RESERVED_TOP_LEVEL_COMMAND_NAMES),
   shortValueOptions: COMMAND_ROUTING_METADATA.shortValueOptions,
 });
 

--- a/packages/wp-typia/src/command-registry.ts
+++ b/packages/wp-typia/src/command-registry.ts
@@ -10,6 +10,7 @@ export const WP_TYPIA_COMMAND_REGISTRY = [
   {
     commandTree: true,
     description: 'Scaffold a new wp-typia project.',
+    interactiveRuntime: true,
     name: 'create',
     nodeFallback: true,
     optionGroups: ['create'],
@@ -36,6 +37,7 @@ export const WP_TYPIA_COMMAND_REGISTRY = [
   {
     commandTree: true,
     description: 'Extend an official wp-typia workspace.',
+    interactiveRuntime: true,
     name: 'add',
     nodeFallback: true,
     optionGroups: ['add'],
@@ -55,6 +57,7 @@ export const WP_TYPIA_COMMAND_REGISTRY = [
   {
     commandTree: true,
     description: 'Run migration workflows.',
+    interactiveRuntime: true,
     name: 'migrate',
     nodeFallback: true,
     optionGroups: ['migrate'],
@@ -149,6 +152,10 @@ export type WpTypiaNodeFallbackCommandName = Extract<
   WpTypiaCommandRegistryEntry,
   { nodeFallback: true }
 >['name'];
+export type WpTypiaInteractiveRuntimeCommandName = Extract<
+  WpTypiaCommandRegistryEntry,
+  { interactiveRuntime: true }
+>['name'];
 export type WpTypiaTopLevelCommandName = WpTypiaCommandTreeEntry['name'];
 
 export const WP_TYPIA_RESERVED_TOP_LEVEL_COMMAND_NAMES =
@@ -160,6 +167,18 @@ export const WP_TYPIA_NODE_FALLBACK_TOP_LEVEL_COMMAND_NAMES =
   WP_TYPIA_COMMAND_REGISTRY.filter((command) => command.nodeFallback).map(
     (command) => command.name,
   ) as readonly WpTypiaNodeFallbackCommandName[];
+
+export const WP_TYPIA_INTERACTIVE_RUNTIME_TOP_LEVEL_COMMAND_NAMES =
+  WP_TYPIA_COMMAND_REGISTRY.filter(
+    (
+      command,
+    ): command is Extract<
+      WpTypiaCommandRegistryEntry,
+      { interactiveRuntime: true }
+    > => 'interactiveRuntime' in command && command.interactiveRuntime,
+  ).map(
+    (command) => command.name,
+  ) as readonly WpTypiaInteractiveRuntimeCommandName[];
 
 export const WP_TYPIA_TOP_LEVEL_COMMAND_NAMES =
   WP_TYPIA_COMMAND_REGISTRY.filter((command) => command.commandTree).map(

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -14,7 +14,6 @@ import {
   DOCTOR_OPTION_METADATA,
   extractKnownOptionValuesFromArgv,
   formatNodeFallbackOptionHelp,
-  GLOBAL_OPTION_METADATA,
   INIT_OPTION_METADATA,
   MIGRATE_OPTION_METADATA,
   parseCommandArgvWithMetadata,
@@ -472,7 +471,7 @@ const NODE_FALLBACK_COMMAND_DISPATCHERS = {
     await executeAddCommand({
       cwd,
       flags: mergedFlags,
-      interactive: false,
+      interactive: undefined,
       kind: positionals[1],
       name: positionals[2],
     });
@@ -499,7 +498,7 @@ const NODE_FALLBACK_COMMAND_DISPATCHERS = {
         cwd,
         emitOutput: mergedFlags.format !== 'json',
         flags: mergedFlags,
-        interactive: false,
+        interactive: mergedFlags.format === 'json' ? false : undefined,
         projectDir,
       });
     } catch (error) {

--- a/packages/wp-typia/tests/bunli-prep.test.ts
+++ b/packages/wp-typia/tests/bunli-prep.test.ts
@@ -119,6 +119,10 @@ describe('wp-typia Bunli preparation', () => {
       path.join(packageRoot, 'bin', 'wp-typia.js'),
       'utf8',
     );
+    const runtimeRoutingSource = fs.readFileSync(
+      path.join(packageRoot, 'bin', 'runtime-routing.js'),
+      'utf8',
+    );
 
     expect(fullRuntimeCommands).toEqual(
       Array.from(WP_TYPIA_BUN_REQUIRED_TOP_LEVEL_COMMAND_NAMES),
@@ -130,7 +134,8 @@ describe('wp-typia Bunli preparation', () => {
     expect(binEntrypointSource).toMatch(
       /from ['"]\.\/routing-metadata\.generated\.js['"]/,
     );
-    expect(binEntrypointSource).toMatch(/from ['"]\.\/argv-walker\.js['"]/);
+    expect(binEntrypointSource).toMatch(/from ['"]\.\/runtime-routing\.js['"]/);
+    expect(runtimeRoutingSource).toMatch(/from ['"]\.\/argv-walker\.js['"]/);
     expect(binEntrypointSource).not.toContain(
       'const fullRuntimeCommands = new Set([',
     );

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -391,6 +391,11 @@ describe('wp-typia package', () => {
     ).toBe(false);
     expect(
       shouldRouteTestInvocationToFullRuntime(['create'], {
+        hasBuiltRuntime: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldRouteTestInvocationToFullRuntime(['create'], {
         isTTY: false,
       }),
     ).toBe(false);
@@ -405,6 +410,13 @@ describe('wp-typia package', () => {
     expect(shouldRouteTestInvocationToFullRuntime(['create', '-h'])).toBe(
       false,
     );
+    expect(
+      shouldRouteTestInvocationToFullRuntime([
+        'create',
+        '--help=false',
+        '--help',
+      ]),
+    ).toBe(false);
     expect(
       shouldRouteTestInvocationToFullRuntime([
         'create',

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -10,6 +10,14 @@ import {
 } from '../src/command-contract';
 import { formatAddKindUsagePlaceholder } from '../src/add-kind-registry';
 import {
+  fullRuntimeCommands,
+  interactiveRuntimeCommands,
+  longValueOptions,
+  reservedCommands,
+  shortValueOptions,
+} from '../bin/routing-metadata.generated.js';
+import { shouldRouteToFullRuntime } from '../bin/runtime-routing.js';
+import {
   hasFlagBeforeTerminator,
   parseGlobalFlags,
   runNodeCli,
@@ -116,6 +124,30 @@ function withoutLocalBunEnv(): NodeJS.ProcessEnv {
     BUN_BIN: path.join(os.tmpdir(), 'wp-typia-missing-bun'),
     PATH: path.dirname(process.execPath),
   };
+}
+
+function shouldRouteTestInvocationToFullRuntime(
+  argv: string[],
+  options: {
+    hasBuiltRuntime?: boolean;
+    hasWorkingBun?: boolean;
+    isTTY?: boolean;
+    term?: string;
+  } = {},
+): boolean {
+  return shouldRouteToFullRuntime({
+    argv,
+    fullRuntimeCommands,
+    hasBuiltRuntime: options.hasBuiltRuntime ?? true,
+    hasWorkingBun: options.hasWorkingBun ?? true,
+    interactiveRuntimeCommands,
+    longValueOptions,
+    reservedCommands,
+    shortValueOptions,
+    stdin: { isTTY: options.isTTY ?? true },
+    stdout: { isTTY: options.isTTY ?? true },
+    term: options.term ?? 'xterm-256color',
+  });
 }
 
 function createSyncFixture(options: {
@@ -340,6 +372,60 @@ describe('wp-typia package', () => {
     expect(nodeCliSource).not.toMatch(/process\.exit\s*\(\s*1\s*\)/);
     expect(cliSource).toContain('process.exitCode = 1');
     expect(cliSource).not.toMatch(/process\.exit\s*\(\s*1\s*\)/);
+  });
+
+  test('routes interactive create/add/migrate invocations to the Bunli runtime when Bun and a TTY are available', () => {
+    expect(shouldRouteTestInvocationToFullRuntime(['create'])).toBe(true);
+    expect(shouldRouteTestInvocationToFullRuntime(['create', '--dry-run'])).toBe(
+      true,
+    );
+    expect(shouldRouteTestInvocationToFullRuntime(['add'])).toBe(true);
+    expect(shouldRouteTestInvocationToFullRuntime(['migrate'])).toBe(true);
+    expect(shouldRouteTestInvocationToFullRuntime(['demo-block'])).toBe(true);
+    expect(shouldRouteTestInvocationToFullRuntime(['mcp', 'list'])).toBe(true);
+
+    expect(
+      shouldRouteTestInvocationToFullRuntime(['create'], {
+        hasWorkingBun: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldRouteTestInvocationToFullRuntime(['create'], {
+        isTTY: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldRouteTestInvocationToFullRuntime(['create'], {
+        term: 'dumb',
+      }),
+    ).toBe(false);
+    expect(shouldRouteTestInvocationToFullRuntime(['create', '--help'])).toBe(
+      false,
+    );
+    expect(shouldRouteTestInvocationToFullRuntime(['create', '-h'])).toBe(
+      false,
+    );
+    expect(
+      shouldRouteTestInvocationToFullRuntime([
+        'create',
+        'demo-block',
+        '--format',
+        'json',
+      ]),
+    ).toBe(false);
+    expect(
+      shouldRouteTestInvocationToFullRuntime([
+        'create',
+        'demo-block',
+        '--yes',
+      ]),
+    ).toBe(false);
+    expect(
+      shouldRouteTestInvocationToFullRuntime(['create', 'demo-block', '-y']),
+    ).toBe(false);
+    expect(shouldRouteTestInvocationToFullRuntime(['temlates', 'list'])).toBe(
+      false,
+    );
   });
 
   test('renders help output through the canonical bin', () => {


### PR DESCRIPTION
## Summary

- route interactive `create`, `add`, and `migrate` invocations to the Bunli/OpenTUI runtime when Bun and a real TTY are available
- keep help, version, explicit `--format`, `--yes`, non-TTY, and Bun-free calls on the Node fallback path
- restore Node fallback readline prompting for human TTY fallback runs while preserving JSON mode as non-interactive

## Root Cause

The package bin treated `create`, `add`, and `migrate` as Node fallback-supported commands unconditionally. That meant `bunx wp-typia create` could be dispatched to the fallback runtime before the Bunli `render` path had a chance to open the interactive UI.

## Validation

- `node packages/wp-typia/scripts/generate-routing-metadata.mjs --check`
- `./node_modules/.bin/eslint packages/wp-typia/bin/runtime-routing.js packages/wp-typia/bin/wp-typia.js packages/wp-typia/scripts/generate-routing-metadata.mjs packages/wp-typia/src/command-registry.ts packages/wp-typia/src/node-cli.ts packages/wp-typia/tests/cli-package.test.ts --max-warnings=0`
- `./node_modules/.bin/tsc -p packages/wp-typia/tsconfig.json --noEmit`
- `git diff --check`
- fake-Bun routing smoke check with `TERM=xterm-256color BUN_BIN=/usr/bin/true node packages/wp-typia/bin/wp-typia.js create`

Note: full `bun test` was not run in this environment because `bun` is not installed on PATH.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Interactive commands (`create`, `add`, `migrate`) now leverage enhanced runtime capabilities when running under Bun with a TTY terminal for an improved user experience
  * Intelligent runtime routing automatically falls back to Node.js for CI environments, non-interactive output, help requests, and systems without Bun support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->