### PR TITLE
[codex] fix external layer selection cleanup

### DIFF
--- a/.sampo/changesets/fix-external-layer-cleanup.md
+++ b/.sampo/changesets/fix-external-layer-cleanup.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Ensure interactive external layer selection cleans up resolved layer seeds only
+once when selection or layer discovery fails.

--- a/packages/wp-typia-project-tools/src/runtime/external-layer-selection.ts
+++ b/packages/wp-typia-project-tools/src/runtime/external-layer-selection.ts
@@ -16,15 +16,22 @@ export interface ResolvedExternalLayerSelection {
 	externalLayerSource?: string;
 }
 
+type ResolveExternalTemplateSeed = typeof resolveTemplateSeed;
+type ListExternalTemplateLayers = typeof listSelectableExternalTemplateLayers;
+
 export async function resolveOptionalInteractiveExternalLayerId({
 	callerCwd,
 	externalLayerId,
 	externalLayerSource,
+	listExternalTemplateLayers = listSelectableExternalTemplateLayers,
+	resolveExternalTemplateSeed = resolveTemplateSeed,
 	selectExternalLayerId,
 }: {
 	callerCwd: string;
 	externalLayerId?: string;
 	externalLayerSource?: string;
+	listExternalTemplateLayers?: ListExternalTemplateLayers;
+	resolveExternalTemplateSeed?: ResolveExternalTemplateSeed;
 	selectExternalLayerId?: (
 		options: ExternalLayerSelectionOption[],
 	) => Promise<string>;
@@ -36,12 +43,12 @@ export async function resolveOptionalInteractiveExternalLayerId({
 		};
 	}
 
-	const layerSeed = await resolveTemplateSeed(
+	const layerSeed = await resolveExternalTemplateSeed(
 		parseTemplateLocator(externalLayerSource),
 		callerCwd,
 	);
 	try {
-		const selectableLayers = await listSelectableExternalTemplateLayers(
+		const selectableLayers = await listExternalTemplateLayers(
 			layerSeed.rootDir,
 		);
 		if (selectableLayers.length <= 1) {
@@ -61,7 +68,6 @@ export async function resolveOptionalInteractiveExternalLayerId({
 			};
 		}
 
-		await layerSeed.cleanup?.();
 		throw new Error(
 			`Unknown external layer "${selectedLayerId}". Expected one of: ${selectableLayers.map((layer) => layer.id).join(", ")}`,
 		);

--- a/packages/wp-typia-project-tools/tests/external-layer-selection.test.ts
+++ b/packages/wp-typia-project-tools/tests/external-layer-selection.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveOptionalInteractiveExternalLayerId } from "../src/runtime/external-layer-selection.js";
+import type { ExternalLayerSelectionOption } from "../src/runtime/external-layer-selection.js";
+
+const selectableLayers: ExternalLayerSelectionOption[] = [
+	{
+		description: "Alpha external layer",
+		extends: [],
+		id: "acme/alpha",
+	},
+	{
+		description: "Beta external layer",
+		extends: [],
+		id: "acme/beta",
+	},
+];
+
+function createSeed(cleanup: () => Promise<void>) {
+	return {
+		blockDir: "/virtual/layers",
+		cleanup,
+		rootDir: "/virtual/layers",
+	};
+}
+
+describe("@wp-typia/project-tools external layer selection", () => {
+	test("cleans up exactly once when interactive selection returns an unknown external layer id", async () => {
+		let cleanupCalls = 0;
+		const cleanup = async () => {
+			cleanupCalls += 1;
+		};
+
+		await expect(
+			resolveOptionalInteractiveExternalLayerId({
+				callerCwd: "/virtual/project",
+				externalLayerSource: "virtual-layer-source",
+				listExternalTemplateLayers: async (rootDir) => {
+					expect(rootDir).toBe("/virtual/layers");
+					return selectableLayers;
+				},
+				resolveExternalTemplateSeed: async () => createSeed(cleanup),
+				selectExternalLayerId: async (options) => {
+					expect(options).toEqual(selectableLayers);
+					return "acme/missing";
+				},
+			}),
+		).rejects.toThrow(
+			'Unknown external layer "acme/missing". Expected one of: acme/alpha, acme/beta',
+		);
+		expect(cleanupCalls).toBe(1);
+	});
+
+	test("cleans up once when external layer listing throws", async () => {
+		let cleanupCalls = 0;
+		const cleanup = async () => {
+			cleanupCalls += 1;
+		};
+
+		await expect(
+			resolveOptionalInteractiveExternalLayerId({
+				callerCwd: "/virtual/project",
+				externalLayerSource: "virtual-layer-source",
+				listExternalTemplateLayers: async () => {
+					throw new Error("layer listing failed");
+				},
+				resolveExternalTemplateSeed: async () => createSeed(cleanup),
+				selectExternalLayerId: async () => "acme/beta",
+			}),
+		).rejects.toThrow("layer listing failed");
+		expect(cleanupCalls).toBe(1);
+	});
+
+	test("cleans up once when interactive external layer selection throws", async () => {
+		let cleanupCalls = 0;
+		const cleanup = async () => {
+			cleanupCalls += 1;
+		};
+
+		await expect(
+			resolveOptionalInteractiveExternalLayerId({
+				callerCwd: "/virtual/project",
+				externalLayerSource: "virtual-layer-source",
+				listExternalTemplateLayers: async () => selectableLayers,
+				resolveExternalTemplateSeed: async () => createSeed(cleanup),
+				selectExternalLayerId: async () => {
+					throw new Error("selection failed");
+				},
+			}),
+		).rejects.toThrow("selection failed");
+		expect(cleanupCalls).toBe(1);
+	});
+
+	test("returns cleanup to the caller after a successful interactive selection", async () => {
+		let cleanupCalls = 0;
+		const cleanup = async () => {
+			cleanupCalls += 1;
+		};
+
+		const selection = await resolveOptionalInteractiveExternalLayerId({
+			callerCwd: "/virtual/project",
+			externalLayerSource: "virtual-layer-source",
+			listExternalTemplateLayers: async () => selectableLayers,
+			resolveExternalTemplateSeed: async () => createSeed(cleanup),
+			selectExternalLayerId: async () => "acme/beta",
+		});
+
+		expect(selection).toEqual({
+			cleanup,
+			externalLayerId: "acme/beta",
+			externalLayerSource: "/virtual/layers",
+		});
+		expect(cleanupCalls).toBe(0);
+
+		await selection.cleanup?.();
+		expect(cleanupCalls).toBe(1);
+	});
+});


### PR DESCRIPTION
## Summary

Closes #626.

- let the external-layer selection `catch` block own cleanup for unknown interactive selections
- keep cleanup behavior for layer listing and selection failures
- return the seed cleanup callback to callers after successful selected-layer resolution
- add focused regression coverage for unknown selection, listing failure, selection failure, and successful caller-owned cleanup

## Why

`resolveOptionalInteractiveExternalLayerId()` previously called `layerSeed.cleanup?.()` before throwing for an unknown selected layer and then called cleanup again in the surrounding `catch`. If cleanup was not idempotent, that could mask the real unknown-layer diagnostic with a duplicate cleanup failure.

## Validation

- `node scripts/validate-sampo-changesets.mjs`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/eslint packages/wp-typia-project-tools/src/runtime/external-layer-selection.ts packages/wp-typia-project-tools/tests/external-layer-selection.test.ts --max-warnings=0`
- `git diff --check`

Note: `bun test packages/wp-typia-project-tools/tests/external-layer-selection.test.ts` was not run locally because `bun` is not installed on PATH in this environment (`zsh: command not found: bun`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed external layer selection cleanup behavior to ensure resolved layer seeds are cleaned up only once, improving reliability when layer selection or discovery encounters errors and preventing duplicate cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->