### PR TITLE
fix: gate admin-view until dataviews is published

### DIFF
--- a/.sampo/changesets/gate-admin-view-until-dataviews-publish.md
+++ b/.sampo/changesets/gate-admin-view-until-dataviews-publish.md
@@ -1,0 +1,8 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Gate `wp-typia add admin-view` in public installs until
+`@wp-typia/dataviews` is published to npm, while preserving an internal test
+override for monorepo validation.

--- a/apps/docs/src/content/docs/reference/dataviews.md
+++ b/apps/docs/src/content/docs/reference/dataviews.md
@@ -163,6 +163,11 @@ wp-typia add admin-view products
 wp-typia add admin-view products --source rest-resource:products
 ```
 
+Current public CLI releases gate `wp-typia add admin-view` until
+`@wp-typia/dataviews` is published to npm. Until that package is publicly
+available, treat the examples below as the intended scaffold shape rather than a
+workflow that is installable from npm today.
+
 The scaffold writes `src/admin-views/<name>/` plus
 `inc/admin-views/<name>.php`, adds `@wp-typia/dataviews` and
 `@wordpress/dataviews` only to that workspace, and wires the screen under the

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-shared.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-shared.ts
@@ -734,7 +734,7 @@ Notes:
   \`wp-typia add\` runs only inside official ${WORKSPACE_TEMPLATE_PACKAGE} workspaces scaffolded via \`wp-typia create <project-dir> --template workspace\`.
   Pass \`--dry-run\` to preview the workspace files that would change without writing them.
   Interactive add flows let you choose a template when \`--template\` is omitted; non-interactive runs default to \`basic\`.
-  \`add admin-view\` scaffolds an opt-in DataViews-powered WordPress admin screen under \`src/admin-views/\`; pass \`--source rest-resource:<slug>\` to reuse a list-capable REST resource.
+  \`add admin-view\` scaffolds an opt-in DataViews-powered WordPress admin screen under \`src/admin-views/\`; pass \`--source rest-resource:<slug>\` to reuse a list-capable REST resource. Public installs currently gate this workflow until \`@wp-typia/dataviews\` is published to npm.
   \`query-loop\` is a create-time scaffold family. Use \`wp-typia create <project-dir> --template query-loop\` instead of \`wp-typia add block\`.
   \`add variation\` targets an existing block slug from \`scripts/block-config.ts\`.
   \`add style\` registers a Block Styles option for an existing generated block.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-admin-view.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-admin-view.ts
@@ -87,19 +87,33 @@ function readPackageManifestVersion(packageJsonPath: string): string | undefined
 	return readPackageManifest(packageJsonPath)?.version;
 }
 
+function readInstalledPackageManifest(packageName: string): PackageManifestSummary | undefined {
+	try {
+		return readPackageManifest(require.resolve(`${packageName}/package.json`));
+	} catch {
+		return undefined;
+	}
+}
+
 function isAdminViewUnpublishedDataViewsOverrideEnabled(): boolean {
 	return process.env[ADMIN_VIEW_ALLOW_UNPUBLISHED_DATAVIEWS_ENV]?.trim() === "1";
 }
 
-function isAdminViewDataViewsPackagePublished(): boolean {
-	const packageJson = readPackageManifest(
-		path.join(
-			PROJECT_TOOLS_PACKAGE_ROOT,
-			"..",
-			WP_TYPIA_DATAVIEWS_WORKSPACE_PACKAGE_DIR,
-			"package.json",
-		),
+function resolveAdminViewDataViewsPackageManifest(): PackageManifestSummary | undefined {
+	return (
+		readPackageManifest(
+			path.join(
+				PROJECT_TOOLS_PACKAGE_ROOT,
+				"..",
+				WP_TYPIA_DATAVIEWS_WORKSPACE_PACKAGE_DIR,
+				"package.json",
+			),
+		) ?? readInstalledPackageManifest("@wp-typia/dataviews")
 	);
+}
+
+function isAdminViewDataViewsPackagePublished(): boolean {
+	const packageJson = resolveAdminViewDataViewsPackageManifest();
 	return packageJson?.private === false;
 }
 

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-admin-view.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-admin-view.ts
@@ -28,6 +28,10 @@ import {
 	type WorkspaceMutationSnapshot,
 	snapshotWorkspaceFiles,
 } from "./cli-add-shared.js";
+import {
+	CLI_DIAGNOSTIC_CODES,
+	createCliDiagnosticCodeError,
+} from "./cli-diagnostics.js";
 
 const ADMIN_VIEW_SOURCE_KIND = "rest-resource";
 const ADMIN_VIEWS_SCRIPT = "build/admin-views/index.js";
@@ -37,8 +41,16 @@ const ADMIN_VIEWS_STYLE_RTL = "build/admin-views/style-index-rtl.css";
 const ADMIN_VIEWS_PHP_GLOB = "/inc/admin-views/*.php";
 const DEFAULT_WP_TYPIA_DATAVIEWS_VERSION = "^0.1.0";
 const DEFAULT_WORDPRESS_DATAVIEWS_VERSION = "^14.1.0";
+const ADMIN_VIEW_ALLOW_UNPUBLISHED_DATAVIEWS_ENV =
+	"WP_TYPIA_ALLOW_UNPUBLISHED_DATAVIEWS";
+const WP_TYPIA_DATAVIEWS_WORKSPACE_PACKAGE_DIR = "wp-typia-dataviews";
 
 const require = createRequire(import.meta.url);
+
+interface PackageManifestSummary {
+	private?: boolean;
+	version?: string;
+}
 
 interface AdminViewRestResourceSource {
 	kind: typeof ADMIN_VIEW_SOURCE_KIND;
@@ -63,15 +75,46 @@ function normalizeVersionRange(value: string | undefined, fallback: string): str
 	return /^[~^<>=]/u.test(trimmed) ? trimmed : `^${trimmed}`;
 }
 
-function readPackageManifestVersion(packageJsonPath: string): string | undefined {
+function readPackageManifest(packageJsonPath: string): PackageManifestSummary | undefined {
 	try {
-		const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as {
-			version?: string;
-		};
-		return packageJson.version;
+		return JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as PackageManifestSummary;
 	} catch {
 		return undefined;
 	}
+}
+
+function readPackageManifestVersion(packageJsonPath: string): string | undefined {
+	return readPackageManifest(packageJsonPath)?.version;
+}
+
+function isAdminViewUnpublishedDataViewsOverrideEnabled(): boolean {
+	return process.env[ADMIN_VIEW_ALLOW_UNPUBLISHED_DATAVIEWS_ENV]?.trim() === "1";
+}
+
+function isAdminViewDataViewsPackagePublished(): boolean {
+	const packageJson = readPackageManifest(
+		path.join(
+			PROJECT_TOOLS_PACKAGE_ROOT,
+			"..",
+			WP_TYPIA_DATAVIEWS_WORKSPACE_PACKAGE_DIR,
+			"package.json",
+		),
+	);
+	return packageJson?.private === false;
+}
+
+function assertAdminViewPackageAvailability(): void {
+	if (
+		isAdminViewUnpublishedDataViewsOverrideEnabled() ||
+		isAdminViewDataViewsPackagePublished()
+	) {
+		return;
+	}
+
+	throw createCliDiagnosticCodeError(
+		CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
+		"`wp-typia add admin-view` is temporarily unavailable because `@wp-typia/dataviews` is not published to npm for public installs yet.",
+	);
 }
 
 function detectJsonIndent(source: string): string | number {
@@ -1016,6 +1059,7 @@ export async function runAddAdminViewCommand({
 	source?: string;
 }> {
 	const workspace = resolveWorkspaceProject(cwd);
+	assertAdminViewPackageAvailability();
 	const adminViewSlug = assertValidGeneratedSlug(
 		"Admin view name",
 		normalizeBlockSlug(adminViewName),

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-admin-view.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-admin-view.ts
@@ -43,12 +43,12 @@ const DEFAULT_WP_TYPIA_DATAVIEWS_VERSION = "^0.1.0";
 const DEFAULT_WORDPRESS_DATAVIEWS_VERSION = "^14.1.0";
 const ADMIN_VIEW_ALLOW_UNPUBLISHED_DATAVIEWS_ENV =
 	"WP_TYPIA_ALLOW_UNPUBLISHED_DATAVIEWS";
-const WP_TYPIA_DATAVIEWS_WORKSPACE_PACKAGE_DIR = "wp-typia-dataviews";
+// Lift this gate in the same release that publishes @wp-typia/dataviews.
+const ADMIN_VIEW_PUBLIC_INSTALLS_ENABLED = false;
 
 const require = createRequire(import.meta.url);
 
 interface PackageManifestSummary {
-	private?: boolean;
 	version?: string;
 }
 
@@ -87,41 +87,12 @@ function readPackageManifestVersion(packageJsonPath: string): string | undefined
 	return readPackageManifest(packageJsonPath)?.version;
 }
 
-function readInstalledPackageManifest(packageName: string): PackageManifestSummary | undefined {
-	try {
-		return readPackageManifest(require.resolve(`${packageName}/package.json`));
-	} catch {
-		return undefined;
-	}
-}
-
 function isAdminViewUnpublishedDataViewsOverrideEnabled(): boolean {
 	return process.env[ADMIN_VIEW_ALLOW_UNPUBLISHED_DATAVIEWS_ENV]?.trim() === "1";
 }
 
-function resolveAdminViewDataViewsPackageManifest(): PackageManifestSummary | undefined {
-	return (
-		readPackageManifest(
-			path.join(
-				PROJECT_TOOLS_PACKAGE_ROOT,
-				"..",
-				WP_TYPIA_DATAVIEWS_WORKSPACE_PACKAGE_DIR,
-				"package.json",
-			),
-		) ?? readInstalledPackageManifest("@wp-typia/dataviews")
-	);
-}
-
-function isAdminViewDataViewsPackagePublished(): boolean {
-	const packageJson = resolveAdminViewDataViewsPackageManifest();
-	return packageJson !== undefined && packageJson.private !== true;
-}
-
 function assertAdminViewPackageAvailability(): void {
-	if (
-		isAdminViewUnpublishedDataViewsOverrideEnabled() ||
-		isAdminViewDataViewsPackagePublished()
-	) {
+	if (isAdminViewUnpublishedDataViewsOverrideEnabled() || ADMIN_VIEW_PUBLIC_INSTALLS_ENABLED) {
 		return;
 	}
 

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-admin-view.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-admin-view.ts
@@ -114,7 +114,7 @@ function resolveAdminViewDataViewsPackageManifest(): PackageManifestSummary | un
 
 function isAdminViewDataViewsPackagePublished(): boolean {
 	const packageJson = resolveAdminViewDataViewsPackageManifest();
-	return packageJson?.private === false;
+	return packageJson !== undefined && packageJson.private !== true;
 }
 
 function assertAdminViewPackageAvailability(): void {

--- a/packages/wp-typia-project-tools/src/runtime/cli-help.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-help.ts
@@ -50,7 +50,7 @@ Notes:
   \`wp-typia init\` previews the minimum retrofit sync surface by default; rerun with \`--apply\` to write package.json updates and generated helper scripts.
   Use \`--template workspace\` as shorthand for \`@wp-typia/create-workspace-template\`, the official empty workspace scaffold behind \`wp-typia add ...\`.
   Interactive add flows let you choose a template when \`--template\` is omitted; non-interactive runs default to \`basic\`.
-  \`add admin-view\` scaffolds an opt-in DataViews-powered WordPress admin screen under \`src/admin-views/\`; pass \`--source rest-resource:<slug>\` to reuse a list-capable REST resource.
+  \`add admin-view\` scaffolds an opt-in DataViews-powered WordPress admin screen under \`src/admin-views/\`; pass \`--source rest-resource:<slug>\` to reuse a list-capable REST resource. Public installs currently gate this workflow until \`@wp-typia/dataviews\` is published to npm.
   \`query-loop\` is create-only. Use \`wp-typia create <project-dir> --template query-loop\`; \`wp-typia add block\` accepts only basic, interactivity, persistence, and compound families.
   \`add variation\` uses an existing workspace block from \`scripts/block-config.ts\`.
   \`add style\` registers a Block Styles option for an existing generated block.

--- a/packages/wp-typia-project-tools/tests/workspace-add.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-add.test.ts
@@ -100,6 +100,13 @@ function replaceFixtureSource(
   return nextSource;
 }
 
+function withUnpublishedDataViewsEnv(): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    WP_TYPIA_ALLOW_UNPUBLISHED_DATAVIEWS: "1",
+  };
+}
+
 describe("@wp-typia/project-tools workspace add", () => {
   const tempRoot = createScaffoldTempRoot("wp-typia-workspace-add-");
 
@@ -3200,6 +3207,46 @@ test("canonical CLI can add a plugin-level REST resource to an official workspac
   typecheckGeneratedProject(targetDir);
 }, 30_000);
 
+test("canonical CLI blocks admin-view scaffolds until @wp-typia/dataviews is published", async () => {
+  const targetDir = path.join(tempRoot, "demo-workspace-add-admin-view-blocked");
+
+  await scaffoldProject({
+    projectDir: targetDir,
+    templateId: workspaceTemplatePackageManifest.name,
+    packageManager: "npm",
+    noInstall: true,
+    answers: {
+      author: "Test Runner",
+      description: "Demo workspace add admin view blocked",
+      namespace: "demo-space",
+      phpPrefix: "demo_space",
+      slug: "demo-workspace-add-admin-view-blocked",
+      textDomain: "demo-space",
+      title: "Demo Workspace Add Admin View Blocked",
+    },
+  });
+
+  linkWorkspaceNodeModules(targetDir);
+
+  const errorMessage = getCommandErrorMessage(() =>
+    runCli("node", [entryPath, "add", "admin-view", "snapshots"], {
+      cwd: targetDir,
+    })
+  );
+  const packageJson = JSON.parse(
+    fs.readFileSync(path.join(targetDir, "package.json"), "utf8")
+  ) as {
+    devDependencies?: Record<string, string>;
+  };
+
+  expect(errorMessage).toContain("@wp-typia/dataviews");
+  expect(errorMessage).toContain("not published to npm for public installs yet");
+  expect(packageJson.devDependencies?.["@wp-typia/dataviews"]).toBeUndefined();
+  expect(
+    fs.existsSync(path.join(targetDir, "src", "admin-views", "snapshots"))
+  ).toBe(false);
+}, 20_000);
+
 test("canonical CLI can add a DataViews admin screen with a REST resource source", async () => {
   const targetDir = path.join(tempRoot, "demo-workspace-add-admin-view");
 
@@ -3235,6 +3282,7 @@ test("canonical CLI can add a DataViews admin screen with a REST resource source
     ],
     {
       cwd: targetDir,
+      env: withUnpublishedDataViewsEnv(),
     }
   );
   runCli(
@@ -3249,6 +3297,7 @@ test("canonical CLI can add a DataViews admin screen with a REST resource source
     ],
     {
       cwd: targetDir,
+      env: withUnpublishedDataViewsEnv(),
     }
   );
 
@@ -3423,6 +3472,7 @@ test("admin view workflow accepts formatted shared webpack entries", async () =>
 
   runCli("node", [entryPath, "add", "admin-view", "reports"], {
     cwd: targetDir,
+    env: withUnpublishedDataViewsEnv(),
   });
 
   expect(fs.readFileSync(buildScriptPath, "utf8")).toContain(


### PR DESCRIPTION
## Summary
- gate `wp-typia add admin-view` before any workspace mutation when `@wp-typia/dataviews` is not yet publishable for public installs
- keep the admin-view scaffold covered in-repo through an explicit unpublished-package test override
- document the temporary package-availability limitation in CLI help and the DataViews reference

## Testing
- `PATH=/Users/imjlk/.bun/bin:/opt/homebrew/bin:$PATH /Users/imjlk/.bun/bin/bun run typecheck`
- `PATH=/Users/imjlk/.bun/bin:/opt/homebrew/bin:$PATH /Users/imjlk/.bun/bin/bun test packages/wp-typia-project-tools/tests/workspace-add.test.ts -t "canonical CLI blocks admin-view scaffolds"`
- `PATH=/Users/imjlk/.bun/bin:/opt/homebrew/bin:$PATH /Users/imjlk/.bun/bin/bun test packages/wp-typia-project-tools/tests/workspace-add.test.ts -t "canonical CLI can add a DataViews admin screen"`
- `PATH=/Users/imjlk/.bun/bin:/opt/homebrew/bin:$PATH /Users/imjlk/.bun/bin/bun test packages/wp-typia-project-tools/tests/workspace-add.test.ts -t "admin view workflow accepts formatted shared webpack entries"`

Closes #632

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added availability gate for `wp-typia add admin-view` in public installs, blocking the command until its required dependency is published to npm.

* **Documentation**
  * Updated CLI help text and reference documentation to clarify the gating behavior for `wp-typia add admin-view`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->