### PR TITLE
refactor: centralize managed package version defaults

### DIFF
--- a/.sampo/changesets/centralize-managed-package-defaults.md
+++ b/.sampo/changesets/centralize-managed-package-defaults.md
@@ -1,0 +1,8 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Centralize managed WordPress dependency fallback ranges for ability and
+admin-view scaffolds in `package-versions.ts` so add-command defaults do not
+drift across runtime modules.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ability.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ability.ts
@@ -37,14 +37,16 @@ import {
 	type ScaffoldCompatibilityPolicy,
 	updatePluginHeaderCompatibility,
 } from "./scaffold-compatibility.js";
+import {
+	DEFAULT_WORDPRESS_ABILITIES_VERSION,
+	DEFAULT_WORDPRESS_CORE_ABILITIES_VERSION,
+} from "./package-versions.js";
 
 const ABILITY_SERVER_GLOB = "/inc/abilities/*.php";
 const ABILITY_EDITOR_SCRIPT = "build/abilities/index.js";
 const ABILITY_EDITOR_ASSET = "build/abilities/index.asset.php";
 const ABILITY_REGISTRY_END_MARKER = "// wp-typia add ability entries end";
 const ABILITY_REGISTRY_START_MARKER = "// wp-typia add ability entries start";
-const WP_ABILITIES_PACKAGE_VERSION = "^0.10.0";
-const WP_CORE_ABILITIES_PACKAGE_VERSION = "^0.9.0";
 const WP_ABILITIES_SCRIPT_MODULE_ID = "@wordpress/abilities";
 const WP_CORE_ABILITIES_SCRIPT_MODULE_ID = "@wordpress/core-abilities";
 
@@ -775,11 +777,11 @@ async function ensureAbilityPackageScripts(
 		...(packageJson.dependencies ?? {}),
 		[WP_ABILITIES_SCRIPT_MODULE_ID]: resolveManagedDependencyVersion(
 			packageJson.dependencies?.[WP_ABILITIES_SCRIPT_MODULE_ID],
-			WP_ABILITIES_PACKAGE_VERSION,
+			DEFAULT_WORDPRESS_ABILITIES_VERSION,
 		),
 		[WP_CORE_ABILITIES_SCRIPT_MODULE_ID]: resolveManagedDependencyVersion(
 			packageJson.dependencies?.[WP_CORE_ABILITIES_SCRIPT_MODULE_ID],
-			WP_CORE_ABILITIES_PACKAGE_VERSION,
+			DEFAULT_WORDPRESS_CORE_ABILITIES_VERSION,
 		),
 	};
 

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-admin-view.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-admin-view.ts
@@ -32,6 +32,10 @@ import {
 	CLI_DIAGNOSTIC_CODES,
 	createCliDiagnosticCodeError,
 } from "./cli-diagnostics.js";
+import {
+	DEFAULT_WORDPRESS_DATAVIEWS_VERSION,
+	DEFAULT_WP_TYPIA_DATAVIEWS_VERSION,
+} from "./package-versions.js";
 
 const ADMIN_VIEW_SOURCE_KIND = "rest-resource";
 const ADMIN_VIEWS_SCRIPT = "build/admin-views/index.js";
@@ -39,8 +43,6 @@ const ADMIN_VIEWS_ASSET = "build/admin-views/index.asset.php";
 const ADMIN_VIEWS_STYLE = "build/admin-views/style-index.css";
 const ADMIN_VIEWS_STYLE_RTL = "build/admin-views/style-index-rtl.css";
 const ADMIN_VIEWS_PHP_GLOB = "/inc/admin-views/*.php";
-const DEFAULT_WP_TYPIA_DATAVIEWS_VERSION = "^0.1.0";
-const DEFAULT_WORDPRESS_DATAVIEWS_VERSION = "^14.1.0";
 const ADMIN_VIEW_ALLOW_UNPUBLISHED_DATAVIEWS_ENV =
 	"WP_TYPIA_ALLOW_UNPUBLISHED_DATAVIEWS";
 // Lift this gate in the same release that publishes @wp-typia/dataviews.

--- a/packages/wp-typia-project-tools/src/runtime/package-versions.ts
+++ b/packages/wp-typia-project-tools/src/runtime/package-versions.ts
@@ -35,6 +35,17 @@ const DEFAULT_VERSION_RANGE = "^0.0.0";
 const DEFAULT_EXACT_VERSION = "0.0.0";
 const DEFAULT_TSX_PACKAGE_VERSION = "^4.20.5";
 const DEFAULT_TYPIA_UNPLUGIN_PACKAGE_VERSION = "^12.0.1";
+/**
+ * Explicit fallback ranges for managed WordPress-facing workspace dependencies.
+ *
+ * These remain centralized here even when individual scaffold flows resolve a
+ * fresher local or installed manifest version first, so add-command defaults do
+ * not drift across runtime modules.
+ */
+export const DEFAULT_WORDPRESS_ABILITIES_VERSION = "^0.10.0";
+export const DEFAULT_WORDPRESS_CORE_ABILITIES_VERSION = "^0.9.0";
+export const DEFAULT_WORDPRESS_DATAVIEWS_VERSION = "^14.1.0";
+export const DEFAULT_WP_TYPIA_DATAVIEWS_VERSION = "^0.1.0";
 
 let cachedPackageVersions:
 	| {

--- a/packages/wp-typia-project-tools/tests/package-versions.test.ts
+++ b/packages/wp-typia-project-tools/tests/package-versions.test.ts
@@ -125,4 +125,42 @@ describe("package version cache invalidation", () => {
 		expect(result.stdout).toBe("");
 		expect(result.stderr).toBe("");
 	});
+
+	test("centralizes managed workspace dependency fallback ranges", async () => {
+		const packageVersionsModuleUrl = pathToFileURL(
+			path.join(import.meta.dir, "..", "src", "runtime", "package-versions.ts"),
+		).href;
+		const {
+			DEFAULT_WORDPRESS_ABILITIES_VERSION,
+			DEFAULT_WORDPRESS_CORE_ABILITIES_VERSION,
+			DEFAULT_WORDPRESS_DATAVIEWS_VERSION,
+			DEFAULT_WP_TYPIA_DATAVIEWS_VERSION,
+		} = await import(packageVersionsModuleUrl);
+
+		const abilityRuntimeSource = fs.readFileSync(
+			path.join(import.meta.dir, "..", "src", "runtime", "cli-add-workspace-ability.ts"),
+			"utf8",
+		);
+		const adminViewRuntimeSource = fs.readFileSync(
+			path.join(import.meta.dir, "..", "src", "runtime", "cli-add-workspace-admin-view.ts"),
+			"utf8",
+		);
+
+		expect(DEFAULT_WORDPRESS_ABILITIES_VERSION).toBe("^0.10.0");
+		expect(DEFAULT_WORDPRESS_CORE_ABILITIES_VERSION).toBe("^0.9.0");
+		expect(DEFAULT_WORDPRESS_DATAVIEWS_VERSION).toBe("^14.1.0");
+		expect(DEFAULT_WP_TYPIA_DATAVIEWS_VERSION).toBe("^0.1.0");
+		expect(abilityRuntimeSource).not.toContain("const WP_ABILITIES_PACKAGE_VERSION");
+		expect(abilityRuntimeSource).not.toContain(
+			"const WP_CORE_ABILITIES_PACKAGE_VERSION",
+		);
+		expect(adminViewRuntimeSource).not.toContain(
+			"const DEFAULT_WP_TYPIA_DATAVIEWS_VERSION",
+		);
+		expect(adminViewRuntimeSource).not.toContain(
+			"const DEFAULT_WORDPRESS_DATAVIEWS_VERSION",
+		);
+		expect(abilityRuntimeSource).toContain('from "./package-versions.js"');
+		expect(adminViewRuntimeSource).toContain('from "./package-versions.js"');
+	});
 });


### PR DESCRIPTION
## Summary
- move managed WordPress/DataViews fallback ranges into `package-versions.ts`
- switch ability and admin-view scaffold runtimes to import the shared defaults instead of owning local copies
- add structural test coverage that the defaults stay centralized

## Testing
- `PATH=/Users/imjlk/.bun/bin:/opt/homebrew/bin:$PATH /Users/imjlk/.bun/bin/bun run typecheck`
- `PATH=/Users/imjlk/.bun/bin:/opt/homebrew/bin:$PATH /Users/imjlk/.bun/bin/bun run --cwd packages/wp-typia-project-tools build`
- `PATH=/Users/imjlk/.bun/bin:/opt/homebrew/bin:$PATH /Users/imjlk/.bun/bin/bun test packages/wp-typia-project-tools/tests/package-versions.test.ts`
- `PATH=/Users/imjlk/.bun/bin:/opt/homebrew/bin:$PATH /Users/imjlk/.bun/bin/bun test packages/wp-typia-project-tools/tests/workspace-add.test.ts -t "canonical CLI blocks admin-view scaffolds"`
- `PATH=/Users/imjlk/.bun/bin:/opt/homebrew/bin:$PATH /Users/imjlk/.bun/bin/bun test packages/wp-typia-project-tools/tests/workspace-add.test.ts -t "canonical CLI can add a DataViews admin screen"`
- `PATH=/Users/imjlk/.bun/bin:/opt/homebrew/bin:$PATH /Users/imjlk/.bun/bin/bun test packages/wp-typia-project-tools/tests/workspace-add.test.ts -t "canonical CLI can add a typed workflow ability to an official workspace template"`

Closes #633