### PR TITLE
fix(cli): normalize init --format json envelope

### DIFF
--- a/.sampo/changesets/normalize-init-json-envelope.md
+++ b/.sampo/changesets/normalize-init-json-envelope.md
@@ -1,0 +1,7 @@
+---
+npm/wp-typia: patch
+---
+
+Normalize `wp-typia init --format json` and `wp-typia init --apply --format json`
+to the standard `{ ok: true, data: ... }` CLI success envelope while keeping
+the detailed retrofit plan nested under `data.plan`.

--- a/apps/docs/src/content/docs/reference/cli.md
+++ b/apps/docs/src/content/docs/reference/cli.md
@@ -170,16 +170,20 @@ matching canonical slot.
 
 ## `init`
 
-Preview the minimum adoption plan for an existing project. The command is
-read-only today.
+Preview or apply the minimum adoption plan for an existing project.
 
 ```bash
 wp-typia init [project-dir]
+wp-typia init [project-dir] --apply
 wp-typia init [project-dir] --format json
 ```
 
 `init` reports dependency, script, generated artifact, and migration follow-up
-steps for supported single-block and multi-block layouts.
+steps for supported single-block and multi-block layouts. `--apply` writes the
+planned `package.json` changes and retrofit helper files with
+rollback-on-failure protection. `--format json` emits the standard CLI success
+envelope (`{ ok: true, data: ... }`) and keeps the detailed init plan nested
+under `data.plan`.
 
 ## `sync`
 

--- a/packages/wp-typia/src/commands/init.ts
+++ b/packages/wp-typia/src/commands/init.ts
@@ -1,44 +1,48 @@
-import { defineCommand } from "@bunli/core";
+import { defineCommand } from '@bunli/core';
 
 import {
-	buildCommandOptions,
-	INIT_OPTION_METADATA,
-} from "../command-option-metadata";
-import { emitCliDiagnosticFailure, prefersStructuredCliOutput } from "../cli-diagnostic-output";
-import { executeInitCommand } from "../runtime-bridge";
+  buildCommandOptions,
+  INIT_OPTION_METADATA,
+} from '../command-option-metadata';
+import {
+  emitCliDiagnosticFailure,
+  prefersStructuredCliOutput,
+} from '../cli-diagnostic-output';
+import { executeInitCommand } from '../runtime-bridge';
+import { buildStructuredInitSuccessPayload } from '../runtime-bridge-output';
 
 export const initCommand = defineCommand({
-	defaultFormat: "toon",
-	description:
-		"Preview or apply the minimum wp-typia retrofit plan for an existing project.",
-	handler: async (args) => {
-		const prefersStructuredOutput = prefersStructuredCliOutput(args);
+  defaultFormat: 'toon',
+  description:
+    'Preview or apply the minimum wp-typia retrofit plan for an existing project.',
+  handler: async (args) => {
+    const prefersStructuredOutput = prefersStructuredCliOutput(args);
 
-		try {
-			const plan = await executeInitCommand(
-				{
-					apply: Boolean(args.flags.apply),
-					cwd: args.cwd,
-					packageManager:
-						typeof args.flags["package-manager"] === "string"
-							? args.flags["package-manager"]
-							: undefined,
-					projectDir: args.positional[0] as string | undefined,
-				},
-				{ emitOutput: !prefersStructuredOutput },
-			);
-			if (prefersStructuredOutput) {
-				args.output({ init: plan });
-			}
-		} catch (error) {
-			emitCliDiagnosticFailure(args, {
-				command: "init",
-				error,
-			});
-		}
-	},
-	name: "init",
-	options: buildCommandOptions(INIT_OPTION_METADATA),
+    try {
+      const plan = await executeInitCommand(
+        {
+          apply: Boolean(args.flags.apply),
+          cwd: args.cwd,
+          packageManager:
+            typeof args.flags['package-manager'] === 'string'
+              ? args.flags['package-manager']
+              : undefined,
+          projectDir: args.positional[0] as string | undefined,
+        },
+        { emitOutput: !prefersStructuredOutput },
+      );
+      if (prefersStructuredOutput) {
+        args.output(buildStructuredInitSuccessPayload(plan));
+      }
+    } catch (error) {
+      emitCliDiagnosticFailure(args, {
+        command: 'init',
+        error,
+      });
+    }
+  },
+  name: 'init',
+  options: buildCommandOptions(INIT_OPTION_METADATA),
 });
 
 export default initCommand;

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -47,6 +47,7 @@ import {
   executeTemplatesCommand,
 } from './runtime-bridge';
 import {
+  buildStructuredInitSuccessPayload,
   buildStructuredCompletionSuccessPayload,
   buildSyncDryRunPayload,
   extractCompletionProjectDir,
@@ -552,13 +553,7 @@ const NODE_FALLBACK_COMMAND_DISPATCHERS = {
     );
     if (mergedFlags.format === 'json') {
       printLine(
-        JSON.stringify(
-          {
-            init: plan,
-          },
-          null,
-          2,
-        ),
+        JSON.stringify(buildStructuredInitSuccessPayload(plan), null, 2),
       );
     }
   },

--- a/packages/wp-typia/src/runtime-bridge-output.ts
+++ b/packages/wp-typia/src/runtime-bridge-output.ts
@@ -39,6 +39,70 @@ export type StructuredCompletionSuccessPayload = {
   } & Record<string, unknown>;
 };
 
+type InitPlanLayoutKind =
+  | 'generated-project'
+  | 'multi-block'
+  | 'official-workspace'
+  | 'single-block'
+  | 'unsupported';
+
+type StructuredInitPlan = {
+  commandMode: 'apply' | 'preview-only';
+  detectedLayout: {
+    blockNames: string[];
+    description: string;
+    kind: InitPlanLayoutKind;
+  };
+  generatedArtifacts: string[];
+  nextSteps: string[];
+  notes: string[];
+  packageChanges: {
+    addDevDependencies: Array<{
+      action: 'add' | 'update';
+      name: string;
+      requiredValue: string;
+    }>;
+    packageManagerField?: {
+      action: 'add' | 'update';
+      requiredValue: string;
+    };
+    scripts: Array<{
+      action: 'add' | 'update';
+      name: string;
+      requiredValue: string;
+    }>;
+  };
+  plannedFiles: Array<{
+    action: 'add' | 'update';
+    path: string;
+    purpose: string;
+  }>;
+  packageManager: PackageManagerId;
+  projectDir: string;
+  projectName: string;
+  status: 'already-initialized' | 'applied' | 'preview';
+  summary: string;
+};
+
+export type StructuredInitSuccessPayload = {
+  ok: true;
+  data: {
+    command: 'init';
+    completion: SerializableCompletionPayload;
+    detectedLayout: StructuredInitPlan['detectedLayout'];
+    files?: string[];
+    mode: 'apply' | 'preview';
+    nextSteps?: string[];
+    packageManager: PackageManagerId;
+    plan: StructuredInitPlan;
+    projectDir: string;
+    status: StructuredInitPlan['status'];
+    summary: string;
+    title?: string;
+    warnings?: string[];
+  };
+};
+
 export type SerializableCompletionPayload = {
   nextSteps?: string[];
   optionalLines?: string[];
@@ -117,10 +181,14 @@ function toNonEmptyArray(values: string[] | undefined): string[] | undefined {
   return values && values.length > 0 ? values : undefined;
 }
 
-function extractPlannedFiles(payload: SerializableCompletionPayload): string[] | undefined {
+function extractPlannedFiles(
+  payload: SerializableCompletionPayload,
+): string[] | undefined {
   const files = payload.optionalLines
     ?.map((line) => line.match(/^(?:delete|update|write)\s+(.+)$/u)?.[1])
-    .filter((value): value is string => typeof value === 'string' && value.length > 0);
+    .filter(
+      (value): value is string => typeof value === 'string' && value.length > 0,
+    );
 
   return toNonEmptyArray(files);
 }
@@ -201,6 +269,39 @@ export function buildStructuredCompletionSuccessPayload(
             warnings: serializedCompletion.warningLines,
           }
         : {}),
+    },
+  };
+}
+
+export function buildStructuredInitSuccessPayload(
+  plan: StructuredInitPlan,
+): StructuredInitSuccessPayload {
+  const completion = serializeCompletionPayload(
+    buildInitCompletionPayload(plan),
+  );
+  const files = Array.from(
+    new Set([
+      ...plan.plannedFiles.map((filePlan) => filePlan.path),
+      ...(plan.commandMode === 'preview-only' ? plan.generatedArtifacts : []),
+    ]),
+  );
+
+  return {
+    ok: true,
+    data: {
+      command: 'init',
+      completion,
+      detectedLayout: plan.detectedLayout,
+      files: toNonEmptyArray(files),
+      mode: plan.commandMode === 'apply' ? 'apply' : 'preview',
+      nextSteps: toNonEmptyArray(plan.nextSteps),
+      packageManager: plan.packageManager,
+      plan,
+      projectDir: plan.projectDir,
+      status: plan.status,
+      summary: plan.summary,
+      title: completion.title,
+      warnings: toNonEmptyArray(plan.notes),
     },
   };
 }

--- a/packages/wp-typia/src/runtime-bridge-output.ts
+++ b/packages/wp-typia/src/runtime-bridge-output.ts
@@ -446,43 +446,7 @@ export function buildCreateDryRunPayload(
  * @returns A structured alternate-buffer completion payload.
  */
 export function buildInitCompletionPayload(
-  plan: {
-    commandMode: 'apply' | 'preview-only';
-    detectedLayout: {
-      blockNames: string[];
-      description: string;
-      kind: string;
-    };
-    generatedArtifacts: string[];
-    nextSteps: string[];
-    notes: string[];
-    packageChanges: {
-      addDevDependencies: Array<{
-        action: 'add' | 'update';
-        name: string;
-        requiredValue: string;
-      }>;
-      packageManagerField?: {
-        action: 'add' | 'update';
-        requiredValue: string;
-      };
-      scripts: Array<{
-        action: 'add' | 'update';
-        name: string;
-        requiredValue: string;
-      }>;
-    };
-    plannedFiles: Array<{
-      action: 'add' | 'update';
-      path: string;
-      purpose: string;
-    }>;
-    packageManager: PackageManagerId;
-    projectDir: string;
-    projectName: string;
-    status: 'already-initialized' | 'applied' | 'preview';
-    summary: string;
-  },
+  plan: StructuredInitPlan,
   markerOptions?: OutputMarkerOptions,
 ): AlternateBufferCompletionPayload {
   const changeLines = [

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -376,9 +376,9 @@ describe('wp-typia package', () => {
 
   test('routes interactive create/add/migrate invocations to the Bunli runtime when Bun and a TTY are available', () => {
     expect(shouldRouteTestInvocationToFullRuntime(['create'])).toBe(true);
-    expect(shouldRouteTestInvocationToFullRuntime(['create', '--dry-run'])).toBe(
-      true,
-    );
+    expect(
+      shouldRouteTestInvocationToFullRuntime(['create', '--dry-run']),
+    ).toBe(true);
     expect(shouldRouteTestInvocationToFullRuntime(['add'])).toBe(true);
     expect(shouldRouteTestInvocationToFullRuntime(['migrate'])).toBe(true);
     expect(shouldRouteTestInvocationToFullRuntime(['demo-block'])).toBe(true);
@@ -426,11 +426,7 @@ describe('wp-typia package', () => {
       ]),
     ).toBe(false);
     expect(
-      shouldRouteTestInvocationToFullRuntime([
-        'create',
-        'demo-block',
-        '--yes',
-      ]),
+      shouldRouteTestInvocationToFullRuntime(['create', 'demo-block', '--yes']),
     ).toBe(false);
     expect(
       shouldRouteTestInvocationToFullRuntime(['create', 'demo-block', '-y']),
@@ -491,27 +487,55 @@ describe('wp-typia package', () => {
         },
       );
       const parsed = parseJsonObjectFromOutput<{
-        init?: {
-          commandMode?: string;
-          detectedLayout?: { kind?: string; blockNames?: string[] };
-          nextSteps?: string[];
-          packageChanges?: {
-            scripts?: Array<{ name?: string }>;
+        data?: {
+          command?: string;
+          completion?: {
+            title?: string;
           };
+          detectedLayout?: { kind?: string; blockNames?: string[] };
+          files?: string[];
+          mode?: string;
+          nextSteps?: string[];
+          packageManager?: string;
+          plan?: {
+            commandMode?: string;
+            packageChanges?: {
+              scripts?: Array<{ name?: string }>;
+            };
+          };
+          projectDir?: string;
           status?: string;
         };
+        ok?: boolean;
       }>(output);
 
-      expect(parsed.init?.status).toBe('preview');
-      expect(parsed.init?.commandMode).toBe('preview-only');
-      expect(parsed.init?.detectedLayout?.kind).toBe('single-block');
-      expect(parsed.init?.detectedLayout?.blockNames).toEqual([
+      expect(parsed.ok).toBe(true);
+      expect(parsed.data?.command).toBe('init');
+      expect(parsed.data?.status).toBe('preview');
+      expect(parsed.data?.mode).toBe('preview');
+      expect(parsed.data?.plan?.commandMode).toBe('preview-only');
+      expect(parsed.data?.detectedLayout?.kind).toBe('single-block');
+      expect(parsed.data?.detectedLayout?.blockNames).toEqual([
         'create-block/retrofit-init',
       ]);
       expect(
-        parsed.init?.packageChanges?.scripts?.map((script) => script.name),
+        parsed.data?.plan?.packageChanges?.scripts?.map(
+          (script) => script.name,
+        ),
       ).toEqual(['sync', 'sync-types', 'typecheck']);
-      expect(parsed.init?.nextSteps).toContain(
+      expect(parsed.data?.projectDir).toBe(fs.realpathSync(fixtureRoot));
+      expect(parsed.data?.packageManager).toBe('npm');
+      expect(parsed.data?.files).toEqual(
+        expect.arrayContaining([
+          'scripts/block-config.ts',
+          'scripts/sync-types-to-block-json.ts',
+          'scripts/sync-project.ts',
+          'src/typia.manifest.json',
+          'src/typia.schema.json',
+        ]),
+      );
+      expect(parsed.data?.completion?.title).toContain('Retrofit init plan');
+      expect(parsed.data?.nextSteps).toContain(
         `npx --yes wp-typia@${packageManifest.version} doctor`,
       );
     } finally {
@@ -539,12 +563,22 @@ describe('wp-typia package', () => {
         },
       );
       const parsed = parseJsonObjectFromOutput<{
-        init?: {
-          commandMode?: string;
+        data?: {
+          command?: string;
+          completion?: {
+            title?: string;
+          };
+          files?: string[];
+          mode?: string;
           packageManager?: string;
-          plannedFiles?: Array<{ action?: string; path?: string }>;
+          plan?: {
+            commandMode?: string;
+            plannedFiles?: Array<{ action?: string; path?: string }>;
+          };
+          projectDir?: string;
           status?: string;
         };
+        ok?: boolean;
       }>(output);
       const packageJson = JSON.parse(
         fs.readFileSync(path.join(fixtureRoot, 'package.json'), 'utf8'),
@@ -553,10 +587,14 @@ describe('wp-typia package', () => {
         scripts?: Record<string, string>;
       };
 
-      expect(parsed.init?.status).toBe('applied');
-      expect(parsed.init?.commandMode).toBe('apply');
-      expect(parsed.init?.packageManager).toBe('pnpm');
-      expect(parsed.init?.plannedFiles).toEqual(
+      expect(parsed.ok).toBe(true);
+      expect(parsed.data?.command).toBe('init');
+      expect(parsed.data?.status).toBe('applied');
+      expect(parsed.data?.mode).toBe('apply');
+      expect(parsed.data?.plan?.commandMode).toBe('apply');
+      expect(parsed.data?.packageManager).toBe('pnpm');
+      expect(parsed.data?.projectDir).toBe(fs.realpathSync(fixtureRoot));
+      expect(parsed.data?.plan?.plannedFiles).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
             action: 'add',
@@ -572,6 +610,14 @@ describe('wp-typia package', () => {
           }),
         ]),
       );
+      expect(parsed.data?.files).toEqual(
+        expect.arrayContaining([
+          'scripts/block-config.ts',
+          'scripts/sync-types-to-block-json.ts',
+          'scripts/sync-project.ts',
+        ]),
+      );
+      expect(parsed.data?.completion?.title).toContain('Applied retrofit init');
       expect(packageJson.packageManager).toBe('pnpm@8.3.1');
       expect(packageJson.scripts?.sync).toBe('tsx scripts/sync-project.ts');
       expect(packageJson.scripts?.typecheck).toBe(

--- a/packages/wp-typia/tests/completion-output.test.ts
+++ b/packages/wp-typia/tests/completion-output.test.ts
@@ -12,6 +12,7 @@ import {
   buildAddCompletionPayload,
   buildAddDryRunPayload,
   buildStructuredCompletionSuccessPayload,
+  buildStructuredInitSuccessPayload,
   buildSyncDryRunPayload,
 } from '../src/runtime-bridge-output';
 
@@ -326,6 +327,67 @@ describe('alternate-buffer completion output helpers', () => {
       'scripts/block-config.ts',
       'src/blocks/old-card/block.json',
     ]);
+  });
+
+  test('structured init success payload uses the standard CLI envelope', () => {
+    const payload = buildStructuredInitSuccessPayload({
+      commandMode: 'preview-only',
+      detectedLayout: {
+        blockNames: ['demo-space/promo-card'],
+        description: 'Single block layout',
+        kind: 'single-block',
+      },
+      generatedArtifacts: ['src/typia.manifest.json', 'src/typia.schema.json'],
+      nextSteps: ['npm run sync -- --check', 'npm run typecheck'],
+      notes: ['Preview only: no files were written.'],
+      packageChanges: {
+        addDevDependencies: [
+          {
+            action: 'add',
+            name: '@wp-typia/project-tools',
+            requiredValue: '^0.0.0-test',
+          },
+        ],
+        scripts: [
+          {
+            action: 'add',
+            name: 'sync',
+            requiredValue: 'tsx scripts/sync-project.ts',
+          },
+        ],
+      },
+      packageManager: 'npm',
+      plannedFiles: [
+        {
+          action: 'add',
+          path: 'scripts/sync-project.ts',
+          purpose: 'Project-level sync entrypoint',
+        },
+      ],
+      projectDir: '/tmp/demo-workspace',
+      projectName: 'demo-workspace',
+      status: 'preview',
+      summary: 'Preview the minimum retrofit surface.',
+    });
+
+    expect(payload.ok).toBe(true);
+    expect(payload.data.command).toBe('init');
+    expect(payload.data.mode).toBe('preview');
+    expect(payload.data.projectDir).toBe('/tmp/demo-workspace');
+    expect(payload.data.plan.commandMode).toBe('preview-only');
+    expect(payload.data.files).toEqual([
+      'scripts/sync-project.ts',
+      'src/typia.manifest.json',
+      'src/typia.schema.json',
+    ]);
+    expect(payload.data.nextSteps).toEqual([
+      'npm run sync -- --check',
+      'npm run typecheck',
+    ]);
+    expect(payload.data.warnings).toEqual([
+      'Preview only: no files were written.',
+    ]);
+    expect(payload.data.completion.title).toContain('Retrofit init plan');
   });
 
   test('dry-run sync payload previews the generated sync commands', () => {


### PR DESCRIPTION
## Summary
- normalize `wp-typia init --format json` and `wp-typia init --apply --format json` to the shared `{ ok: true, data: ... }` success envelope
- keep the detailed retrofit plan nested under `data.plan` while surfacing common fields like `mode`, `files`, `nextSteps`, and `warnings`
- update CLI docs and JSON/output coverage for the canonical bin plus helper-level success payloads

## Testing
- bun run typecheck
- bun run --cwd packages/wp-typia build
- bun test packages/wp-typia/tests/cli-package.test.ts
- bun test packages/wp-typia/tests/completion-output.test.ts
- bun run docs:build:site

Closes #631

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `init` command JSON output (`--format json`) now uses standard CLI envelope format with `ok` status and nested response data.
  * `--apply` flag persists planned modifications and generates helper files with rollback-on-failure safeguards.

* **Documentation**
  * Updated `init` command reference documenting preview and apply modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->