### PR TITLE
test(cli): harden add-kind registry type coverage

### DIFF
--- a/.sampo/changesets/add-kind-registry-type-coverage.md
+++ b/.sampo/changesets/add-kind-registry-type-coverage.md
@@ -1,0 +1,7 @@
+---
+npm/wp-typia: patch
+---
+
+Strengthen add-kind registry type coverage so each add kind's
+`prepareExecution()` result stays compile-time compatible with its
+corresponding `getValues(result)` contract as the registry grows.

--- a/packages/wp-typia/src/add-kind-registry.ts
+++ b/packages/wp-typia/src/add-kind-registry.ts
@@ -110,6 +110,27 @@ type AddVariationResult = Awaited<
   ReturnType<AddRuntime['runAddVariationCommand']>
 >;
 
+type AddKindExecutionResultById = {
+  'admin-view': AddAdminViewResult;
+  ability: AddAbilityResult;
+  'ai-feature': AddAiFeatureResult;
+  'binding-source': AddBindingSourceResult;
+  block: AddBlockResult;
+  'editor-plugin': AddEditorPluginResult;
+  'hooked-block': AddHookedBlockResult;
+  pattern: AddPatternResult;
+  'rest-resource': AddRestResourceResult;
+  style: AddBlockStyleResult;
+  transform: AddBlockTransformResult;
+  variation: AddVariationResult;
+};
+
+type AddKindRegistry = {
+  [TKey in CliAddRuntime.AddKindId]: AddKindRegistryEntry<
+    AddKindExecutionResultById[TKey]
+  >;
+};
+
 const BLOCK_VISIBLE_FIELD_ORDER = [
   'kind',
   'name',
@@ -174,9 +195,9 @@ function toExternalLayerPromptOptions(options: ExternalLayerSelectOption[]) {
   }));
 }
 
-function defineAddKindRegistryEntry<
-  TResult extends AddKindExecutionResultBase,
->(entry: AddKindRegistryEntry<TResult>) {
+function defineAddKindRegistryEntry<TResult extends AddKindExecutionResultBase>(
+  entry: AddKindRegistryEntry<TResult>,
+) {
   return entry;
 }
 
@@ -813,13 +834,15 @@ export const ADD_KIND_REGISTRY = {
     usage: 'wp-typia add variation <name> --block <block-slug> [--dry-run]',
     visibleFieldNames: () => ['kind', 'name', 'block'],
   }),
-} as const satisfies Record<CliAddRuntime.AddKindId, AddKindRegistryEntry<any>>;
+} as const satisfies AddKindRegistry;
 
 export type AddKindId = keyof typeof ADD_KIND_REGISTRY;
 export type AddKindExecutionPlanFor<TKey extends AddKindId> = Awaited<
   ReturnType<(typeof ADD_KIND_REGISTRY)[TKey]['prepareExecution']>
 >;
-export const ADD_KIND_IDS = (Object.keys(ADD_KIND_REGISTRY) as AddKindId[]).sort(
+export const ADD_KIND_IDS = (
+  Object.keys(ADD_KIND_REGISTRY) as AddKindId[]
+).sort(
   (left, right) =>
     ADD_KIND_REGISTRY[left].sortOrder - ADD_KIND_REGISTRY[right].sortOrder,
 );
@@ -835,8 +858,9 @@ export async function getAddKindExecutionPlan<TKey extends AddKindId>(
   kind: TKey,
   context: AddKindExecutionContext,
 ): Promise<AddKindExecutionPlanFor<TKey>> {
-  return ADD_KIND_REGISTRY[kind]
-    .prepareExecution(context) as Promise<AddKindExecutionPlanFor<TKey>>;
+  return ADD_KIND_REGISTRY[kind].prepareExecution(context) as Promise<
+    AddKindExecutionPlanFor<TKey>
+  >;
 }
 
 export function buildAddKindCompletionDetails(

--- a/packages/wp-typia/tests/add-kind-registry.test.ts
+++ b/packages/wp-typia/tests/add-kind-registry.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from 'bun:test';
+
+import { type AddKindExecutionPlanFor } from '../src/add-kind-registry';
+
+type ExpectTrue<TValue extends true> = TValue;
+type IsEqual<TLeft, TRight> =
+  (<TValue>() => TValue extends TLeft ? 1 : 2) extends <
+    TValue,
+  >() => TValue extends TRight ? 1 : 2
+    ? true
+    : false;
+
+type AdminViewPlanCompatibility = ExpectTrue<
+  IsEqual<
+    Awaited<ReturnType<AddKindExecutionPlanFor<'admin-view'>['execute']>>,
+    Parameters<AddKindExecutionPlanFor<'admin-view'>['getValues']>[0]
+  >
+>;
+
+type BindingSourcePlanCompatibility = ExpectTrue<
+  IsEqual<
+    Awaited<ReturnType<AddKindExecutionPlanFor<'binding-source'>['execute']>>,
+    Parameters<AddKindExecutionPlanFor<'binding-source'>['getValues']>[0]
+  >
+>;
+
+const addKindPlanCompatibilityChecks: {
+  'admin-view': AdminViewPlanCompatibility;
+  'binding-source': BindingSourcePlanCompatibility;
+} = {
+  'admin-view': true,
+  'binding-source': true,
+};
+
+test('preserves compile-time compatibility between execute and getValues for representative add kinds', () => {
+  expect(addKindPlanCompatibilityChecks).toEqual({
+    'admin-view': true,
+    'binding-source': true,
+  });
+});


### PR DESCRIPTION
## Summary
- replace the top-level add-kind registry `any` constraint with a per-kind execution-result map
- keep every `CliAddRuntime.AddKindId` covered while preserving each add kind's specific `prepareExecution()` result type
- add compile-time coverage for representative add kinds to prove `execute()` results stay compatible with `getValues(result)`

## Testing
- bun run typecheck
- bun run --cwd packages/wp-typia build
- bun test packages/wp-typia/tests/add-kind-registry.test.ts packages/wp-typia/tests/add-command.test.ts

Closes #628

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Reinforced TypeScript type definitions for the add-kind registry to maintain proper type compatibility between command execution and value retrieval as the registry expands.

* **Tests**
  * Added compile-time type validation tests ensuring that command execution output and value retrieval input types remain synchronized, preventing future type compatibility regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->