### PR TITLE
refactor(project-tools): centralize version floor utils

### DIFF
--- a/.sampo/changesets/centralize-version-floor-utils.md
+++ b/.sampo/changesets/centralize-version-floor-utils.md
@@ -1,0 +1,8 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Centralize runtime version-floor parsing and comparison helpers shared by
+scaffold compatibility and AI feature capability planning, and add edge-case
+coverage for empty, duplicate, and mixed AI capability selections.

--- a/packages/wp-typia-project-tools/src/runtime/ai-feature-capability.ts
+++ b/packages/wp-typia-project-tools/src/runtime/ai-feature-capability.ts
@@ -1,4 +1,7 @@
 /** Declares whether a generated feature is optional or required at runtime. */
+import { pickHigherVersionFloor } from './version-floor.js';
+
+/** Declares whether a generated feature is optional or required at runtime. */
 export type AiFeatureCapabilityMode = 'optional' | 'required';
 
 /** Describes the minimum compatible platform versions for a feature. */
@@ -132,50 +135,6 @@ const DEFAULT_AI_FEATURE_REGISTRY: Readonly<
   accumulator[definition.id] = definition;
   return accumulator;
 }, {});
-
-function parseVersionFloorParts(value: string): number[] {
-  return value.split('.').map((part, index) => {
-    if (!/^\d+$/.test(part)) {
-      throw new Error(
-        `parseVersionFloorParts received an invalid version floor "${value}" at segment ${index + 1}.`,
-      );
-    }
-    return Number.parseInt(part, 10);
-  });
-}
-
-function compareVersionFloors(left: string, right: string): number {
-  const leftParts = parseVersionFloorParts(left);
-  const rightParts = parseVersionFloorParts(right);
-  const length = Math.max(leftParts.length, rightParts.length);
-
-  for (let index = 0; index < length; index += 1) {
-    const leftValue = leftParts[index] ?? 0;
-    const rightValue = rightParts[index] ?? 0;
-    if (leftValue > rightValue) {
-      return 1;
-    }
-    if (leftValue < rightValue) {
-      return -1;
-    }
-  }
-
-  return 0;
-}
-
-function pickHigherVersionFloor(
-  current: string | undefined,
-  candidate: string | undefined,
-): string | undefined {
-  if (!candidate) {
-    return current;
-  }
-  if (!current) {
-    return candidate;
-  }
-
-  return compareVersionFloors(current, candidate) >= 0 ? current : candidate;
-}
 
 function normalizeSelections(
   selections: readonly AiFeatureCapabilitySelection[],

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-compatibility.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-compatibility.ts
@@ -5,228 +5,209 @@
  * metadata aligned when optional or required AI-capable features are added.
  */
 import {
-	AI_FEATURE_DEFINITIONS,
-	type AiFeatureCapabilitySelection,
-	type AiFeatureCompatibilityFloor,
-	type ResolvedAiFeatureCapability,
-	type ResolvedAiFeatureCapabilityPlan,
-	resolveAiFeatureCapabilityPlan,
-} from "./ai-feature-capability.js";
+  AI_FEATURE_DEFINITIONS,
+  type AiFeatureCapabilitySelection,
+  type AiFeatureCompatibilityFloor,
+  type ResolvedAiFeatureCapability,
+  type ResolvedAiFeatureCapabilityPlan,
+  resolveAiFeatureCapabilityPlan,
+} from './ai-feature-capability.js';
+import { pickHigherVersionFloor } from './version-floor.js';
 
 /**
  * WordPress plugin header version floors emitted by scaffold templates.
  */
 export interface ScaffoldPluginHeaderCompatibility {
-	requiresAtLeast: string;
-	requiresPhp: string;
-	testedUpTo: string;
+  requiresAtLeast: string;
+  requiresPhp: string;
+  testedUpTo: string;
 }
 
 /**
  * Resolved compatibility policy for a set of scaffold feature capabilities.
  */
 export interface ScaffoldCompatibilityPolicy {
-	capabilityPlan: ResolvedAiFeatureCapabilityPlan;
-	pluginHeader: ScaffoldPluginHeaderCompatibility;
+  capabilityPlan: ResolvedAiFeatureCapabilityPlan;
+  pluginHeader: ScaffoldPluginHeaderCompatibility;
 }
 
 /**
  * Serializable compatibility metadata stored in generated workspace inventory.
  */
 export interface ScaffoldCompatibilityConfig {
-	hardMinimums: AiFeatureCompatibilityFloor;
-	mode: "baseline" | "optional" | "required";
-	optionalFeatures: string[];
-	requiredFeatures: string[];
-	runtimeGates: string[];
+  hardMinimums: AiFeatureCompatibilityFloor;
+  mode: 'baseline' | 'optional' | 'required';
+  optionalFeatures: string[];
+  requiredFeatures: string[];
+  runtimeGates: string[];
 }
 
 /**
  * Baseline headers used by scaffold output before optional features are added.
  */
-export const DEFAULT_SCAFFOLD_COMPATIBILITY: ScaffoldPluginHeaderCompatibility = {
-	requiresAtLeast: "6.7",
-	requiresPhp: "8.0",
-	testedUpTo: "6.9",
-};
+export const DEFAULT_SCAFFOLD_COMPATIBILITY: ScaffoldPluginHeaderCompatibility =
+  {
+    requiresAtLeast: '6.7',
+    requiresPhp: '8.0',
+    testedUpTo: '6.9',
+  };
 
 /**
  * Optional WordPress AI Client surface used by server-only AI feature scaffold.
  */
 export const OPTIONAL_WORDPRESS_AI_CLIENT_COMPATIBILITY: readonly AiFeatureCapabilitySelection[] =
-	[
-		{
-			featureId: AI_FEATURE_DEFINITIONS.wordpressAiClient.id,
-			mode: "optional",
-		},
-	];
+  [
+    {
+      featureId: AI_FEATURE_DEFINITIONS.wordpressAiClient.id,
+      mode: 'optional',
+    },
+  ];
 
 /**
  * Required Abilities API surface used by typed workflow ability scaffold.
  */
 export const REQUIRED_WORKSPACE_ABILITY_COMPATIBILITY: readonly AiFeatureCapabilitySelection[] =
-	[
-		{
-			featureId: AI_FEATURE_DEFINITIONS.wordpressServerAbilities.id,
-			mode: "required",
-		},
-		{
-			featureId: AI_FEATURE_DEFINITIONS.wordpressCoreAbilities.id,
-			mode: "required",
-		},
-	];
+  [
+    {
+      featureId: AI_FEATURE_DEFINITIONS.wordpressServerAbilities.id,
+      mode: 'required',
+    },
+    {
+      featureId: AI_FEATURE_DEFINITIONS.wordpressCoreAbilities.id,
+      mode: 'required',
+    },
+  ];
 
-function parseVersionFloorParts(value: string): number[] {
-	return value.split(".").map((part, index) => {
-		if (!/^\d+$/u.test(part)) {
-			throw new Error(
-				`parseVersionFloorParts received an invalid version floor "${value}" at segment ${index + 1}.`,
-			);
-		}
-		return Number.parseInt(part, 10);
-	});
+function pickHigherScaffoldVersionFloor(
+  current: string,
+  candidate: string | undefined,
+): string {
+  return pickHigherVersionFloor(current, candidate) ?? current;
 }
 
-function compareVersionFloors(left: string, right: string): number {
-	const leftParts = parseVersionFloorParts(left);
-	const rightParts = parseVersionFloorParts(right);
-	const length = Math.max(leftParts.length, rightParts.length);
+function pickHigherHeaderVersionFloor(
+  policyValue: string,
+  currentValue: string,
+): string {
+  const normalizedCurrentValue = currentValue.trim();
+  if (!normalizedCurrentValue) {
+    return policyValue;
+  }
 
-	for (let index = 0; index < length; index += 1) {
-		const leftValue = leftParts[index] ?? 0;
-		const rightValue = rightParts[index] ?? 0;
-		if (leftValue > rightValue) {
-			return 1;
-		}
-		if (leftValue < rightValue) {
-			return -1;
-		}
-	}
-
-	return 0;
-}
-
-function pickHigherVersionFloor(current: string, candidate: string | undefined): string {
-	if (!candidate) {
-		return current;
-	}
-
-	return compareVersionFloors(current, candidate) >= 0 ? current : candidate;
-}
-
-function pickHigherHeaderVersionFloor(policyValue: string, currentValue: string): string {
-	const normalizedCurrentValue = currentValue.trim();
-	if (!normalizedCurrentValue) {
-		return policyValue;
-	}
-
-	try {
-		return pickHigherVersionFloor(policyValue, normalizedCurrentValue);
-	} catch {
-		return policyValue;
-	}
+  try {
+    return pickHigherScaffoldVersionFloor(policyValue, normalizedCurrentValue);
+  } catch {
+    return policyValue;
+  }
 }
 
 function formatRuntimeGate(feature: ResolvedAiFeatureCapability): string[] {
-	return (feature.runtimeGates ?? []).map(
-		(gate) => `${feature.label}: ${gate.kind} ${gate.value}`,
-	);
+  return (feature.runtimeGates ?? []).map(
+    (gate) => `${feature.label}: ${gate.kind} ${gate.value}`,
+  );
 }
 
 function getPolicyMode(
-	capabilityPlan: ResolvedAiFeatureCapabilityPlan,
-): ScaffoldCompatibilityConfig["mode"] {
-	if (capabilityPlan.requiredFeatures.length > 0) {
-		return "required";
-	}
-	if (capabilityPlan.optionalFeatures.length > 0) {
-		return "optional";
-	}
-	return "baseline";
+  capabilityPlan: ResolvedAiFeatureCapabilityPlan,
+): ScaffoldCompatibilityConfig['mode'] {
+  if (capabilityPlan.requiredFeatures.length > 0) {
+    return 'required';
+  }
+  if (capabilityPlan.optionalFeatures.length > 0) {
+    return 'optional';
+  }
+  return 'baseline';
 }
 
 /**
  * Resolve plugin header floors and capability gates for scaffold selections.
  */
 export function resolveScaffoldCompatibilityPolicy(
-	selections: readonly AiFeatureCapabilitySelection[],
-	{
-		baseline = DEFAULT_SCAFFOLD_COMPATIBILITY,
-	}: {
-		baseline?: ScaffoldPluginHeaderCompatibility;
-	} = {},
+  selections: readonly AiFeatureCapabilitySelection[],
+  {
+    baseline = DEFAULT_SCAFFOLD_COMPATIBILITY,
+  }: {
+    baseline?: ScaffoldPluginHeaderCompatibility;
+  } = {},
 ): ScaffoldCompatibilityPolicy {
-	const capabilityPlan = resolveAiFeatureCapabilityPlan(selections);
-	const requiresAtLeast = pickHigherVersionFloor(
-		baseline.requiresAtLeast,
-		capabilityPlan.hardMinimums.wordpress,
-	);
-	const requiresPhp = pickHigherVersionFloor(
-		baseline.requiresPhp,
-		capabilityPlan.hardMinimums.php,
-	);
-	const testedUpTo = pickHigherVersionFloor(baseline.testedUpTo, requiresAtLeast);
+  const capabilityPlan = resolveAiFeatureCapabilityPlan(selections);
+  const requiresAtLeast = pickHigherScaffoldVersionFloor(
+    baseline.requiresAtLeast,
+    capabilityPlan.hardMinimums.wordpress,
+  );
+  const requiresPhp = pickHigherScaffoldVersionFloor(
+    baseline.requiresPhp,
+    capabilityPlan.hardMinimums.php,
+  );
+  const testedUpTo = pickHigherScaffoldVersionFloor(
+    baseline.testedUpTo,
+    requiresAtLeast,
+  );
 
-	return {
-		capabilityPlan,
-		pluginHeader: {
-			requiresAtLeast,
-			requiresPhp,
-			testedUpTo,
-		},
-	};
+  return {
+    capabilityPlan,
+    pluginHeader: {
+      requiresAtLeast,
+      requiresPhp,
+      testedUpTo,
+    },
+  };
 }
 
 /**
  * Convert a resolved policy into workspace-inventory-safe JSON metadata.
  */
 export function createScaffoldCompatibilityConfig(
-	policy: ScaffoldCompatibilityPolicy,
+  policy: ScaffoldCompatibilityPolicy,
 ): ScaffoldCompatibilityConfig {
-	const { capabilityPlan } = policy;
+  const { capabilityPlan } = policy;
 
-	return {
-		hardMinimums: capabilityPlan.hardMinimums,
-		mode: getPolicyMode(capabilityPlan),
-		optionalFeatures: capabilityPlan.optionalFeatures.map((feature) => feature.label),
-		requiredFeatures: capabilityPlan.requiredFeatures.map((feature) => feature.label),
-		runtimeGates: [
-			...capabilityPlan.requiredFeatures.flatMap(formatRuntimeGate),
-			...capabilityPlan.optionalFeatures.flatMap(formatRuntimeGate),
-		],
-	};
+  return {
+    hardMinimums: capabilityPlan.hardMinimums,
+    mode: getPolicyMode(capabilityPlan),
+    optionalFeatures: capabilityPlan.optionalFeatures.map(
+      (feature) => feature.label,
+    ),
+    requiredFeatures: capabilityPlan.requiredFeatures.map(
+      (feature) => feature.label,
+    ),
+    runtimeGates: [
+      ...capabilityPlan.requiredFeatures.flatMap(formatRuntimeGate),
+      ...capabilityPlan.optionalFeatures.flatMap(formatRuntimeGate),
+    ],
+  };
 }
 
 /**
  * Render compatibility metadata as formatted TypeScript object literal JSON.
  */
 export function renderScaffoldCompatibilityConfig(
-	policy: ScaffoldCompatibilityPolicy,
-	indent = "\t\t",
+  policy: ScaffoldCompatibilityPolicy,
+  indent = '\t\t',
 ): string {
-	const config = createScaffoldCompatibilityConfig(policy);
+  const config = createScaffoldCompatibilityConfig(policy);
 
-	return JSON.stringify(config, null, "\t")
-		.split("\n")
-		.map((line, index) => (index === 0 ? line : `${indent}${line}`))
-		.join("\n");
+  return JSON.stringify(config, null, '\t')
+    .split('\n')
+    .map((line, index) => (index === 0 ? line : `${indent}${line}`))
+    .join('\n');
 }
 
 function replacePluginHeaderVersionFloor(
-	source: string,
-	pattern: RegExp,
-	policyValue: string,
+  source: string,
+  pattern: RegExp,
+  policyValue: string,
 ): string {
-	return source.replace(
-		pattern,
-		(_match, prefix: string, currentValue: string, lineEnding: string) => {
-			const versionPrefix = prefix.endsWith(":") ? `${prefix} ` : prefix;
-			return `${versionPrefix}${pickHigherHeaderVersionFloor(
-				policyValue,
-				currentValue,
-			)}${lineEnding}`;
-		},
-	);
+  return source.replace(
+    pattern,
+    (_match, prefix: string, currentValue: string, lineEnding: string) => {
+      const versionPrefix = prefix.endsWith(':') ? `${prefix} ` : prefix;
+      return `${versionPrefix}${pickHigherHeaderVersionFloor(
+        policyValue,
+        currentValue,
+      )}${lineEnding}`;
+    },
+  );
 }
 
 /**
@@ -236,24 +217,24 @@ function replacePluginHeaderVersionFloor(
  * version strings with the policy values.
  */
 export function updatePluginHeaderCompatibility(
-	source: string,
-	policy: ScaffoldCompatibilityPolicy,
+  source: string,
+  policy: ScaffoldCompatibilityPolicy,
 ): string {
-	const { pluginHeader } = policy;
+  const { pluginHeader } = policy;
 
-	const nextSource = replacePluginHeaderVersionFloor(
-		source,
-		/(\* Requires at least:[^\S\r\n]*)([^\r\n]*)(\r?)/u,
-		pluginHeader.requiresAtLeast,
-	);
-	const nextSourceWithTestedUpTo = replacePluginHeaderVersionFloor(
-		nextSource,
-		/(\* Tested up to:[^\S\r\n]*)([^\r\n]*)(\r?)/u,
-		pluginHeader.testedUpTo,
-	);
-	return replacePluginHeaderVersionFloor(
-		nextSourceWithTestedUpTo,
-		/(\* Requires PHP:[^\S\r\n]*)([^\r\n]*)(\r?)/u,
-		pluginHeader.requiresPhp,
-	);
+  const nextSource = replacePluginHeaderVersionFloor(
+    source,
+    /(\* Requires at least:[^\S\r\n]*)([^\r\n]*)(\r?)/u,
+    pluginHeader.requiresAtLeast,
+  );
+  const nextSourceWithTestedUpTo = replacePluginHeaderVersionFloor(
+    nextSource,
+    /(\* Tested up to:[^\S\r\n]*)([^\r\n]*)(\r?)/u,
+    pluginHeader.testedUpTo,
+  );
+  return replacePluginHeaderVersionFloor(
+    nextSourceWithTestedUpTo,
+    /(\* Requires PHP:[^\S\r\n]*)([^\r\n]*)(\r?)/u,
+    pluginHeader.requiresPhp,
+  );
 }

--- a/packages/wp-typia-project-tools/src/runtime/version-floor.ts
+++ b/packages/wp-typia-project-tools/src/runtime/version-floor.ts
@@ -1,0 +1,66 @@
+/**
+ * Parse a dotted version floor into numeric parts for stable comparisons.
+ *
+ * @param value Human-authored version floor such as `7.0` or `8.1.2`.
+ * @returns Numeric version segments suitable for ordered comparison.
+ * @throws When any segment contains non-digit characters.
+ */
+export function parseVersionFloorParts(value: string): number[] {
+  return value.split('.').map((part, index) => {
+    if (!/^\d+$/u.test(part)) {
+      throw new Error(
+        `parseVersionFloorParts received an invalid version floor "${value}" at segment ${index + 1}.`,
+      );
+    }
+    return Number.parseInt(part, 10);
+  });
+}
+
+/**
+ * Compare two dotted version floors.
+ *
+ * Missing trailing segments are treated as zero so `7.0` equals `7.0.0`.
+ *
+ * @param left Left-hand version floor.
+ * @param right Right-hand version floor.
+ * @returns `1` when left is higher, `-1` when right is higher, or `0` when equal.
+ */
+export function compareVersionFloors(left: string, right: string): number {
+  const leftParts = parseVersionFloorParts(left);
+  const rightParts = parseVersionFloorParts(right);
+  const length = Math.max(leftParts.length, rightParts.length);
+
+  for (let index = 0; index < length; index += 1) {
+    const leftValue = leftParts[index] ?? 0;
+    const rightValue = rightParts[index] ?? 0;
+    if (leftValue > rightValue) {
+      return 1;
+    }
+    if (leftValue < rightValue) {
+      return -1;
+    }
+  }
+
+  return 0;
+}
+
+/**
+ * Pick the higher version floor while tolerating undefined values.
+ *
+ * @param current Current resolved floor, when present.
+ * @param candidate Candidate floor to compare against the current floor.
+ * @returns The higher defined floor, or undefined when neither value exists.
+ */
+export function pickHigherVersionFloor(
+  current: string | undefined,
+  candidate: string | undefined,
+): string | undefined {
+  if (!candidate) {
+    return current;
+  }
+  if (!current) {
+    return candidate;
+  }
+
+  return compareVersionFloors(current, candidate) >= 0 ? current : candidate;
+}

--- a/packages/wp-typia-project-tools/tests/wordpress-ai-spec.test.ts
+++ b/packages/wp-typia-project-tools/tests/wordpress-ai-spec.test.ts
@@ -256,18 +256,111 @@ describe('WordPress AI AbilitySpec foundation', () => {
     ]);
   });
 
+  test('returns an empty AI capability plan when no features are selected', () => {
+    expect(resolveAiFeatureCapabilityPlan([])).toEqual({
+      hardMinimums: {},
+      optionalFeatures: [],
+      requiredFeatures: [],
+    });
+  });
+
+  test('deduplicates repeated feature ids and lets required mode win', () => {
+    const plan = resolveAiFeatureCapabilityPlan([
+      {
+        featureId: AI_FEATURE_DEFINITIONS.wordpressAiClient.id,
+        mode: 'optional',
+      },
+      {
+        featureId: AI_FEATURE_DEFINITIONS.wordpressAiClient.id,
+        mode: 'required',
+      },
+      {
+        featureId: AI_FEATURE_DEFINITIONS.wordpressAiClient.id,
+        mode: 'optional',
+      },
+    ]);
+
+    expect(plan.requiredFeatures.map((feature) => feature.id)).toEqual([
+      AI_FEATURE_DEFINITIONS.wordpressAiClient.id,
+    ]);
+    expect(plan.optionalFeatures).toEqual([]);
+    expect(plan.hardMinimums).toEqual({
+      wordpress: '7.0',
+    });
+  });
+
+  test('picks the highest WordPress and PHP minimums across required AI features only', () => {
+    const plan = resolveAiFeatureCapabilityPlan(
+      [
+        {
+          featureId: 'required-low',
+          mode: 'required',
+        },
+        {
+          featureId: 'required-high',
+          mode: 'required',
+        },
+        {
+          featureId: 'optional-higher',
+          mode: 'optional',
+        },
+      ],
+      {
+        'optional-higher': {
+          description: 'Optional higher floors',
+          id: 'optional-higher',
+          label: 'Optional higher floors',
+          minimumVersions: {
+            php: '8.3',
+            wordpress: '7.2',
+          },
+        },
+        'required-high': {
+          description: 'Required high floors',
+          id: 'required-high',
+          label: 'Required high floors',
+          minimumVersions: {
+            php: '8.1',
+            wordpress: '7.0',
+          },
+        },
+        'required-low': {
+          description: 'Required low floors',
+          id: 'required-low',
+          label: 'Required low floors',
+          minimumVersions: {
+            php: '8.0',
+            wordpress: '6.8',
+          },
+        },
+      },
+    );
+
+    expect(plan.hardMinimums).toEqual({
+      php: '8.1',
+      wordpress: '7.0',
+    });
+    expect(plan.requiredFeatures.map((feature) => feature.id)).toEqual([
+      'required-low',
+      'required-high',
+    ]);
+    expect(plan.optionalFeatures.map((feature) => feature.id)).toEqual([
+      'optional-higher',
+    ]);
+  });
+
   test('maps optional and required AI scaffold compatibility into headers and generated config', () => {
     const optionalPolicy = resolveScaffoldCompatibilityPolicy(
       OPTIONAL_WORDPRESS_AI_CLIENT_COMPATIBILITY,
     );
-    expect(optionalPolicy.pluginHeader).toEqual(
-      DEFAULT_SCAFFOLD_COMPATIBILITY,
-    );
+    expect(optionalPolicy.pluginHeader).toEqual(DEFAULT_SCAFFOLD_COMPATIBILITY);
     expect(createScaffoldCompatibilityConfig(optionalPolicy)).toMatchObject({
       mode: 'optional',
       optionalFeatures: ['WordPress AI Client'],
       requiredFeatures: [],
-      runtimeGates: ['WordPress AI Client: wordpress-core-feature WordPress AI Client'],
+      runtimeGates: [
+        'WordPress AI Client: wordpress-core-feature WordPress AI Client',
+      ],
     });
 
     const requiredPolicy = resolveScaffoldCompatibilityPolicy(


### PR DESCRIPTION
## Summary
- extract shared runtime version-floor parsing/comparison helpers into a focused utility module
- update scaffold compatibility and AI feature capability planning to delegate to the shared implementation while preserving their current caller behavior
- add AI capability edge-case coverage for empty selections, duplicate ids, mixed required/optional inputs, and required-only version floor selection

## Testing
- bun run typecheck
- bun run --cwd packages/wp-typia-project-tools build
- bun test packages/wp-typia-project-tools/tests/wordpress-ai-spec.test.ts

Closes #627