### PR TITLE
[codex] Document core-data adapter boundary for admin-view sources

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,6 +101,7 @@ bun run docs:build
 - [`docs/block-generator-architecture.md`](https://imjlk.github.io/wp-typia/architecture/block-generator-architecture/) records the typed generator architecture and phase map
 - [`docs/block-generator-tool-contract.md`](https://imjlk.github.io/wp-typia/architecture/block-generator-tool-contract/) records the non-mutating staged controller/tool payload contract on top of the typed generator boundary
 - [`docs/external-template-layer-composition.md`](https://imjlk.github.io/wp-typia/architecture/external-template-layer-composition/) records the external layer package RFC on top of the built-in shared scaffold model
+- [`docs/core-data-adapter-boundary.md`](https://imjlk.github.io/wp-typia/maintainers/core-data-adapter-boundary/) records when future `@wordpress/core-data` adapters should be preferred over `@wp-typia/rest`
 - [`docs/formatting-toolchain-policy.md`](https://imjlk.github.io/wp-typia/maintainers/formatting-toolchain-policy/) records the formatter baseline and CI gate
 - [`docs/maintenance-automation-policy.md`](https://imjlk.github.io/wp-typia/maintainers/maintenance-automation-policy/) records the dependency update and audit baseline
 

--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ npx wp-typia create my-block --template @scope/create-block-template --variant h
 - [Retrofit and Init Direction](RETROFIT_INIT_DIRECTION.md)
 - [Error and Export Contract Guide](https://imjlk.github.io/wp-typia/reference/error-export-contracts/)
 - [Formatting Toolchain Policy](https://imjlk.github.io/wp-typia/maintainers/formatting-toolchain-policy/)
+- [Core Data Adapter Boundary](https://imjlk.github.io/wp-typia/maintainers/core-data-adapter-boundary/)
 - [Maintenance Automation Policy](https://imjlk.github.io/wp-typia/maintainers/maintenance-automation-policy/)
 - [Package Manifest Policy](https://imjlk.github.io/wp-typia/maintainers/package-manifest-policy/)
 - [Scaffold Toolchain Policy](https://imjlk.github.io/wp-typia/maintainers/scaffold-toolchain-policy/)

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -196,6 +196,10 @@ export default defineConfig({
               link: '/maintainers/bunli-cli-migration/',
             },
             {
+              label: 'Core Data Adapter Boundary',
+              link: '/maintainers/core-data-adapter-boundary/',
+            },
+            {
               label: 'Formatting Toolchain Policy',
               link: '/maintainers/formatting-toolchain-policy/',
             },

--- a/apps/docs/src/content/docs/maintainers/core-data-adapter-boundary.md
+++ b/apps/docs/src/content/docs/maintainers/core-data-adapter-boundary.md
@@ -1,0 +1,149 @@
+---
+title: 'Core Data Adapter Boundary'
+---
+
+This note records the current maintainer decision for optional
+`@wordpress/core-data` support in `wp-typia`.
+
+`#622` is intentionally investigation-first. The goal is to define where a
+future core-data adapter fits without blurring the existing `@wp-typia/rest`
+and `@wp-typia/dataviews` boundaries.
+
+## Current platform facts
+
+According to the official WordPress package references:
+
+- `@wordpress/core-data` is a separate installable package
+- it registers its own data store and resolves entity data through the WordPress
+  REST API automatically
+- its primary entity-facing hooks include `useEntityRecord`,
+  `useEntityRecords`, and `useEntityProp`
+- `@wordpress/data` is also a separate installable package and owns the generic
+  store registration and selector/dispatch primitives underneath that model
+
+That means generated code should treat `@wordpress/core-data` and
+`@wordpress/data` as explicit dependencies whenever a scaffold wants them.
+Generated projects must not rely on transitive availability through
+`@wordpress/editor` or any other package.
+
+## When core-data is the better fit
+
+Prefer `@wordpress/core-data` when all of the following are true:
+
+- the resource is already a WordPress entity with stable `kind`, `name`, and
+  record-id semantics
+- the UI is primarily an editor/admin surface that already benefits from
+  WordPress entity caching, permissions, and edit state
+- the generated code only needs thin typed wrappers around existing entity
+  hooks such as `useEntityRecord`, `useEntityRecords`, or `useEntityProp`
+- the resource is conceptually “WordPress-owned data”, not a plugin-specific
+  transport contract
+
+Typical examples:
+
+- posts and pages exposed through the `postType` entity family
+- taxonomies or media where the project is consuming existing WordPress entity
+  behavior
+- admin/DataViews screens that are browsing an entity collection WordPress
+  already models
+
+## When `@wp-typia/rest` stays the right boundary
+
+Prefer `@wp-typia/rest` when any of the following are true:
+
+- the resource is a plugin-level REST contract that `wp-typia` generates and
+  owns
+- the project needs endpoint-level request/response validation, manifest/openapi
+  generation, or typed client/resource facades
+- the data source is a custom table, persistence block workflow, or bespoke
+  plugin endpoint
+- the resource does not already map cleanly to a WordPress entity model
+
+In short:
+
+- use core-data for existing WordPress entity behavior
+- use `@wp-typia/rest` for plugin-owned transport contracts
+
+The two boundaries are complementary. A future core-data adapter must not
+replace `@wp-typia/rest` for custom REST resources.
+
+## First adapter target
+
+The first adapter target should stay narrow:
+
+- only support entities that WordPress already exposes cleanly through the
+  existing core-data entity model
+- do not start with arbitrary plugin resources or client-side entity
+  registration scaffolds
+
+Practically, this means the first shipped adapter can target entity-backed admin
+screens such as `postType` or other existing core-data-visible entities, but it
+should not attempt to turn `wp-typia add rest-resource` outputs into core-data
+entities.
+
+This is intentionally closer to “core entities first” than to “arbitrary
+registered custom entities”. If a future project wants broader support, it
+should prove that boundary in a separate follow-up issue instead of widening the
+first implementation by default.
+
+## Dependency policy
+
+If a future scaffold explicitly opts into core-data:
+
+- add `@wordpress/core-data` as a direct dependency
+- add `@wordpress/data` as a direct dependency
+- do not add either package to every generated project by default
+- do not rely on `@wordpress/editor` or other packages to provide them
+  transitively
+
+If the same scaffold also renders a DataViews UI:
+
+- keep `@wp-typia/dataviews` and `@wordpress/dataviews` opt-in as they are
+  today
+- do not add `@wp-typia/rest` unless the generated project also needs
+  plugin-owned REST contracts for a separate resource
+
+## DataViews admin-view source policy
+
+A future admin-view implementation may accept:
+
+- `core-data:<kind>/<name>`
+
+That source shape is useful because it makes the entity boundary explicit at the
+CLI layer and keeps it distinct from:
+
+- `rest-resource:<slug>`
+
+However, that locator should remain future work until the first adapter target
+is implemented. Current public surface area still supports only
+`rest-resource:<slug>`.
+
+## Validation and ownership boundary
+
+For future core-data adapters:
+
+- `wp-typia` should generate typed wrapper code and clear locator/configuration
+  boundaries
+- WordPress/core-data should remain the owner of entity fetch/edit semantics
+- `wp-typia` should not duplicate `@wp-typia/rest` request/response validation,
+  endpoint manifests, or OpenAPI generation for those entity flows
+
+This keeps the distinction understandable:
+
+- core-data adapters are entity consumers
+- rest adapters are transport-contract owners
+
+## Explicit non-goals for the first implementation
+
+- no default `@wordpress/core-data` dependency in every scaffold
+- no conversion of custom REST resources into core-data entities
+- no custom `@wordpress/data` store scaffolds
+- no client-side `addEntities`-driven expansion of arbitrary plugin resources in
+  the first wave
+
+## Follow-up implementation lane
+
+When the implementation work starts, it should begin with an opt-in admin-view
+source and thin typed entity wrappers, not a broad runtime abstraction rewrite.
+
+The current follow-up implementation lane is tracked in issue `#644`.

--- a/apps/docs/src/content/docs/reference/cli.md
+++ b/apps/docs/src/content/docs/reference/cli.md
@@ -139,26 +139,26 @@ wp-typia add hooked-block <block-slug> --anchor core/post-content --position aft
 
 Common flags:
 
-| Flag                                                             | Description                                                                                                                     |
-| ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `--template <basic \| interactivity \| persistence \| compound>` | Built-in block family for `add block`.                                                                                          |
-| `--dry-run`                                                      | Preview workspace file updates and completion guidance.                                                                         |
-| `--block <block-slug>`                                           | Target block for variation, style, and end-to-end binding-source workflows.                                                     |
-| `--attribute <attribute>`                                        | Target block attribute for end-to-end binding-source workflows.                                                                 |
-| `--from <namespace/block>`                                       | Source block name for transform workflows.                                                                                      |
-| `--to <block-slug \| namespace/block-slug>`                      | Target workspace block for transform workflows.                                                                                 |
-| `--anchor <block-name>`                                          | Anchor block for hooked-block workflows.                                                                                        |
-| `--position <before \| after \| firstChild \| lastChild>`        | Hook position for hooked blocks.                                                                                                |
-| `--slot <sidebar \| document-setting-panel>`                     | Editor shell slot for editor-plugin scaffolds; legacy aliases `PluginSidebar` and `PluginDocumentSettingPanel` remain accepted. |
-| `--namespace <vendor/v1>`                                        | REST namespace for REST resource and AI feature workflows.                                                                      |
-| `--methods <method[,method...]>`                                 | REST methods for REST resource workflows.                                                                                       |
-| `--source <locator>`                                             | Optional data source locator for admin-view workflows, such as `rest-resource:products`.                                        |
-| `--external-layer-source <source>`                               | Compose an external layer package on top of a built-in block template.                                                          |
-| `--external-layer-id <id>`                                       | Select a specific external layer.                                                                                               |
-| `--inner-blocks-preset <id>`                                     | Select a compound `InnerBlocks` preset.                                                                                         |
-| `--alternate-render-targets <list>`                              | Add alternate render targets for persistence-capable dynamic scaffolds.                                                         |
-| `--data-storage <post-meta \| custom-table>`                     | Select persistence storage.                                                                                                     |
-| `--persistence-policy <authenticated \| public>`                 | Select persistence write policy.                                                                                                |
+| Flag                                                             | Description                                                                                                                                                              |
+| ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--template <basic \| interactivity \| persistence \| compound>` | Built-in block family for `add block`.                                                                                                                                   |
+| `--dry-run`                                                      | Preview workspace file updates and completion guidance.                                                                                                                  |
+| `--block <block-slug>`                                           | Target block for variation, style, and end-to-end binding-source workflows.                                                                                              |
+| `--attribute <attribute>`                                        | Target block attribute for end-to-end binding-source workflows.                                                                                                          |
+| `--from <namespace/block>`                                       | Source block name for transform workflows.                                                                                                                               |
+| `--to <block-slug \| namespace/block-slug>`                      | Target workspace block for transform workflows.                                                                                                                          |
+| `--anchor <block-name>`                                          | Anchor block for hooked-block workflows.                                                                                                                                 |
+| `--position <before \| after \| firstChild \| lastChild>`        | Hook position for hooked blocks.                                                                                                                                         |
+| `--slot <sidebar \| document-setting-panel>`                     | Editor shell slot for editor-plugin scaffolds; legacy aliases `PluginSidebar` and `PluginDocumentSettingPanel` remain accepted.                                          |
+| `--namespace <vendor/v1>`                                        | REST namespace for REST resource and AI feature workflows.                                                                                                               |
+| `--methods <method[,method...]>`                                 | REST methods for REST resource workflows.                                                                                                                                |
+| `--source <locator>`                                             | Optional data source locator for admin-view workflows. Current public support is `rest-resource:products`; `core-data:<kind>/<name>` is reserved for future opt-in work. |
+| `--external-layer-source <source>`                               | Compose an external layer package on top of a built-in block template.                                                                                                   |
+| `--external-layer-id <id>`                                       | Select a specific external layer.                                                                                                                                        |
+| `--inner-blocks-preset <id>`                                     | Select a compound `InnerBlocks` preset.                                                                                                                                  |
+| `--alternate-render-targets <list>`                              | Add alternate render targets for persistence-capable dynamic scaffolds.                                                                                                  |
+| `--data-storage <post-meta \| custom-table>`                     | Select persistence storage.                                                                                                                                              |
+| `--persistence-policy <authenticated \| public>`                 | Select persistence write policy.                                                                                                                                         |
 
 Use variations when you want alternate inserter presets for the same block,
 Block Styles when you want a named visual class for an existing block, transforms
@@ -180,6 +180,9 @@ Admin-view scaffolds can optionally bind to a generated data source with
 `--source`. For example, `rest-resource:products` points at a matching
 `wp-typia add rest-resource products` scaffold. Published npm installs
 currently gate `admin-view` scaffolds until `@wp-typia/dataviews` is published.
+Future maintainer direction also leaves room for an explicit
+`core-data:<kind>/<name>` source shape, but that remains deferred until the
+core-data adapter boundary is implemented.
 
 ## `init`
 

--- a/apps/docs/src/content/docs/reference/dataviews.md
+++ b/apps/docs/src/content/docs/reference/dataviews.md
@@ -179,6 +179,13 @@ to export individual endpoint helpers, or it can group them with
 `defineRestResource(...)` from `@wp-typia/rest` and let the admin view consume
 the same resource facade.
 
+Future opt-in work may add `core-data:<kind>/<name>` entity sources for
+WordPress-owned collections, but that locator is intentionally deferred until
+the maintainer boundary in
+[`docs/core-data-adapter-boundary.md`](../maintainers/core-data-adapter-boundary.md)
+graduates into an implementation PR. Current public scaffolds only support
+`rest-resource:<slug>`.
+
 Prefer custom UI instead of DataViews when the interaction is primarily a
 guided flow, a canvas/editor experience, a dense dashboard with unrelated
 widgets, or a purpose-built form where table/list/grid view state is incidental.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-shared.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-shared.ts
@@ -164,7 +164,8 @@ export interface RunAddRestResourceCommandOptions {
  * Defaults to `process.cwd()`.
  * @property source Optional data source locator. The first supported source is
  * `rest-resource:<slug>`, which wires the generated screen to an existing
- * list-capable REST resource.
+ * list-capable REST resource. A future opt-in `core-data:<kind>/<name>`
+ * locator remains intentionally reserved for later implementation work.
  */
 export interface RunAddAdminViewCommandOptions {
 	adminViewName: string;
@@ -734,7 +735,7 @@ Notes:
   \`wp-typia add\` runs only inside official ${WORKSPACE_TEMPLATE_PACKAGE} workspaces scaffolded via \`wp-typia create <project-dir> --template workspace\`.
   Pass \`--dry-run\` to preview the workspace files that would change without writing them.
   Interactive add flows let you choose a template when \`--template\` is omitted; non-interactive runs default to \`basic\`.
-  \`add admin-view\` scaffolds an opt-in DataViews-powered WordPress admin screen under \`src/admin-views/\`; pass \`--source rest-resource:<slug>\` to reuse a list-capable REST resource. Public installs currently gate this workflow until \`@wp-typia/dataviews\` is published to npm.
+  \`add admin-view\` scaffolds an opt-in DataViews-powered WordPress admin screen under \`src/admin-views/\`; pass \`--source rest-resource:<slug>\` to reuse a list-capable REST resource. Future core-data entity locators stay intentionally deferred. Public installs currently gate this workflow until \`@wp-typia/dataviews\` is published to npm.
   \`query-loop\` is a create-time scaffold family. Use \`wp-typia create <project-dir> --template query-loop\` instead of \`wp-typia add block\`.
   \`add variation\` targets an existing block slug from \`scripts/block-config.ts\`.
   \`add style\` registers a Block Styles option for an existing generated block.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-shared.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-shared.ts
@@ -735,7 +735,9 @@ Notes:
   \`wp-typia add\` runs only inside official ${WORKSPACE_TEMPLATE_PACKAGE} workspaces scaffolded via \`wp-typia create <project-dir> --template workspace\`.
   Pass \`--dry-run\` to preview the workspace files that would change without writing them.
   Interactive add flows let you choose a template when \`--template\` is omitted; non-interactive runs default to \`basic\`.
-  \`add admin-view\` scaffolds an opt-in DataViews-powered WordPress admin screen under \`src/admin-views/\`; pass \`--source rest-resource:<slug>\` to reuse a list-capable REST resource. Future core-data entity locators stay intentionally deferred. Public installs currently gate this workflow until \`@wp-typia/dataviews\` is published to npm.
+  \`add admin-view\` scaffolds an opt-in DataViews-powered WordPress admin screen under \`src/admin-views/\`.
+  Pass \`--source rest-resource:<slug>\` to reuse a list-capable REST resource.
+  Future core-data locators and public installs remain deferred until \`@wp-typia/dataviews\` is published to npm.
   \`query-loop\` is a create-time scaffold family. Use \`wp-typia create <project-dir> --template query-loop\` instead of \`wp-typia add block\`.
   \`add variation\` targets an existing block slug from \`scripts/block-config.ts\`.
   \`add style\` registers a Block Styles option for an existing generated block.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-admin-view.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-admin-view.ts
@@ -151,7 +151,7 @@ function parseAdminViewSource(source?: string): AdminViewSource | undefined {
 	const [kind, slug, extra] = trimmed.split(":");
 	if (kind !== ADMIN_VIEW_SOURCE_KIND || !slug || extra !== undefined) {
 		throw new Error(
-			"Admin view source must use `rest-resource:<slug>` for now.",
+			"Admin view source must use `rest-resource:<slug>` for now. A future `core-data:<kind>/<name>` locator is intentionally not implemented yet.",
 		);
 	}
 
@@ -1029,7 +1029,8 @@ async function writeAdminViewRegistry(
  * @param options.cwd Working directory used to resolve the nearest official workspace.
  * Defaults to `process.cwd()`.
  * @param options.source Optional data source locator. `rest-resource:<slug>`
- * wires the screen to an existing list-capable REST resource.
+ * wires the screen to an existing list-capable REST resource. Future
+ * `core-data:<kind>/<name>` support is intentionally deferred.
  * @returns A promise that resolves with the normalized `adminViewSlug`, optional
  * `source`, and owning `projectDir` after scaffold files and inventory entries
  * are written successfully.

--- a/packages/wp-typia-project-tools/src/runtime/cli-help.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-help.ts
@@ -50,7 +50,9 @@ Notes:
   \`wp-typia init\` previews the minimum retrofit sync surface by default; rerun with \`--apply\` to write package.json updates and generated helper scripts.
   Use \`--template workspace\` as shorthand for \`@wp-typia/create-workspace-template\`, the official empty workspace scaffold behind \`wp-typia add ...\`.
   Interactive add flows let you choose a template when \`--template\` is omitted; non-interactive runs default to \`basic\`.
-  \`add admin-view\` scaffolds an opt-in DataViews-powered WordPress admin screen under \`src/admin-views/\`; pass \`--source rest-resource:<slug>\` to reuse a list-capable REST resource. Future core-data entity locators stay intentionally deferred. Public installs currently gate this workflow until \`@wp-typia/dataviews\` is published to npm.
+  \`add admin-view\` scaffolds an opt-in DataViews-powered WordPress admin screen under \`src/admin-views/\`.
+  Pass \`--source rest-resource:<slug>\` to reuse a list-capable REST resource.
+  Future core-data locators and public installs remain deferred until \`@wp-typia/dataviews\` is published to npm.
   \`query-loop\` is create-only. Use \`wp-typia create <project-dir> --template query-loop\`; \`wp-typia add block\` accepts only basic, interactivity, persistence, and compound families.
   \`add variation\` uses an existing workspace block from \`scripts/block-config.ts\`.
   \`add style\` registers a Block Styles option for an existing generated block.

--- a/packages/wp-typia-project-tools/src/runtime/cli-help.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-help.ts
@@ -50,7 +50,7 @@ Notes:
   \`wp-typia init\` previews the minimum retrofit sync surface by default; rerun with \`--apply\` to write package.json updates and generated helper scripts.
   Use \`--template workspace\` as shorthand for \`@wp-typia/create-workspace-template\`, the official empty workspace scaffold behind \`wp-typia add ...\`.
   Interactive add flows let you choose a template when \`--template\` is omitted; non-interactive runs default to \`basic\`.
-  \`add admin-view\` scaffolds an opt-in DataViews-powered WordPress admin screen under \`src/admin-views/\`; pass \`--source rest-resource:<slug>\` to reuse a list-capable REST resource. Public installs currently gate this workflow until \`@wp-typia/dataviews\` is published to npm.
+  \`add admin-view\` scaffolds an opt-in DataViews-powered WordPress admin screen under \`src/admin-views/\`; pass \`--source rest-resource:<slug>\` to reuse a list-capable REST resource. Future core-data entity locators stay intentionally deferred. Public installs currently gate this workflow until \`@wp-typia/dataviews\` is published to npm.
   \`query-loop\` is create-only. Use \`wp-typia create <project-dir> --template query-loop\`; \`wp-typia add block\` accepts only basic, interactivity, persistence, and compound families.
   \`add variation\` uses an existing workspace block from \`scripts/block-config.ts\`.
   \`add style\` registers a Block Styles option for an existing generated block.

--- a/packages/wp-typia/src/add-kind-registry.ts
+++ b/packages/wp-typia/src/add-kind-registry.ts
@@ -224,7 +224,7 @@ export const ADD_KIND_REGISTRY = {
     async prepareExecution(context) {
       const name = requireAddKindName(
         context,
-        '`wp-typia add admin-view` requires <name>. Usage: wp-typia add admin-view <name> [--source <rest-resource:slug>].',
+        '`wp-typia add admin-view` requires <name>. Usage: wp-typia add admin-view <name> [--source <rest-resource:slug>]. Future core-data locators are not implemented yet.',
       );
       const source = readOptionalStringFlag(context.flags, 'source');
 

--- a/tests/unit/repo-dx-baseline.test.ts
+++ b/tests/unit/repo-dx-baseline.test.ts
@@ -133,6 +133,20 @@ describe('repository DX baseline', () => {
           'content',
           'docs',
           'maintainers',
+          'core-data-adapter-boundary.md',
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(
+          repoRoot,
+          'apps',
+          'docs',
+          'src',
+          'content',
+          'docs',
+          'maintainers',
           'formatting-toolchain-policy.md',
         ),
       ),
@@ -305,6 +319,9 @@ describe('repository DX baseline', () => {
       'Root ESLint covers repository infrastructure code',
     );
     expect(readme).toContain(
+      '[Core Data Adapter Boundary](https://imjlk.github.io/wp-typia/maintainers/core-data-adapter-boundary/)',
+    );
+    expect(readme).toContain(
       '[Formatting Toolchain Policy](https://imjlk.github.io/wp-typia/maintainers/formatting-toolchain-policy/)',
     );
     expect(readme).toContain(
@@ -336,6 +353,9 @@ describe('repository DX baseline', () => {
     );
     expect(contributing).toContain(
       '[`docs/external-template-layer-composition.md`](https://imjlk.github.io/wp-typia/architecture/external-template-layer-composition/)',
+    );
+    expect(contributing).toContain(
+      '[`docs/core-data-adapter-boundary.md`](https://imjlk.github.io/wp-typia/maintainers/core-data-adapter-boundary/)',
     );
     expect(contributing).toContain(
       '[`docs/formatting-toolchain-policy.md`](https://imjlk.github.io/wp-typia/maintainers/formatting-toolchain-policy/)',


### PR DESCRIPTION
## Summary
- document the current maintainer boundary for optional `@wordpress/core-data` adapters
- clarify that `admin-view --source` currently supports `rest-resource:<slug>` only while reserving `core-data:<kind>/<name>` for future opt-in work
- link the investigation outcome to follow-up implementation issue `#644`

## Why
Issue `#622` is investigation-first work. We needed a clear boundary for when generated projects should prefer `@wordpress/core-data` over `@wp-typia/rest` before opening a broader implementation PR.

## Changes
- add a maintainer note for the core-data adapter boundary and dependency policy
- expose that note in the docs sidebar plus README/CONTRIBUTING reference lists
- update CLI/reference wording so admin-view help and docs describe the deferred `core-data:<kind>/<name>` locator explicitly
- extend the repository DX baseline to keep the new maintainer document linked

## Validation
- `bun test tests/unit/repo-dx-baseline.test.ts`
- `bun test packages/wp-typia/tests/add-kind-registry.test.ts packages/wp-typia/tests/add-command.test.ts`
- `bun test packages/wp-typia-project-tools/tests/cli-entry.test.ts`

## Notes
- `bun run docs:build:site` could not complete in this environment because the checked-in Rollup native module fails to load locally with `ERR_DLOPEN_FAILED` (code-signature mismatch for `@rollup/rollup-darwin-arm64`).
- Closes #622
- Follow-up implementation: #644

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Core Data Adapter Boundary maintainer documentation defining adapter selection criteria and boundaries.
  * Updated CLI help text and reference documentation to clarify that `core-data:<kind>/<name>` source locators are reserved for future implementation; currently only `rest-resource:<slug>` is supported for admin-view sources.

* **Tests**
  * Added validation for new maintainer documentation presence and corresponding documentation links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->