### PR TITLE
fix(cli): derive add subcommands from shared ids

### DIFF
--- a/.sampo/changesets/648-derive-add-subcommands.md
+++ b/.sampo/changesets/648-derive-add-subcommands.md
@@ -1,0 +1,7 @@
+---
+npm/wp-typia: patch
+---
+
+Derive the `wp-typia add` command tree subcommands from shared add-kind ids so
+CLI metadata, help, and routing consumers stay aligned when new add kinds are
+added.

--- a/packages/wp-typia/scripts/generate-routing-metadata.mjs
+++ b/packages/wp-typia/scripts/generate-routing-metadata.mjs
@@ -1,8 +1,9 @@
 import fs from 'node:fs/promises';
+import { createRequire } from 'node:module';
 import path from 'node:path';
-import { pathToFileURL } from 'node:url';
 
 const packageRoot = path.resolve(import.meta.dirname, '..');
+const require = createRequire(import.meta.url);
 const routingMetadataFile = path.join(
   packageRoot,
   'bin',
@@ -23,16 +24,21 @@ const commandRegistryModulePath = path.join(
   'src',
   'command-registry.ts',
 );
+const addKindIdsModulePath = path.join(packageRoot, 'src', 'add-kind-ids.ts');
 const checkOnly = process.argv.includes('--check');
 
-async function importTranspiledTypeScriptModule(modulePath) {
-  const [{ default: ts }, source] = await Promise.all([
+async function importTranspiledTypeScriptModule(
+  modulePath,
+  siblingModules = [],
+) {
+  const [{ default: ts }, source, ...siblingSources] = await Promise.all([
     import('typescript'),
     fs.readFile(modulePath, 'utf8'),
+    ...siblingModules.map((siblingPath) => fs.readFile(siblingPath, 'utf8')),
   ]);
   const transpiled = ts.transpileModule(source, {
     compilerOptions: {
-      module: ts.ModuleKind.ESNext,
+      module: ts.ModuleKind.CommonJS,
       target: ts.ScriptTarget.ES2020,
     },
     fileName: modulePath,
@@ -44,12 +50,32 @@ async function importTranspiledTypeScriptModule(modulePath) {
   );
   const tempFile = path.join(
     tempDir,
-    path.basename(modulePath).replace(/\.ts$/u, '.mjs'),
+    path.basename(modulePath).replace(/\.ts$/u, '.js'),
   );
 
-  await fs.writeFile(tempFile, transpiled.outputText, 'utf8');
+  await Promise.all([
+    fs.writeFile(
+      path.join(tempDir, 'package.json'),
+      JSON.stringify({ type: 'commonjs' }),
+      'utf8',
+    ),
+    fs.writeFile(tempFile, transpiled.outputText, 'utf8'),
+    ...siblingModules.map((siblingPath, index) =>
+      fs.writeFile(
+        path.join(tempDir, path.basename(siblingPath).replace(/\.ts$/u, '.js')),
+        ts.transpileModule(siblingSources[index], {
+          compilerOptions: {
+            module: ts.ModuleKind.CommonJS,
+            target: ts.ScriptTarget.ES2020,
+          },
+          fileName: siblingPath,
+        }).outputText,
+        'utf8',
+      ),
+    ),
+  ]);
   try {
-    return await import(pathToFileURL(tempFile).href);
+    return require(tempFile);
   } finally {
     await fs.rm(tempDir, { force: true, recursive: true });
   }
@@ -124,7 +150,9 @@ const [
   },
 ] = await Promise.all([
   importTranspiledTypeScriptModule(commandOptionMetadataModulePath),
-  importTranspiledTypeScriptModule(commandRegistryModulePath),
+  importTranspiledTypeScriptModule(commandRegistryModulePath, [
+    addKindIdsModulePath,
+  ]),
 ]);
 
 const renderedFiles = renderRoutingMetadataFiles({

--- a/packages/wp-typia/src/add-kind-ids.ts
+++ b/packages/wp-typia/src/add-kind-ids.ts
@@ -1,0 +1,16 @@
+export const ADD_KIND_IDS = [
+  'admin-view',
+  'block',
+  'variation',
+  'style',
+  'transform',
+  'pattern',
+  'binding-source',
+  'rest-resource',
+  'ability',
+  'ai-feature',
+  'hooked-block',
+  'editor-plugin',
+] as const;
+
+export type AddKindId = (typeof ADD_KIND_IDS)[number];

--- a/packages/wp-typia/src/add-kind-registry.ts
+++ b/packages/wp-typia/src/add-kind-registry.ts
@@ -4,6 +4,10 @@ import {
 } from '@wp-typia/project-tools/cli-diagnostics';
 import type * as CliAddRuntime from '@wp-typia/project-tools/cli-add';
 import type { ReadlinePrompt } from '@wp-typia/project-tools/cli-prompt';
+import { ADD_KIND_IDS, type AddKindId } from './add-kind-ids';
+
+export { ADD_KIND_IDS } from './add-kind-ids';
+export type { AddKindId } from './add-kind-ids';
 
 type PrintLine = (line: string) => void;
 type AddRuntime = typeof CliAddRuntime;
@@ -836,16 +840,9 @@ export const ADD_KIND_REGISTRY = {
   }),
 } as const satisfies AddKindRegistry;
 
-export type AddKindId = keyof typeof ADD_KIND_REGISTRY;
 export type AddKindExecutionPlanFor<TKey extends AddKindId> = Awaited<
   ReturnType<(typeof ADD_KIND_REGISTRY)[TKey]['prepareExecution']>
 >;
-export const ADD_KIND_IDS = (
-  Object.keys(ADD_KIND_REGISTRY) as AddKindId[]
-).sort(
-  (left, right) =>
-    ADD_KIND_REGISTRY[left].sortOrder - ADD_KIND_REGISTRY[right].sortOrder,
-);
 
 export function isAddKindId(value?: string): value is AddKindId {
   return (

--- a/packages/wp-typia/src/command-registry.ts
+++ b/packages/wp-typia/src/command-registry.ts
@@ -1,3 +1,5 @@
+import { ADD_KIND_IDS } from './add-kind-ids';
+
 export const WP_TYPIA_CANONICAL_CREATE_USAGE = 'wp-typia create <project-dir>';
 export const WP_TYPIA_POSITIONAL_ALIAS_USAGE = 'wp-typia <project-dir>';
 export const WP_TYPIA_CANONICAL_MIGRATE_USAGE = 'wp-typia migrate <subcommand>';
@@ -42,17 +44,7 @@ export const WP_TYPIA_COMMAND_REGISTRY = [
     nodeFallback: true,
     optionGroups: ['add'],
     requiresBunRuntime: false,
-    subcommands: [
-      'block',
-      'variation',
-      'style',
-      'transform',
-      'pattern',
-      'binding-source',
-      'rest-resource',
-      'editor-plugin',
-      'hooked-block',
-    ],
+    subcommands: ADD_KIND_IDS,
   },
   {
     commandTree: true,

--- a/packages/wp-typia/tests/add-command.test.ts
+++ b/packages/wp-typia/tests/add-command.test.ts
@@ -5,6 +5,7 @@ import * as path from 'node:path';
 
 import type { ReadlinePrompt } from '@wp-typia/project-tools/cli-prompt';
 import { ADD_KIND_IDS, supportsAddKindDryRun } from '../src/add-kind-registry';
+import { WP_TYPIA_COMMAND_REGISTRY } from '../src/command-registry';
 import { executeAddCommand } from '../src/runtime-bridge';
 import {
   linkWorkspaceNodeModules,
@@ -254,5 +255,12 @@ describe('wp-typia add command bridge', () => {
       'hooked-block',
       'editor-plugin',
     ]);
+  });
+
+  test('derives add subcommands from the canonical add-kind registry', () => {
+    expect(
+      WP_TYPIA_COMMAND_REGISTRY.find((command) => command.name === 'add')
+        ?.subcommands,
+    ).toEqual([...ADD_KIND_IDS]);
   });
 });

--- a/packages/wp-typia/tests/add-kind-registry.test.ts
+++ b/packages/wp-typia/tests/add-kind-registry.test.ts
@@ -1,6 +1,11 @@
 import { expect, test } from 'bun:test';
 
-import { type AddKindExecutionPlanFor } from '../src/add-kind-registry';
+import {
+  ADD_KIND_IDS,
+  ADD_KIND_REGISTRY,
+  type AddKindId,
+  type AddKindExecutionPlanFor,
+} from '../src/add-kind-registry';
 
 type ExpectTrue<TValue extends true> = TValue;
 type IsEqual<TLeft, TRight> =
@@ -23,18 +28,32 @@ type BindingSourcePlanCompatibility = ExpectTrue<
     Parameters<AddKindExecutionPlanFor<'binding-source'>['getValues']>[0]
   >
 >;
+type SharedAddKindIdCompatibility = ExpectTrue<
+  IsEqual<keyof typeof ADD_KIND_REGISTRY, AddKindId>
+>;
 
 const addKindPlanCompatibilityChecks: {
   'admin-view': AdminViewPlanCompatibility;
   'binding-source': BindingSourcePlanCompatibility;
+  registryKeys: SharedAddKindIdCompatibility;
 } = {
   'admin-view': true,
   'binding-source': true,
+  registryKeys: true,
 };
 
 test('preserves compile-time compatibility between execute and getValues for representative add kinds', () => {
   expect(addKindPlanCompatibilityChecks).toEqual({
     'admin-view': true,
     'binding-source': true,
+    registryKeys: true,
   });
+});
+
+test('keeps shared add-kind ids aligned with registry sort order', () => {
+  expect(
+    Object.entries(ADD_KIND_REGISTRY)
+      .sort(([, left], [, right]) => left.sortOrder - right.sortOrder)
+      .map(([kind]) => kind),
+  ).toEqual([...ADD_KIND_IDS]);
 });

--- a/packages/wp-typia/tests/bunli-prep.test.ts
+++ b/packages/wp-typia/tests/bunli-prep.test.ts
@@ -14,6 +14,7 @@ import {
   WP_TYPIA_TOP_LEVEL_COMMAND_NAMES,
   normalizeWpTypiaArgv,
 } from '../src/command-contract';
+import { ADD_KIND_IDS } from '../src/add-kind-registry';
 import { wpTypiaCommands } from '../src/command-list';
 import {
   fullRuntimeCommands,
@@ -237,6 +238,17 @@ describe('wp-typia Bunli preparation', () => {
     expect(
       fs.readFileSync(path.join(packageRoot, 'src', 'cli.ts'), 'utf8'),
     ).toContain('createCLI(');
+  });
+
+  test('future Bunli command tree exposes every supported add kind', () => {
+    const addCommand = WP_TYPIA_FUTURE_COMMAND_TREE.find(
+      (command) => command.name === 'add',
+    );
+
+    expect(addCommand?.subcommands).toEqual([...ADD_KIND_IDS]);
+    expect(addCommand?.subcommands).toContain('admin-view');
+    expect(addCommand?.subcommands).toContain('ability');
+    expect(addCommand?.subcommands).toContain('ai-feature');
   });
 
   test('maintainer docs keep wp-typia as the only CLI owner', () => {


### PR DESCRIPTION
## Summary

- derive `wp-typia add` command metadata subcommands from shared add-kind ids instead of a separate manual list
- add structural tests so add-kind registry ids, command-tree metadata, and registry keys stay aligned
- keep the routing metadata generator working when `command-registry.ts` depends on a shared sibling module

## Validation

- `./node_modules/.bin/tsc --noEmit`
- `node scripts/validate-sampo-changesets.mjs`
- `cd packages/wp-typia && node scripts/generate-routing-metadata.mjs --check`
- `export PATH=/tmp/codex-bun-1.3.11/bun-darwin-aarch64:$PATH; cd packages/wp-typia && bun test tests/add-kind-registry.test.ts tests/add-command.test.ts tests/bunli-prep.test.ts`
- `export PATH=/tmp/codex-real-npm:/tmp/codex-bun-1.3.11/bun-darwin-aarch64:$PATH; cd packages/wp-typia && bun test tests/*.test.ts`

## Release notes

- changeset added for `npm/wp-typia`

## Docs

- no user-facing docs changes needed; this is a CLI metadata correctness fix

## Migration / compatibility

- preserves the existing add-kind order while removing a second source of truth for command metadata

Closes #648

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Restructured the `add` command configuration to be automatically derived from a shared registry, improving consistency across CLI metadata and help documentation.

* **Tests**
  * Added tests to verify the command registry remains synchronized with supported kinds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->