### PR TITLE
fix(cli): route mcp output-dir through metadata

### DIFF
--- a/.sampo/changesets/650-route-mcp-output-dir.md
+++ b/.sampo/changesets/650-route-mcp-output-dir.md
@@ -1,0 +1,6 @@
+---
+npm/wp-typia: patch
+---
+
+Route `wp-typia mcp --output-dir` through shared command option metadata so
+routing metadata, argv walking, and Bun runtime help stay aligned.

--- a/packages/wp-typia/src/command-option-metadata.ts
+++ b/packages/wp-typia/src/command-option-metadata.ts
@@ -27,6 +27,7 @@ export type CommandOptionGroupName =
   | 'add'
   | 'init'
   | 'migrate'
+  | 'mcp'
   | 'sync'
   | 'doctor'
   | 'templates';
@@ -281,6 +282,16 @@ export const MIGRATE_OPTION_METADATA = {
 } as const satisfies CommandOptionMetadataMap;
 
 /**
+ * Shared `wp-typia mcp` option metadata.
+ */
+export const MCP_OPTION_METADATA = {
+  'output-dir': {
+    description: 'Output directory for generated MCP metadata.',
+    type: 'string',
+  },
+} as const satisfies CommandOptionMetadataMap;
+
+/**
  * Shared `wp-typia sync` option metadata used by both runtime entry paths.
  */
 export const SYNC_OPTION_METADATA = {
@@ -335,10 +346,6 @@ export const GLOBAL_OPTION_METADATA = {
     description: 'Template id for top-level `templates inspect` convenience.',
     type: 'string',
   },
-  'output-dir': {
-    description: 'Output directory for generated MCP metadata.',
-    type: 'string',
-  },
 } as const satisfies CommandOptionMetadataMap;
 
 export const COMMAND_OPTION_METADATA_BY_GROUP = {
@@ -348,6 +355,7 @@ export const COMMAND_OPTION_METADATA_BY_GROUP = {
   global: GLOBAL_OPTION_METADATA,
   init: INIT_OPTION_METADATA,
   migrate: MIGRATE_OPTION_METADATA,
+  mcp: MCP_OPTION_METADATA,
   sync: SYNC_OPTION_METADATA,
   templates: TEMPLATES_OPTION_METADATA,
 } as const satisfies Record<CommandOptionGroupName, CommandOptionMetadataMap>;

--- a/packages/wp-typia/src/command-registry.ts
+++ b/packages/wp-typia/src/command-registry.ts
@@ -89,7 +89,7 @@ export const WP_TYPIA_COMMAND_REGISTRY = [
     description: 'Inspect or sync schema-driven MCP metadata.',
     name: 'mcp',
     nodeFallback: false,
-    optionGroups: [],
+    optionGroups: ['mcp'],
     requiresBunRuntime: true,
     subcommands: ['list', 'sync'],
   },

--- a/packages/wp-typia/src/commands/mcp.ts
+++ b/packages/wp-typia/src/commands/mcp.ts
@@ -1,94 +1,93 @@
-import { defineCommand } from "@bunli/core";
-import { z } from "zod";
+import { defineCommand } from '@bunli/core';
 
+import { CLI_DIAGNOSTIC_CODES } from '@wp-typia/project-tools/cli-diagnostics';
 import {
-	CLI_DIAGNOSTIC_CODES,
-} from "@wp-typia/project-tools/cli-diagnostics";
+  emitCliDiagnosticFailure,
+  prefersStructuredCliOutput,
+} from '../cli-diagnostic-output';
 import {
-	emitCliDiagnosticFailure,
-	prefersStructuredCliOutput,
-} from "../cli-diagnostic-output";
-import { getMcpSchemaSources } from "../config";
-import { loadMcpToolGroups, syncMcpSchemas } from "../mcp";
+  buildCommandOptions,
+  MCP_OPTION_METADATA,
+} from '../command-option-metadata';
+import { getMcpSchemaSources } from '../config';
+import { loadMcpToolGroups, syncMcpSchemas } from '../mcp';
 
 export const mcpCommand = defineCommand({
-	defaultFormat: "json",
-	description: "Inspect or sync schema-driven MCP metadata for wp-typia.",
-	handler: async (args) => {
-		const subcommand = args.positional[0] ?? "list";
-		const prefersStructuredOutput = prefersStructuredCliOutput(args);
-		const userConfig =
-			args.context?.store?.wpTypiaUserConfig &&
-			typeof args.context.store.wpTypiaUserConfig === "object"
-				? args.context.store.wpTypiaUserConfig
-				: {};
-		const schemaSources = getMcpSchemaSources(userConfig);
+  defaultFormat: 'json',
+  description: 'Inspect or sync schema-driven MCP metadata for wp-typia.',
+  handler: async (args) => {
+    const subcommand = args.positional[0] ?? 'list';
+    const prefersStructuredOutput = prefersStructuredCliOutput(args);
+    const userConfig =
+      args.context?.store?.wpTypiaUserConfig &&
+      typeof args.context.store.wpTypiaUserConfig === 'object'
+        ? args.context.store.wpTypiaUserConfig
+        : {};
+    const schemaSources = getMcpSchemaSources(userConfig);
 
-		if (schemaSources.length === 0) {
-			emitCliDiagnosticFailure(args, {
-				code: CLI_DIAGNOSTIC_CODES.CONFIGURATION_MISSING,
-				command: "mcp",
-				detailLines: [
-					"No MCP schema sources are configured. Add `mcp.schemaSources` in ~/.config/wp-typia/config.json, .wp-typiarc(.json), or package.json#wp-typia.",
-				],
-			});
-			return;
-		}
+    if (schemaSources.length === 0) {
+      emitCliDiagnosticFailure(args, {
+        code: CLI_DIAGNOSTIC_CODES.CONFIGURATION_MISSING,
+        command: 'mcp',
+        detailLines: [
+          'No MCP schema sources are configured. Add `mcp.schemaSources` in ~/.config/wp-typia/config.json, .wp-typiarc(.json), or package.json#wp-typia.',
+        ],
+      });
+      return;
+    }
 
-		try {
-			if (subcommand === "list") {
-				const groups = await loadMcpToolGroups(args.cwd, schemaSources);
-				const summary = groups.map((group) => ({
-					namespace: group.namespace,
-					toolCount: group.tools.length,
-					tools: group.tools.map((tool) => tool.name),
-				}));
-				if (prefersStructuredOutput) {
-					args.output({ groups: summary });
-					return;
-				}
-				for (const group of summary) {
-					console.log(`${group.namespace} (${group.toolCount})`);
-					for (const tool of group.tools) {
-						console.log(`  - ${tool}`);
-					}
-				}
-				return;
-			}
+    try {
+      if (subcommand === 'list') {
+        const groups = await loadMcpToolGroups(args.cwd, schemaSources);
+        const summary = groups.map((group) => ({
+          namespace: group.namespace,
+          toolCount: group.tools.length,
+          tools: group.tools.map((tool) => tool.name),
+        }));
+        if (prefersStructuredOutput) {
+          args.output({ groups: summary });
+          return;
+        }
+        for (const group of summary) {
+          console.log(`${group.namespace} (${group.toolCount})`);
+          for (const tool of group.tools) {
+            console.log(`  - ${tool}`);
+          }
+        }
+        return;
+      }
 
-			if (subcommand === "sync") {
-				const outputDir =
-					(args.flags["output-dir"] as string | undefined) ?? `${args.cwd}/.bunli/mcp`;
-				const result = await syncMcpSchemas(args.cwd, schemaSources, outputDir);
-				if (prefersStructuredOutput) {
-					args.output({ sync: result });
-					return;
-				}
-				console.log(
-					`Synced ${result.commandCount} MCP tools across ${result.groups.length} namespaces into ${result.outputDir}.`,
-				);
-				return;
-			}
+      if (subcommand === 'sync') {
+        const outputDir =
+          (args.flags['output-dir'] as string | undefined) ??
+          `${args.cwd}/.bunli/mcp`;
+        const result = await syncMcpSchemas(args.cwd, schemaSources, outputDir);
+        if (prefersStructuredOutput) {
+          args.output({ sync: result });
+          return;
+        }
+        console.log(
+          `Synced ${result.commandCount} MCP tools across ${result.groups.length} namespaces into ${result.outputDir}.`,
+        );
+        return;
+      }
 
-			emitCliDiagnosticFailure(args, {
-				code: CLI_DIAGNOSTIC_CODES.INVALID_COMMAND,
-				command: "mcp",
-				detailLines: [`Unknown mcp subcommand "${subcommand}". Expected list or sync.`],
-			});
-		} catch (error) {
-			emitCliDiagnosticFailure(args, {
-				command: "mcp",
-				error,
-			});
-		}
-	},
-	name: "mcp",
-	options: {
-		"output-dir": {
-			description: "Output directory for generated MCP metadata during `mcp sync`.",
-			schema: z.string().optional(),
-		},
-	},
+      emitCliDiagnosticFailure(args, {
+        code: CLI_DIAGNOSTIC_CODES.INVALID_COMMAND,
+        command: 'mcp',
+        detailLines: [
+          `Unknown mcp subcommand "${subcommand}". Expected list or sync.`,
+        ],
+      });
+    } catch (error) {
+      emitCliDiagnosticFailure(args, {
+        command: 'mcp',
+        error,
+      });
+    }
+  },
+  name: 'mcp',
+  options: buildCommandOptions(MCP_OPTION_METADATA),
 });
 
 export default mcpCommand;

--- a/packages/wp-typia/tests/bunli-prep.test.ts
+++ b/packages/wp-typia/tests/bunli-prep.test.ts
@@ -343,6 +343,12 @@ describe('wp-typia Bunli preparation', () => {
     expect(() => normalizeWpTypiaArgv(['mcp', 'sync', '--output-dir'])).toThrow(
       /`--output-dir` requires a value\./,
     );
+    expect(
+      normalizeWpTypiaArgv(['mcp', 'sync', '--output-dir=.bunli/custom-mcp']),
+    ).toEqual(['mcp', 'sync', '--output-dir=.bunli/custom-mcp']);
+    expect(
+      normalizeWpTypiaArgv(['mcp', 'sync', '--output-dir', '.bunli/custom']),
+    ).toEqual(['mcp', 'sync', '--output-dir', '.bunli/custom']);
     expect(() => normalizeWpTypiaArgv(['temlates', 'list'])).toThrow(
       /only accepts a single project directory.*check the command spelling.*`list`/s,
     );

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -73,6 +73,10 @@ const templatesCommandSource = fs.readFileSync(
   path.join(packageRoot, 'src', 'commands', 'templates.ts'),
   'utf8',
 );
+const mcpCommandSource = fs.readFileSync(
+  path.join(packageRoot, 'src', 'commands', 'mcp.ts'),
+  'utf8',
+);
 const nodeCliSource = fs.readFileSync(
   path.join(packageRoot, 'src', 'node-cli.ts'),
   'utf8',
@@ -353,6 +357,9 @@ describe('wp-typia package', () => {
     expect(createCommandSource).toContain('resolveCommandOptionValues');
     expect(addCommandSource).toContain('resolveCommandOptionValues');
     expect(migrateCommandSource).toContain('resolveCommandOptionValues');
+    expect(mcpCommandSource).toContain('buildCommandOptions');
+    expect(mcpCommandSource).toContain('MCP_OPTION_METADATA');
+    expect(mcpCommandSource).not.toContain('schema: z.string().optional()');
   });
 
   test('gates interactive TUI rendering on real terminal capability and avoids hard exit short-circuits', () => {

--- a/packages/wp-typia/tests/command-option-metadata.test.ts
+++ b/packages/wp-typia/tests/command-option-metadata.test.ts
@@ -12,6 +12,7 @@ import {
   extractKnownOptionValuesFromArgv,
   GLOBAL_OPTION_METADATA,
   INIT_OPTION_METADATA,
+  MCP_OPTION_METADATA,
   parseCommandArgvWithMetadata,
   resolveCommandOptionValues,
   SYNC_OPTION_METADATA,
@@ -182,6 +183,34 @@ describe('command option metadata helpers', () => {
     expect(parsed.positionals).toEqual(['doctor']);
   });
 
+  test('parses mcp output-dir flags from shared metadata', () => {
+    const spaced = parseCommandArgvWithMetadata(
+      ['mcp', 'sync', '--output-dir', '.bunli/mcp'],
+      {
+        extraBooleanOptionNames: ['help', 'version'],
+        parser: buildCommandOptionParser(
+          GLOBAL_OPTION_METADATA,
+          MCP_OPTION_METADATA,
+        ),
+      },
+    );
+    const inline = parseCommandArgvWithMetadata(
+      ['mcp', 'sync', '--output-dir=.cache/mcp'],
+      {
+        extraBooleanOptionNames: ['help', 'version'],
+        parser: buildCommandOptionParser(
+          GLOBAL_OPTION_METADATA,
+          MCP_OPTION_METADATA,
+        ),
+      },
+    );
+
+    expect(spaced.flags['output-dir']).toBe('.bunli/mcp');
+    expect(spaced.positionals).toEqual(['mcp', 'sync']);
+    expect(inline.flags['output-dir']).toBe('.cache/mcp');
+    expect(inline.positionals).toEqual(['mcp', 'sync']);
+  });
+
   test('derives canonical routing metadata from every command option group', () => {
     const expectedRoutingMetadata = buildArgvWalkerRoutingMetadata(
       ...Object.values(COMMAND_OPTION_METADATA_BY_GROUP),
@@ -192,6 +221,7 @@ describe('command option metadata helpers', () => {
       SYNC_OPTION_METADATA.check,
     );
     expect(COMMAND_ROUTING_METADATA.longValueOptions).toContain('--config');
+    expect(COMMAND_ROUTING_METADATA.longValueOptions).toContain('--output-dir');
     expect(COMMAND_ROUTING_METADATA.shortValueOptions).toContain('-c');
   });
 


### PR DESCRIPTION
## Summary

- move `mcp --output-dir` into a dedicated shared `MCP_OPTION_METADATA` group
- wire the `mcp` command registry entry and Bunli command definition to that shared metadata instead of an inline option schema
- add coverage for routing metadata, argv walking, and shared-source wiring around `--output-dir`

## Validation

- `./node_modules/.bin/tsc --noEmit`
- `node scripts/validate-sampo-changesets.mjs`
- `./node_modules/.bin/prettier --check .sampo/changesets/650-route-mcp-output-dir.md packages/wp-typia/src/command-option-metadata.ts packages/wp-typia/src/command-registry.ts packages/wp-typia/src/commands/mcp.ts packages/wp-typia/tests/bunli-prep.test.ts packages/wp-typia/tests/cli-package.test.ts packages/wp-typia/tests/command-option-metadata.test.ts`
- `cd packages/wp-typia && node scripts/generate-routing-metadata.mjs --check`
- `export PATH=/tmp/codex-real-npm:/tmp/codex-bun-1.3.11/bun-darwin-aarch64:$PATH; cd packages/wp-typia && bun test tests/command-option-metadata.test.ts tests/bunli-prep.test.ts tests/cli-package.test.ts`
- `export PATH=/tmp/codex-bun-1.3.11/bun-darwin-aarch64:$PATH; cd packages/wp-typia && bun run build`

## Release notes

- changeset added for `npm/wp-typia`

## Docs

- no user-facing docs change needed; existing CLI docs already describe `mcp sync --output-dir`

## Migration / compatibility

- no CLI surface change beyond moving `--output-dir` onto the shared metadata path used by routing/help generation

Closes #650

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized command option handling for `wp-typia mcp --output-dir` by consolidating option metadata definitions, ensuring consistent behavior across command routing, argument processing, and help documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->