### PR TITLE
fix(cli): standardize structured json output

### DIFF
--- a/.sampo/changesets/649-structured-cli-streams.md
+++ b/.sampo/changesets/649-structured-cli-streams.md
@@ -1,0 +1,7 @@
+---
+npm/wp-typia: patch
+---
+
+Standardize JSON CLI diagnostics so success payloads stay on stdout, error
+payloads go to stderr, and completion-oriented success payloads use one
+canonical nested completion shape.

--- a/apps/docs/src/content/docs/reference/cli.md
+++ b/apps/docs/src/content/docs/reference/cli.md
@@ -34,6 +34,11 @@ and wrapper integrations. The `error.code` field is the integration contract;
 human-readable `message`, `summary`, and `detailLines` can change as guidance
 improves.
 
+- `ok: true` JSON success payloads are written to stdout.
+- `ok: false` JSON error payloads are written to stderr.
+- Completion-oriented success payloads keep human-facing title/summary/next-step
+  data under `data.completion`.
+
 ```json
 {
   "ok": false,

--- a/packages/wp-typia/src/cli-diagnostic-output.ts
+++ b/packages/wp-typia/src/cli-diagnostic-output.ts
@@ -31,6 +31,12 @@ function resolveEntrypointCliCommand(argv: string[]): string {
   return findFirstPositional(argv, COMMAND_ROUTING_METADATA) ?? 'wp-typia';
 }
 
+function writeStructuredCliJsonToStderr(
+  payload: Record<string, unknown>,
+): void {
+  process.stderr.write(`${JSON.stringify(payload, null, 2)}\n`);
+}
+
 export function prefersStructuredCliArgv(argv: string[]): boolean {
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -70,7 +76,7 @@ export function emitCliDiagnosticFailure(
 ): true | never {
   const diagnostic = createCliCommandError(options);
   if (prefersStructuredCliOutput(args)) {
-    args.output({
+    writeStructuredCliJsonToStderr({
       ...(options.extraOutput ?? {}),
       error: serializeCliDiagnosticError(diagnostic),
       ok: false,
@@ -90,21 +96,15 @@ export function writeStructuredCliDiagnosticError(
     return false;
   }
 
-  console.log(
-    JSON.stringify(
-      {
-        error: serializeCliDiagnosticError(
-          createCliCommandError({
-            command: resolveEntrypointCliCommand(argv),
-            error,
-          }),
-        ),
-        ok: false,
-      },
-      null,
-      2,
+  writeStructuredCliJsonToStderr({
+    error: serializeCliDiagnosticError(
+      createCliCommandError({
+        command: resolveEntrypointCliCommand(argv),
+        error,
+      }),
     ),
-  );
+    ok: false,
+  });
   process.exitCode = 1;
   return true;
 }

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -21,6 +21,7 @@ import {
   SYNC_OPTION_METADATA,
   TEMPLATES_OPTION_METADATA,
 } from './command-option-metadata';
+import { prefersStructuredCliArgv } from './cli-diagnostic-output';
 import {
   getTemplateById,
   listTemplates,
@@ -733,28 +734,21 @@ export async function runNodeCli(argv = process.argv.slice(2)): Promise<void> {
 export async function runNodeCliEntrypoint(
   argv = process.argv.slice(2),
 ): Promise<void> {
+  const prefersStructuredErrorOutput = prefersStructuredCliArgv(argv);
+
   try {
     await runNodeCli(argv);
   } catch (error) {
-    let prefersStructuredErrorOutput = false;
-    try {
-      const normalizedArgv = normalizeWpTypiaArgv(argv);
-      const { argv: argvWithoutConfigOverride } =
-        extractWpTypiaConfigOverride(normalizedArgv);
-      const { flags } = parseGlobalFlags(argvWithoutConfigOverride);
-      prefersStructuredErrorOutput = flags.format === 'json';
-    } catch {}
-
     if (prefersStructuredErrorOutput) {
-      console.error(
-        JSON.stringify(
+      process.stderr.write(
+        `${JSON.stringify(
           {
             ok: false,
             error: serializeCliDiagnosticError(error),
           },
           null,
           2,
-        ),
+        )}\n`,
       );
       process.exitCode = 1;
       return;

--- a/packages/wp-typia/src/runtime-bridge-output.ts
+++ b/packages/wp-typia/src/runtime-bridge-output.ts
@@ -28,14 +28,6 @@ export type StructuredCompletionSuccessPayload = {
     command: string;
     completion?: SerializableCompletionPayload;
     files?: string[];
-    nextSteps?: string[];
-    optionalLines?: string[];
-    optionalNote?: string;
-    optionalTitle?: string;
-    preambleLines?: string[];
-    summaryLines?: string[];
-    title?: string;
-    warnings?: string[];
   } & Record<string, unknown>;
 };
 
@@ -92,14 +84,11 @@ export type StructuredInitSuccessPayload = {
     detectedLayout: StructuredInitPlan['detectedLayout'];
     files?: string[];
     mode: 'apply' | 'preview';
-    nextSteps?: string[];
     packageManager: PackageManagerId;
     plan: StructuredInitPlan;
     projectDir: string;
     status: StructuredInitPlan['status'];
     summary: string;
-    title?: string;
-    warnings?: string[];
   };
 };
 
@@ -259,14 +248,6 @@ export function buildStructuredCompletionSuccessPayload(
         ? {
             completion: serializedCompletion,
             files: extractPlannedFiles(serializedCompletion),
-            nextSteps: serializedCompletion.nextSteps,
-            optionalLines: serializedCompletion.optionalLines,
-            optionalNote: serializedCompletion.optionalNote,
-            optionalTitle: serializedCompletion.optionalTitle,
-            preambleLines: serializedCompletion.preambleLines,
-            summaryLines: serializedCompletion.summaryLines,
-            title: serializedCompletion.title,
-            warnings: serializedCompletion.warningLines,
           }
         : {}),
     },
@@ -294,14 +275,11 @@ export function buildStructuredInitSuccessPayload(
       detectedLayout: plan.detectedLayout,
       files: toNonEmptyArray(files),
       mode: plan.commandMode === 'apply' ? 'apply' : 'preview',
-      nextSteps: toNonEmptyArray(plan.nextSteps),
       packageManager: plan.packageManager,
       plan,
       projectDir: plan.projectDir,
       status: plan.status,
       summary: plan.summary,
-      title: completion.title,
-      warnings: toNonEmptyArray(plan.notes),
     },
   };
 }

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -497,6 +497,7 @@ describe('wp-typia package', () => {
         data?: {
           command?: string;
           completion?: {
+            nextSteps?: string[];
             title?: string;
           };
           detectedLayout?: { kind?: string; blockNames?: string[] };
@@ -542,9 +543,10 @@ describe('wp-typia package', () => {
         ]),
       );
       expect(parsed.data?.completion?.title).toContain('Retrofit init plan');
-      expect(parsed.data?.nextSteps).toContain(
+      expect(parsed.data?.completion?.nextSteps).toContain(
         `npx --yes wp-typia@${packageManifest.version} doctor`,
       );
+      expect(parsed.data).not.toHaveProperty('nextSteps');
     } finally {
       fs.rmSync(fixtureRoot, { force: true, recursive: true });
     }
@@ -683,7 +685,6 @@ describe('wp-typia package', () => {
           files?: string[];
           projectDir?: string;
           template?: string;
-          title?: string;
         };
         ok?: boolean;
       }>(result.stdout);
@@ -698,8 +699,8 @@ describe('wp-typia package', () => {
         path.join(fs.realpathSync(tempRoot), 'demo-json'),
       );
       expect(parsed.data?.template).toBe('basic');
-      expect(parsed.data?.title).toContain('Dry run for Demo Json');
-      expect(parsed.data?.completion?.title).toBe(parsed.data?.title);
+      expect(parsed.data?.completion?.title).toContain('Dry run for Demo Json');
+      expect(parsed.data).not.toHaveProperty('title');
       expect(parsed.data?.files).toContain('package.json');
       expect(parsed.data?.files).toContain('src/index.tsx');
       expect(serialized).not.toMatch(/[✅🧪⏳⚠]/u);
@@ -1493,15 +1494,13 @@ describe('wp-typia package', () => {
           },
         },
       );
-      const diagnosticOutput = result.stderr.includes('{')
-        ? result.stderr
-        : result.stdout;
       const parsed = parseJsonObjectFromOutput<{
         error?: { code?: string; message?: string };
         ok?: boolean;
-      }>(diagnosticOutput);
+      }>(result.stderr);
 
       expect(result.status).toBe(1);
+      expect(result.stdout).toBe('');
       expect(parsed.ok).toBe(false);
       expect(parsed.error?.code).toBe('template-source-timeout');
       expect(parsed.error?.message).toContain(
@@ -1702,8 +1701,6 @@ describe('wp-typia package', () => {
           kind?: string;
           name?: string;
           projectDir?: string;
-          summaryLines?: string[];
-          title?: string;
         };
         ok?: boolean;
       }>(result.stdout);
@@ -1716,9 +1713,12 @@ describe('wp-typia package', () => {
       expect(parsed.data?.kind).toBe('block');
       expect(parsed.data?.name).toBe('promo-card');
       expect(parsed.data?.projectDir).toBe(fs.realpathSync(projectDir));
-      expect(parsed.data?.title).toContain('Added workspace block');
-      expect(parsed.data?.completion?.title).toBe(parsed.data?.title);
-      expect(parsed.data?.summaryLines).toContain('Template family: basic');
+      expect(parsed.data?.completion?.title).toContain('Added workspace block');
+      expect(parsed.data?.completion?.summaryLines).toContain(
+        'Template family: basic',
+      );
+      expect(parsed.data).not.toHaveProperty('title');
+      expect(parsed.data).not.toHaveProperty('summaryLines');
       expect(serialized).not.toMatch(/[✅🧪⏳⚠]/u);
       expect(
         fs.existsSync(
@@ -2019,13 +2019,13 @@ describe('wp-typia package', () => {
       '--format',
       'json',
     ]);
-    const parsed = JSON.parse(result.stdout.trim()) as {
+    const parsed = JSON.parse(result.stderr.trim()) as {
       error?: { code?: string; command?: string; kind?: string };
       ok?: boolean;
     };
 
     expect(result.status).toBe(1);
-    expect(result.stderr).toBe('');
+    expect(result.stdout).toBe('');
     expect(parsed.ok).toBe(false);
     expect(parsed.error?.kind).toBe('command-execution');
     expect(parsed.error?.command).toBe('mcp');
@@ -2040,13 +2040,13 @@ describe('wp-typia package', () => {
         env: withoutAIAgentEnv(),
       },
     );
-    const parsed = JSON.parse(result.stdout.trim()) as {
+    const parsed = JSON.parse(result.stderr.trim()) as {
       error?: { code?: string; command?: string; kind?: string };
       ok?: boolean;
     };
 
     expect(result.status).toBe(1);
-    expect(result.stderr).toBe('');
+    expect(result.stdout).toBe('');
     expect(parsed.ok).toBe(false);
     expect(parsed.error?.kind).toBe('command-execution');
     expect(parsed.error?.command).toBe('create');
@@ -2067,13 +2067,13 @@ describe('wp-typia package', () => {
           env: withoutAIAgentEnv(),
         },
       );
-      const parsed = JSON.parse(result.stdout.trim()) as {
+      const parsed = JSON.parse(result.stderr.trim()) as {
         error?: { code?: string; command?: string; kind?: string };
         ok?: boolean;
       };
 
       expect(result.status).toBe(1);
-      expect(result.stderr).toBe('');
+      expect(result.stdout).toBe('');
       expect(parsed.ok).toBe(false);
       expect(parsed.error?.kind).toBe('command-execution');
       expect(parsed.error?.command).toBe('sync');
@@ -2091,13 +2091,13 @@ describe('wp-typia package', () => {
         env: withoutAIAgentEnv(),
       },
     );
-    const parsed = JSON.parse(result.stdout.trim()) as {
+    const parsed = JSON.parse(result.stderr.trim()) as {
       error?: { code?: string; command?: string; kind?: string };
       ok?: boolean;
     };
 
     expect(result.status).toBe(1);
-    expect(result.stderr).toBe('');
+    expect(result.stdout).toBe('');
     expect(parsed.ok).toBe(false);
     expect(parsed.error?.kind).toBe('command-execution');
     expect(parsed.error?.command).toBe('wp-typia');
@@ -2120,13 +2120,13 @@ describe('wp-typia package', () => {
         env: withoutAIAgentEnv(),
       },
     );
-    const parsed = JSON.parse(result.stdout.trim()) as {
+    const parsed = JSON.parse(result.stderr.trim()) as {
       error?: { code?: string; command?: string; kind?: string };
       ok?: boolean;
     };
 
     expect(result.status).toBe(1);
-    expect(result.stderr).toBe('');
+    expect(result.stdout).toBe('');
     expect(parsed.ok).toBe(false);
     expect(parsed.error?.kind).toBe('command-execution');
     expect(parsed.error?.command).toBe('temlates');

--- a/packages/wp-typia/tests/completion-output.test.ts
+++ b/packages/wp-typia/tests/completion-output.test.ts
@@ -327,6 +327,9 @@ describe('alternate-buffer completion output helpers', () => {
       'scripts/block-config.ts',
       'src/blocks/old-card/block.json',
     ]);
+    expect(payload.data).not.toHaveProperty('title');
+    expect(payload.data).not.toHaveProperty('summaryLines');
+    expect(payload.data).not.toHaveProperty('nextSteps');
   });
 
   test('structured init success payload uses the standard CLI envelope', () => {
@@ -380,14 +383,14 @@ describe('alternate-buffer completion output helpers', () => {
       'src/typia.manifest.json',
       'src/typia.schema.json',
     ]);
-    expect(payload.data.nextSteps).toEqual([
+    expect(payload.data.completion.nextSteps).toEqual([
       'npm run sync -- --check',
       'npm run typecheck',
     ]);
-    expect(payload.data.warnings).toEqual([
-      'Preview only: no files were written.',
-    ]);
     expect(payload.data.completion.title).toContain('Retrofit init plan');
+    expect(payload.data).not.toHaveProperty('nextSteps');
+    expect(payload.data).not.toHaveProperty('warnings');
+    expect(payload.data).not.toHaveProperty('title');
   });
 
   test('dry-run sync payload previews the generated sync commands', () => {


### PR DESCRIPTION
## Summary

- send structured JSON error payloads to stderr while keeping structured success payloads on stdout
- stop reparsing argv in the Node fallback catch path by capturing JSON preference once up front
- remove duplicated top-level completion fields so completion-oriented success payloads use `data.completion` as the canonical human-facing shape
- document the JSON stdout/stderr policy in the CLI reference and update coverage accordingly

## Validation

- `./node_modules/.bin/tsc --noEmit`
- `node scripts/validate-sampo-changesets.mjs`
- `./node_modules/.bin/prettier --check .sampo/changesets/649-structured-cli-streams.md apps/docs/src/content/docs/reference/cli.md packages/wp-typia/src/cli-diagnostic-output.ts packages/wp-typia/src/node-cli.ts packages/wp-typia/src/runtime-bridge-output.ts packages/wp-typia/tests/cli-package.test.ts packages/wp-typia/tests/completion-output.test.ts`
- `export PATH=/tmp/codex-bun-1.3.11/bun-darwin-aarch64:$PATH; cd packages/wp-typia && bun run build`
- `export PATH=/tmp/codex-real-npm:/tmp/codex-bun-1.3.11/bun-darwin-aarch64:$PATH; cd packages/wp-typia && bun test tests/completion-output.test.ts tests/cli-package.test.ts`
- `cd packages/wp-typia && node scripts/generate-routing-metadata.mjs --check`

## Release notes

- changeset added for `npm/wp-typia`

## Docs

- updated the CLI reference with JSON stdout/stderr stream policy and canonical `data.completion` guidance

## Migration / compatibility

- JSON consumers should now read error envelopes from stderr and use `data.completion` rather than duplicated top-level completion fields

Closes #649