### PR TITLE
test: harden interactivity scaffold coverage

### DIFF
--- a/.sampo/changesets/653-harden-interactivity-coverage.md
+++ b/.sampo/changesets/653-harden-interactivity-coverage.md
@@ -1,0 +1,8 @@
+---
+npm/wp-typia: patch
+npm/@wp-typia/project-tools: patch
+---
+
+Harden the interactivity block scaffold by replacing loose `Function` typings
+with safer callable signatures, and add regression coverage for workspace
+interactivity helpers plus add-kind execution-plan compatibility.

--- a/packages/wp-typia-project-tools/src/runtime/built-in-block-code-templates/interactivity.ts
+++ b/packages/wp-typia-project-tools/src/runtime/built-in-block-code-templates/interactivity.ts
@@ -431,7 +431,7 @@ type InteractivityActionShape = object;
 type InteractivityCallbackShape = object;
 type InteractivityContextShape = object;
 type InteractivityStateShape = object;
-type InteractivityCallable = Function;
+type InteractivityCallable = (...args: unknown[]) => unknown;
 type InteractivityKey<T extends object> = Extract<keyof T, string>;
 type InteractivityMethodKey<T extends object> = {
   [Key in InteractivityKey<T>]: T[Key] extends InteractivityCallable ? Key : never;
@@ -534,7 +534,7 @@ export function defineInteractivityStore<
   };
 }
 
-type InteractivityActionHandler = Function;
+type InteractivityActionHandler = (...args: unknown[]) => unknown;
 
 export interface {{pascalCase}}StoreActions {
   handleClick: InteractivityActionHandler;

--- a/packages/wp-typia-project-tools/src/runtime/built-in-block-code-templates/interactivity.ts
+++ b/packages/wp-typia-project-tools/src/runtime/built-in-block-code-templates/interactivity.ts
@@ -431,7 +431,7 @@ type InteractivityActionShape = object;
 type InteractivityCallbackShape = object;
 type InteractivityContextShape = object;
 type InteractivityStateShape = object;
-type InteractivityCallable = (...args: unknown[]) => unknown;
+type InteractivityCallable = CallableFunction;
 type InteractivityKey<T extends object> = Extract<keyof T, string>;
 type InteractivityMethodKey<T extends object> = {
   [Key in InteractivityKey<T>]: T[Key] extends InteractivityCallable ? Key : never;
@@ -534,7 +534,7 @@ export function defineInteractivityStore<
   };
 }
 
-type InteractivityActionHandler = (...args: unknown[]) => unknown;
+type InteractivityActionHandler = CallableFunction;
 
 export interface {{pascalCase}}StoreActions {
   handleClick: InteractivityActionHandler;

--- a/packages/wp-typia-project-tools/tests/built-in-block-artifacts.test.ts
+++ b/packages/wp-typia-project-tools/tests/built-in-block-artifacts.test.ts
@@ -108,10 +108,10 @@ function summarizeArtifactAttributes(
 type ArtifactAttributeSummary = ReturnType<typeof summarizeArtifactAttributes>;
 type CodeArtifactHashSummary = Record<string, string>;
 const SNAPSHOT_TEMPLATE_IDS = [
-	"basic",
-	"interactivity",
-	"persistence",
-	"compound",
+  'basic',
+  'interactivity',
+  'persistence',
+  'compound',
 ] as const satisfies ReadonlyArray<BuiltInTemplateId>;
 
 const EXPECTED_ARTIFACT_ATTRIBUTE_SUMMARIES: Record<
@@ -237,7 +237,8 @@ const EXPECTED_ARTIFACT_ATTRIBUTE_SUMMARIES: Record<
         },
         intro: {
           blockJson: {
-            default: 'Add and reorder internal items inside this compound block.',
+            default:
+              'Add and reorder internal items inside this compound block.',
             selector: '.wp-block-demo-space-demo-compound__intro',
             source: 'html',
             type: 'string',
@@ -586,7 +587,7 @@ const EXPECTED_CODE_ARTIFACT_HASH_SUMMARIES: Record<
     'src/editor.scss': '7da532bf2acdc7c1',
     'src/hooks.ts': '3c1b432bd711ee70',
     'src/index.tsx': '09971fea0bb30b8f',
-    'src/interactivity-store.ts': '265758339878f831',
+    'src/interactivity-store.ts': 'be4a237b99d622ce',
     'src/interactivity.ts': '02607a60ca356d79',
     'src/manifest-defaults-document.ts': '16818959f3d5a7d6',
     'src/manifest-document.ts': 'b8fffee2c728488e',
@@ -614,8 +615,7 @@ const EXPECTED_CODE_ARTIFACT_HASH_SUMMARIES: Record<
     'src/blocks/demo-compound-item/index.tsx': '5b5805db42c0b1f6',
     'src/blocks/demo-compound-item/manifest-defaults-document.ts':
       '16818959f3d5a7d6',
-    'src/blocks/demo-compound-item/manifest-document.ts':
-      'b8fffee2c728488e',
+    'src/blocks/demo-compound-item/manifest-document.ts': 'b8fffee2c728488e',
     'src/blocks/demo-compound-item/save.tsx': 'e2a9d7c5df3e615f',
     'src/blocks/demo-compound-item/validators.ts': '7123c8ea0e650172',
     'src/blocks/demo-compound/block-metadata.ts': '50956333a97a824a',
@@ -712,12 +712,8 @@ describe('built-in block artifacts', () => {
       'from "./built-in-block-code-templates/compound.js"',
     );
     expect(basicTemplateSource).toContain('export const BASIC_EDIT_TEMPLATE =');
-    expect(compoundTemplateSource).toContain(
-      "from './compound-parent.js'",
-    );
-    expect(compoundTemplateSource).toContain(
-      "from './compound-child.js'",
-    );
+    expect(compoundTemplateSource).toContain("from './compound-parent.js'");
+    expect(compoundTemplateSource).toContain("from './compound-child.js'");
     expect(compoundTemplateSource).toContain(
       "from './compound-persistence.js'",
     );
@@ -1011,7 +1007,9 @@ describe('built-in block artifacts', () => {
       templateId: 'persistence',
       variables,
     });
-    const relativePaths = codeArtifacts.map((artifact) => artifact.relativePath);
+    const relativePaths = codeArtifacts.map(
+      (artifact) => artifact.relativePath,
+    );
 
     expect(relativePaths).toContain('src/render-targets.php');
     expect(relativePaths).toContain('src/render.php');
@@ -1019,12 +1017,15 @@ describe('built-in block artifacts', () => {
     expect(relativePaths).toContain('src/render-mjml.php');
     expect(relativePaths).toContain('src/render-text.php');
     expect(
-      codeArtifacts.find((artifact) => artifact.relativePath === 'src/render.php')?.source,
+      codeArtifacts.find(
+        (artifact) => artifact.relativePath === 'src/render.php',
+      )?.source,
     ).toContain("render_target( 'web'");
     expect(
-      codeArtifacts.find((artifact) => artifact.relativePath === 'src/render-targets.php')
-        ?.source,
-    ).toContain("function demo_space_demo_persistence_render_target");
+      codeArtifacts.find(
+        (artifact) => artifact.relativePath === 'src/render-targets.php',
+      )?.source,
+    ).toContain('function demo_space_demo_persistence_render_target');
   });
 
   test('compound persistence artifacts emit alternate render target entries when requested', () => {
@@ -1041,7 +1042,9 @@ describe('built-in block artifacts', () => {
       templateId: 'compound',
       variables,
     });
-    const relativePaths = codeArtifacts.map((artifact) => artifact.relativePath);
+    const relativePaths = codeArtifacts.map(
+      (artifact) => artifact.relativePath,
+    );
     const parentDir = `src/blocks/${variables.slugKebabCase}`;
 
     expect(relativePaths).toContain(`${parentDir}/render-targets.php`);
@@ -1050,14 +1053,16 @@ describe('built-in block artifacts', () => {
     expect(relativePaths).toContain(`${parentDir}/render-text.php`);
     expect(relativePaths).not.toContain(`${parentDir}/render-mjml.php`);
     expect(
-      codeArtifacts.find((artifact) => artifact.relativePath === `${parentDir}/render.php`)
-        ?.source,
+      codeArtifacts.find(
+        (artifact) => artifact.relativePath === `${parentDir}/render.php`,
+      )?.source,
     ).toContain("render_target( 'web'");
     expect(
       codeArtifacts.find(
-        (artifact) => artifact.relativePath === `${parentDir}/render-targets.php`,
+        (artifact) =>
+          artifact.relativePath === `${parentDir}/render-targets.php`,
       )?.source,
-    ).toContain("function demo_space_demo_compound_render_target");
+    ).toContain('function demo_space_demo_compound_render_target');
   });
 
   test.each([
@@ -1115,21 +1120,21 @@ describe('built-in block artifacts', () => {
       [
         'src/hooks.ts',
         'src/blocks/demo-compound/block-metadata.ts',
-          'src/blocks/demo-compound/manifest-document.ts',
-          'src/blocks/demo-compound/manifest-defaults-document.ts',
-          'src/blocks/demo-compound/edit.tsx',
-          'src/blocks/demo-compound/save.tsx',
-          'src/blocks/demo-compound/index.tsx',
+        'src/blocks/demo-compound/manifest-document.ts',
+        'src/blocks/demo-compound/manifest-defaults-document.ts',
+        'src/blocks/demo-compound/edit.tsx',
+        'src/blocks/demo-compound/save.tsx',
+        'src/blocks/demo-compound/index.tsx',
         'src/blocks/demo-compound/hooks.ts',
         'src/blocks/demo-compound/validators.ts',
-          'src/blocks/demo-compound/children.ts',
-          'src/blocks/demo-compound/interactivity.ts',
-          'src/blocks/demo-compound-item/block-metadata.ts',
-          'src/blocks/demo-compound-item/manifest-document.ts',
-          'src/blocks/demo-compound-item/manifest-defaults-document.ts',
-          'src/blocks/demo-compound-item/edit.tsx',
-          'src/blocks/demo-compound-item/save.tsx',
-          'src/blocks/demo-compound-item/index.tsx',
+        'src/blocks/demo-compound/children.ts',
+        'src/blocks/demo-compound/interactivity.ts',
+        'src/blocks/demo-compound-item/block-metadata.ts',
+        'src/blocks/demo-compound-item/manifest-document.ts',
+        'src/blocks/demo-compound-item/manifest-defaults-document.ts',
+        'src/blocks/demo-compound-item/edit.tsx',
+        'src/blocks/demo-compound-item/save.tsx',
+        'src/blocks/demo-compound-item/index.tsx',
         'src/blocks/demo-compound-item/hooks.ts',
         'src/blocks/demo-compound-item/validators.ts',
         'src/blocks/demo-compound/style.scss',

--- a/packages/wp-typia/tests/add-command.test.ts
+++ b/packages/wp-typia/tests/add-command.test.ts
@@ -45,6 +45,108 @@ describe('wp-typia add command bridge', () => {
     ).toBe(true);
   });
 
+  test('scaffolds interactivity block templates with typed store helpers', async () => {
+    const projectDir = path.join(tempRoot, 'demo-add-interactivity-template');
+
+    await scaffoldOfficialWorkspace(projectDir);
+    linkWorkspaceNodeModules(projectDir);
+
+    const payload = await executeAddCommand({
+      cwd: projectDir,
+      emitOutput: false,
+      flags: {
+        template: 'interactivity',
+      },
+      interactive: false,
+      kind: 'block',
+      name: 'signal-board',
+    });
+
+    const blockDir = path.join(projectDir, 'src', 'blocks', 'signal-board');
+    const generatedInteractivityStore = fs.readFileSync(
+      path.join(blockDir, 'interactivity-store.ts'),
+      'utf8',
+    );
+    const generatedInteractivityRuntime = fs.readFileSync(
+      path.join(blockDir, 'interactivity.ts'),
+      'utf8',
+    );
+    const generatedSave = fs.readFileSync(
+      path.join(blockDir, 'save.tsx'),
+      'utf8',
+    );
+
+    expect(payload?.summaryLines).toContain('Template family: interactivity');
+    expect(fs.existsSync(path.join(blockDir, 'interactivity-store.ts'))).toBe(
+      true,
+    );
+    expect(fs.existsSync(path.join(blockDir, 'interactivity.ts'))).toBe(true);
+    expect(generatedInteractivityStore).toContain(
+      'type InteractivityCallable = (...args: unknown[]) => unknown;',
+    );
+    expect(generatedInteractivityStore).not.toContain(
+      'type InteractivityCallable = Function;',
+    );
+    expect(generatedInteractivityStore).not.toContain(
+      'type InteractivityActionHandler = Function;',
+    );
+    expect(generatedInteractivityStore).toContain(
+      'action<Key extends InteractivityMethodKey<Actions>>',
+    );
+    expect(generatedInteractivityStore).toContain(
+      'callback<Key extends InteractivityMethodKey<Callbacks>>',
+    );
+    expect(generatedInteractivityStore).toContain(
+      'context<Key extends InteractivityKey<Context>>',
+    );
+    expect(generatedInteractivityStore).toContain(
+      'negate<Path extends string>(',
+    );
+    expect(generatedInteractivityStore).toContain(
+      'export interface SignalBoardStoreActions',
+    );
+    expect(generatedInteractivityStore).toContain(
+      'export interface SignalBoardStoreCallbacks {}',
+    );
+    expect(generatedInteractivityStore).toContain(
+      'export const signalBoardStore = defineInteractivityStore({',
+    );
+    expect(generatedInteractivityRuntime).toContain(
+      "import {\n  signalBoardStore,\n  type SignalBoardStoreActions,\n} from './interactivity-store';",
+    );
+    expect(generatedInteractivityRuntime).toContain(
+      'const actions: SignalBoardStoreActions = {',
+    );
+    expect(generatedInteractivityRuntime).toContain(
+      'store(signalBoardStore.namespace, {',
+    );
+    expect(generatedInteractivityRuntime).toContain(
+      'callbacks: signalBoardStore.callbacks,',
+    );
+    expect(generatedSave).toContain(
+      "const clickActionDirective = signalBoardStore.directive.action('handleClick');",
+    );
+    expect(generatedSave).toContain(
+      'const visibilityHiddenDirective = signalBoardStore.directive.negate(',
+    );
+    expect(generatedSave).toContain(
+      "signalBoardStore.directive.state('isVisible')",
+    );
+    expect(generatedSave).toContain(
+      "const clampedClicksDirective = signalBoardStore.directive.state('clampedClicks');",
+    );
+    expect(generatedSave).toContain(
+      "const resetActionDirective = signalBoardStore.directive.action('reset');",
+    );
+    expect(generatedSave).toContain(
+      "'data-wp-interactive': signalBoardStore.directive.interactive,",
+    );
+    expect(generatedSave).toContain(
+      'data-wp-bind--aria-valuenow={clampedClicksDirective}',
+    );
+    expect(generatedSave).toContain('data-wp-on--click={clickActionDirective}');
+  });
+
   test('passes binding-source target flags through the add bridge', async () => {
     const projectDir = path.join(tempRoot, 'demo-add-binding-target');
 

--- a/packages/wp-typia/tests/add-command.test.ts
+++ b/packages/wp-typia/tests/add-command.test.ts
@@ -82,7 +82,7 @@ describe('wp-typia add command bridge', () => {
     );
     expect(fs.existsSync(path.join(blockDir, 'interactivity.ts'))).toBe(true);
     expect(generatedInteractivityStore).toContain(
-      'type InteractivityCallable = (...args: unknown[]) => unknown;',
+      'type InteractivityCallable = CallableFunction;',
     );
     expect(generatedInteractivityStore).not.toContain(
       'type InteractivityCallable = Function;',
@@ -145,7 +145,7 @@ describe('wp-typia add command bridge', () => {
       'data-wp-bind--aria-valuenow={clampedClicksDirective}',
     );
     expect(generatedSave).toContain('data-wp-on--click={clickActionDirective}');
-  });
+  }, 15_000);
 
   test('passes binding-source target flags through the add bridge', async () => {
     const projectDir = path.join(tempRoot, 'demo-add-binding-target');
@@ -334,7 +334,7 @@ describe('wp-typia add command bridge', () => {
         path.join(projectDir, 'src', 'blocks', 'faq-stack', 'children.ts'),
       ),
     ).toBe(true);
-  });
+  }, 15_000);
 
   test('every registered add kind currently advertises dry-run support', () => {
     expect(ADD_KIND_IDS.every((kind) => supportsAddKindDryRun(kind))).toBe(

--- a/packages/wp-typia/tests/add-kind-registry.test.ts
+++ b/packages/wp-typia/tests/add-kind-registry.test.ts
@@ -22,30 +22,131 @@ type AdminViewPlanCompatibility = ExpectTrue<
   >
 >;
 
+type BlockPlanCompatibility = ExpectTrue<
+  IsEqual<
+    Awaited<ReturnType<AddKindExecutionPlanFor<'block'>['execute']>>,
+    Parameters<AddKindExecutionPlanFor<'block'>['getValues']>[0]
+  >
+>;
+
+type VariationPlanCompatibility = ExpectTrue<
+  IsEqual<
+    Awaited<ReturnType<AddKindExecutionPlanFor<'variation'>['execute']>>,
+    Parameters<AddKindExecutionPlanFor<'variation'>['getValues']>[0]
+  >
+>;
+
+type StylePlanCompatibility = ExpectTrue<
+  IsEqual<
+    Awaited<ReturnType<AddKindExecutionPlanFor<'style'>['execute']>>,
+    Parameters<AddKindExecutionPlanFor<'style'>['getValues']>[0]
+  >
+>;
+
+type TransformPlanCompatibility = ExpectTrue<
+  IsEqual<
+    Awaited<ReturnType<AddKindExecutionPlanFor<'transform'>['execute']>>,
+    Parameters<AddKindExecutionPlanFor<'transform'>['getValues']>[0]
+  >
+>;
+
+type PatternPlanCompatibility = ExpectTrue<
+  IsEqual<
+    Awaited<ReturnType<AddKindExecutionPlanFor<'pattern'>['execute']>>,
+    Parameters<AddKindExecutionPlanFor<'pattern'>['getValues']>[0]
+  >
+>;
+
 type BindingSourcePlanCompatibility = ExpectTrue<
   IsEqual<
     Awaited<ReturnType<AddKindExecutionPlanFor<'binding-source'>['execute']>>,
     Parameters<AddKindExecutionPlanFor<'binding-source'>['getValues']>[0]
   >
 >;
+
+type RestResourcePlanCompatibility = ExpectTrue<
+  IsEqual<
+    Awaited<ReturnType<AddKindExecutionPlanFor<'rest-resource'>['execute']>>,
+    Parameters<AddKindExecutionPlanFor<'rest-resource'>['getValues']>[0]
+  >
+>;
+
+type AbilityPlanCompatibility = ExpectTrue<
+  IsEqual<
+    Awaited<ReturnType<AddKindExecutionPlanFor<'ability'>['execute']>>,
+    Parameters<AddKindExecutionPlanFor<'ability'>['getValues']>[0]
+  >
+>;
+
+type AiFeaturePlanCompatibility = ExpectTrue<
+  IsEqual<
+    Awaited<ReturnType<AddKindExecutionPlanFor<'ai-feature'>['execute']>>,
+    Parameters<AddKindExecutionPlanFor<'ai-feature'>['getValues']>[0]
+  >
+>;
+
+type HookedBlockPlanCompatibility = ExpectTrue<
+  IsEqual<
+    Awaited<ReturnType<AddKindExecutionPlanFor<'hooked-block'>['execute']>>,
+    Parameters<AddKindExecutionPlanFor<'hooked-block'>['getValues']>[0]
+  >
+>;
+
+type EditorPluginPlanCompatibility = ExpectTrue<
+  IsEqual<
+    Awaited<ReturnType<AddKindExecutionPlanFor<'editor-plugin'>['execute']>>,
+    Parameters<AddKindExecutionPlanFor<'editor-plugin'>['getValues']>[0]
+  >
+>;
+
 type SharedAddKindIdCompatibility = ExpectTrue<
   IsEqual<keyof typeof ADD_KIND_REGISTRY, AddKindId>
 >;
 
-const addKindPlanCompatibilityChecks: {
-  'admin-view': AdminViewPlanCompatibility;
-  'binding-source': BindingSourcePlanCompatibility;
-  registryKeys: SharedAddKindIdCompatibility;
-} = {
+const addKindPlanCompatibilityChecks = {
   'admin-view': true,
+  block: true,
+  variation: true,
+  style: true,
+  transform: true,
+  pattern: true,
   'binding-source': true,
+  'rest-resource': true,
+  ability: true,
+  'ai-feature': true,
+  'hooked-block': true,
+  'editor-plugin': true,
   registryKeys: true,
+} satisfies {
+  'admin-view': AdminViewPlanCompatibility;
+  block: BlockPlanCompatibility;
+  variation: VariationPlanCompatibility;
+  style: StylePlanCompatibility;
+  transform: TransformPlanCompatibility;
+  pattern: PatternPlanCompatibility;
+  'binding-source': BindingSourcePlanCompatibility;
+  'rest-resource': RestResourcePlanCompatibility;
+  ability: AbilityPlanCompatibility;
+  'ai-feature': AiFeaturePlanCompatibility;
+  'hooked-block': HookedBlockPlanCompatibility;
+  'editor-plugin': EditorPluginPlanCompatibility;
+  registryKeys: SharedAddKindIdCompatibility;
 };
 
-test('preserves compile-time compatibility between execute and getValues for representative add kinds', () => {
+test('preserves compile-time compatibility between execute and getValues for every add kind', () => {
   expect(addKindPlanCompatibilityChecks).toEqual({
     'admin-view': true,
+    block: true,
+    variation: true,
+    style: true,
+    transform: true,
+    pattern: true,
     'binding-source': true,
+    'rest-resource': true,
+    ability: true,
+    'ai-feature': true,
+    'hooked-block': true,
+    'editor-plugin': true,
     registryKeys: true,
   });
 });


### PR DESCRIPTION
## Summary
- replace loose interactivity scaffold function typings with safer callable signatures
- add workspace `wp-typia add block --template interactivity` regression coverage for generated store and directive helpers
- expand add-kind registry compatibility tests so every add kind validates execute/getValues alignment

## Testing
- `./node_modules/.bin/prettier --check .sampo/changesets/653-harden-interactivity-coverage.md packages/wp-typia-project-tools/src/runtime/built-in-block-code-templates/interactivity.ts packages/wp-typia/tests/add-kind-registry.test.ts packages/wp-typia/tests/add-command.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `export PATH=/tmp/codex-real-npm:/tmp/codex-bun-1.3.11/bun-darwin-aarch64:$PATH && cd packages/wp-typia && bun test tests/add-command.test.ts tests/add-kind-registry.test.ts`
- `export PATH=/tmp/codex-bun-1.3.11/bun-darwin-aarch64:$PATH && bun run --cwd packages/wp-typia-project-tools build && bun run --cwd packages/wp-typia build`
- `node scripts/validate-sampo-changesets.mjs`

Closes #653.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened interactivity block scaffold by replacing loose function types with stricter callable signatures for improved type safety.

* **Tests**
  * Added regression test coverage for workspace interactivity helpers.
  * Extended compatibility test coverage across all add-kind registry entries.
  * New integration test for interactivity template scaffolding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->