### PR TITLE
refactor: consolidate add-kind guard helpers

### DIFF
--- a/packages/wp-typia/src/add-kind-registry.ts
+++ b/packages/wp-typia/src/add-kind-registry.ts
@@ -144,6 +144,54 @@ const BLOCK_VISIBLE_FIELD_ORDER = [
   'data-storage',
   'persistence-policy',
 ] as const satisfies ReadonlyArray<AddFieldName>;
+const NAME_ONLY_VISIBLE_FIELDS = [
+  'kind',
+  'name',
+] as const satisfies ReadonlyArray<AddFieldName>;
+const NAME_SOURCE_VISIBLE_FIELDS = [
+  'kind',
+  'name',
+  'source',
+] as const satisfies ReadonlyArray<AddFieldName>;
+const NAME_BLOCK_ATTRIBUTE_VISIBLE_FIELDS = [
+  'kind',
+  'name',
+  'block',
+  'attribute',
+] as const satisfies ReadonlyArray<AddFieldName>;
+const NAME_BLOCK_VISIBLE_FIELDS = [
+  'kind',
+  'name',
+  'block',
+] as const satisfies ReadonlyArray<AddFieldName>;
+const NAME_SLOT_VISIBLE_FIELDS = [
+  'kind',
+  'name',
+  'slot',
+] as const satisfies ReadonlyArray<AddFieldName>;
+const NAME_ANCHOR_POSITION_VISIBLE_FIELDS = [
+  'kind',
+  'name',
+  'anchor',
+  'position',
+] as const satisfies ReadonlyArray<AddFieldName>;
+const NAME_FROM_TO_VISIBLE_FIELDS = [
+  'kind',
+  'name',
+  'from',
+  'to',
+] as const satisfies ReadonlyArray<AddFieldName>;
+const NAME_NAMESPACE_METHODS_VISIBLE_FIELDS = [
+  'kind',
+  'name',
+  'namespace',
+  'methods',
+] as const satisfies ReadonlyArray<AddFieldName>;
+const NAME_NAMESPACE_VISIBLE_FIELDS = [
+  'kind',
+  'name',
+  'namespace',
+] as const satisfies ReadonlyArray<AddFieldName>;
 
 function readOptionalStringFlag(
   flags: Record<string, unknown>,
@@ -160,6 +208,40 @@ function readOptionalStringFlag(
     );
   }
   return value;
+}
+
+function requireStringFlag(
+  flags: Record<string, unknown>,
+  name: string,
+  message: string,
+): string {
+  const value = readOptionalStringFlag(flags, name);
+  if (!value) {
+    throw createCliDiagnosticCodeError(
+      CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
+      message,
+    );
+  }
+
+  return value;
+}
+
+function readOptionalPairedStringFlags(
+  flags: Record<string, unknown>,
+  leftName: string,
+  rightName: string,
+  message: string,
+): readonly [string | undefined, string | undefined] {
+  const leftValue = readOptionalStringFlag(flags, leftName);
+  const rightValue = readOptionalStringFlag(flags, rightName);
+  if (Boolean(leftValue) !== Boolean(rightValue)) {
+    throw createCliDiagnosticCodeError(
+      CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
+      message,
+    );
+  }
+
+  return [leftValue, rightValue] as const;
 }
 
 function requireAddKindName(
@@ -205,6 +287,26 @@ function defineAddKindRegistryEntry<TResult extends AddKindExecutionResultBase>(
   return entry;
 }
 
+function createNamedExecutionPlan<TResult extends AddKindExecutionResultBase>(
+  context: AddKindExecutionContext,
+  options: {
+    execute: (params: { cwd: string; name: string }) => Promise<TResult>;
+    getValues: (result: TResult) => Record<string, string>;
+    getWarnings?: (result: TResult) => string[] | undefined;
+    missingNameMessage: string;
+    warnLine?: PrintLine;
+  },
+): AddKindExecutionPlan<TResult> {
+  const name = requireAddKindName(context, options.missingNameMessage);
+
+  return {
+    execute: (cwd) => options.execute({ cwd, name }),
+    getValues: options.getValues,
+    ...(options.getWarnings ? { getWarnings: options.getWarnings } : {}),
+    ...(options.warnLine ? { warnLine: options.warnLine } : {}),
+  };
+}
+
 export function isAddPersistenceTemplate(template?: string): boolean {
   return template === 'persistence' || template === 'compound';
 }
@@ -226,30 +328,28 @@ export const ADD_KIND_REGISTRY = {
     description: 'Add an opt-in DataViews-powered admin screen',
     nameLabel: 'Admin view name',
     async prepareExecution(context) {
-      const name = requireAddKindName(
-        context,
-        '`wp-typia add admin-view` requires <name>. Usage: wp-typia add admin-view <name> [--source <rest-resource:slug|core-data:kind/name>].',
-      );
       const source = readOptionalStringFlag(context.flags, 'source');
 
-      return {
-        execute: (cwd) =>
+      return createNamedExecutionPlan(context, {
+        execute: ({ cwd, name }) =>
           context.addRuntime.runAddAdminViewCommand({
             adminViewName: name,
             cwd,
             source,
           }),
-        getValues: (result: AddAdminViewResult) => ({
+        getValues: (result) => ({
           adminViewSlug: result.adminViewSlug,
           ...(result.source ? { source: result.source } : {}),
         }),
-      };
+        missingNameMessage:
+          '`wp-typia add admin-view` requires <name>. Usage: wp-typia add admin-view <name> [--source <rest-resource:slug|core-data:kind/name>].',
+      });
     },
     sortOrder: 10,
     supportsDryRun: true,
     usage:
       'wp-typia add admin-view <name> [--source <rest-resource:slug|core-data:kind/name>] [--dry-run]',
-    visibleFieldNames: () => ['kind', 'name', 'source'],
+    visibleFieldNames: () => NAME_SOURCE_VISIBLE_FIELDS,
   }),
   'binding-source': defineAddKindRegistryEntry<AddBindingSourceResult>({
     completion: {
@@ -274,41 +374,37 @@ export const ADD_KIND_REGISTRY = {
     description: 'Add a shared block bindings source',
     nameLabel: 'Binding source name',
     async prepareExecution(context) {
-      const name = requireAddKindName(
-        context,
-        '`wp-typia add binding-source` requires <name>. Usage: wp-typia add binding-source <name> [--block <block-slug|namespace/block-slug> --attribute <attribute>].',
+      const [blockName, attributeName] = readOptionalPairedStringFlags(
+        context.flags,
+        'block',
+        'attribute',
+        '`wp-typia add binding-source` requires --block and --attribute to be provided together.',
       );
-      const blockName = readOptionalStringFlag(context.flags, 'block');
-      const attributeName = readOptionalStringFlag(context.flags, 'attribute');
-      if (Boolean(blockName) !== Boolean(attributeName)) {
-        throw createCliDiagnosticCodeError(
-          CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
-          '`wp-typia add binding-source` requires --block and --attribute to be provided together.',
-        );
-      }
 
-      return {
-        execute: (cwd) =>
+      return createNamedExecutionPlan(context, {
+        execute: ({ cwd, name }) =>
           context.addRuntime.runAddBindingSourceCommand({
             attributeName,
             bindingSourceName: name,
             blockName,
             cwd,
           }),
-        getValues: (result: AddBindingSourceResult) => ({
+        getValues: (result) => ({
           ...(result.attributeName
             ? { attributeName: result.attributeName }
             : {}),
           ...(result.blockSlug ? { blockSlug: result.blockSlug } : {}),
           bindingSourceSlug: result.bindingSourceSlug,
         }),
-      };
+        missingNameMessage:
+          '`wp-typia add binding-source` requires <name>. Usage: wp-typia add binding-source <name> [--block <block-slug|namespace/block-slug> --attribute <attribute>].',
+      });
     },
     sortOrder: 70,
     supportsDryRun: true,
     usage:
       'wp-typia add binding-source <name> [--block <block-slug|namespace/block-slug> --attribute <attribute>] [--dry-run]',
-    visibleFieldNames: () => ['kind', 'name', 'block', 'attribute'],
+    visibleFieldNames: () => NAME_BLOCK_ATTRIBUTE_VISIBLE_FIELDS,
   }),
   block: defineAddKindRegistryEntry<AddBlockResult>({
     completion: {
@@ -327,10 +423,6 @@ export const ADD_KIND_REGISTRY = {
     hiddenStringSubmitFields: ['external-layer-id', 'external-layer-source'],
     nameLabel: 'Block name',
     async prepareExecution(context) {
-      const name = requireAddKindName(
-        context,
-        '`wp-typia add block` requires <name>. Usage: wp-typia add block <name> [--template <basic|interactivity|persistence|compound>]',
-      );
       const externalLayerId = readOptionalStringFlag(
         context.flags,
         'external-layer-id',
@@ -380,8 +472,8 @@ export const ADD_KIND_REGISTRY = {
       }
       resolvedTemplateId ??= 'basic';
 
-      return {
-        execute: (cwd) =>
+      return createNamedExecutionPlan(context, {
+        execute: ({ cwd, name }) =>
           context.addRuntime.runAddBlockCommand({
             alternateRenderTargets,
             blockName: name,
@@ -401,13 +493,15 @@ export const ADD_KIND_REGISTRY = {
               : undefined,
             templateId: resolvedTemplateId,
           }),
-        getValues: (result: AddBlockResult) => ({
+        getValues: (result) => ({
           blockSlugs: result.blockSlugs.join(', '),
           templateId: result.templateId,
         }),
-        getWarnings: (result: AddBlockResult) => result.warnings,
+        getWarnings: (result) => result.warnings,
+        missingNameMessage:
+          '`wp-typia add block` requires <name>. Usage: wp-typia add block <name> [--template <basic|interactivity|persistence|compound>]',
         warnLine: context.warnLine,
-      };
+      });
     },
     sortOrder: 20,
     supportsDryRun: true,
@@ -445,26 +539,23 @@ export const ADD_KIND_REGISTRY = {
     description: 'Add a typed server/client workflow ability scaffold',
     nameLabel: 'Ability name',
     async prepareExecution(context) {
-      const name = requireAddKindName(
-        context,
-        '`wp-typia add ability` requires <name>. Usage: wp-typia add ability <name>.',
-      );
-
-      return {
-        execute: (cwd) =>
+      return createNamedExecutionPlan(context, {
+        execute: ({ cwd, name }) =>
           context.addRuntime.runAddAbilityCommand({
             abilityName: name,
             cwd,
           }),
-        getValues: (result: AddAbilityResult) => ({
+        getValues: (result) => ({
           abilitySlug: result.abilitySlug,
         }),
-      };
+        missingNameMessage:
+          '`wp-typia add ability` requires <name>. Usage: wp-typia add ability <name>.',
+      });
     },
     sortOrder: 90,
     supportsDryRun: true,
     usage: 'wp-typia add ability <name> [--dry-run]',
-    visibleFieldNames: () => ['kind', 'name'],
+    visibleFieldNames: () => NAME_ONLY_VISIBLE_FIELDS,
   }),
   'editor-plugin': defineAddKindRegistryEntry<AddEditorPluginResult>({
     completion: {
@@ -482,30 +573,28 @@ export const ADD_KIND_REGISTRY = {
     description: 'Add a slot-aware document editor extension shell',
     nameLabel: 'Editor plugin name',
     async prepareExecution(context) {
-      const name = requireAddKindName(
-        context,
-        '`wp-typia add editor-plugin` requires <name>. Usage: wp-typia add editor-plugin <name> [--slot <sidebar|document-setting-panel>].',
-      );
       const slot = readOptionalStringFlag(context.flags, 'slot');
 
-      return {
-        execute: (cwd) =>
+      return createNamedExecutionPlan(context, {
+        execute: ({ cwd, name }) =>
           context.addRuntime.runAddEditorPluginCommand({
             cwd,
             editorPluginName: name,
             slot,
           }),
-        getValues: (result: AddEditorPluginResult) => ({
+        getValues: (result) => ({
           editorPluginSlug: result.editorPluginSlug,
           slot: result.slot,
         }),
-      };
+        missingNameMessage:
+          '`wp-typia add editor-plugin` requires <name>. Usage: wp-typia add editor-plugin <name> [--slot <sidebar|document-setting-panel>].',
+      });
     },
     sortOrder: 120,
     supportsDryRun: true,
     usage:
       'wp-typia add editor-plugin <name> [--slot <sidebar|document-setting-panel>] [--dry-run]',
-    visibleFieldNames: () => ['kind', 'name', 'slot'],
+    visibleFieldNames: () => NAME_SLOT_VISIBLE_FIELDS,
   }),
   'hooked-block': defineAddKindRegistryEntry<AddHookedBlockResult>({
     completion: {
@@ -524,45 +613,39 @@ export const ADD_KIND_REGISTRY = {
     description: 'Add block.json hook metadata to an existing block',
     nameLabel: 'Target block',
     async prepareExecution(context) {
-      const name = requireAddKindName(
-        context,
-        '`wp-typia add hooked-block` requires <block-slug>. Usage: wp-typia add hooked-block <block-slug> --anchor <anchor-block-name> --position <before|after|firstChild|lastChild>.',
+      const anchorBlockName = requireStringFlag(
+        context.flags,
+        'anchor',
+        '`wp-typia add hooked-block` requires --anchor <anchor-block-name>.',
       );
-      const anchorBlockName = readOptionalStringFlag(context.flags, 'anchor');
-      if (!anchorBlockName) {
-        throw createCliDiagnosticCodeError(
-          CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
-          '`wp-typia add hooked-block` requires --anchor <anchor-block-name>.',
-        );
-      }
-      const position = readOptionalStringFlag(context.flags, 'position');
-      if (!position) {
-        throw createCliDiagnosticCodeError(
-          CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
-          '`wp-typia add hooked-block` requires --position <before|after|firstChild|lastChild>.',
-        );
-      }
+      const position = requireStringFlag(
+        context.flags,
+        'position',
+        '`wp-typia add hooked-block` requires --position <before|after|firstChild|lastChild>.',
+      );
 
-      return {
-        execute: (cwd) =>
+      return createNamedExecutionPlan(context, {
+        execute: ({ cwd, name }) =>
           context.addRuntime.runAddHookedBlockCommand({
             anchorBlockName,
             blockName: name,
             cwd,
             position,
           }),
-        getValues: (result: AddHookedBlockResult) => ({
+        getValues: (result) => ({
           anchorBlockName: result.anchorBlockName,
           blockSlug: result.blockSlug,
           position: result.position,
         }),
-      };
+        missingNameMessage:
+          '`wp-typia add hooked-block` requires <block-slug>. Usage: wp-typia add hooked-block <block-slug> --anchor <anchor-block-name> --position <before|after|firstChild|lastChild>.',
+      });
     },
     sortOrder: 110,
     supportsDryRun: true,
     usage:
       'wp-typia add hooked-block <block-slug> --anchor <anchor-block-name> --position <before|after|firstChild|lastChild> [--dry-run]',
-    visibleFieldNames: () => ['kind', 'name', 'anchor', 'position'],
+    visibleFieldNames: () => NAME_ANCHOR_POSITION_VISIBLE_FIELDS,
   }),
   pattern: defineAddKindRegistryEntry<AddPatternResult>({
     completion: {
@@ -579,26 +662,23 @@ export const ADD_KIND_REGISTRY = {
     description: 'Add a PHP block pattern shell',
     nameLabel: 'Pattern name',
     async prepareExecution(context) {
-      const name = requireAddKindName(
-        context,
-        '`wp-typia add pattern` requires <name>. Usage: wp-typia add pattern <name>.',
-      );
-
-      return {
-        execute: (cwd) =>
+      return createNamedExecutionPlan(context, {
+        execute: ({ cwd, name }) =>
           context.addRuntime.runAddPatternCommand({
             cwd,
             patternName: name,
           }),
-        getValues: (result: AddPatternResult) => ({
+        getValues: (result) => ({
           patternSlug: result.patternSlug,
         }),
-      };
+        missingNameMessage:
+          '`wp-typia add pattern` requires <name>. Usage: wp-typia add pattern <name>.',
+      });
     },
     sortOrder: 60,
     supportsDryRun: true,
     usage: 'wp-typia add pattern <name> [--dry-run]',
-    visibleFieldNames: () => ['kind', 'name'],
+    visibleFieldNames: () => NAME_ONLY_VISIBLE_FIELDS,
   }),
   style: defineAddKindRegistryEntry<AddBlockStyleResult>({
     completion: {
@@ -616,35 +696,31 @@ export const ADD_KIND_REGISTRY = {
     description: 'Add a Block Styles registration to an existing block',
     nameLabel: 'Style name',
     async prepareExecution(context) {
-      const name = requireAddKindName(
-        context,
-        '`wp-typia add style` requires <name>. Usage: wp-typia add style <name> --block <block-slug>.',
+      const blockSlug = requireStringFlag(
+        context.flags,
+        'block',
+        '`wp-typia add style` requires --block <block-slug>.',
       );
-      const blockSlug = readOptionalStringFlag(context.flags, 'block');
-      if (!blockSlug) {
-        throw createCliDiagnosticCodeError(
-          CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
-          '`wp-typia add style` requires --block <block-slug>.',
-        );
-      }
 
-      return {
-        execute: (cwd) =>
+      return createNamedExecutionPlan(context, {
+        execute: ({ cwd, name }) =>
           context.addRuntime.runAddBlockStyleCommand({
             blockName: blockSlug,
             cwd,
             styleName: name,
           }),
-        getValues: (result: AddBlockStyleResult) => ({
+        getValues: (result) => ({
           blockSlug: result.blockSlug,
           styleSlug: result.styleSlug,
         }),
-      };
+        missingNameMessage:
+          '`wp-typia add style` requires <name>. Usage: wp-typia add style <name> --block <block-slug>.',
+      });
     },
     sortOrder: 40,
     supportsDryRun: true,
     usage: 'wp-typia add style <name> --block <block-slug> [--dry-run]',
-    visibleFieldNames: () => ['kind', 'name', 'block'],
+    visibleFieldNames: () => NAME_BLOCK_VISIBLE_FIELDS,
   }),
   transform: defineAddKindRegistryEntry<AddBlockTransformResult>({
     completion: {
@@ -663,46 +739,40 @@ export const ADD_KIND_REGISTRY = {
     description: 'Add a block-to-block transform into a workspace block',
     nameLabel: 'Transform name',
     async prepareExecution(context) {
-      const name = requireAddKindName(
-        context,
-        '`wp-typia add transform` requires <name>. Usage: wp-typia add transform <name> --from <namespace/block> --to <block-slug|namespace/block-slug>.',
+      const fromBlockName = requireStringFlag(
+        context.flags,
+        'from',
+        '`wp-typia add transform` requires --from <namespace/block>.',
       );
-      const fromBlockName = readOptionalStringFlag(context.flags, 'from');
-      if (!fromBlockName) {
-        throw createCliDiagnosticCodeError(
-          CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
-          '`wp-typia add transform` requires --from <namespace/block>.',
-        );
-      }
-      const toBlockName = readOptionalStringFlag(context.flags, 'to');
-      if (!toBlockName) {
-        throw createCliDiagnosticCodeError(
-          CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
-          '`wp-typia add transform` requires --to <block-slug|namespace/block-slug>.',
-        );
-      }
+      const toBlockName = requireStringFlag(
+        context.flags,
+        'to',
+        '`wp-typia add transform` requires --to <block-slug|namespace/block-slug>.',
+      );
 
-      return {
-        execute: (cwd) =>
+      return createNamedExecutionPlan(context, {
+        execute: ({ cwd, name }) =>
           context.addRuntime.runAddBlockTransformCommand({
             cwd,
             fromBlockName,
             toBlockName,
             transformName: name,
           }),
-        getValues: (result: AddBlockTransformResult) => ({
+        getValues: (result) => ({
           blockSlug: result.blockSlug,
           fromBlockName: result.fromBlockName,
           toBlockName: result.toBlockName,
           transformSlug: result.transformSlug,
         }),
-      };
+        missingNameMessage:
+          '`wp-typia add transform` requires <name>. Usage: wp-typia add transform <name> --from <namespace/block> --to <block-slug|namespace/block-slug>.',
+      });
     },
     sortOrder: 50,
     supportsDryRun: true,
     usage:
       'wp-typia add transform <name> --from <namespace/block> --to <block-slug|namespace/block-slug> [--dry-run]',
-    visibleFieldNames: () => ['kind', 'name', 'from', 'to'],
+    visibleFieldNames: () => NAME_FROM_TO_VISIBLE_FIELDS,
   }),
   'rest-resource': defineAddKindRegistryEntry<AddRestResourceResult>({
     completion: {
@@ -721,33 +791,31 @@ export const ADD_KIND_REGISTRY = {
     description: 'Add a plugin-level typed REST resource',
     nameLabel: 'REST resource name',
     async prepareExecution(context) {
-      const name = requireAddKindName(
-        context,
-        '`wp-typia add rest-resource` requires <name>. Usage: wp-typia add rest-resource <name> [--namespace <vendor/v1>] [--methods <list,read,create>].',
-      );
       const methods = readOptionalStringFlag(context.flags, 'methods');
       const namespace = readOptionalStringFlag(context.flags, 'namespace');
 
-      return {
-        execute: (cwd) =>
+      return createNamedExecutionPlan(context, {
+        execute: ({ cwd, name }) =>
           context.addRuntime.runAddRestResourceCommand({
             cwd,
             methods,
             namespace,
             restResourceName: name,
           }),
-        getValues: (result: AddRestResourceResult) => ({
+        getValues: (result) => ({
           methods: result.methods.join(', '),
           namespace: result.namespace,
           restResourceSlug: result.restResourceSlug,
         }),
-      };
+        missingNameMessage:
+          '`wp-typia add rest-resource` requires <name>. Usage: wp-typia add rest-resource <name> [--namespace <vendor/v1>] [--methods <list,read,create>].',
+      });
     },
     sortOrder: 80,
     supportsDryRun: true,
     usage:
       'wp-typia add rest-resource <name> [--namespace <vendor/v1>] [--methods <list,read,create,update,delete>] [--dry-run]',
-    visibleFieldNames: () => ['kind', 'name', 'namespace', 'methods'],
+    visibleFieldNames: () => NAME_NAMESPACE_METHODS_VISIBLE_FIELDS,
   }),
   'ai-feature': defineAddKindRegistryEntry<AddAiFeatureResult>({
     completion: {
@@ -765,32 +833,30 @@ export const ADD_KIND_REGISTRY = {
     description: 'Add a server-owned WordPress AI feature endpoint',
     nameLabel: 'AI feature name',
     async prepareExecution(context) {
-      const name = requireAddKindName(
-        context,
-        '`wp-typia add ai-feature` requires <name>. Usage: wp-typia add ai-feature <name> [--namespace <vendor/v1>].',
-      );
       const namespace = readOptionalStringFlag(context.flags, 'namespace');
 
-      return {
-        execute: (cwd) =>
+      return createNamedExecutionPlan(context, {
+        execute: ({ cwd, name }) =>
           context.addRuntime.runAddAiFeatureCommand({
             aiFeatureName: name,
             cwd,
             namespace,
           }),
-        getValues: (result: AddAiFeatureResult) => ({
+        getValues: (result) => ({
           aiFeatureSlug: result.aiFeatureSlug,
           namespace: result.namespace,
         }),
-        getWarnings: (result: AddAiFeatureResult) => result.warnings,
+        getWarnings: (result) => result.warnings,
+        missingNameMessage:
+          '`wp-typia add ai-feature` requires <name>. Usage: wp-typia add ai-feature <name> [--namespace <vendor/v1>].',
         warnLine: context.warnLine,
-      };
+      });
     },
     sortOrder: 100,
     supportsDryRun: true,
     usage:
       'wp-typia add ai-feature <name> [--namespace <vendor/v1>] [--dry-run]',
-    visibleFieldNames: () => ['kind', 'name', 'namespace'],
+    visibleFieldNames: () => NAME_NAMESPACE_VISIBLE_FIELDS,
   }),
   variation: defineAddKindRegistryEntry<AddVariationResult>({
     completion: {
@@ -808,35 +874,31 @@ export const ADD_KIND_REGISTRY = {
     description: 'Add a variation to an existing block',
     nameLabel: 'Variation name',
     async prepareExecution(context) {
-      const name = requireAddKindName(
-        context,
-        '`wp-typia add variation` requires <name>. Usage: wp-typia add variation <name> --block <block-slug>',
+      const blockSlug = requireStringFlag(
+        context.flags,
+        'block',
+        '`wp-typia add variation` requires --block <block-slug>.',
       );
-      const blockSlug = readOptionalStringFlag(context.flags, 'block');
-      if (!blockSlug) {
-        throw createCliDiagnosticCodeError(
-          CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
-          '`wp-typia add variation` requires --block <block-slug>.',
-        );
-      }
 
-      return {
-        execute: (cwd) =>
+      return createNamedExecutionPlan(context, {
+        execute: ({ cwd, name }) =>
           context.addRuntime.runAddVariationCommand({
             blockName: blockSlug,
             cwd,
             variationName: name,
           }),
-        getValues: (result: AddVariationResult) => ({
+        getValues: (result) => ({
           blockSlug: result.blockSlug,
           variationSlug: result.variationSlug,
         }),
-      };
+        missingNameMessage:
+          '`wp-typia add variation` requires <name>. Usage: wp-typia add variation <name> --block <block-slug>',
+      });
     },
     sortOrder: 30,
     supportsDryRun: true,
     usage: 'wp-typia add variation <name> --block <block-slug> [--dry-run]',
-    visibleFieldNames: () => ['kind', 'name', 'block'],
+    visibleFieldNames: () => NAME_BLOCK_VISIBLE_FIELDS,
   }),
 } as const satisfies AddKindRegistry;
 

--- a/packages/wp-typia/src/add-kind-registry.ts
+++ b/packages/wp-typia/src/add-kind-registry.ts
@@ -294,10 +294,12 @@ function createNamedExecutionPlan<TResult extends AddKindExecutionResultBase>(
     getValues: (result: TResult) => Record<string, string>;
     getWarnings?: (result: TResult) => string[] | undefined;
     missingNameMessage: string;
+    name?: string;
     warnLine?: PrintLine;
   },
 ): AddKindExecutionPlan<TResult> {
-  const name = requireAddKindName(context, options.missingNameMessage);
+  const name =
+    options.name ?? requireAddKindName(context, options.missingNameMessage);
 
   return {
     execute: (cwd) => options.execute({ cwd, name }),
@@ -328,6 +330,10 @@ export const ADD_KIND_REGISTRY = {
     description: 'Add an opt-in DataViews-powered admin screen',
     nameLabel: 'Admin view name',
     async prepareExecution(context) {
+      const name = requireAddKindName(
+        context,
+        '`wp-typia add admin-view` requires <name>. Usage: wp-typia add admin-view <name> [--source <rest-resource:slug|core-data:kind/name>].',
+      );
       const source = readOptionalStringFlag(context.flags, 'source');
 
       return createNamedExecutionPlan(context, {
@@ -343,6 +349,7 @@ export const ADD_KIND_REGISTRY = {
         }),
         missingNameMessage:
           '`wp-typia add admin-view` requires <name>. Usage: wp-typia add admin-view <name> [--source <rest-resource:slug|core-data:kind/name>].',
+        name,
       });
     },
     sortOrder: 10,
@@ -374,6 +381,10 @@ export const ADD_KIND_REGISTRY = {
     description: 'Add a shared block bindings source',
     nameLabel: 'Binding source name',
     async prepareExecution(context) {
+      const name = requireAddKindName(
+        context,
+        '`wp-typia add binding-source` requires <name>. Usage: wp-typia add binding-source <name> [--block <block-slug|namespace/block-slug> --attribute <attribute>].',
+      );
       const [blockName, attributeName] = readOptionalPairedStringFlags(
         context.flags,
         'block',
@@ -398,6 +409,7 @@ export const ADD_KIND_REGISTRY = {
         }),
         missingNameMessage:
           '`wp-typia add binding-source` requires <name>. Usage: wp-typia add binding-source <name> [--block <block-slug|namespace/block-slug> --attribute <attribute>].',
+        name,
       });
     },
     sortOrder: 70,
@@ -476,8 +488,8 @@ export const ADD_KIND_REGISTRY = {
       }
       resolvedTemplateId ??= 'basic';
 
-      return {
-        execute: (cwd) =>
+      return createNamedExecutionPlan(context, {
+        execute: ({ cwd, name }) =>
           context.addRuntime.runAddBlockCommand({
             alternateRenderTargets,
             blockName: name,
@@ -502,8 +514,11 @@ export const ADD_KIND_REGISTRY = {
           templateId: result.templateId,
         }),
         getWarnings: (result) => result.warnings,
+        missingNameMessage:
+          '`wp-typia add block` requires <name>. Usage: wp-typia add block <name> [--template <basic|interactivity|persistence|compound>]',
+        name,
         warnLine: context.warnLine,
-      };
+      });
     },
     sortOrder: 20,
     supportsDryRun: true,
@@ -575,6 +590,10 @@ export const ADD_KIND_REGISTRY = {
     description: 'Add a slot-aware document editor extension shell',
     nameLabel: 'Editor plugin name',
     async prepareExecution(context) {
+      const name = requireAddKindName(
+        context,
+        '`wp-typia add editor-plugin` requires <name>. Usage: wp-typia add editor-plugin <name> [--slot <sidebar|document-setting-panel>].',
+      );
       const slot = readOptionalStringFlag(context.flags, 'slot');
 
       return createNamedExecutionPlan(context, {
@@ -590,6 +609,7 @@ export const ADD_KIND_REGISTRY = {
         }),
         missingNameMessage:
           '`wp-typia add editor-plugin` requires <name>. Usage: wp-typia add editor-plugin <name> [--slot <sidebar|document-setting-panel>].',
+        name,
       });
     },
     sortOrder: 120,
@@ -615,6 +635,10 @@ export const ADD_KIND_REGISTRY = {
     description: 'Add block.json hook metadata to an existing block',
     nameLabel: 'Target block',
     async prepareExecution(context) {
+      const name = requireAddKindName(
+        context,
+        '`wp-typia add hooked-block` requires <block-slug>. Usage: wp-typia add hooked-block <block-slug> --anchor <anchor-block-name> --position <before|after|firstChild|lastChild>.',
+      );
       const anchorBlockName = requireStringFlag(
         context.flags,
         'anchor',
@@ -641,6 +665,7 @@ export const ADD_KIND_REGISTRY = {
         }),
         missingNameMessage:
           '`wp-typia add hooked-block` requires <block-slug>. Usage: wp-typia add hooked-block <block-slug> --anchor <anchor-block-name> --position <before|after|firstChild|lastChild>.',
+        name,
       });
     },
     sortOrder: 110,
@@ -698,6 +723,10 @@ export const ADD_KIND_REGISTRY = {
     description: 'Add a Block Styles registration to an existing block',
     nameLabel: 'Style name',
     async prepareExecution(context) {
+      const name = requireAddKindName(
+        context,
+        '`wp-typia add style` requires <name>. Usage: wp-typia add style <name> --block <block-slug>.',
+      );
       const blockSlug = requireStringFlag(
         context.flags,
         'block',
@@ -717,6 +746,7 @@ export const ADD_KIND_REGISTRY = {
         }),
         missingNameMessage:
           '`wp-typia add style` requires <name>. Usage: wp-typia add style <name> --block <block-slug>.',
+        name,
       });
     },
     sortOrder: 40,
@@ -741,6 +771,10 @@ export const ADD_KIND_REGISTRY = {
     description: 'Add a block-to-block transform into a workspace block',
     nameLabel: 'Transform name',
     async prepareExecution(context) {
+      const name = requireAddKindName(
+        context,
+        '`wp-typia add transform` requires <name>. Usage: wp-typia add transform <name> --from <namespace/block> --to <block-slug|namespace/block-slug>.',
+      );
       const fromBlockName = requireStringFlag(
         context.flags,
         'from',
@@ -768,6 +802,7 @@ export const ADD_KIND_REGISTRY = {
         }),
         missingNameMessage:
           '`wp-typia add transform` requires <name>. Usage: wp-typia add transform <name> --from <namespace/block> --to <block-slug|namespace/block-slug>.',
+        name,
       });
     },
     sortOrder: 50,
@@ -793,6 +828,10 @@ export const ADD_KIND_REGISTRY = {
     description: 'Add a plugin-level typed REST resource',
     nameLabel: 'REST resource name',
     async prepareExecution(context) {
+      const name = requireAddKindName(
+        context,
+        '`wp-typia add rest-resource` requires <name>. Usage: wp-typia add rest-resource <name> [--namespace <vendor/v1>] [--methods <list,read,create>].',
+      );
       const methods = readOptionalStringFlag(context.flags, 'methods');
       const namespace = readOptionalStringFlag(context.flags, 'namespace');
 
@@ -811,6 +850,7 @@ export const ADD_KIND_REGISTRY = {
         }),
         missingNameMessage:
           '`wp-typia add rest-resource` requires <name>. Usage: wp-typia add rest-resource <name> [--namespace <vendor/v1>] [--methods <list,read,create>].',
+        name,
       });
     },
     sortOrder: 80,
@@ -835,6 +875,10 @@ export const ADD_KIND_REGISTRY = {
     description: 'Add a server-owned WordPress AI feature endpoint',
     nameLabel: 'AI feature name',
     async prepareExecution(context) {
+      const name = requireAddKindName(
+        context,
+        '`wp-typia add ai-feature` requires <name>. Usage: wp-typia add ai-feature <name> [--namespace <vendor/v1>].',
+      );
       const namespace = readOptionalStringFlag(context.flags, 'namespace');
 
       return createNamedExecutionPlan(context, {
@@ -851,6 +895,7 @@ export const ADD_KIND_REGISTRY = {
         getWarnings: (result) => result.warnings,
         missingNameMessage:
           '`wp-typia add ai-feature` requires <name>. Usage: wp-typia add ai-feature <name> [--namespace <vendor/v1>].',
+        name,
         warnLine: context.warnLine,
       });
     },
@@ -876,6 +921,10 @@ export const ADD_KIND_REGISTRY = {
     description: 'Add a variation to an existing block',
     nameLabel: 'Variation name',
     async prepareExecution(context) {
+      const name = requireAddKindName(
+        context,
+        '`wp-typia add variation` requires <name>. Usage: wp-typia add variation <name> --block <block-slug>',
+      );
       const blockSlug = requireStringFlag(
         context.flags,
         'block',
@@ -895,6 +944,7 @@ export const ADD_KIND_REGISTRY = {
         }),
         missingNameMessage:
           '`wp-typia add variation` requires <name>. Usage: wp-typia add variation <name> --block <block-slug>',
+        name,
       });
     },
     sortOrder: 30,

--- a/packages/wp-typia/src/add-kind-registry.ts
+++ b/packages/wp-typia/src/add-kind-registry.ts
@@ -423,6 +423,10 @@ export const ADD_KIND_REGISTRY = {
     hiddenStringSubmitFields: ['external-layer-id', 'external-layer-source'],
     nameLabel: 'Block name',
     async prepareExecution(context) {
+      const name = requireAddKindName(
+        context,
+        '`wp-typia add block` requires <name>. Usage: wp-typia add block <name> [--template <basic|interactivity|persistence|compound>]',
+      );
       const externalLayerId = readOptionalStringFlag(
         context.flags,
         'external-layer-id',
@@ -472,8 +476,8 @@ export const ADD_KIND_REGISTRY = {
       }
       resolvedTemplateId ??= 'basic';
 
-      return createNamedExecutionPlan(context, {
-        execute: ({ cwd, name }) =>
+      return {
+        execute: (cwd) =>
           context.addRuntime.runAddBlockCommand({
             alternateRenderTargets,
             blockName: name,
@@ -498,10 +502,8 @@ export const ADD_KIND_REGISTRY = {
           templateId: result.templateId,
         }),
         getWarnings: (result) => result.warnings,
-        missingNameMessage:
-          '`wp-typia add block` requires <name>. Usage: wp-typia add block <name> [--template <basic|interactivity|persistence|compound>]',
         warnLine: context.warnLine,
-      });
+      };
     },
     sortOrder: 20,
     supportsDryRun: true,

--- a/packages/wp-typia/tests/add-command.test.ts
+++ b/packages/wp-typia/tests/add-command.test.ts
@@ -368,6 +368,78 @@ describe('wp-typia add command bridge', () => {
     expect(selectedPrompts).toEqual([]);
   }, 15_000);
 
+  test('named add commands validate the missing name before flag-specific errors', async () => {
+    const projectDir = path.join(
+      tempRoot,
+      'demo-add-missing-name-validation-order',
+    );
+
+    await scaffoldOfficialWorkspace(projectDir);
+    linkWorkspaceNodeModules(projectDir);
+
+    const cases = [
+      {
+        flags: {
+          block: 'counter-card',
+        },
+        kind: 'variation' as const,
+        message:
+          '`wp-typia add variation` requires <name>. Usage: wp-typia add variation <name> --block <block-slug>',
+      },
+      {
+        flags: {},
+        kind: 'style' as const,
+        message:
+          '`wp-typia add style` requires <name>. Usage: wp-typia add style <name> --block <block-slug>.',
+      },
+      {
+        flags: {
+          to: 'counter-card',
+        },
+        kind: 'transform' as const,
+        message:
+          '`wp-typia add transform` requires <name>. Usage: wp-typia add transform <name> --from <namespace/block> --to <block-slug|namespace/block-slug>.',
+      },
+      {
+        flags: {
+          position: 'after',
+        },
+        kind: 'hooked-block' as const,
+        message:
+          '`wp-typia add hooked-block` requires <block-slug>. Usage: wp-typia add hooked-block <block-slug> --anchor <anchor-block-name> --position <before|after|firstChild|lastChild>.',
+      },
+      {
+        flags: {
+          block: 'counter-card',
+        },
+        kind: 'binding-source' as const,
+        message:
+          '`wp-typia add binding-source` requires <name>. Usage: wp-typia add binding-source <name> [--block <block-slug|namespace/block-slug> --attribute <attribute>].',
+      },
+    ] satisfies Array<{
+      flags: Record<string, unknown>;
+      kind:
+        | 'binding-source'
+        | 'hooked-block'
+        | 'style'
+        | 'transform'
+        | 'variation';
+      message: string;
+    }>;
+
+    for (const { flags, kind, message } of cases) {
+      await expect(
+        executeAddCommand({
+          cwd: projectDir,
+          emitOutput: false,
+          flags,
+          interactive: false,
+          kind,
+        }),
+      ).rejects.toThrow(message);
+    }
+  }, 15_000);
+
   test('every registered add kind currently advertises dry-run support', () => {
     expect(ADD_KIND_IDS.every((kind) => supportsAddKindDryRun(kind))).toBe(
       true,

--- a/packages/wp-typia/tests/add-command.test.ts
+++ b/packages/wp-typia/tests/add-command.test.ts
@@ -336,6 +336,38 @@ describe('wp-typia add command bridge', () => {
     ).toBe(true);
   }, 15_000);
 
+  test('interactive add block validates the missing name before prompting', async () => {
+    const projectDir = path.join(tempRoot, 'demo-add-interactive-missing-name');
+    const selectedPrompts: string[] = [];
+    const prompt: ReadlinePrompt = {
+      close() {},
+      async select(message: string) {
+        selectedPrompts.push(message);
+        throw new Error('select() should not be called before name validation');
+      },
+      async text() {
+        throw new Error('text() should not be called before name validation');
+      },
+    };
+
+    await scaffoldOfficialWorkspace(projectDir);
+    linkWorkspaceNodeModules(projectDir);
+
+    await expect(
+      executeAddCommand({
+        cwd: projectDir,
+        emitOutput: false,
+        flags: {},
+        interactive: true,
+        kind: 'block',
+        prompt,
+      }),
+    ).rejects.toThrow(
+      '`wp-typia add block` requires <name>. Usage: wp-typia add block <name> [--template <basic|interactivity|persistence|compound>]',
+    );
+    expect(selectedPrompts).toEqual([]);
+  }, 15_000);
+
   test('every registered add kind currently advertises dry-run support', () => {
     expect(ADD_KIND_IDS.every((kind) => supportsAddKindDryRun(kind))).toBe(
       true,

--- a/packages/wp-typia/tests/add-kind-registry.test.ts
+++ b/packages/wp-typia/tests/add-kind-registry.test.ts
@@ -5,6 +5,7 @@ import {
   ADD_KIND_REGISTRY,
   type AddKindId,
   type AddKindExecutionPlanFor,
+  getAddVisibleFieldNames,
 } from '../src/add-kind-registry';
 
 type ExpectTrue<TValue extends true> = TValue;
@@ -157,4 +158,48 @@ test('keeps shared add-kind ids aligned with registry sort order', () => {
       .sort(([, left], [, right]) => left.sortOrder - right.sortOrder)
       .map(([kind]) => kind),
   ).toEqual([...ADD_KIND_IDS]);
+});
+
+test('keeps shared visible-field groups aligned for refactored add kinds', () => {
+  expect(getAddVisibleFieldNames({ kind: 'admin-view' })).toEqual([
+    'kind',
+    'name',
+    'source',
+  ]);
+  expect(getAddVisibleFieldNames({ kind: 'style' })).toEqual([
+    'kind',
+    'name',
+    'block',
+  ]);
+  expect(getAddVisibleFieldNames({ kind: 'variation' })).toEqual([
+    'kind',
+    'name',
+    'block',
+  ]);
+  expect(getAddVisibleFieldNames({ kind: 'transform' })).toEqual([
+    'kind',
+    'name',
+    'from',
+    'to',
+  ]);
+  expect(getAddVisibleFieldNames({ kind: 'hooked-block' })).toEqual([
+    'kind',
+    'name',
+    'anchor',
+    'position',
+  ]);
+  expect(getAddVisibleFieldNames({ kind: 'block', template: 'basic' })).toEqual(
+    ['kind', 'name', 'template'],
+  );
+  expect(
+    getAddVisibleFieldNames({ kind: 'block', template: 'compound' }),
+  ).toEqual([
+    'kind',
+    'name',
+    'template',
+    'alternate-render-targets',
+    'inner-blocks-preset',
+    'data-storage',
+    'persistence-policy',
+  ]);
 });


### PR DESCRIPTION
## Summary
- extract shared add-kind guard helpers for required flags, paired flags, and named execution plans
- collapse repeated visible-field groups behind shared constants so add-kind metadata stays aligned
- add regression coverage for the shared visible-field layouts that the refactor now reuses

## Testing
- `./node_modules/.bin/tsc --noEmit`
- `export PATH=/tmp/codex-real-npm:/tmp/codex-bun-1.3.11/bun-darwin-aarch64:$PATH && cd packages/wp-typia && bun test tests/add-kind-registry.test.ts tests/add-command.test.ts tests/cli-package.test.ts`
- `export PATH=/tmp/codex-bun-1.3.11/bun-darwin-aarch64:$PATH && bun run --cwd packages/wp-typia build`

## Notes
- No changeset: this refactor keeps the CLI contract and output behavior unchanged while reducing duplication in the registry implementation.

Closes #654.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive validation tests for visible field groups across multiple add-kind configurations to ensure consistency and correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->