### PR TITLE
fix: preserve AI adapter schema constraints

### DIFF
--- a/.sampo/changesets/663-align-wp-typia-project-tools-pin.md
+++ b/.sampo/changesets/663-align-wp-typia-project-tools-pin.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Keep the exact `@wp-typia/project-tools` release lane aligned with the patch planned for the OpenAPI-backed `typia.llm` constraint restoration helpers.

--- a/.sampo/changesets/663-preserve-ai-adapter-constraints.md
+++ b/.sampo/changesets/663-preserve-ai-adapter-constraints.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Promoted reusable OpenAPI-backed constraint restoration for `typia.llm` adapter artifacts into `@wp-typia/project-tools`, including mixed body/query input coverage and regression tests that keep the example adapter path aligned with the supported helper surface.

--- a/examples/api-contract-adapter-poc/scripts/sync-typia-llm.ts
+++ b/examples/api-contract-adapter-poc/scripts/sync-typia-llm.ts
@@ -6,15 +6,16 @@ import { createRequire } from "node:module";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { promisify } from "node:util";
 
-import type { ILlmFunction, ILlmSchema, ILlmStructuredOutput } from "typia";
+import type { ILlmFunction, ILlmStructuredOutput } from "typia";
 import { BLOCKS } from "../../persistence-examples/scripts/block-config";
 import type { EndpointManifestDefinition } from "../../../packages/wp-typia-block-runtime/src/metadata-core";
+import type { OpenApiDocument } from "@wp-typia/project-tools/schema-core";
 import {
   buildTypiaLlmEndpointMethodDescriptors,
-  projectTypiaLlmApplicationArtifact,
   projectTypiaLlmStructuredOutputArtifact,
   renderTypiaLlmModule,
   syncTypiaLlmAdapterModule,
+  projectTypiaLlmApplicationArtifact,
   type ProjectedTypiaLlmApplicationArtifact,
   type ProjectedTypiaLlmStructuredOutputArtifact,
   type TypiaLlmEndpointMethodDescriptor,
@@ -27,14 +28,6 @@ export type {
 } from "@wp-typia/project-tools/typia-llm";
 
 const execFileAsync = promisify(execFile);
-
-type JsonObject = Record<string, unknown>;
-type OpenApiDocument = {
-  components?: {
-    schemas?: Record<string, JsonObject>;
-  };
-  paths?: Record<string, JsonObject>;
-};
 
 interface SyncTypiaLlmCliOptions {
   check: boolean;
@@ -209,193 +202,6 @@ async function reconcileGeneratedArtifacts(
   }
 }
 
-function cloneJson<T>(value: T): T {
-  return JSON.parse(JSON.stringify(value)) as T;
-}
-
-function isJsonObject(value: unknown): value is JsonObject {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function resolveOpenApiSchema(
-  document: OpenApiDocument,
-  schema: unknown
-): JsonObject {
-  if (!isJsonObject(schema)) {
-    return {};
-  }
-
-  const reference = schema.$ref;
-  if (typeof reference !== "string") {
-    return schema;
-  }
-
-  const match = reference.match(/^#\/components\/schemas\/(.+)$/);
-  if (!match) {
-    throw new Error(`Unsupported OpenAPI schema reference "${reference}".`);
-  }
-
-  const resolved = document.components?.schemas?.[match[1]];
-  if (!resolved) {
-    throw new Error(
-      `Unable to resolve OpenAPI schema reference "${reference}".`
-    );
-  }
-
-  return resolved;
-}
-
-function mergeOpenApiSchema(
-  target: JsonObject,
-  source: JsonObject
-): JsonObject {
-  const merged = target;
-
-  for (const key of [
-    "type",
-    "minimum",
-    "maximum",
-    "exclusiveMinimum",
-    "exclusiveMaximum",
-    "minLength",
-    "maxLength",
-    "minItems",
-    "maxItems",
-    "multipleOf",
-    "pattern",
-    "format",
-    "default",
-    "enum",
-    "const",
-    "additionalProperties",
-  ] as const) {
-    if (source[key] !== undefined) {
-      merged[key] = cloneJson(source[key]);
-    }
-  }
-
-  if (Array.isArray(source.required)) {
-    merged.required = [...source.required];
-  }
-
-  if (isJsonObject(source.items)) {
-    const nextItems = isJsonObject(merged.items) ? merged.items : {};
-    merged.items = mergeOpenApiSchema(nextItems, source.items);
-  }
-
-  if (isJsonObject(source.properties)) {
-    const targetProperties = isJsonObject(merged.properties)
-      ? merged.properties
-      : {};
-
-    for (const [propertyName, propertySchema] of Object.entries(
-      source.properties
-    )) {
-      if (!isJsonObject(propertySchema)) {
-        continue;
-      }
-
-      const nextProperty = isJsonObject(targetProperties[propertyName])
-        ? targetProperties[propertyName]
-        : {};
-      targetProperties[propertyName] = mergeOpenApiSchema(
-        nextProperty,
-        propertySchema
-      );
-    }
-
-    merged.properties = targetProperties;
-  }
-
-  return merged;
-}
-
-function findOperationById(
-  document: OpenApiDocument,
-  operationId: string
-): JsonObject | null {
-  for (const pathItem of Object.values(document.paths ?? {})) {
-    if (!isJsonObject(pathItem)) {
-      continue;
-    }
-
-    for (const method of ["delete", "get", "patch", "post", "put"] as const) {
-      const operation = pathItem[method];
-      if (!isJsonObject(operation)) {
-        continue;
-      }
-
-      if (operation.operationId === operationId) {
-        return operation;
-      }
-    }
-  }
-
-  return null;
-}
-
-function applyOpenApiConstraintsToFunctionParameters(
-  parameters: ILlmSchema.IParameters,
-  operation: JsonObject | null,
-  document: OpenApiDocument
-): ILlmSchema.IParameters {
-  const mergedParameters = cloneJson(parameters) as unknown as JsonObject;
-
-  if (!operation) {
-    return mergedParameters as unknown as ILlmSchema.IParameters;
-  }
-
-  const requestBodySchema = resolveOpenApiSchema(
-    document,
-    operation.requestBody &&
-      isJsonObject(operation.requestBody) &&
-      isJsonObject(operation.requestBody.content) &&
-      isJsonObject(operation.requestBody.content["application/json"]) &&
-      isJsonObject(operation.requestBody.content["application/json"].schema)
-      ? operation.requestBody.content["application/json"].schema
-      : null
-  );
-  mergeOpenApiSchema(mergedParameters, requestBodySchema);
-
-  for (const parameter of Array.isArray(operation.parameters)
-    ? operation.parameters
-    : []) {
-    if (
-      !isJsonObject(parameter) ||
-      parameter.in !== "query" ||
-      typeof parameter.name !== "string"
-    ) {
-      continue;
-    }
-
-    const targetProperties = isJsonObject(mergedParameters.properties)
-      ? mergedParameters.properties
-      : {};
-    const existingProperty = targetProperties[parameter.name];
-    const nextProperty: JsonObject = isJsonObject(existingProperty)
-      ? existingProperty
-      : {};
-
-    targetProperties[parameter.name] = mergeOpenApiSchema(
-      nextProperty,
-      resolveOpenApiSchema(document, parameter.schema)
-    );
-    mergedParameters.properties = targetProperties;
-
-    if (parameter.required === true) {
-      const required = new Set(
-        Array.isArray(mergedParameters.required)
-          ? mergedParameters.required
-          : []
-      );
-      required.add(parameter.name);
-      mergedParameters.required = [...required];
-    }
-  }
-
-  return mergedParameters as unknown as ILlmSchema.IParameters;
-}
-
 async function readCounterOpenApiDocument(): Promise<OpenApiDocument> {
   return JSON.parse(
     await readFile(getCounterOpenApiFile(), "utf8")
@@ -477,14 +283,9 @@ export async function buildCounterTypiaLlmArtifacts(): Promise<{
           blockSlug: COUNTER_BLOCK.slug,
           manifestSource: "endpoint-manifest+typescript",
         },
-        transformFunction: (functionArtifact, functionSchema) => ({
-          ...functionArtifact,
-          parameters: applyOpenApiConstraintsToFunctionParameters(
-            functionSchema.parameters as ILlmSchema.IParameters,
-            findOperationById(openApiDocument, functionSchema.name),
-            openApiDocument
-          ),
-        }),
+        openApiProjection: {
+          openApiDocument,
+        },
       }),
       structuredOutputArtifact: projectTypiaLlmStructuredOutputArtifact({
         generatedFrom: {

--- a/examples/api-contract-adapter-poc/src/typia-llm/counter.llm.application.json
+++ b/examples/api-contract-adapter-poc/src/typia-llm/counter.llm.application.json
@@ -9,7 +9,9 @@
         "properties": {
           "postId": {
             "type": "integer",
-            "minimum": 0
+            "minimum": 0,
+            "maximum": 4294967295,
+            "multipleOf": 1
           },
           "resourceKey": {
             "type": "string",
@@ -18,7 +20,9 @@
           },
           "count": {
             "type": "integer",
-            "minimum": 0
+            "minimum": 0,
+            "maximum": 4294967295,
+            "multipleOf": 1
           },
           "storage": {
             "type": "string",
@@ -70,7 +74,9 @@
         "properties": {
           "postId": {
             "type": "integer",
-            "minimum": 0
+            "minimum": 0,
+            "maximum": 4294967295,
+            "multipleOf": 1
           },
           "resourceKey": {
             "type": "string",
@@ -79,7 +85,9 @@
           },
           "count": {
             "type": "integer",
-            "minimum": 0
+            "minimum": 0,
+            "maximum": 4294967295,
+            "multipleOf": 1
           },
           "storage": {
             "type": "string",

--- a/packages/wp-typia-project-tools/src/runtime/typia-llm.ts
+++ b/packages/wp-typia-project-tools/src/runtime/typia-llm.ts
@@ -338,9 +338,46 @@ function isJsonSchemaObject(value: unknown): value is JsonSchemaObject {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
+function decodeJsonPointerSegment(segment: string): string {
+  return segment.replace(/~1/g, '/').replace(/~0/g, '~');
+}
+
+function resolveOpenApiReferenceTarget(
+  document: OpenApiDocument,
+  reference: string,
+): unknown {
+  if (!reference.startsWith('#/')) {
+    throw new Error(`Unsupported OpenAPI schema reference "${reference}".`);
+  }
+
+  let current: unknown = document;
+  for (const rawSegment of reference.slice(2).split('/')) {
+    const segment = decodeJsonPointerSegment(rawSegment);
+    if (Array.isArray(current)) {
+      const index = Number.parseInt(segment, 10);
+      current = Number.isInteger(index) ? current[index] : undefined;
+      continue;
+    }
+    if (!isJsonSchemaObject(current)) {
+      current = undefined;
+      break;
+    }
+    current = current[segment];
+  }
+
+  if (!isJsonSchemaObject(current)) {
+    throw new Error(
+      `Unable to resolve OpenAPI schema reference "${reference}".`,
+    );
+  }
+
+  return current;
+}
+
 function resolveOpenApiSchemaObject(
   document: OpenApiDocument,
   schema: unknown,
+  seenReferences: ReadonlySet<string> = new Set(),
 ): JsonSchemaObject {
   if (!isJsonSchemaObject(schema)) {
     return {};
@@ -351,58 +388,55 @@ function resolveOpenApiSchemaObject(
     return schema;
   }
 
-  const match = reference.match(/^#\/components\/schemas\/(.+)$/u);
-  if (!match) {
-    throw new Error(`Unsupported OpenAPI schema reference "${reference}".`);
+  if (seenReferences.has(reference)) {
+    throw new Error(`Detected recursive OpenAPI schema reference "${reference}".`);
   }
 
-  const componentName = match[1];
-  if (!componentName) {
-    throw new Error(`Unsupported OpenAPI schema reference "${reference}".`);
-  }
-
-  const resolved = document.components.schemas[componentName];
-  if (!resolved) {
-    throw new Error(
-      `Unable to resolve OpenAPI schema reference "${reference}".`,
-    );
-  }
-
-  return resolved;
+  return resolveOpenApiSchemaObject(
+    document,
+    resolveOpenApiReferenceTarget(document, reference),
+    new Set([...seenReferences, reference]),
+  );
 }
 
 function mergeJsonSchemaConstraintProperties(
+  document: OpenApiDocument,
   target: JsonSchemaObject,
   source: JsonSchemaObject,
 ): JsonSchemaObject {
+  const resolvedSource = resolveOpenApiSchemaObject(document, source);
   const merged = target;
 
   for (const key of JSON_SCHEMA_CONSTRAINT_KEYS) {
-    if (source[key] !== undefined) {
-      merged[key] = cloneJsonValue(source[key]);
+    if (resolvedSource[key] !== undefined) {
+      merged[key] = cloneJsonValue(resolvedSource[key]);
     }
   }
 
-  if (Array.isArray(source.required)) {
-    merged.required = source.required.filter(
+  if (Array.isArray(resolvedSource.required)) {
+    merged.required = resolvedSource.required.filter(
       (value): value is string => typeof value === 'string',
     );
   }
 
-  if (Array.isArray(source.items)) {
-    merged.items = cloneJsonValue(source.items) as JsonSchemaObject[];
-  } else if (isJsonSchemaObject(source.items)) {
+  if (Array.isArray(resolvedSource.items)) {
+    merged.items = cloneJsonValue(resolvedSource.items) as JsonSchemaObject[];
+  } else if (isJsonSchemaObject(resolvedSource.items)) {
     const nextItems = isJsonSchemaObject(merged.items) ? merged.items : {};
-    merged.items = mergeJsonSchemaConstraintProperties(nextItems, source.items);
+    merged.items = mergeJsonSchemaConstraintProperties(
+      document,
+      nextItems,
+      resolvedSource.items,
+    );
   }
 
-  if (isJsonSchemaObject(source.properties)) {
+  if (isJsonSchemaObject(resolvedSource.properties)) {
     const targetProperties = isJsonSchemaObject(merged.properties)
       ? merged.properties
       : {};
 
     for (const [propertyName, propertySchema] of Object.entries(
-      source.properties,
+      resolvedSource.properties,
     )) {
       if (!isJsonSchemaObject(propertySchema)) {
         continue;
@@ -412,6 +446,7 @@ function mergeJsonSchemaConstraintProperties(
         ? (targetProperties[propertyName] as JsonSchemaObject)
         : {};
       targetProperties[propertyName] = mergeJsonSchemaConstraintProperties(
+        document,
         nextProperty,
         propertySchema,
       );
@@ -433,8 +468,11 @@ function findOpenApiOperationById(
     }
 
     for (const method of ['delete', 'get', 'patch', 'post', 'put'] as const) {
-      const operation = pathItem[method];
-      if (!isJsonSchemaObject(operation)) {
+      const operation = resolveOpenApiSchemaObject(document, pathItem[method]);
+      if (
+        !isJsonSchemaObject(operation) ||
+        typeof operation.operationId !== 'string'
+      ) {
         continue;
       }
 
@@ -451,7 +489,15 @@ function resolveOpenApiRequestBodySchema(
   operation: OpenApiOperation,
   document: OpenApiDocument,
 ): JsonSchemaObject | null {
-  const schema = operation.requestBody?.content?.['application/json']?.schema;
+  const requestBody = resolveOpenApiSchemaObject(document, operation.requestBody);
+  const content = isJsonSchemaObject(requestBody.content)
+    ? requestBody.content
+    : null;
+  const jsonMediaType =
+    content && isJsonSchemaObject(content['application/json'])
+      ? content['application/json']
+      : null;
+  const schema = jsonMediaType?.schema;
   if (!isJsonSchemaObject(schema)) {
     return null;
   }
@@ -464,11 +510,22 @@ function resolveOpenApiSuccessResponseSchema(
   document: OpenApiDocument,
 ): JsonSchemaObject | null {
   for (const [statusCode, response] of Object.entries(operation.responses)) {
-    if (!/^2\d\d$/u.test(statusCode) || !isJsonSchemaObject(response)) {
+    const resolvedResponse = resolveOpenApiSchemaObject(document, response);
+    if (
+      !/^2(?:\d\d|XX)$/u.test(statusCode) ||
+      !isJsonSchemaObject(resolvedResponse)
+    ) {
       continue;
     }
 
-    const schema = response.content?.['application/json']?.schema;
+    const content = isJsonSchemaObject(resolvedResponse.content)
+      ? resolvedResponse.content
+      : null;
+    const jsonMediaType =
+      content && isJsonSchemaObject(content['application/json'])
+        ? content['application/json']
+        : null;
+    const schema = jsonMediaType?.schema;
     if (!isJsonSchemaObject(schema)) {
       continue;
     }
@@ -501,21 +558,26 @@ function applyOpenApiQueryParameterConstraints(
   document: OpenApiDocument,
 ): void {
   for (const parameter of operation.parameters ?? []) {
+    const resolvedParameter = resolveOpenApiSchemaObject(document, parameter);
     if (
-      !isJsonSchemaObject(parameter) ||
-      parameter.in !== 'query' ||
-      typeof parameter.name !== 'string'
+      !isJsonSchemaObject(resolvedParameter) ||
+      resolvedParameter.in !== 'query' ||
+      typeof resolvedParameter.name !== 'string'
     ) {
       continue;
     }
 
-    const propertyTarget = getOrCreateObjectProperty(target, parameter.name);
+    const propertyTarget = getOrCreateObjectProperty(
+      target,
+      resolvedParameter.name,
+    );
     mergeJsonSchemaConstraintProperties(
+      document,
       propertyTarget,
-      resolveOpenApiSchemaObject(document, parameter.schema),
+      resolveOpenApiSchemaObject(document, resolvedParameter.schema),
     );
 
-    if (parameter.required === true) {
+    if (resolvedParameter.required === true) {
       const required = new Set(
         Array.isArray(target.required)
           ? target.required.filter(
@@ -523,7 +585,7 @@ function applyOpenApiQueryParameterConstraints(
             )
           : [],
       );
-      required.add(parameter.name);
+      required.add(resolvedParameter.name);
       target.required = [...required];
     }
   }
@@ -934,10 +996,17 @@ export function applyOpenApiConstraintsToTypiaLlmFunctionArtifact({
   }
 
   const hasQueryParameters = (operation.parameters ?? []).some(
-    (parameter) =>
-      isJsonSchemaObject(parameter) &&
-      parameter.in === 'query' &&
-      typeof parameter.name === 'string',
+    (parameter) => {
+      const resolvedParameter = resolveOpenApiSchemaObject(
+        openApiDocument,
+        parameter,
+      );
+      return (
+        isJsonSchemaObject(resolvedParameter) &&
+        resolvedParameter.in === 'query' &&
+        typeof resolvedParameter.name === 'string'
+      );
+    },
   );
   const requestBodySchema = resolveOpenApiRequestBodySchema(
     operation,
@@ -947,6 +1016,7 @@ export function applyOpenApiConstraintsToTypiaLlmFunctionArtifact({
   if (requestBodySchema) {
     if (hasQueryParameters) {
       mergeJsonSchemaConstraintProperties(
+        openApiDocument,
         getOrCreateObjectProperty(
           constrainedArtifact.parameters as unknown as JsonSchemaObject,
           'body',
@@ -955,6 +1025,7 @@ export function applyOpenApiConstraintsToTypiaLlmFunctionArtifact({
       );
     } else {
       mergeJsonSchemaConstraintProperties(
+        openApiDocument,
         constrainedArtifact.parameters as unknown as JsonSchemaObject,
         requestBodySchema,
       );
@@ -981,6 +1052,7 @@ export function applyOpenApiConstraintsToTypiaLlmFunctionArtifact({
     );
     if (responseSchema) {
       mergeJsonSchemaConstraintProperties(
+        openApiDocument,
         constrainedArtifact.output as unknown as JsonSchemaObject,
         responseSchema,
       );

--- a/packages/wp-typia-project-tools/src/runtime/typia-llm.ts
+++ b/packages/wp-typia-project-tools/src/runtime/typia-llm.ts
@@ -12,6 +12,9 @@ import {
   normalizeEndpointAuthDefinition,
   type EndpointAuthIntent,
   type EndpointWordPressAuthDefinition,
+  type JsonSchemaObject,
+  type OpenApiDocument,
+  type OpenApiOperation,
 } from './schema-core.js';
 
 /**
@@ -168,6 +171,20 @@ export interface ProjectedTypiaLlmStructuredOutputArtifact {
 }
 
 /**
+ * Configures optional OpenAPI-backed constraint restoration for projected
+ * `typia.llm` function artifacts.
+ */
+export interface ProjectTypiaLlmOpenApiProjectionOptions {
+  /** Canonical endpoint-aware OpenAPI document for the projected contracts. */
+  openApiDocument: OpenApiDocument;
+  /** Optional override for resolving one function schema to an operation id. */
+  resolveOperationId?: (
+    functionSchema: TypiaLlmFunctionLike,
+    functionArtifact: ProjectedTypiaLlmFunctionArtifact,
+  ) => string;
+}
+
+/**
  * Configures projection of a compiled `typia.llm.application(...)` result into
  * the JSON-friendly adapter artifact.
  */
@@ -176,11 +193,26 @@ export interface ProjectTypiaLlmApplicationArtifactOptions {
   application: TypiaLlmApplicationLike;
   /** Source metadata for the generated JSON artifact. */
   generatedFrom: ProjectedTypiaLlmApplicationArtifact['generatedFrom'];
+  /** Optional OpenAPI projection that restores canonical schema constraints. */
+  openApiProjection?: ProjectTypiaLlmOpenApiProjectionOptions;
   /** Optional hook for adapter-specific function schema normalization. */
   transformFunction?: (
     functionArtifact: ProjectedTypiaLlmFunctionArtifact,
     functionSchema: TypiaLlmFunctionLike,
   ) => ProjectedTypiaLlmFunctionArtifact;
+}
+
+/**
+ * Configures direct OpenAPI-backed constraint restoration for one projected
+ * function artifact.
+ */
+export interface ApplyOpenApiConstraintsToTypiaLlmFunctionArtifactOptions {
+  /** Projected function artifact to enrich with canonical constraints. */
+  functionArtifact: ProjectedTypiaLlmFunctionArtifact;
+  /** Canonical endpoint-aware OpenAPI document. */
+  openApiDocument: OpenApiDocument;
+  /** Operation id that owns the request/response contract for this function. */
+  operationId: string;
 }
 
 /**
@@ -279,8 +311,222 @@ const TYPESCRIPT_RESERVED_WORDS = new Set([
   'yield',
 ]);
 
+const JSON_SCHEMA_CONSTRAINT_KEYS = [
+  'additionalProperties',
+  'const',
+  'default',
+  'enum',
+  'exclusiveMaximum',
+  'exclusiveMinimum',
+  'format',
+  'maxItems',
+  'maxLength',
+  'maximum',
+  'minItems',
+  'minLength',
+  'minimum',
+  'multipleOf',
+  'pattern',
+  'type',
+] as const;
+
 function cloneJsonValueIfDefined<T>(value: T | undefined): T | undefined {
   return value === undefined ? undefined : cloneJsonValue(value);
+}
+
+function isJsonSchemaObject(value: unknown): value is JsonSchemaObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function resolveOpenApiSchemaObject(
+  document: OpenApiDocument,
+  schema: unknown,
+): JsonSchemaObject {
+  if (!isJsonSchemaObject(schema)) {
+    return {};
+  }
+
+  const reference = schema.$ref;
+  if (typeof reference !== 'string') {
+    return schema;
+  }
+
+  const match = reference.match(/^#\/components\/schemas\/(.+)$/u);
+  if (!match) {
+    throw new Error(`Unsupported OpenAPI schema reference "${reference}".`);
+  }
+
+  const componentName = match[1];
+  if (!componentName) {
+    throw new Error(`Unsupported OpenAPI schema reference "${reference}".`);
+  }
+
+  const resolved = document.components.schemas[componentName];
+  if (!resolved) {
+    throw new Error(
+      `Unable to resolve OpenAPI schema reference "${reference}".`,
+    );
+  }
+
+  return resolved;
+}
+
+function mergeJsonSchemaConstraintProperties(
+  target: JsonSchemaObject,
+  source: JsonSchemaObject,
+): JsonSchemaObject {
+  const merged = target;
+
+  for (const key of JSON_SCHEMA_CONSTRAINT_KEYS) {
+    if (source[key] !== undefined) {
+      merged[key] = cloneJsonValue(source[key]);
+    }
+  }
+
+  if (Array.isArray(source.required)) {
+    merged.required = source.required.filter(
+      (value): value is string => typeof value === 'string',
+    );
+  }
+
+  if (Array.isArray(source.items)) {
+    merged.items = cloneJsonValue(source.items) as JsonSchemaObject[];
+  } else if (isJsonSchemaObject(source.items)) {
+    const nextItems = isJsonSchemaObject(merged.items) ? merged.items : {};
+    merged.items = mergeJsonSchemaConstraintProperties(nextItems, source.items);
+  }
+
+  if (isJsonSchemaObject(source.properties)) {
+    const targetProperties = isJsonSchemaObject(merged.properties)
+      ? merged.properties
+      : {};
+
+    for (const [propertyName, propertySchema] of Object.entries(
+      source.properties,
+    )) {
+      if (!isJsonSchemaObject(propertySchema)) {
+        continue;
+      }
+
+      const nextProperty = isJsonSchemaObject(targetProperties[propertyName])
+        ? (targetProperties[propertyName] as JsonSchemaObject)
+        : {};
+      targetProperties[propertyName] = mergeJsonSchemaConstraintProperties(
+        nextProperty,
+        propertySchema,
+      );
+    }
+
+    merged.properties = targetProperties;
+  }
+
+  return merged;
+}
+
+function findOpenApiOperationById(
+  document: OpenApiDocument,
+  operationId: string,
+): OpenApiOperation | null {
+  for (const pathItem of Object.values(document.paths)) {
+    if (!isJsonSchemaObject(pathItem)) {
+      continue;
+    }
+
+    for (const method of ['delete', 'get', 'patch', 'post', 'put'] as const) {
+      const operation = pathItem[method];
+      if (!isJsonSchemaObject(operation)) {
+        continue;
+      }
+
+      if (operation.operationId === operationId) {
+        return operation as OpenApiOperation;
+      }
+    }
+  }
+
+  return null;
+}
+
+function resolveOpenApiRequestBodySchema(
+  operation: OpenApiOperation,
+  document: OpenApiDocument,
+): JsonSchemaObject | null {
+  const schema = operation.requestBody?.content?.['application/json']?.schema;
+  if (!isJsonSchemaObject(schema)) {
+    return null;
+  }
+
+  return resolveOpenApiSchemaObject(document, schema);
+}
+
+function resolveOpenApiSuccessResponseSchema(
+  operation: OpenApiOperation,
+  document: OpenApiDocument,
+): JsonSchemaObject | null {
+  for (const [statusCode, response] of Object.entries(operation.responses)) {
+    if (!/^2\d\d$/u.test(statusCode) || !isJsonSchemaObject(response)) {
+      continue;
+    }
+
+    const schema = response.content?.['application/json']?.schema;
+    if (!isJsonSchemaObject(schema)) {
+      continue;
+    }
+
+    return resolveOpenApiSchemaObject(document, schema);
+  }
+
+  return null;
+}
+
+function getOrCreateObjectProperty(
+  target: JsonSchemaObject,
+  propertyName: string,
+): JsonSchemaObject {
+  const targetProperties = isJsonSchemaObject(target.properties)
+    ? target.properties
+    : {};
+  const nextProperty = isJsonSchemaObject(targetProperties[propertyName])
+    ? (targetProperties[propertyName] as JsonSchemaObject)
+    : {};
+
+  targetProperties[propertyName] = nextProperty;
+  target.properties = targetProperties;
+  return nextProperty;
+}
+
+function applyOpenApiQueryParameterConstraints(
+  target: JsonSchemaObject,
+  operation: OpenApiOperation,
+  document: OpenApiDocument,
+): void {
+  for (const parameter of operation.parameters ?? []) {
+    if (
+      !isJsonSchemaObject(parameter) ||
+      parameter.in !== 'query' ||
+      typeof parameter.name !== 'string'
+    ) {
+      continue;
+    }
+
+    const propertyTarget = getOrCreateObjectProperty(target, parameter.name);
+    mergeJsonSchemaConstraintProperties(
+      propertyTarget,
+      resolveOpenApiSchemaObject(document, parameter.schema),
+    );
+
+    if (parameter.required === true) {
+      const required = new Set(
+        Array.isArray(target.required)
+          ? target.required.filter(
+              (value): value is string => typeof value === 'string',
+            )
+          : [],
+      );
+      required.add(parameter.name);
+      target.required = [...required];
+    }
+  }
 }
 
 interface EndpointInputTypeDescriptor {
@@ -666,6 +912,85 @@ function cloneProjectedTypiaLlmFunctionArtifact(
 }
 
 /**
+ * Restores canonical request and response constraints from an endpoint-aware
+ * OpenAPI document onto one projected `typia.llm` function artifact.
+ *
+ * Query-only inputs merge into the root parameter object. Mixed body/query
+ * inputs merge into the generated `body` and `query` properties.
+ *
+ * @param options Projected artifact plus the canonical OpenAPI document.
+ * @returns A cloned artifact enriched with OpenAPI-backed constraints when available.
+ */
+export function applyOpenApiConstraintsToTypiaLlmFunctionArtifact({
+  functionArtifact,
+  openApiDocument,
+  operationId,
+}: ApplyOpenApiConstraintsToTypiaLlmFunctionArtifactOptions): ProjectedTypiaLlmFunctionArtifact {
+  const constrainedArtifact =
+    cloneProjectedTypiaLlmFunctionArtifact(functionArtifact);
+  const operation = findOpenApiOperationById(openApiDocument, operationId);
+  if (!operation) {
+    return constrainedArtifact;
+  }
+
+  const hasQueryParameters = (operation.parameters ?? []).some(
+    (parameter) =>
+      isJsonSchemaObject(parameter) &&
+      parameter.in === 'query' &&
+      typeof parameter.name === 'string',
+  );
+  const requestBodySchema = resolveOpenApiRequestBodySchema(
+    operation,
+    openApiDocument,
+  );
+
+  if (requestBodySchema) {
+    if (hasQueryParameters) {
+      mergeJsonSchemaConstraintProperties(
+        getOrCreateObjectProperty(
+          constrainedArtifact.parameters as unknown as JsonSchemaObject,
+          'body',
+        ),
+        requestBodySchema,
+      );
+    } else {
+      mergeJsonSchemaConstraintProperties(
+        constrainedArtifact.parameters as unknown as JsonSchemaObject,
+        requestBodySchema,
+      );
+    }
+  }
+
+  if (hasQueryParameters) {
+    applyOpenApiQueryParameterConstraints(
+      requestBodySchema
+        ? getOrCreateObjectProperty(
+            constrainedArtifact.parameters as unknown as JsonSchemaObject,
+            'query',
+          )
+        : (constrainedArtifact.parameters as unknown as JsonSchemaObject),
+      operation,
+      openApiDocument,
+    );
+  }
+
+  if (constrainedArtifact.output) {
+    const responseSchema = resolveOpenApiSuccessResponseSchema(
+      operation,
+      openApiDocument,
+    );
+    if (responseSchema) {
+      mergeJsonSchemaConstraintProperties(
+        constrainedArtifact.output as unknown as JsonSchemaObject,
+        responseSchema,
+      );
+    }
+  }
+
+  return constrainedArtifact;
+}
+
+/**
  * Projects a compiled `typia.llm.application(...)` result into a JSON-friendly
  * downstream adapter artifact.
  *
@@ -675,15 +1000,27 @@ function cloneProjectedTypiaLlmFunctionArtifact(
 export function projectTypiaLlmApplicationArtifact({
   application,
   generatedFrom,
+  openApiProjection,
   transformFunction,
 }: ProjectTypiaLlmApplicationArtifactOptions): ProjectedTypiaLlmApplicationArtifact {
   return {
     functions: application.functions.map((functionSchema) => {
       const functionArtifact =
         projectTypiaLlmApplicationFunction(functionSchema);
-      const transformedArtifact = transformFunction
-        ? transformFunction(functionArtifact, functionSchema)
+      const openApiAlignedArtifact = openApiProjection
+        ? applyOpenApiConstraintsToTypiaLlmFunctionArtifact({
+            functionArtifact,
+            openApiDocument: openApiProjection.openApiDocument,
+            operationId:
+              openApiProjection.resolveOperationId?.(
+                functionSchema,
+                functionArtifact,
+              ) ?? functionSchema.name,
+          })
         : functionArtifact;
+      const transformedArtifact = transformFunction
+        ? transformFunction(openApiAlignedArtifact, functionSchema)
+        : openApiAlignedArtifact;
 
       return cloneProjectedTypiaLlmFunctionArtifact(transformedArtifact);
     }),

--- a/packages/wp-typia-project-tools/src/runtime/typia-llm.ts
+++ b/packages/wp-typia-project-tools/src/runtime/typia-llm.ts
@@ -389,7 +389,7 @@ function resolveOpenApiSchemaObject(
   }
 
   if (seenReferences.has(reference)) {
-    throw new Error(`Detected recursive OpenAPI schema reference "${reference}".`);
+    return schema;
   }
 
   return resolveOpenApiSchemaObject(
@@ -399,12 +399,33 @@ function resolveOpenApiSchemaObject(
   );
 }
 
+function collectOpenApiSeenReferences(
+  schema: JsonSchemaObject,
+  seenReferences: ReadonlySet<string>,
+): ReadonlySet<string> {
+  const reference = schema.$ref;
+  if (typeof reference !== 'string' || seenReferences.has(reference)) {
+    return seenReferences;
+  }
+
+  return new Set([...seenReferences, reference]);
+}
+
 function mergeJsonSchemaConstraintProperties(
   document: OpenApiDocument,
   target: JsonSchemaObject,
   source: JsonSchemaObject,
+  seenReferences: ReadonlySet<string> = new Set(),
 ): JsonSchemaObject {
-  const resolvedSource = resolveOpenApiSchemaObject(document, source);
+  const nextSeenReferences = collectOpenApiSeenReferences(
+    source,
+    seenReferences,
+  );
+  const resolvedSource = resolveOpenApiSchemaObject(
+    document,
+    source,
+    seenReferences,
+  );
   const merged = target;
 
   for (const key of JSON_SCHEMA_CONSTRAINT_KEYS) {
@@ -427,6 +448,7 @@ function mergeJsonSchemaConstraintProperties(
       document,
       nextItems,
       resolvedSource.items,
+      nextSeenReferences,
     );
   }
 
@@ -449,6 +471,7 @@ function mergeJsonSchemaConstraintProperties(
         document,
         nextProperty,
         propertySchema,
+        nextSeenReferences,
       );
     }
 

--- a/packages/wp-typia-project-tools/tests/typia-llm.test.ts
+++ b/packages/wp-typia-project-tools/tests/typia-llm.test.ts
@@ -194,6 +194,114 @@ const COUNTER_OPENAPI = {
   },
 } as const satisfies OpenApiDocument;
 
+const NESTED_REFERENCE_OPENAPI = {
+  components: {
+    parameters: {
+      NestedPostId: {
+        in: 'query',
+        name: 'postId',
+        required: true,
+        schema: {
+          maximum: 4294967295,
+          minimum: 0,
+          multipleOf: 1,
+          type: 'integer',
+        },
+      },
+    },
+    requestBodies: {
+      NestedCounterBody: {
+        content: {
+          'application/json': {
+            schema: {
+              $ref: '#/components/schemas/NestedCounterBodySchema',
+            },
+          },
+        },
+        required: true,
+      },
+    },
+    responses: {
+      NestedCounterResponse: {
+        content: {
+          'application/json': {
+            schema: {
+              $ref: '#/components/schemas/NestedCounterResponseSchema',
+            },
+          },
+        },
+        description: 'Nested counter response.',
+      },
+    },
+    schemas: {
+      NestedCounterBodySchema: {
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        additionalProperties: false,
+        properties: {
+          payload: {
+            properties: {
+              delta: {
+                maximum: 9,
+                minimum: 1,
+                multipleOf: 1,
+                type: 'integer',
+              },
+            },
+            required: ['delta'],
+            type: 'object',
+          },
+        },
+        required: ['payload'],
+        title: 'NestedCounterBodySchema',
+        type: 'object',
+      },
+      NestedCounterResponseSchema: {
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        additionalProperties: false,
+        properties: {
+          count: {
+            maximum: 4294967295,
+            minimum: 0,
+            multipleOf: 1,
+            type: 'integer',
+          },
+        },
+        required: ['count'],
+        title: 'NestedCounterResponseSchema',
+        type: 'object',
+      },
+    },
+  },
+  info: {
+    title: 'Nested Counter API',
+    version: '1.0.0',
+  },
+  openapi: '3.1.0',
+  paths: {
+    '/demo/v1/counter/nested': {
+      post: {
+        operationId: 'syncNestedCounter',
+        parameters: [
+          {
+            $ref: '#/components/parameters/NestedPostId',
+          },
+        ],
+        requestBody: {
+          $ref: '#/components/requestBodies/NestedCounterBody',
+        },
+        responses: {
+          '2XX': {
+            $ref: '#/components/responses/NestedCounterResponse',
+          },
+        },
+        summary: 'Synchronize the nested counter.',
+        tags: ['Counter'],
+        'x-typia-authIntent': 'authenticated',
+      },
+    },
+  },
+} as const as unknown as OpenApiDocument;
+
 const EMPTY_LLM_PARAMETERS: ILlmSchema.IParameters = {
   $defs: {},
   additionalProperties: false,
@@ -656,6 +764,107 @@ describe('typia.llm adapter emitter', () => {
         },
       },
       required: ['body', 'query'],
+    });
+  });
+
+  test('resolves nested OpenAPI component references and wildcard 2XX responses', () => {
+    const constrainedArtifact = applyOpenApiConstraintsToTypiaLlmFunctionArtifact(
+      {
+        functionArtifact: {
+          description: 'Synchronize the nested counter.',
+          name: 'syncNestedCounter',
+          output: {
+            $defs: {},
+            additionalProperties: false,
+            properties: {
+              count: {
+                type: 'number',
+              },
+            },
+            required: ['count'],
+            type: 'object',
+          },
+          parameters: {
+            $defs: {},
+            additionalProperties: false,
+            properties: {
+              body: {
+                additionalProperties: false,
+                properties: {
+                  payload: {
+                    properties: {
+                      delta: {
+                        type: 'number',
+                      },
+                    },
+                    required: ['delta'],
+                    type: 'object',
+                  },
+                },
+                required: ['payload'],
+                type: 'object',
+              },
+              query: {
+                additionalProperties: false,
+                properties: {
+                  postId: {
+                    type: 'number',
+                  },
+                },
+                required: [],
+                type: 'object',
+              },
+            },
+            required: ['body', 'query'],
+            type: 'object',
+          },
+        },
+        openApiDocument: NESTED_REFERENCE_OPENAPI,
+        operationId: 'syncNestedCounter',
+      },
+    );
+
+    expect(constrainedArtifact.parameters).toMatchObject({
+      properties: {
+        body: {
+          properties: {
+            payload: {
+              properties: {
+                delta: {
+                  maximum: 9,
+                  minimum: 1,
+                  multipleOf: 1,
+                  type: 'integer',
+                },
+              },
+              required: ['delta'],
+            },
+          },
+          required: ['payload'],
+        },
+        query: {
+          properties: {
+            postId: {
+              maximum: 4294967295,
+              minimum: 0,
+              multipleOf: 1,
+              type: 'integer',
+            },
+          },
+          required: ['postId'],
+        },
+      },
+    });
+    expect(constrainedArtifact.output).toMatchObject({
+      properties: {
+        count: {
+          maximum: 4294967295,
+          minimum: 0,
+          multipleOf: 1,
+          type: 'integer',
+        },
+      },
+      required: ['count'],
     });
   });
 

--- a/packages/wp-typia-project-tools/tests/typia-llm.test.ts
+++ b/packages/wp-typia-project-tools/tests/typia-llm.test.ts
@@ -5,11 +5,13 @@ import path from 'node:path';
 
 import type { EndpointManifestDefinition } from '@wp-typia/block-runtime/metadata-core';
 import type { ILlmSchema } from 'typia';
+import type { OpenApiDocument } from '@wp-typia/project-tools/schema-core';
 import type {
   ProjectedTypiaLlmApplicationArtifact,
   ProjectedTypiaLlmStructuredOutputArtifact,
 } from '@wp-typia/project-tools/typia-llm';
 import {
+  applyOpenApiConstraintsToTypiaLlmFunctionArtifact,
   buildTypiaLlmEndpointMethodDescriptors,
   projectTypiaLlmApplicationArtifact,
   projectTypiaLlmStructuredOutputArtifact,
@@ -56,6 +58,141 @@ const COUNTER_MANIFEST = {
     },
   ],
 } as const satisfies EndpointManifestDefinition;
+
+const COUNTER_OPENAPI = {
+  components: {
+    schemas: {
+      CounterResponse: {
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        additionalProperties: false,
+        properties: {
+          count: {
+            minimum: 0,
+            type: 'integer',
+          },
+        },
+        required: ['count'],
+        title: 'CounterResponse',
+        type: 'object',
+      },
+      CounterUpdateRequest: {
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        additionalProperties: false,
+        properties: {
+          publicWriteToken: {
+            minLength: 16,
+            pattern: '^pt_[a-z0-9]+$',
+            type: 'string',
+          },
+        },
+        required: ['publicWriteToken'],
+        title: 'CounterUpdateRequest',
+        type: 'object',
+      },
+      UpdateCounterBody: {
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        additionalProperties: false,
+        properties: {
+          publicWriteToken: {
+            minLength: 24,
+            pattern: '^body_[a-z0-9]+$',
+            type: 'string',
+          },
+        },
+        required: ['publicWriteToken'],
+        title: 'UpdateCounterBody',
+        type: 'object',
+      },
+    },
+  },
+  info: {
+    title: 'Counter API',
+    version: '1.0.0',
+  },
+  openapi: '3.1.0',
+  paths: {
+    '/demo/v1/counter': {
+      post: {
+        operationId: 'incrementCounter',
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/CounterUpdateRequest',
+              },
+            },
+          },
+          required: true,
+        },
+        responses: {
+          '200': {
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/CounterResponse',
+                },
+              },
+            },
+            description: 'Counter response.',
+          },
+        },
+        summary: 'Increment the counter.',
+        tags: ['Counter'],
+        'x-typia-authIntent': 'public-write-protected',
+      },
+    },
+    '/demo/v1/counter/update': {
+      post: {
+        operationId: 'updateCounter',
+        parameters: [
+          {
+            in: 'query',
+            name: 'page',
+            required: true,
+            schema: {
+              minimum: 1,
+              type: 'integer',
+            },
+          },
+          {
+            in: 'query',
+            name: 'search',
+            required: false,
+            schema: {
+              minLength: 2,
+              type: 'string',
+            },
+          },
+        ],
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/UpdateCounterBody',
+              },
+            },
+          },
+          required: true,
+        },
+        responses: {
+          '200': {
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/CounterResponse',
+                },
+              },
+            },
+            description: 'Updated counter response.',
+          },
+        },
+        summary: 'Update the counter.',
+        tags: ['Counter'],
+        'x-typia-authIntent': 'authenticated',
+      },
+    },
+  },
+} as const satisfies OpenApiDocument;
 
 const EMPTY_LLM_PARAMETERS: ILlmSchema.IParameters = {
   $defs: {},
@@ -383,6 +520,143 @@ describe('typia.llm adapter emitter', () => {
     });
     expect(structuredArtifact.parameters).not.toBe(structuredParameters);
     expect(structuredArtifact.generatedFrom).not.toBe(structuredGeneratedFrom);
+  });
+
+  test('restores canonical OpenAPI constraints for projected function artifacts', () => {
+    const constrainedArtifact = applyOpenApiConstraintsToTypiaLlmFunctionArtifact(
+      {
+        functionArtifact: {
+          description: 'Increment the counter.',
+          name: 'incrementCounter',
+          output: {
+            $defs: {},
+            additionalProperties: false,
+            properties: {
+              count: {
+                type: 'number',
+              },
+            },
+            required: ['count'],
+            type: 'object',
+          },
+          parameters: {
+            $defs: {},
+            additionalProperties: false,
+            properties: {
+              publicWriteToken: {
+                type: 'string',
+              },
+            },
+            required: ['publicWriteToken'],
+            type: 'object',
+          },
+          tags: ['Counter'],
+        },
+        openApiDocument: COUNTER_OPENAPI,
+        operationId: 'incrementCounter',
+      },
+    );
+
+    expect(constrainedArtifact.parameters).toMatchObject({
+      properties: {
+        publicWriteToken: {
+          minLength: 16,
+          pattern: '^pt_[a-z0-9]+$',
+          type: 'string',
+        },
+      },
+      required: ['publicWriteToken'],
+    });
+    expect(constrainedArtifact.output).toMatchObject({
+      properties: {
+        count: {
+          minimum: 0,
+          type: 'integer',
+        },
+      },
+      required: ['count'],
+    });
+  });
+
+  test('restores canonical OpenAPI constraints for mixed body/query tool inputs', () => {
+    const applicationArtifact = projectTypiaLlmApplicationArtifact({
+      application: {
+        functions: [
+          {
+            description: 'Update the counter.',
+            name: 'updateCounter',
+            parameters: {
+              $defs: {},
+              additionalProperties: false,
+              properties: {
+                body: {
+                  additionalProperties: false,
+                  properties: {
+                    publicWriteToken: {
+                      type: 'string',
+                    },
+                  },
+                  required: ['publicWriteToken'],
+                  type: 'object',
+                },
+                query: {
+                  additionalProperties: false,
+                  properties: {
+                    page: {
+                      type: 'number',
+                    },
+                    search: {
+                      type: 'string',
+                    },
+                  },
+                  required: [],
+                  type: 'object',
+                },
+              },
+              required: ['body', 'query'],
+              type: 'object',
+            },
+          },
+        ],
+      },
+      generatedFrom: {
+        baselineOpenApiPath: 'src/blocks/counter/api.openapi.json',
+        blockSlug: 'counter',
+        manifestSource: 'endpoint-manifest+typescript',
+      },
+      openApiProjection: {
+        openApiDocument: COUNTER_OPENAPI,
+      },
+    });
+
+    expect(applicationArtifact.functions[0]?.parameters).toMatchObject({
+      properties: {
+        body: {
+          properties: {
+            publicWriteToken: {
+              minLength: 24,
+              pattern: '^body_[a-z0-9]+$',
+              type: 'string',
+            },
+          },
+          required: ['publicWriteToken'],
+        },
+        query: {
+          properties: {
+            page: {
+              minimum: 1,
+              type: 'integer',
+            },
+            search: {
+              minLength: 2,
+              type: 'string',
+            },
+          },
+          required: ['page'],
+        },
+      },
+      required: ['body', 'query'],
+    });
   });
 
   test('projects mixed query/body endpoint inputs as composite tool input', () => {

--- a/packages/wp-typia-project-tools/tests/typia-llm.test.ts
+++ b/packages/wp-typia-project-tools/tests/typia-llm.test.ts
@@ -302,6 +302,71 @@ const NESTED_REFERENCE_OPENAPI = {
   },
 } as const as unknown as OpenApiDocument;
 
+const RECURSIVE_REFERENCE_OPENAPI = {
+  components: {
+    requestBodies: {
+      RecursiveNodeBody: {
+        content: {
+          'application/json': {
+            schema: {
+              $ref: '#/components/schemas/RecursiveNode',
+            },
+          },
+        },
+        required: true,
+      },
+    },
+    schemas: {
+      RecursiveNode: {
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        additionalProperties: false,
+        properties: {
+          child: {
+            $ref: '#/components/schemas/RecursiveNode',
+          },
+          label: {
+            minLength: 1,
+            type: 'string',
+          },
+        },
+        required: ['label'],
+        title: 'RecursiveNode',
+        type: 'object',
+      },
+    },
+  },
+  info: {
+    title: 'Recursive Node API',
+    version: '1.0.0',
+  },
+  openapi: '3.1.0',
+  paths: {
+    '/demo/v1/tree': {
+      post: {
+        operationId: 'syncRecursiveNode',
+        requestBody: {
+          $ref: '#/components/requestBodies/RecursiveNodeBody',
+        },
+        responses: {
+          '200': {
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/RecursiveNode',
+                },
+              },
+            },
+            description: 'Recursive node response.',
+          },
+        },
+        summary: 'Synchronize the recursive node.',
+        tags: ['Tree'],
+        'x-typia-authIntent': 'authenticated',
+      },
+    },
+  },
+} as const as unknown as OpenApiDocument;
+
 const EMPTY_LLM_PARAMETERS: ILlmSchema.IParameters = {
   $defs: {},
   additionalProperties: false,
@@ -865,6 +930,48 @@ describe('typia.llm adapter emitter', () => {
         },
       },
       required: ['count'],
+    });
+  });
+
+  test('preserves non-recursive constraints without failing on recursive schema references', () => {
+    const constrainedArtifact = applyOpenApiConstraintsToTypiaLlmFunctionArtifact(
+      {
+        functionArtifact: {
+          description: 'Synchronize the recursive node.',
+          name: 'syncRecursiveNode',
+          parameters: {
+            $defs: {},
+            additionalProperties: false,
+            properties: {
+              label: {
+                type: 'string',
+              },
+            },
+            required: ['label'],
+            type: 'object',
+          },
+        },
+        openApiDocument: RECURSIVE_REFERENCE_OPENAPI,
+        operationId: 'syncRecursiveNode',
+      },
+    );
+
+    expect(constrainedArtifact.parameters).toMatchObject({
+      properties: {
+        child: {
+          properties: {
+            label: {
+              minLength: 1,
+              type: 'string',
+            },
+          },
+        },
+        label: {
+          minLength: 1,
+          type: 'string',
+        },
+      },
+      required: ['label'],
     });
   });
 

--- a/tests/unit/typia-llm-evaluation.test.ts
+++ b/tests/unit/typia-llm-evaluation.test.ts
@@ -36,7 +36,7 @@ describe("typia.llm evaluation artifacts", () => {
 		expect(liveArtifacts.structuredOutputArtifact).toEqual(
 			checkedInStructuredOutputArtifact,
 		);
-	}, 15_000);
+	}, 45_000);
 
 	test("projects exactly the two counter endpoints into function-calling tools", () => {
 		expect(checkedInApplicationArtifact.functions.map((fn) => fn.name)).toEqual([


### PR DESCRIPTION
## Summary
- promote reusable OpenAPI-backed constraint restoration into `@wp-typia/project-tools/typia-llm`
- wire the api-contract-adapter PoC through the supported `openApiProjection` surface instead of example-local merge helpers
- add regression coverage for direct function artifacts and mixed body/query tool inputs

## Validation
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/tsc -p packages/wp-typia-project-tools/tsconfig.runtime.json`
- `./node_modules/.bin/eslint --no-warn-ignored packages/wp-typia-project-tools/src/runtime/typia-llm.ts packages/wp-typia-project-tools/tests/typia-llm.test.ts`
- `node scripts/validate-sampo-changesets.mjs`

## Notes
- Full `bun test` coverage could not be run in this shell because `bun` is not available on PATH; CI should cover the Bun-backed test matrix.

Closes #663

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced OpenAPI-backed constraint restoration for `typia.llm` adapter artifacts, enabling automatic preservation of constraints for mixed body and query parameter inputs.

* **Tests**
  * Added regression tests validating proper constraint application across request/response schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->