### PR TITLE
[codex] Expose AI feature support metadata to generated clients

### DIFF
--- a/.sampo/changesets/665-ai-feature-support-metadata.md
+++ b/.sampo/changesets/665-ai-feature-support-metadata.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Expose generated AI feature support metadata to client and editor helpers, including compatibility feature ids, runtime gates, support-hint exports, and unavailable-error helpers for graceful UI degradation.

--- a/.sampo/changesets/665-align-wp-typia-project-tools-pin.md
+++ b/.sampo/changesets/665-align-wp-typia-project-tools-pin.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Keep the exact `@wp-typia/project-tools` release lane aligned with the patch planned for generated AI feature support metadata helpers.

--- a/apps/docs/src/content/docs/reference/api.md
+++ b/apps/docs/src/content/docs/reference/api.md
@@ -773,7 +773,9 @@ sync, server-side Abilities API registration, and a lightweight admin/editor
 client helper that expects the WordPress abilities client to be available.
 AI features are generated under `src/ai-features/*/` plus `inc/ai-features/*.php`
 and scaffold a server-owned REST endpoint, AI-safe response schema projection,
-typed endpoint client wrapper, and WordPress AI Client feature-detection seam.
+typed endpoint client wrapper, WordPress AI Client feature-detection seam, and
+generated support metadata helpers that expose runtime gates, feature ids, and
+unavailable-message helpers to admin/editor UI code.
 Hooked blocks patch `src/blocks/<block>/block.json` with `blockHooks` metadata
 so the target block is inserted relative to the chosen anchor block.
 

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai-source-emitters.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai-source-emitters.ts
@@ -279,7 +279,7 @@ export const aiFeatureSupportMetadata = {
 \t\t\t\t'Support is verified when the feature runs, so editor and admin UIs should degrade gracefully when the site rejects the request.',
 \t\t},
 \t],
-} as const satisfies ${pascalCase}AiFeatureSupportMetadata;
+} satisfies ${pascalCase}AiFeatureSupportMetadata;
 
 export function getAiFeatureSupportHintLines() {
 \treturn aiFeatureSupportMetadata.unavailableReasons.map(

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai-source-emitters.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai-source-emitters.ts
@@ -2,6 +2,7 @@ import { quoteTsString } from "./cli-add-shared.js";
 import { buildAiFeatureEndpointManifest } from "./ai-feature-artifacts.js";
 import {
 	OPTIONAL_WORDPRESS_AI_CLIENT_COMPATIBILITY,
+	createScaffoldCompatibilityConfig,
 	renderScaffoldCompatibilityConfig,
 	resolveScaffoldCompatibilityPolicy,
 } from "./scaffold-compatibility.js";
@@ -105,6 +106,45 @@ export interface ${pascalCase}AiFeatureResponse {
 \tresult: ${pascalCase}AiFeatureResult;
 \ttelemetry: ${pascalCase}AiFeatureTelemetry;
 }
+
+export type ${pascalCase}AiFeatureSupportProbeMode = 'request-time';
+
+export type ${pascalCase}AiFeatureUnavailableErrorCode =
+\t'ai_client_unavailable';
+
+export type ${pascalCase}AiFeatureUnavailableReasonCode =
+\t| 'missing-wordpress-ai-client'
+\t| 'request-time-support-probe';
+
+export interface ${pascalCase}AiFeatureSupportReason {
+\tcode: ${pascalCase}AiFeatureUnavailableReasonCode;
+\tlabel: string & tags.MinLength< 1 > & tags.MaxLength< 160 >;
+\tmessage: string & tags.MinLength< 1 > & tags.MaxLength< 4000 >;
+}
+
+export interface ${pascalCase}AiFeatureSupportMetadata {
+\tfeatureLabel: string & tags.MinLength< 1 > & tags.MaxLength< 160 >;
+\tfeatureSlug: string & tags.MinLength< 1 > & tags.MaxLength< 160 >;
+\tcompatibility: {
+\t\thardMinimums: {
+\t\t\tphp?: string;
+\t\t\twordpress?: string;
+\t\t};
+\t\tmode: 'baseline' | 'optional' | 'required';
+\t\toptionalFeatureIds: string[];
+\t\toptionalFeatures: string[];
+\t\trequiredFeatureIds: string[];
+\t\trequiredFeatures: string[];
+\t\truntimeGates: string[];
+\t};
+\tsupportProbe: {
+\t\tendpointMethod: 'POST';
+\t\tendpointPath: string & tags.MinLength< 1 > & tags.MaxLength< 200 >;
+\t\tmode: ${pascalCase}AiFeatureSupportProbeMode;
+\t\tunavailableErrorCode: ${pascalCase}AiFeatureUnavailableErrorCode;
+\t};
+\tunavailableReasons: ${pascalCase}AiFeatureSupportReason[];
+}
 `;
 }
 
@@ -151,6 +191,12 @@ export const apiValidators = {
  */
 export function buildAiFeatureApiSource(aiFeatureSlug: string): string {
 	const pascalCase = toPascalCase(aiFeatureSlug);
+	const compatibility = createScaffoldCompatibilityConfig(
+		resolveScaffoldCompatibilityPolicy(
+			OPTIONAL_WORDPRESS_AI_CLIENT_COMPATIBILITY,
+		),
+	);
+	const title = toTitleCase(aiFeatureSlug);
 
 	return `import {
 \tcallEndpoint,
@@ -159,6 +205,7 @@ export function buildAiFeatureApiSource(aiFeatureSlug: string): string {
 
 import type {
 \t${pascalCase}AiFeatureRequest,
+\t${pascalCase}AiFeatureSupportMetadata,
 } from './api-types';
 import {
 \trun${pascalCase}AiFeatureEndpoint,
@@ -185,6 +232,14 @@ function resolveRestNonce( fallback?: string ): string | undefined {
 \t\t: undefined;
 }
 
+function isPlainObject( value: unknown ): value is Record< string, unknown > {
+\treturn (
+\t\t!! value &&
+\t\ttypeof value === 'object' &&
+\t\t! Array.isArray( value )
+\t);
+}
+
 export const aiFeatureRunEndpoint = {
 \t...run${pascalCase}AiFeatureEndpoint,
 \tbuildRequestOptions: () => {
@@ -199,6 +254,63 @@ export const aiFeatureRunEndpoint = {
 \t\t};
 \t},
 };
+
+export const aiFeatureSupportMetadata = {
+\tcompatibility: ${JSON.stringify(compatibility, null, "\t")},
+\tfeatureLabel: ${quoteTsString(title)},
+\tfeatureSlug: ${quoteTsString(aiFeatureSlug)},
+\tsupportProbe: {
+\t\tendpointMethod: 'POST',
+\t\tendpointPath: aiFeatureRunEndpoint.path,
+\t\tmode: 'request-time',
+\t\tunavailableErrorCode: 'ai_client_unavailable',
+\t},
+\tunavailableReasons: [
+\t\t{
+\t\t\tcode: 'missing-wordpress-ai-client',
+\t\t\tlabel: 'WordPress AI Client unavailable',
+\t\t\tmessage:
+\t\t\t\t'This AI feature stays disabled until the WordPress AI Client is available on the site.',
+\t\t},
+\t\t{
+\t\t\tcode: 'request-time-support-probe',
+\t\t\tlabel: 'Support is checked at request time',
+\t\t\tmessage:
+\t\t\t\t'Support is verified when the feature runs, so editor and admin UIs should degrade gracefully when the site rejects the request.',
+\t\t},
+\t],
+} as const satisfies ${pascalCase}AiFeatureSupportMetadata;
+
+export function getAiFeatureSupportHintLines() {
+\treturn aiFeatureSupportMetadata.unavailableReasons.map(
+\t\t( reason ) => reason.message
+\t);
+}
+
+export function isAiFeatureSupportUnavailableError( error: unknown ) {
+\tif ( ! isPlainObject( error ) ) {
+\t\treturn false;
+\t}
+
+\tconst data = isPlainObject( error.data ) ? error.data : undefined;
+\treturn (
+\t\terror.code === aiFeatureSupportMetadata.supportProbe.unavailableErrorCode ||
+\t\tdata?.status === 501
+\t);
+}
+
+export function resolveAiFeatureUnavailableMessage( error: unknown ) {
+\tif (
+\t\tisPlainObject( error ) &&
+\t\ttypeof error.message === 'string' &&
+\t\terror.message.length > 0
+\t) {
+\t\treturn error.message;
+\t}
+
+\treturn aiFeatureSupportMetadata.unavailableReasons[ 0 ]?.message ??
+\t\t'This AI feature is currently unavailable.';
+}
 
 export function runAiFeature( request: ${pascalCase}AiFeatureRequest ) {
 \treturn callEndpoint( aiFeatureRunEndpoint, request );
@@ -223,6 +335,10 @@ import type {
 } from './api-types';
 import {
 \taiFeatureRunEndpoint,
+\taiFeatureSupportMetadata,
+\tgetAiFeatureSupportHintLines,
+\tisAiFeatureSupportUnavailableError,
+\tresolveAiFeatureUnavailableMessage,
 } from './api';
 
 export type UseRun${pascalCase}AiFeatureMutationOptions =
@@ -237,6 +353,13 @@ export function useRun${pascalCase}AiFeatureMutation(
 ) {
 \treturn useEndpointMutation( aiFeatureRunEndpoint, options );
 }
+
+export {
+\taiFeatureSupportMetadata,
+\tgetAiFeatureSupportHintLines,
+\tisAiFeatureSupportUnavailableError,
+\tresolveAiFeatureUnavailableMessage,
+};
 `;
 }
 

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-compatibility.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-compatibility.ts
@@ -37,7 +37,9 @@ export interface ScaffoldCompatibilityPolicy {
 export interface ScaffoldCompatibilityConfig {
   hardMinimums: AiFeatureCompatibilityFloor;
   mode: 'baseline' | 'optional' | 'required';
+  optionalFeatureIds: string[];
   optionalFeatures: string[];
+  requiredFeatureIds: string[];
   requiredFeatures: string[];
   runtimeGates: string[];
 }
@@ -165,8 +167,14 @@ export function createScaffoldCompatibilityConfig(
   return {
     hardMinimums: capabilityPlan.hardMinimums,
     mode: getPolicyMode(capabilityPlan),
+    optionalFeatureIds: capabilityPlan.optionalFeatures.map(
+      (feature) => feature.id,
+    ),
     optionalFeatures: capabilityPlan.optionalFeatures.map(
       (feature) => feature.label,
+    ),
+    requiredFeatureIds: capabilityPlan.requiredFeatures.map(
+      (feature) => feature.id,
     ),
     requiredFeatures: capabilityPlan.requiredFeatures.map(
       (feature) => feature.label,

--- a/packages/wp-typia-project-tools/src/runtime/workspace-inventory.ts
+++ b/packages/wp-typia-project-tools/src/runtime/workspace-inventory.ts
@@ -293,7 +293,9 @@ const WORKSPACE_COMPATIBILITY_CONFIG_FIELD = `\tcompatibility?: {
 \t\t\twordpress?: string;
 \t\t};
 \t\tmode: 'baseline' | 'optional' | 'required';
+\t\toptionalFeatureIds: string[];
 \t\toptionalFeatures: string[];
+\t\trequiredFeatureIds: string[];
 \t\trequiredFeatures: string[];
 \t\truntimeGates: string[];
 \t};
@@ -1095,6 +1097,57 @@ function ensureInterfaceField(
 	);
 }
 
+function normalizeInterfaceFieldBlock(
+	source: string,
+	interfaceName: string,
+	fieldName: string,
+	fieldSource: string,
+	requiredFragments: string[],
+): string {
+	const interfacePattern = new RegExp(
+		`(export\\s+interface\\s+${escapeRegex(
+			interfaceName,
+		)}\\s*\\{\\r?\\n)([\\s\\S]*?)(\\r?\\n\\})`,
+		"u",
+	);
+
+	return source.replace(
+		interfacePattern,
+		(match, start: string, body: string, end: string) => {
+			const fieldPattern = new RegExp(
+				`^[ \\t]*${escapeRegex(
+					fieldName,
+				)}\\??:\\s*\\{[\\s\\S]*?^[ \\t]*\\};\\r?\\n?`,
+				"mu",
+			);
+			const fieldMatch = fieldPattern.exec(body);
+			if (!fieldMatch) {
+				return match;
+			}
+
+			const existingFieldSource = fieldMatch[0];
+			if (
+				requiredFragments.every((fragment) =>
+					existingFieldSource.includes(fragment),
+				)
+			) {
+				return match;
+			}
+
+			const lineEnding = start.endsWith("\r\n") ? "\r\n" : "\n";
+			const formattedFieldSource = `${fieldSource
+				.replace(/\r?\n$/u, "")
+				.split("\n")
+				.join(lineEnding)}${lineEnding}`;
+
+			return `${start}${body.slice(
+				0,
+				fieldMatch.index,
+			)}${formattedFieldSource}${body.slice(fieldMatch.index + existingFieldSource.length)}${end}`;
+		},
+	);
+}
+
 /**
  * Update `scripts/block-config.ts` source text with additional inventory entries.
  *
@@ -1198,11 +1251,25 @@ export function updateWorkspaceInventorySource(
 		"compatibility",
 		WORKSPACE_COMPATIBILITY_CONFIG_FIELD,
 	);
+	nextSource = normalizeInterfaceFieldBlock(
+		nextSource,
+		"WorkspaceAbilityConfig",
+		"compatibility",
+		WORKSPACE_COMPATIBILITY_CONFIG_FIELD,
+		["optionalFeatureIds: string[];", "requiredFeatureIds: string[];"],
+	);
 	nextSource = ensureInterfaceField(
 		nextSource,
 		"WorkspaceAiFeatureConfig",
 		"compatibility",
 		WORKSPACE_COMPATIBILITY_CONFIG_FIELD,
+	);
+	nextSource = normalizeInterfaceFieldBlock(
+		nextSource,
+		"WorkspaceAiFeatureConfig",
+		"compatibility",
+		WORKSPACE_COMPATIBILITY_CONFIG_FIELD,
+		["optionalFeatureIds: string[];", "requiredFeatureIds: string[];"],
 	);
 	nextSource = appendEntriesAtMarker(
 		nextSource,

--- a/packages/wp-typia-project-tools/src/runtime/workspace-inventory.ts
+++ b/packages/wp-typia-project-tools/src/runtime/workspace-inventory.ts
@@ -1115,9 +1115,9 @@ function normalizeInterfaceFieldBlock(
 		interfacePattern,
 		(match, start: string, body: string, end: string) => {
 			const fieldPattern = new RegExp(
-				`^[ \\t]*${escapeRegex(
+				`(^([ \\t]*)${escapeRegex(
 					fieldName,
-				)}\\??:\\s*\\{[\\s\\S]*?^[ \\t]*\\};\\r?\\n?`,
+				)}\\??:\\s*\\{[ \\t]*\\r?\\n)([\\s\\S]*?)(^\\2\\};\\r?\\n?)`,
 				"mu",
 			);
 			const fieldMatch = fieldPattern.exec(body);

--- a/packages/wp-typia-project-tools/tests/wordpress-ai-spec.test.ts
+++ b/packages/wp-typia-project-tools/tests/wordpress-ai-spec.test.ts
@@ -356,7 +356,9 @@ describe('WordPress AI AbilitySpec foundation', () => {
     expect(optionalPolicy.pluginHeader).toEqual(DEFAULT_SCAFFOLD_COMPATIBILITY);
     expect(createScaffoldCompatibilityConfig(optionalPolicy)).toMatchObject({
       mode: 'optional',
+      optionalFeatureIds: ['wordpress-ai-client'],
       optionalFeatures: ['WordPress AI Client'],
+      requiredFeatureIds: [],
       requiredFeatures: [],
       runtimeGates: [
         'WordPress AI Client: wordpress-core-feature WordPress AI Client',
@@ -376,7 +378,12 @@ describe('WordPress AI AbilitySpec foundation', () => {
         wordpress: '7.0',
       },
       mode: 'required',
+      optionalFeatureIds: [],
       optionalFeatures: [],
+      requiredFeatureIds: [
+        'wordpress-server-abilities',
+        'wordpress-core-abilities',
+      ],
       requiredFeatures: [
         'WordPress Abilities API',
         '@wordpress/core-abilities',

--- a/packages/wp-typia-project-tools/tests/workspace-add.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-add.test.ts
@@ -4273,6 +4273,8 @@ test("canonical CLI can add a server-only AI feature to an official workspace te
     'phpFile: "inc/ai-features/brief-suggestions.php"'
   );
   expect(blockConfigSource).toContain('"mode": "optional"');
+  expect(blockConfigSource).toContain('"optionalFeatureIds": [');
+  expect(blockConfigSource).toContain('"wordpress-ai-client"');
   expect(blockConfigSource).toContain("WordPress AI Client");
   expect(blockConfigSource).toContain(
     "WordPress AI Client: wordpress-core-feature WordPress AI Client"
@@ -4301,8 +4303,19 @@ test("canonical CLI can add a server-only AI feature to an official workspace te
   expect(validatorsSource).toContain("featureRequest");
   expect(validatorsSource).toContain("featureResponse");
   expect(apiSource).toContain("aiFeatureRunEndpoint");
+  expect(apiSource).toContain("aiFeatureSupportMetadata");
+  expect(apiSource).toContain("getAiFeatureSupportHintLines");
+  expect(apiSource).toContain("isAiFeatureSupportUnavailableError");
+  expect(apiSource).toContain("resolveAiFeatureUnavailableMessage");
+  expect(apiSource).toContain("missing-wordpress-ai-client");
+  expect(apiSource).toContain("request-time-support-probe");
+  expect(apiSource).toContain("endpointMethod: 'POST'");
   expect(apiSource).toContain("resolveRestNonce");
   expect(dataSource).toContain("useRunBriefSuggestionsAiFeatureMutation");
+  expect(dataSource).toContain("aiFeatureSupportMetadata");
+  expect(dataSource).toContain("getAiFeatureSupportHintLines");
+  expect(dataSource).toContain("isAiFeatureSupportUnavailableError");
+  expect(dataSource).toContain("resolveAiFeatureUnavailableMessage");
   expect(phpSource).toContain("wp_ai_client_prompt");
   expect(phpSource).toContain("static $is_supported = null;");
   expect(phpSource).toContain("is_supported_for_text_generation");

--- a/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
@@ -654,8 +654,59 @@ export interface WorkspaceAiFeatureConfig {
 `);
 
   expect(repairedSource.match(/^[ \t]*compatibility\??:/gmu)?.length).toBe(2);
-  expect(repairedSource).toContain("optionalFeatureIds: string[];");
-  expect(repairedSource).toContain("requiredFeatureIds: string[];");
+  expect(
+    repairedSource.match(/\boptionalFeatureIds:\s*string\[\];/gu)?.length
+  ).toBe(2);
+  expect(
+    repairedSource.match(/\brequiredFeatureIds:\s*string\[\];/gu)?.length
+  ).toBe(2);
+});
+
+test("workspace inventory repair replaces legacy spaced compatibility blocks without truncating nested fields", () => {
+  const repairedSource = updateWorkspaceInventorySource(`
+export interface WorkspaceAbilityConfig {
+  clientFile: string;
+  compatibility: {
+    hardMinimums: {
+      php?: string;
+      wordpress?: string;
+    };
+    mode: 'baseline' | 'optional' | 'required';
+    optionalFeatures: string[];
+    requiredFeatures: string[];
+    runtimeGates: string[];
+  };
+  configFile: string;
+  slug: string;
+}
+
+export interface WorkspaceAiFeatureConfig {
+  aiSchemaFile: string;
+  clientFile: string;
+  compatibility?: {
+    hardMinimums: {
+      php?: string;
+      wordpress?: string;
+    };
+    mode: 'baseline' | 'optional' | 'required';
+    optionalFeatures: string[];
+    requiredFeatures: string[];
+    runtimeGates: string[];
+  };
+  dataFile: string;
+  slug: string;
+}
+`);
+
+  expect(repairedSource.match(/^[ \t]*compatibility\??:/gmu)?.length).toBe(2);
+  expect(
+    repairedSource.match(/\boptionalFeatureIds:\s*string\[\];/gu)?.length
+  ).toBe(2);
+  expect(
+    repairedSource.match(/\brequiredFeatureIds:\s*string\[\];/gu)?.length
+  ).toBe(2);
+  expect(repairedSource).toContain("\t};\n  configFile: string;");
+  expect(repairedSource).toContain("\t};\n  dataFile: string;");
 });
 
 test("doctor passes on a healthy multi-block workspace", async () => {

--- a/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
@@ -623,7 +623,9 @@ export interface WorkspaceAbilityConfig {
       wordpress?: string;
     };
     mode: 'baseline' | 'optional' | 'required';
+    optionalFeatureIds: string[];
     optionalFeatures: string[];
+    requiredFeatureIds: string[];
     requiredFeatures: string[];
     runtimeGates: string[];
   };
@@ -640,7 +642,9 @@ export interface WorkspaceAiFeatureConfig {
       wordpress?: string;
     };
     mode: 'baseline' | 'optional' | 'required';
+    optionalFeatureIds: string[];
     optionalFeatures: string[];
+    requiredFeatureIds: string[];
     requiredFeatures: string[];
     runtimeGates: string[];
   };
@@ -650,6 +654,8 @@ export interface WorkspaceAiFeatureConfig {
 `);
 
   expect(repairedSource.match(/^[ \t]*compatibility\??:/gmu)?.length).toBe(2);
+  expect(repairedSource).toContain("optionalFeatureIds: string[];");
+  expect(repairedSource).toContain("requiredFeatureIds: string[];");
 });
 
 test("doctor passes on a healthy multi-block workspace", async () => {


### PR DESCRIPTION
## Summary
- expose generated AI feature support metadata and unavailable-message helpers from the scaffolded `api.ts` and `data.ts` helpers
- carry stable AI capability ids through scaffold compatibility metadata so generated clients can reference runtime gates without relying on display labels alone
- extend AI compatibility and workspace scaffold tests to cover the new metadata surface

## Why
- fixes #665
- gives editor/admin UI code enough static metadata to disable or explain optional AI features before a user has to infer support from a failing request

## Validation
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/eslint --no-warn-ignored packages/wp-typia-project-tools/src/runtime/scaffold-compatibility.ts packages/wp-typia-project-tools/src/runtime/workspace-inventory.ts packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai-source-emitters.ts packages/wp-typia-project-tools/tests/wordpress-ai-spec.test.ts packages/wp-typia-project-tools/tests/workspace-add.test.ts packages/wp-typia-project-tools/tests/workspace-doctor.test.ts apps/docs/src/content/docs/reference/api.md`
- `node scripts/check-repo-format.mjs`
- `node scripts/validate-sampo-changesets.mjs`
- `node scripts/validate-runtime-package-coupling.mjs`
- `PATH=/Users/imjlk/.bun/bin:$PATH bun test packages/wp-typia-project-tools/tests/wordpress-ai-spec.test.ts`
- `PATH=/Users/imjlk/.bun/bin:$PATH bun test packages/wp-typia-project-tools/tests/workspace-doctor.test.ts -t "workspace inventory repair|compatibility"`
- targeted AI feature workspace scaffold test reaches the new support-metadata assertions and doctor checks, then stops in this shell because the local `npm` wrapper remains non-executable for the generated `sync-rest` / `sync-ai` follow-up step; CI should cover the normal environment end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI feature support metadata is now exposed to client and editor layers, including compatibility feature identifiers, runtime gating information, and support hints for UI enablement.
  * New helper functions available for detecting unavailable AI features and generating user-friendly error messages to support graceful UI degradation.

* **Documentation**
  * Updated API reference to document support metadata helpers emitted by the AI-feature scaffold generator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->