### PR TITLE
[codex] Return non-zero status for empty CLI invocations

### DIFF
--- a/.sampo/changesets/678-no-command-exit-code.md
+++ b/.sampo/changesets/678-no-command-exit-code.md
@@ -1,0 +1,7 @@
+---
+npm/wp-typia: patch
+---
+
+Return a non-zero exit code when `wp-typia` is invoked without a command while
+still printing the Node fallback help output, and keep explicit help/version
+requests successful.

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -667,12 +667,16 @@ export async function runNodeCli(argv = process.argv.slice(2)): Promise<void> {
   };
   const [command, subcommand] = positionals;
   const helpRequested =
-    cliArgv.length === 0 ||
-    hasFlagBeforeTerminator(cliArgv, '--help') ||
-    command === 'help';
+    hasFlagBeforeTerminator(cliArgv, '--help') || command === 'help';
   const helpTarget = command === 'help' ? subcommand : command;
   const versionRequested =
     hasFlagBeforeTerminator(cliArgv, '--version') || command === 'version';
+
+  if (cliArgv.length === 0) {
+    renderGeneralHelp();
+    process.exitCode = 1;
+    return;
+  }
 
   if (helpRequested) {
     if (helpTarget) {

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -382,6 +382,7 @@ describe('wp-typia package', () => {
   });
 
   test('routes interactive create/add/migrate invocations to the Bunli runtime when Bun and a TTY are available', () => {
+    expect(shouldRouteTestInvocationToFullRuntime([])).toBe(false);
     expect(shouldRouteTestInvocationToFullRuntime(['create'])).toBe(true);
     expect(
       shouldRouteTestInvocationToFullRuntime(['create', '--dry-run']),
@@ -815,6 +816,9 @@ describe('wp-typia package', () => {
   });
 
   test('renders general and command help without requiring a local Bun binary', () => {
+    const noCommandResult = runCapturedCommand(process.execPath, [entryPath], {
+      env: withoutLocalBunEnv(),
+    });
     const helpResult = runCapturedCommand(
       process.execPath,
       [entryPath, '--help'],
@@ -830,6 +834,12 @@ describe('wp-typia package', () => {
       },
     );
 
+    expect(noCommandResult.status).toBe(1);
+    expect(noCommandResult.stderr).toBe('');
+    expect(noCommandResult.stdout).toContain(
+      'Canonical CLI package for wp-typia scaffolding',
+    );
+    expect(noCommandResult.stdout).toContain('Runtime: Node fallback');
     expect(helpResult.status).toBe(0);
     expect(helpResult.stderr).toBe('');
     expect(helpResult.stdout).toContain(


### PR DESCRIPTION
Closes #678

## Summary
- treat `wp-typia` with no command as a usage error while still rendering the fallback help output
- keep explicit help and version requests successful
- cover the no-arg exit code and routing behavior in CLI package tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CLI now returns a non-zero exit code when invoked without arguments while still displaying help text.
  * Explicit `help` and `version` commands continue to work as expected.

* **Tests**
  * Added test coverage for invocations without subcommands, including exit code and output validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->