### PR TITLE
[codex] Normalize bun-only help routing

### DIFF
--- a/.sampo/changesets/679-bun-only-help-routing.md
+++ b/.sampo/changesets/679-bun-only-help-routing.md
@@ -1,0 +1,7 @@
+---
+npm/wp-typia: patch
+---
+
+Normalize `wp-typia --help <bun-only-command>` so it no longer falls into
+low-level Bunli validation errors and instead matches the existing command-help
+or Bun-runtime guidance flow.

--- a/packages/wp-typia/bin/wp-typia.js
+++ b/packages/wp-typia/bin/wp-typia.js
@@ -38,6 +38,20 @@ const sourceCliEntrypoint = path.join(packageRoot, 'src', 'cli.ts');
 const standaloneGuidance =
   'Prefer not to install Bun? Use the standalone wp-typia binary from the GitHub release assets.';
 
+function normalizeTopLevelHelpArgv(argv) {
+  const [firstArg, secondArg, ...rest] = argv;
+  if (
+    (firstArg === '--help' || firstArg === '-h') &&
+    typeof secondArg === 'string' &&
+    secondArg.length > 0 &&
+    !secondArg.startsWith('-')
+  ) {
+    return [secondArg, firstArg, ...rest];
+  }
+
+  return argv;
+}
+
 function isWorkingBunBinary() {
   const bunCheck = spawnSync(bunBinary, ['--version'], {
     env: process.env,
@@ -75,7 +89,7 @@ function ensureBuiltRuntime() {
   return fs.existsSync(cliEntrypoint) && fs.existsSync(nodeCliEntrypoint);
 }
 
-const argv = process.argv.slice(2);
+const argv = normalizeTopLevelHelpArgv(process.argv.slice(2));
 const { command } = getRuntimeRoutingInvocation(argv, {
   longValueOptions: longValueOptionSet,
   reservedCommands: reservedCommandSet,

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -895,6 +895,40 @@ describe('wp-typia package', () => {
     expect(result.stderr).toContain('GitHub release assets');
   });
 
+  test('normalizes --help <bun-only-command> into command help when Bun is available', () => {
+    const result = runCapturedCommand(process.execPath, [entryPath, '--help', 'mcp']);
+    const parsed = JSON.parse(result.stdout.trim()) as {
+      data?: { path?: string[]; text?: string; type?: string };
+      ok?: boolean;
+    };
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(parsed.ok).toBe(true);
+    expect(parsed.data?.type).toBe('help');
+    expect(parsed.data?.path).toEqual(['mcp']);
+    expect(parsed.data?.text).toContain('Usage: wp-typia mcp [options]');
+  });
+
+  test('keeps --help <bun-only-command> on clear Bun guidance when Bun is unavailable', () => {
+    const result = runCapturedCommand(
+      process.execPath,
+      [entryPath, '--help', 'mcp'],
+      {
+        env: withoutLocalBunEnv(),
+      },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain('requires Bun');
+    expect(result.stderr).not.toContain('BunliValidationError');
+    expect(result.stderr).toContain(
+      'Install Bun locally, run with bunx, or set BUN_BIN',
+    );
+    expect(result.stderr).toContain('standalone wp-typia binary');
+  });
+
   test('keeps value-taking options from being mistaken for Bun-only commands', () => {
     const targetDir = path.join(
       os.tmpdir(),


### PR DESCRIPTION
Closes #679

## Summary
- normalize `wp-typia --help <bun-only-command>` before runtime routing
- keep Bun-available help requests on the existing command help path
- keep no-Bun environments on clear Bun guidance instead of Bunli validation errors