### PR TITLE
fix: replace generated interactivity CallableFunction aliases

### DIFF
--- a/.sampo/changesets/676-concrete-interactivity-callables.md
+++ b/.sampo/changesets/676-concrete-interactivity-callables.md
@@ -1,0 +1,7 @@
+---
+npm/wp-typia: patch
+---
+
+Replace generated interactivity `CallableFunction` aliases with explicit
+callable signatures so scaffolded stores stay lint-friendly without weakening
+the typed directive and action helpers.

--- a/packages/wp-typia-project-tools/src/runtime/built-in-block-code-templates/interactivity.ts
+++ b/packages/wp-typia-project-tools/src/runtime/built-in-block-code-templates/interactivity.ts
@@ -431,7 +431,9 @@ type InteractivityActionShape = object;
 type InteractivityCallbackShape = object;
 type InteractivityContextShape = object;
 type InteractivityStateShape = object;
-type InteractivityCallable = CallableFunction;
+type InteractivityCallable =
+  | ((...args: unknown[]) => unknown)
+  | ReturnType<typeof import('@wordpress/interactivity').withSyncEvent>;
 type InteractivityKey<T extends object> = Extract<keyof T, string>;
 type InteractivityMethodKey<T extends object> = {
   [Key in InteractivityKey<T>]: T[Key] extends InteractivityCallable ? Key : never;
@@ -534,7 +536,7 @@ export function defineInteractivityStore<
   };
 }
 
-type InteractivityActionHandler = CallableFunction;
+type InteractivityActionHandler = InteractivityCallable;
 
 export interface {{pascalCase}}StoreActions {
   handleClick: InteractivityActionHandler;

--- a/packages/wp-typia-project-tools/tests/built-in-block-artifacts.test.ts
+++ b/packages/wp-typia-project-tools/tests/built-in-block-artifacts.test.ts
@@ -587,7 +587,7 @@ const EXPECTED_CODE_ARTIFACT_HASH_SUMMARIES: Record<
     'src/editor.scss': '7da532bf2acdc7c1',
     'src/hooks.ts': '3c1b432bd711ee70',
     'src/index.tsx': '09971fea0bb30b8f',
-    'src/interactivity-store.ts': 'be4a237b99d622ce',
+    'src/interactivity-store.ts': 'c29d6e1f3da5ef8e',
     'src/interactivity.ts': '02607a60ca356d79',
     'src/manifest-defaults-document.ts': '16818959f3d5a7d6',
     'src/manifest-document.ts': 'b8fffee2c728488e',

--- a/packages/wp-typia-project-tools/tests/scaffold-basic.test.ts
+++ b/packages/wp-typia-project-tools/tests/scaffold-basic.test.ts
@@ -836,6 +836,13 @@ describe('@wp-typia/project-tools scaffold core', () => {
       expect(generatedEdit).toContain(
         "data-wp-on--click={isPreviewing ? demoInteractivityStore.directive.action('handleClick') : undefined}",
       );
+      expect(generatedInteractivityStore).toContain(
+        "type InteractivityCallable =\n  | ((...args: unknown[]) => unknown)\n  | ReturnType<typeof import('@wordpress/interactivity').withSyncEvent>;",
+      );
+      expect(generatedInteractivityStore).toContain(
+        'type InteractivityActionHandler = InteractivityCallable;',
+      );
+      expect(generatedInteractivityStore).not.toContain('CallableFunction');
       expect(generatedValidators).toContain('from "./validator-toolkit"');
       expect(generatedBlockMetadata).toContain(
         'defineScaffoldBlockMetadata(rawMetadata)',

--- a/packages/wp-typia/tests/add-command.test.ts
+++ b/packages/wp-typia/tests/add-command.test.ts
@@ -82,7 +82,10 @@ describe('wp-typia add command bridge', () => {
     );
     expect(fs.existsSync(path.join(blockDir, 'interactivity.ts'))).toBe(true);
     expect(generatedInteractivityStore).toContain(
-      'type InteractivityCallable = CallableFunction;',
+      "type InteractivityCallable =\n  | ((...args: unknown[]) => unknown)\n  | ReturnType<typeof import('@wordpress/interactivity').withSyncEvent>;",
+    );
+    expect(generatedInteractivityStore).toContain(
+      'type InteractivityActionHandler = InteractivityCallable;',
     );
     expect(generatedInteractivityStore).not.toContain(
       'type InteractivityCallable = Function;',
@@ -90,6 +93,7 @@ describe('wp-typia add command bridge', () => {
     expect(generatedInteractivityStore).not.toContain(
       'type InteractivityActionHandler = Function;',
     );
+    expect(generatedInteractivityStore).not.toContain('CallableFunction');
     expect(generatedInteractivityStore).toContain(
       'action<Key extends InteractivityMethodKey<Actions>>',
     );


### PR DESCRIPTION
## Summary
- replace generated interactivity CallableFunction aliases with concrete callable types
- keep typed directive helpers compatible with WordPress withSyncEvent wrappers
- extend scaffold regressions and artifact snapshots to guard the generated interactivity store

Closes #676

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined type definitions for interactivity store action handlers with more explicit callable signatures, enhancing type safety and improving compatibility with linters and development tools.

* **Tests**
  * Updated test assertions to validate new type definitions for the generated interactivity store code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->