### PR TITLE
test: expand dataviews runtime normalization coverage

### DIFF
--- a/packages/wp-typia-dataviews/README.md
+++ b/packages/wp-typia-dataviews/README.md
@@ -97,6 +97,32 @@ Enum and const schemas also opt into DataForm element validation. These hints do
 not replace typia/schema runtime validation; keep runtime validation as the
 source of truth for persistence and REST writes.
 
+## Normalization boundaries
+
+`defineDataViews<T>()` performs a small amount of runtime normalization for the
+wp-typia facade:
+
+- field labels and descriptions fall back from the field id and schema metadata;
+- schema metadata can infer DataViews field `type`, enum/const `elements`, and
+  `field.isValid` UI hints;
+- omitted `defaultView.fields` fall back to the normalized field ids, and
+  `titleField` is copied into the normalized default view when declared;
+- `toFormConfig()` / `createDataFormConfig()` fill labels and descriptions from
+  normalized DataViews fields while filtering read-only fields unless
+  `includeReadOnly: true` is requested;
+- `toDataViewsQueryArgs()` emits only the mapped pagination, search, sort, and
+  filter params that the caller explicitly enables.
+
+Other guarantees remain intentionally type-level only:
+
+- TypeScript ensures field ids, sort fields, filter fields, and query adapter
+  option names line up when you stay inside the public types.
+- Runtime helpers do not try to repair arbitrary `view` overrides passed through
+  `createConfig({ view })` or `toDataViewsQueryArgs(view, ...)`; if you cast
+  around the types, the runtime trusts the provided object shape.
+- Query adapters merge mapper results exactly as returned. When multiple mapper
+  calls write the same query key, the last returned value wins.
+
 Map DataViews state into REST or custom data-provider args explicitly:
 
 ```ts

--- a/packages/wp-typia-dataviews/tests/data-form.test.ts
+++ b/packages/wp-typia-dataviews/tests/data-form.test.ts
@@ -189,4 +189,36 @@ describe("DataForm helpers", () => {
       ],
     });
   });
+
+  test("keeps group-only fields while filtering read-only children during normalization", () => {
+    const views = defineDataViews<Product>({
+      defaultView: { type: "table" },
+      fields: {
+        id: { readOnly: true, schema: { type: "integer" } },
+        sku: { schema: { type: "string" } },
+        title: { schema: { type: "string" } },
+      },
+    });
+    const form = views.toFormConfig({
+      fields: [
+        {
+          children: ["id", "sku", "title"] as unknown as DataFormField<Product>[],
+          id: "identity" as never,
+          label: "Identity",
+        } as unknown as DataFormField<Product>,
+      ],
+    });
+
+    expect(form.fields).toHaveLength(1);
+    expect(form.fields[0]?.id as unknown as string).toBe("identity");
+    expect(form.fields[0]?.label).toBe("Identity");
+    expect(form.fields[0]?.children?.map((field) => field.id)).toEqual([
+      "sku",
+      "title",
+    ]);
+    expect(form.fields[0]?.children?.map((field) => field.label)).toEqual([
+      "Sku",
+      "Title",
+    ]);
+  });
 });

--- a/packages/wp-typia-dataviews/tests/define-data-views.test.ts
+++ b/packages/wp-typia-dataviews/tests/define-data-views.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { defineDataViews } from "../src/index.js";
+import { defineDataViews, type DataViewsView } from "../src/index.js";
 
 interface Product {
   readonly createdAt: string;
@@ -29,6 +29,38 @@ const sampleProduct: Product = {
 };
 
 describe("defineDataViews", () => {
+  test("supports empty and minimal field definitions", () => {
+    const emptyViews = defineDataViews<Product>({
+      defaultView: { type: "table" },
+      fields: {},
+    });
+    const minimalViews = defineDataViews<Product>({
+      defaultView: { type: "table" },
+      fields: {
+        title: {},
+      },
+    });
+
+    expect(emptyViews.fields).toEqual([]);
+    expect(emptyViews.defaultView).toEqual({
+      fields: [],
+      type: "table",
+    });
+    expect(emptyViews.createConfig({ data: [] }).fields).toEqual([]);
+    expect(emptyViews.getItemId).toBeUndefined();
+    expect(minimalViews.fieldMap.title).toMatchObject({
+      id: "title",
+      label: "Title",
+    });
+    expect(minimalViews.fieldMap.title?.description).toBeUndefined();
+    expect(minimalViews.fieldMap.title?.elements).toBeUndefined();
+    expect(minimalViews.fieldMap.title?.type).toBeUndefined();
+    expect(minimalViews.defaultView).toEqual({
+      fields: ["title"],
+      type: "table",
+    });
+  });
+
   test("normalizes primitive schema metadata into DataViews field types", () => {
     const views = defineDataViews<Product>({
       defaultView: { type: "table" },
@@ -75,6 +107,30 @@ describe("defineDataViews", () => {
       { label: "Draft", value: "draft" },
       { label: "Published", value: "publish" },
     ]);
+  });
+
+  test("normalizes schema-only fields with const elements and schema descriptions", () => {
+    const views = defineDataViews<Product>({
+      defaultView: { type: "table" },
+      fields: {
+        status: {
+          schema: {
+            const: "draft",
+            description: "Single supported status",
+            type: "string",
+          },
+        },
+      },
+    });
+
+    expect(views.fieldMap.status).toMatchObject({
+      description: "Single supported status",
+      elements: [{ label: "Draft", value: "draft" }],
+      id: "status",
+      label: "Status",
+      type: "text",
+    });
+    expect(views.fieldMap.status?.isValid).toEqual({ elements: true });
   });
 
   test("normalizes date-like and URL metadata while preserving field options", () => {
@@ -171,6 +227,61 @@ describe("defineDataViews", () => {
 
     expect(config.getItemId?.(sampleProduct)).toBe("product:1");
     expect(config.getItemLevel?.(sampleProduct)).toBe(2);
+  });
+
+  test("merges schema validation hints with explicit field validation overrides", () => {
+    const customValidation = () => null;
+    const views = defineDataViews<Product>({
+      defaultView: { type: "table" },
+      fields: {
+        title: {
+          isValid: {
+            custom: customValidation,
+            maxLength: 80,
+            minLength: 20,
+            required: false,
+          },
+          schema: {
+            maxLength: 120,
+            minLength: 10,
+            required: true,
+            type: "string",
+          },
+        },
+      },
+    });
+
+    expect(views.fieldMap.title?.isValid).toEqual({
+      custom: customValidation,
+      maxLength: 80,
+      minLength: 20,
+      required: false,
+    });
+  });
+
+  test("normalizes only declared default views and trusts runtime override views as-is", () => {
+    const views = defineDataViews<Product>({
+      defaultView: {
+        sort: { direction: "desc", field: "views" },
+        type: "table",
+      },
+      fields: {
+        title: { schema: { type: "string" } },
+        views: { schema: { type: "integer" } },
+      },
+      titleField: "title",
+    });
+    const runtimeViewOverride = { type: "grid" } as DataViewsView<Product>;
+
+    expect(views.defaultView).toEqual({
+      fields: ["title", "views"],
+      sort: { direction: "desc", field: "views" },
+      titleField: "title",
+      type: "table",
+    });
+    expect(views.createConfig({ data: [sampleProduct], view: runtimeViewOverride }).view).toBe(
+      runtimeViewOverride,
+    );
   });
 
   test("guards unsafe idField values when runtime input bypasses the type contract", () => {

--- a/packages/wp-typia-dataviews/tests/query-adapter.test.ts
+++ b/packages/wp-typia-dataviews/tests/query-adapter.test.ts
@@ -113,6 +113,41 @@ describe("DataViews query adapters", () => {
     });
   });
 
+  test("keeps missing view data and later filter mappings as runtime no-ops or overrides", () => {
+    const query = toDataViewsQueryArgs<
+      Product,
+      { readonly status?: Product["status"]; readonly title?: string }
+    >(
+      {
+        filters: [
+          { field: "status", operator: "is", value: "draft" },
+          { field: "status", operator: "is", value: "publish" },
+          { field: "title", operator: "is", value: "Typed block patterns" },
+        ],
+        type: "table",
+      },
+      {
+        mapFilter: (filter) => {
+          if (filter.field === "status" && filter.operator === "is") {
+            return { status: filter.value as Product["status"] };
+          }
+
+          return filter.field === "title"
+            ? { title: filter.value as string }
+            : null;
+        },
+        pageParam: false,
+        perPageParam: false,
+        searchParam: false,
+      },
+    );
+
+    expect(query).toEqual({
+      status: "publish",
+      title: "Typed block patterns",
+    });
+  });
+
   test("treats orderByParam false as static sort map suppression", () => {
     const query = toDataViewsQueryArgs<Product, WordPressProductQuery>(productView, {
       mapSort: {
@@ -182,6 +217,19 @@ describe("DataViews query adapters", () => {
       pageNo: 2,
       q: "typed blocks",
     });
+  });
+
+  test("returns an empty query when the view has no mapped runtime state", () => {
+    expect(
+      toDataViewsQueryArgs<Product, CompactProductQuery>(
+        { type: "table" },
+        {
+          pageParam: false,
+          perPageParam: false,
+          searchParam: false,
+        },
+      ),
+    ).toEqual({});
   });
 
   test("exposes toQueryArgs from defineDataViews with normalized fields context", () => {


### PR DESCRIPTION
## Summary
- add focused runtime normalization tests for defineDataViews, query adapters, and DataForm helpers
- cover empty/minimal field definitions, schema-only normalization, validation merging, default-view/runtime-view boundaries, and query adapter edge cases
- document which dataviews guarantees are runtime-normalized versus type-level only

Closes #677