### PR TITLE
[codex] refactor(add): consolidate residual add-command helper duplication

### DIFF
--- a/.sampo/changesets/675-add-command-helper-consolidation.md
+++ b/.sampo/changesets/675-add-command-helper-consolidation.md
@@ -1,0 +1,9 @@
+---
+npm/wp-typia: patch
+npm/@wp-typia/project-tools: patch
+---
+
+Consolidate residual add-command helper duplication by sharing strict versus
+loose CLI string flag readers, external-layer prompt hints, and scaffold
+collision checks while preserving existing diagnostics and add workflow
+behavior.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-shared.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-shared.ts
@@ -502,34 +502,122 @@ export function getMutableBlockHooks(
 	return blockHooks as Record<string, string>;
 }
 
+type ScaffoldFilesystemCollision = {
+	label: string;
+	relativePath: string;
+};
+
+type ScaffoldInventoryCollision<TEntry> = {
+	entries: readonly TEntry[];
+	exists: (entry: TEntry) => boolean;
+	message: string;
+};
+
+export function assertScaffoldDoesNotExist<TEntry>(options: {
+	projectDir: string;
+	filesystemCollisions: readonly ScaffoldFilesystemCollision[];
+	inventoryCollision?: ScaffoldInventoryCollision<TEntry>;
+}): void {
+	for (const collision of options.filesystemCollisions) {
+		const targetPath = path.join(options.projectDir, collision.relativePath);
+		if (fs.existsSync(targetPath)) {
+			throw new Error(
+				`${collision.label} already exists at ${path.relative(options.projectDir, targetPath)}. Choose a different name.`,
+			);
+		}
+	}
+
+	if (
+		options.inventoryCollision &&
+		options.inventoryCollision.entries.some(options.inventoryCollision.exists)
+	) {
+		throw new Error(options.inventoryCollision.message);
+	}
+}
+
 export function assertVariationDoesNotExist(
 	projectDir: string,
 	blockSlug: string,
 	variationSlug: string,
 	inventory: WorkspaceInventory,
 ): void {
-	const variationPath = path.join(
+	assertScaffoldDoesNotExist({
+		filesystemCollisions: [
+			{
+				label: "A variation",
+				relativePath: path.join(
+					"src",
+					"blocks",
+					blockSlug,
+					"variations",
+					`${variationSlug}.ts`,
+				),
+			},
+		],
+		inventoryCollision: {
+			entries: inventory.variations,
+			exists: (entry) => entry.block === blockSlug && entry.slug === variationSlug,
+			message: `A variation inventory entry already exists for ${blockSlug}/${variationSlug}. Choose a different name.`,
+		},
 		projectDir,
-		"src",
-		"blocks",
-		blockSlug,
-		"variations",
-		`${variationSlug}.ts`,
-	);
-	if (fs.existsSync(variationPath)) {
-		throw new Error(
-			`A variation already exists at ${path.relative(projectDir, variationPath)}. Choose a different name.`,
-		);
-	}
-	if (
-		inventory.variations.some(
-			(entry) => entry.block === blockSlug && entry.slug === variationSlug,
-		)
-	) {
-		throw new Error(
-			`A variation inventory entry already exists for ${blockSlug}/${variationSlug}. Choose a different name.`,
-		);
-	}
+	});
+}
+
+export function assertBlockStyleDoesNotExist(
+	projectDir: string,
+	blockSlug: string,
+	styleSlug: string,
+	inventory: WorkspaceInventory,
+): void {
+	assertScaffoldDoesNotExist({
+		filesystemCollisions: [
+			{
+				label: "A block style",
+				relativePath: path.join(
+					"src",
+					"blocks",
+					blockSlug,
+					"styles",
+					`${styleSlug}.ts`,
+				),
+			},
+		],
+		inventoryCollision: {
+			entries: inventory.blockStyles,
+			exists: (entry) => entry.block === blockSlug && entry.slug === styleSlug,
+			message: `A block style inventory entry already exists for ${blockSlug}/${styleSlug}. Choose a different name.`,
+		},
+		projectDir,
+	});
+}
+
+export function assertBlockTransformDoesNotExist(
+	projectDir: string,
+	blockSlug: string,
+	transformSlug: string,
+	inventory: WorkspaceInventory,
+): void {
+	assertScaffoldDoesNotExist({
+		filesystemCollisions: [
+			{
+				label: "A block transform",
+				relativePath: path.join(
+					"src",
+					"blocks",
+					blockSlug,
+					"transforms",
+					`${transformSlug}.ts`,
+				),
+			},
+		],
+		inventoryCollision: {
+			entries: inventory.blockTransforms,
+			exists: (entry) =>
+				entry.block === blockSlug && entry.slug === transformSlug,
+			message: `A block transform inventory entry already exists for ${blockSlug}/${transformSlug}. Choose a different name.`,
+		},
+		projectDir,
+	});
 }
 
 export function assertPatternDoesNotExist(
@@ -537,17 +625,20 @@ export function assertPatternDoesNotExist(
 	patternSlug: string,
 	inventory: WorkspaceInventory,
 ): void {
-	const patternPath = path.join(projectDir, "src", "patterns", `${patternSlug}.php`);
-	if (fs.existsSync(patternPath)) {
-		throw new Error(
-			`A pattern already exists at ${path.relative(projectDir, patternPath)}. Choose a different name.`,
-		);
-	}
-	if (inventory.patterns.some((entry) => entry.slug === patternSlug)) {
-		throw new Error(
-			`A pattern inventory entry already exists for ${patternSlug}. Choose a different name.`,
-		);
-	}
+	assertScaffoldDoesNotExist({
+		filesystemCollisions: [
+			{
+				label: "A pattern",
+				relativePath: path.join("src", "patterns", `${patternSlug}.php`),
+			},
+		],
+		inventoryCollision: {
+			entries: inventory.patterns,
+			exists: (entry) => entry.slug === patternSlug,
+			message: `A pattern inventory entry already exists for ${patternSlug}. Choose a different name.`,
+		},
+		projectDir,
+	});
 }
 
 export function assertBindingSourceDoesNotExist(
@@ -555,17 +646,20 @@ export function assertBindingSourceDoesNotExist(
 	bindingSourceSlug: string,
 	inventory: WorkspaceInventory,
 ): void {
-	const bindingSourceDir = path.join(projectDir, "src", "bindings", bindingSourceSlug);
-	if (fs.existsSync(bindingSourceDir)) {
-		throw new Error(
-			`A binding source already exists at ${path.relative(projectDir, bindingSourceDir)}. Choose a different name.`,
-		);
-	}
-	if (inventory.bindingSources.some((entry) => entry.slug === bindingSourceSlug)) {
-		throw new Error(
-			`A binding source inventory entry already exists for ${bindingSourceSlug}. Choose a different name.`,
-		);
-	}
+	assertScaffoldDoesNotExist({
+		filesystemCollisions: [
+			{
+				label: "A binding source",
+				relativePath: path.join("src", "bindings", bindingSourceSlug),
+			},
+		],
+		inventoryCollision: {
+			entries: inventory.bindingSources,
+			exists: (entry) => entry.slug === bindingSourceSlug,
+			message: `A binding source inventory entry already exists for ${bindingSourceSlug}. Choose a different name.`,
+		},
+		projectDir,
+	});
 }
 
 export function assertRestResourceDoesNotExist(
@@ -573,23 +667,24 @@ export function assertRestResourceDoesNotExist(
 	restResourceSlug: string,
 	inventory: WorkspaceInventory,
 ): void {
-	const restResourceDir = path.join(projectDir, "src", "rest", restResourceSlug);
-	const restResourcePhpPath = path.join(projectDir, "inc", "rest", `${restResourceSlug}.php`);
-	if (fs.existsSync(restResourceDir)) {
-		throw new Error(
-			`A REST resource already exists at ${path.relative(projectDir, restResourceDir)}. Choose a different name.`,
-		);
-	}
-	if (fs.existsSync(restResourcePhpPath)) {
-		throw new Error(
-			`A REST resource bootstrap already exists at ${path.relative(projectDir, restResourcePhpPath)}. Choose a different name.`,
-		);
-	}
-	if (inventory.restResources.some((entry) => entry.slug === restResourceSlug)) {
-		throw new Error(
-			`A REST resource inventory entry already exists for ${restResourceSlug}. Choose a different name.`,
-		);
-	}
+	assertScaffoldDoesNotExist({
+		filesystemCollisions: [
+			{
+				label: "A REST resource",
+				relativePath: path.join("src", "rest", restResourceSlug),
+			},
+			{
+				label: "A REST resource bootstrap",
+				relativePath: path.join("inc", "rest", `${restResourceSlug}.php`),
+			},
+		],
+		inventoryCollision: {
+			entries: inventory.restResources,
+			exists: (entry) => entry.slug === restResourceSlug,
+			message: `A REST resource inventory entry already exists for ${restResourceSlug}. Choose a different name.`,
+		},
+		projectDir,
+	});
 }
 
 /**
@@ -606,23 +701,24 @@ export function assertAdminViewDoesNotExist(
 	adminViewSlug: string,
 	inventory: WorkspaceInventory,
 ): void {
-	const adminViewDir = path.join(projectDir, "src", "admin-views", adminViewSlug);
-	const adminViewPhpPath = path.join(projectDir, "inc", "admin-views", `${adminViewSlug}.php`);
-	if (fs.existsSync(adminViewDir)) {
-		throw new Error(
-			`An admin view already exists at ${path.relative(projectDir, adminViewDir)}. Choose a different name.`,
-		);
-	}
-	if (fs.existsSync(adminViewPhpPath)) {
-		throw new Error(
-			`An admin view bootstrap already exists at ${path.relative(projectDir, adminViewPhpPath)}. Choose a different name.`,
-		);
-	}
-	if (inventory.adminViews.some((entry) => entry.slug === adminViewSlug)) {
-		throw new Error(
-			`An admin view inventory entry already exists for ${adminViewSlug}. Choose a different name.`,
-		);
-	}
+	assertScaffoldDoesNotExist({
+		filesystemCollisions: [
+			{
+				label: "An admin view",
+				relativePath: path.join("src", "admin-views", adminViewSlug),
+			},
+			{
+				label: "An admin view bootstrap",
+				relativePath: path.join("inc", "admin-views", `${adminViewSlug}.php`),
+			},
+		],
+		inventoryCollision: {
+			entries: inventory.adminViews,
+			exists: (entry) => entry.slug === adminViewSlug,
+			message: `An admin view inventory entry already exists for ${adminViewSlug}. Choose a different name.`,
+		},
+		projectDir,
+	});
 }
 
 /**
@@ -642,23 +738,24 @@ export function assertAbilityDoesNotExist(
 	abilitySlug: string,
 	inventory: WorkspaceInventory,
 ): void {
-	const abilityDir = path.join(projectDir, "src", "abilities", abilitySlug);
-	const abilityPhpPath = path.join(projectDir, "inc", "abilities", `${abilitySlug}.php`);
-	if (fs.existsSync(abilityDir)) {
-		throw new Error(
-			`An ability scaffold already exists at ${path.relative(projectDir, abilityDir)}. Choose a different name.`,
-		);
-	}
-	if (fs.existsSync(abilityPhpPath)) {
-		throw new Error(
-			`An ability bootstrap already exists at ${path.relative(projectDir, abilityPhpPath)}. Choose a different name.`,
-		);
-	}
-	if (inventory.abilities.some((entry) => entry.slug === abilitySlug)) {
-		throw new Error(
-			`An ability inventory entry already exists for ${abilitySlug}. Choose a different name.`,
-		);
-	}
+	assertScaffoldDoesNotExist({
+		filesystemCollisions: [
+			{
+				label: "An ability scaffold",
+				relativePath: path.join("src", "abilities", abilitySlug),
+			},
+			{
+				label: "An ability bootstrap",
+				relativePath: path.join("inc", "abilities", `${abilitySlug}.php`),
+			},
+		],
+		inventoryCollision: {
+			entries: inventory.abilities,
+			exists: (entry) => entry.slug === abilitySlug,
+			message: `An ability inventory entry already exists for ${abilitySlug}. Choose a different name.`,
+		},
+		projectDir,
+	});
 }
 
 export function assertAiFeatureDoesNotExist(
@@ -666,28 +763,24 @@ export function assertAiFeatureDoesNotExist(
 	aiFeatureSlug: string,
 	inventory: WorkspaceInventory,
 ): void {
-	const aiFeatureDir = path.join(projectDir, "src", "ai-features", aiFeatureSlug);
-	const aiFeaturePhpPath = path.join(
+	assertScaffoldDoesNotExist({
+		filesystemCollisions: [
+			{
+				label: "An AI feature",
+				relativePath: path.join("src", "ai-features", aiFeatureSlug),
+			},
+			{
+				label: "An AI feature bootstrap",
+				relativePath: path.join("inc", "ai-features", `${aiFeatureSlug}.php`),
+			},
+		],
+		inventoryCollision: {
+			entries: inventory.aiFeatures,
+			exists: (entry) => entry.slug === aiFeatureSlug,
+			message: `An AI feature inventory entry already exists for ${aiFeatureSlug}. Choose a different name.`,
+		},
 		projectDir,
-		"inc",
-		"ai-features",
-		`${aiFeatureSlug}.php`,
-	);
-	if (fs.existsSync(aiFeatureDir)) {
-		throw new Error(
-			`An AI feature already exists at ${path.relative(projectDir, aiFeatureDir)}. Choose a different name.`,
-		);
-	}
-	if (fs.existsSync(aiFeaturePhpPath)) {
-		throw new Error(
-			`An AI feature bootstrap already exists at ${path.relative(projectDir, aiFeaturePhpPath)}. Choose a different name.`,
-		);
-	}
-	if (inventory.aiFeatures.some((entry) => entry.slug === aiFeatureSlug)) {
-		throw new Error(
-			`An AI feature inventory entry already exists for ${aiFeatureSlug}. Choose a different name.`,
-		);
-	}
+	});
 }
 
 /**
@@ -699,18 +792,25 @@ export function assertAiFeatureDoesNotExist(
  * @param inventory Parsed workspace inventory.
  * @throws {Error} When the directory or inventory entry already exists.
  */
-export function assertEditorPluginDoesNotExist(projectDir: string, editorPluginSlug: string, inventory: WorkspaceInventory): void {
-	const editorPluginDir = path.join(projectDir, "src", "editor-plugins", editorPluginSlug);
-	if (fs.existsSync(editorPluginDir)) {
-		throw new Error(
-			`An editor plugin already exists at ${path.relative(projectDir, editorPluginDir)}. Choose a different name.`,
-		);
-	}
-	if (inventory.editorPlugins.some((entry) => entry.slug === editorPluginSlug)) {
-		throw new Error(
-			`An editor plugin inventory entry already exists for ${editorPluginSlug}. Choose a different name.`,
-		);
-	}
+export function assertEditorPluginDoesNotExist(
+	projectDir: string,
+	editorPluginSlug: string,
+	inventory: WorkspaceInventory,
+): void {
+	assertScaffoldDoesNotExist({
+		filesystemCollisions: [
+			{
+				label: "An editor plugin",
+				relativePath: path.join("src", "editor-plugins", editorPluginSlug),
+			},
+		],
+		inventoryCollision: {
+			entries: inventory.editorPlugins,
+			exists: (entry) => entry.slug === editorPluginSlug,
+			message: `An editor plugin inventory entry already exists for ${editorPluginSlug}. Choose a different name.`,
+		},
+		projectDir,
+	});
 }
 
 /**

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-shared.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-shared.ts
@@ -513,6 +513,12 @@ type ScaffoldInventoryCollision<TEntry> = {
 	message: string;
 };
 
+/**
+ * Ensure scaffold targets do not already exist on disk or in workspace inventory.
+ *
+ * @param options Collision checks to run before writing scaffold files.
+ * @throws {Error} When a filesystem path or inventory entry already exists.
+ */
 export function assertScaffoldDoesNotExist<TEntry>(options: {
 	projectDir: string;
 	filesystemCollisions: readonly ScaffoldFilesystemCollision[];
@@ -535,6 +541,15 @@ export function assertScaffoldDoesNotExist<TEntry>(options: {
 	}
 }
 
+/**
+ * Ensure a block variation scaffold does not already exist.
+ *
+ * @param projectDir Absolute workspace root used to resolve scaffold paths.
+ * @param blockSlug Existing workspace block slug that owns the variation.
+ * @param variationSlug Normalized variation slug that would be created.
+ * @param inventory Current workspace inventory used for duplicate detection.
+ * @throws {Error} When the variation file or inventory entry already exists.
+ */
 export function assertVariationDoesNotExist(
 	projectDir: string,
 	blockSlug: string,
@@ -563,6 +578,15 @@ export function assertVariationDoesNotExist(
 	});
 }
 
+/**
+ * Ensure a block style scaffold does not already exist.
+ *
+ * @param projectDir Absolute workspace root used to resolve scaffold paths.
+ * @param blockSlug Existing workspace block slug that owns the style.
+ * @param styleSlug Normalized style slug that would be created.
+ * @param inventory Current workspace inventory used for duplicate detection.
+ * @throws {Error} When the style file or inventory entry already exists.
+ */
 export function assertBlockStyleDoesNotExist(
 	projectDir: string,
 	blockSlug: string,
@@ -591,6 +615,15 @@ export function assertBlockStyleDoesNotExist(
 	});
 }
 
+/**
+ * Ensure a block transform scaffold does not already exist.
+ *
+ * @param projectDir Absolute workspace root used to resolve scaffold paths.
+ * @param blockSlug Existing workspace block slug that owns the transform.
+ * @param transformSlug Normalized transform slug that would be created.
+ * @param inventory Current workspace inventory used for duplicate detection.
+ * @throws {Error} When the transform file or inventory entry already exists.
+ */
 export function assertBlockTransformDoesNotExist(
 	projectDir: string,
 	blockSlug: string,

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-assets.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-assets.ts
@@ -41,6 +41,7 @@ import {
 	type WorkspaceMutationSnapshot,
 	snapshotWorkspaceFiles,
 } from "./cli-add-shared.js";
+import { normalizeOptionalCliString } from "./cli-validation.js";
 
 const PATTERN_BOOTSTRAP_CATEGORY = "register_block_pattern_category";
 const BINDING_SOURCE_SERVER_GLOB = "/src/bindings/*/server.php";
@@ -320,9 +321,10 @@ function resolveBindingTarget(
 	options: Pick<RunAddBindingSourceCommandOptions, "attributeName" | "blockName">,
 	namespace: string,
 ): BindingTarget | undefined {
-	const hasBlock = options.blockName !== undefined && options.blockName.trim().length > 0;
-	const hasAttribute =
-		options.attributeName !== undefined && options.attributeName.trim().length > 0;
+	const blockName = normalizeOptionalCliString(options.blockName);
+	const attributeName = normalizeOptionalCliString(options.attributeName);
+	const hasBlock = blockName !== undefined;
+	const hasAttribute = attributeName !== undefined;
 	if (!hasBlock && !hasAttribute) {
 		return undefined;
 	}
@@ -333,8 +335,8 @@ function resolveBindingTarget(
 	}
 
 	return {
-		attributeName: assertValidBindingAttributeName(options.attributeName ?? ""),
-		blockSlug: resolveBindingTargetBlockSlug(options.blockName ?? "", namespace),
+		attributeName: assertValidBindingAttributeName(attributeName ?? ""),
+		blockSlug: resolveBindingTargetBlockSlug(blockName ?? "", namespace),
 	};
 }
 

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace.ts
@@ -7,6 +7,8 @@ import { resolveWorkspaceProject } from "./workspace-project.js";
 import { appendWorkspaceInventoryEntries, readWorkspaceInventory } from "./workspace-inventory.js";
 import { toKebabCase, toSnakeCase, toTitleCase } from "./string-case.js";
 import {
+	assertBlockStyleDoesNotExist,
+	assertBlockTransformDoesNotExist,
 	assertValidGeneratedSlug,
 	assertValidHookAnchor,
 	assertValidHookedBlockPosition,
@@ -690,66 +692,6 @@ async function writeBlockTransformRegistry(
 		buildBlockTransformIndexSource(nextTransformSlugs),
 		"utf8",
 	);
-}
-
-function assertBlockStyleDoesNotExist(
-	projectDir: string,
-	blockSlug: string,
-	styleSlug: string,
-	inventory: ReturnType<typeof readWorkspaceInventory>,
-): void {
-	const stylePath = path.join(
-		projectDir,
-		"src",
-		"blocks",
-		blockSlug,
-		"styles",
-		`${styleSlug}.ts`,
-	);
-	if (fs.existsSync(stylePath)) {
-		throw new Error(
-			`A block style already exists at ${path.relative(projectDir, stylePath)}. Choose a different name.`,
-		);
-	}
-	if (
-		inventory.blockStyles.some(
-			(entry) => entry.block === blockSlug && entry.slug === styleSlug,
-		)
-	) {
-		throw new Error(
-			`A block style inventory entry already exists for ${blockSlug}/${styleSlug}. Choose a different name.`,
-		);
-	}
-}
-
-function assertBlockTransformDoesNotExist(
-	projectDir: string,
-	blockSlug: string,
-	transformSlug: string,
-	inventory: ReturnType<typeof readWorkspaceInventory>,
-): void {
-	const transformPath = path.join(
-		projectDir,
-		"src",
-		"blocks",
-		blockSlug,
-		"transforms",
-		`${transformSlug}.ts`,
-	);
-	if (fs.existsSync(transformPath)) {
-		throw new Error(
-			`A block transform already exists at ${path.relative(projectDir, transformPath)}. Choose a different name.`,
-		);
-	}
-	if (
-		inventory.blockTransforms.some(
-			(entry) => entry.block === blockSlug && entry.slug === transformSlug,
-		)
-	) {
-		throw new Error(
-			`A block transform inventory entry already exists for ${blockSlug}/${transformSlug}. Choose a different name.`,
-		);
-	}
 }
 
 function assertFullBlockName(blockName: string, flagName: string): string {

--- a/packages/wp-typia-project-tools/tests/cli-add-shared.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-add-shared.test.ts
@@ -1,0 +1,70 @@
+import { afterAll, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  assertScaffoldDoesNotExist,
+} from '../src/runtime/cli-add-shared.js';
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wp-typia-add-shared-'));
+
+afterAll(() => {
+  fs.rmSync(tempRoot, { force: true, recursive: true });
+});
+
+test('shared add collision helper allows missing filesystem paths and inventory entries', () => {
+  expect(() =>
+    assertScaffoldDoesNotExist({
+      filesystemCollisions: [
+        {
+          label: 'A pattern',
+          relativePath: 'src/patterns/hero.php',
+        },
+      ],
+      inventoryCollision: {
+        entries: [],
+        exists: () => false,
+        message: 'inventory collision',
+      },
+      projectDir: tempRoot,
+    }),
+  ).not.toThrow();
+});
+
+test('shared add collision helper preserves filesystem collision messages', () => {
+  const projectDir = path.join(tempRoot, 'filesystem-collision');
+  const patternPath = path.join(projectDir, 'src', 'patterns', 'hero.php');
+  fs.mkdirSync(path.dirname(patternPath), { recursive: true });
+  fs.writeFileSync(patternPath, '<?php\n', 'utf8');
+
+  expect(() =>
+    assertScaffoldDoesNotExist({
+      filesystemCollisions: [
+        {
+          label: 'A pattern',
+          relativePath: path.join('src', 'patterns', 'hero.php'),
+        },
+      ],
+      projectDir,
+    }),
+  ).toThrow(
+    'A pattern already exists at src/patterns/hero.php. Choose a different name.',
+  );
+});
+
+test('shared add collision helper preserves inventory collision messages', () => {
+  expect(() =>
+    assertScaffoldDoesNotExist({
+      inventoryCollision: {
+        entries: [{ slug: 'hero' }],
+        exists: (entry) => entry.slug === 'hero',
+        message: 'A pattern inventory entry already exists for hero. Choose a different name.',
+      },
+      filesystemCollisions: [],
+      projectDir: tempRoot,
+    }),
+  ).toThrow(
+    'A pattern inventory entry already exists for hero. Choose a different name.',
+  );
+});

--- a/packages/wp-typia/src/add-kind-registry.ts
+++ b/packages/wp-typia/src/add-kind-registry.ts
@@ -5,6 +5,15 @@ import {
 import type * as CliAddRuntime from '@wp-typia/project-tools/cli-add';
 import type { ReadlinePrompt } from '@wp-typia/project-tools/cli-prompt';
 import { ADD_KIND_IDS, type AddKindId } from './add-kind-ids';
+import {
+  readOptionalPairedStrictStringFlags,
+  readOptionalStrictStringFlag,
+  requireStrictStringFlag,
+} from './cli-string-flags';
+import {
+  toExternalLayerPromptOptions,
+  type ExternalLayerSelectOption,
+} from './external-layer-prompt-options';
 
 export { ADD_KIND_IDS } from './add-kind-ids';
 export type { AddKindId } from './add-kind-ids';
@@ -13,11 +22,6 @@ type PrintLine = (line: string) => void;
 type AddRuntime = typeof CliAddRuntime;
 type AddKindExecutionResultBase = {
   projectDir: string;
-};
-type ExternalLayerSelectOption = {
-  description?: string;
-  extends: string[];
-  id: string;
 };
 
 export type AddFieldName =
@@ -193,57 +197,6 @@ const NAME_NAMESPACE_VISIBLE_FIELDS = [
   'namespace',
 ] as const satisfies ReadonlyArray<AddFieldName>;
 
-function readOptionalStringFlag(
-  flags: Record<string, unknown>,
-  name: string,
-): string | undefined {
-  const value = flags[name];
-  if (value === undefined || value === null) {
-    return undefined;
-  }
-  if (typeof value !== 'string' || value.trim().length === 0) {
-    throw createCliDiagnosticCodeError(
-      CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
-      `\`--${name}\` requires a value.`,
-    );
-  }
-  return value;
-}
-
-function requireStringFlag(
-  flags: Record<string, unknown>,
-  name: string,
-  message: string,
-): string {
-  const value = readOptionalStringFlag(flags, name);
-  if (!value) {
-    throw createCliDiagnosticCodeError(
-      CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
-      message,
-    );
-  }
-
-  return value;
-}
-
-function readOptionalPairedStringFlags(
-  flags: Record<string, unknown>,
-  leftName: string,
-  rightName: string,
-  message: string,
-): readonly [string | undefined, string | undefined] {
-  const leftValue = readOptionalStringFlag(flags, leftName);
-  const rightValue = readOptionalStringFlag(flags, rightName);
-  if (Boolean(leftValue) !== Boolean(rightValue)) {
-    throw createCliDiagnosticCodeError(
-      CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
-      message,
-    );
-  }
-
-  return [leftValue, rightValue] as const;
-}
-
 function requireAddKindName(
   context: AddKindExecutionContext,
   message: string,
@@ -256,29 +209,6 @@ function requireAddKindName(
   }
 
   return context.name;
-}
-
-function formatExternalLayerSelectHint(
-  option: ExternalLayerSelectOption,
-): string | undefined {
-  const details = [
-    option.description,
-    option.extends.length > 0
-      ? `extends ${option.extends.join(', ')}`
-      : undefined,
-  ].filter(
-    (value): value is string => typeof value === 'string' && value.length > 0,
-  );
-
-  return details.length > 0 ? details.join(' · ') : undefined;
-}
-
-function toExternalLayerPromptOptions(options: ExternalLayerSelectOption[]) {
-  return options.map((option) => ({
-    hint: formatExternalLayerSelectHint(option),
-    label: option.id,
-    value: option.id,
-  }));
 }
 
 function defineAddKindRegistryEntry<TResult extends AddKindExecutionResultBase>(
@@ -334,7 +264,7 @@ export const ADD_KIND_REGISTRY = {
         context,
         '`wp-typia add admin-view` requires <name>. Usage: wp-typia add admin-view <name> [--source <rest-resource:slug|core-data:kind/name>].',
       );
-      const source = readOptionalStringFlag(context.flags, 'source');
+      const source = readOptionalStrictStringFlag(context.flags, 'source');
 
       return createNamedExecutionPlan(context, {
         execute: ({ cwd, name }) =>
@@ -385,7 +315,7 @@ export const ADD_KIND_REGISTRY = {
         context,
         '`wp-typia add binding-source` requires <name>. Usage: wp-typia add binding-source <name> [--block <block-slug|namespace/block-slug> --attribute <attribute>].',
       );
-      const [blockName, attributeName] = readOptionalPairedStringFlags(
+      const [blockName, attributeName] = readOptionalPairedStrictStringFlags(
         context.flags,
         'block',
         'attribute',
@@ -439,11 +369,11 @@ export const ADD_KIND_REGISTRY = {
         context,
         '`wp-typia add block` requires <name>. Usage: wp-typia add block <name> [--template <basic|interactivity|persistence|compound>]',
       );
-      const externalLayerId = readOptionalStringFlag(
+      const externalLayerId = readOptionalStrictStringFlag(
         context.flags,
         'external-layer-id',
       );
-      const externalLayerSource = readOptionalStringFlag(
+      const externalLayerSource = readOptionalStrictStringFlag(
         context.flags,
         'external-layer-source',
       );
@@ -454,23 +384,23 @@ export const ADD_KIND_REGISTRY = {
       const selectPrompt = shouldPromptForLayerSelection
         ? await context.getOrCreatePrompt()
         : undefined;
-      const alternateRenderTargets = readOptionalStringFlag(
+      const alternateRenderTargets = readOptionalStrictStringFlag(
         context.flags,
         'alternate-render-targets',
       );
-      const dataStorageMode = readOptionalStringFlag(
+      const dataStorageMode = readOptionalStrictStringFlag(
         context.flags,
         'data-storage',
       );
-      const innerBlocksPreset = readOptionalStringFlag(
+      const innerBlocksPreset = readOptionalStrictStringFlag(
         context.flags,
         'inner-blocks-preset',
       );
-      const persistencePolicy = readOptionalStringFlag(
+      const persistencePolicy = readOptionalStrictStringFlag(
         context.flags,
         'persistence-policy',
       );
-      let resolvedTemplateId = readOptionalStringFlag(
+      let resolvedTemplateId = readOptionalStrictStringFlag(
         context.flags,
         'template',
       ) as CliAddRuntime.AddBlockTemplateId | undefined;
@@ -594,7 +524,7 @@ export const ADD_KIND_REGISTRY = {
         context,
         '`wp-typia add editor-plugin` requires <name>. Usage: wp-typia add editor-plugin <name> [--slot <sidebar|document-setting-panel>].',
       );
-      const slot = readOptionalStringFlag(context.flags, 'slot');
+      const slot = readOptionalStrictStringFlag(context.flags, 'slot');
 
       return createNamedExecutionPlan(context, {
         execute: ({ cwd, name }) =>
@@ -639,12 +569,12 @@ export const ADD_KIND_REGISTRY = {
         context,
         '`wp-typia add hooked-block` requires <block-slug>. Usage: wp-typia add hooked-block <block-slug> --anchor <anchor-block-name> --position <before|after|firstChild|lastChild>.',
       );
-      const anchorBlockName = requireStringFlag(
+      const anchorBlockName = requireStrictStringFlag(
         context.flags,
         'anchor',
         '`wp-typia add hooked-block` requires --anchor <anchor-block-name>.',
       );
-      const position = requireStringFlag(
+      const position = requireStrictStringFlag(
         context.flags,
         'position',
         '`wp-typia add hooked-block` requires --position <before|after|firstChild|lastChild>.',
@@ -727,7 +657,7 @@ export const ADD_KIND_REGISTRY = {
         context,
         '`wp-typia add style` requires <name>. Usage: wp-typia add style <name> --block <block-slug>.',
       );
-      const blockSlug = requireStringFlag(
+      const blockSlug = requireStrictStringFlag(
         context.flags,
         'block',
         '`wp-typia add style` requires --block <block-slug>.',
@@ -775,12 +705,12 @@ export const ADD_KIND_REGISTRY = {
         context,
         '`wp-typia add transform` requires <name>. Usage: wp-typia add transform <name> --from <namespace/block> --to <block-slug|namespace/block-slug>.',
       );
-      const fromBlockName = requireStringFlag(
+      const fromBlockName = requireStrictStringFlag(
         context.flags,
         'from',
         '`wp-typia add transform` requires --from <namespace/block>.',
       );
-      const toBlockName = requireStringFlag(
+      const toBlockName = requireStrictStringFlag(
         context.flags,
         'to',
         '`wp-typia add transform` requires --to <block-slug|namespace/block-slug>.',
@@ -832,8 +762,8 @@ export const ADD_KIND_REGISTRY = {
         context,
         '`wp-typia add rest-resource` requires <name>. Usage: wp-typia add rest-resource <name> [--namespace <vendor/v1>] [--methods <list,read,create>].',
       );
-      const methods = readOptionalStringFlag(context.flags, 'methods');
-      const namespace = readOptionalStringFlag(context.flags, 'namespace');
+      const methods = readOptionalStrictStringFlag(context.flags, 'methods');
+      const namespace = readOptionalStrictStringFlag(context.flags, 'namespace');
 
       return createNamedExecutionPlan(context, {
         execute: ({ cwd, name }) =>
@@ -879,7 +809,7 @@ export const ADD_KIND_REGISTRY = {
         context,
         '`wp-typia add ai-feature` requires <name>. Usage: wp-typia add ai-feature <name> [--namespace <vendor/v1>].',
       );
-      const namespace = readOptionalStringFlag(context.flags, 'namespace');
+      const namespace = readOptionalStrictStringFlag(context.flags, 'namespace');
 
       return createNamedExecutionPlan(context, {
         execute: ({ cwd, name }) =>
@@ -925,7 +855,7 @@ export const ADD_KIND_REGISTRY = {
         context,
         '`wp-typia add variation` requires <name>. Usage: wp-typia add variation <name> --block <block-slug>',
       );
-      const blockSlug = requireStringFlag(
+      const blockSlug = requireStrictStringFlag(
         context.flags,
         'block',
         '`wp-typia add variation` requires --block <block-slug>.',

--- a/packages/wp-typia/src/cli-string-flags.ts
+++ b/packages/wp-typia/src/cli-string-flags.ts
@@ -1,0 +1,85 @@
+import {
+  CLI_DIAGNOSTIC_CODES,
+  createCliDiagnosticCodeError,
+} from '@wp-typia/project-tools/cli-diagnostics';
+
+type OptionalCliStringFlagMode = 'loose' | 'strict';
+
+function readOptionalCliStringFlagValue(
+  flags: Record<string, unknown>,
+  name: string,
+  mode: OptionalCliStringFlagMode,
+): string | undefined {
+  const value = flags[name];
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value !== 'string') {
+    throw createCliDiagnosticCodeError(
+      CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
+      `\`--${name}\` requires a value.`,
+    );
+  }
+
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    if (mode === 'strict') {
+      throw createCliDiagnosticCodeError(
+        CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
+        `\`--${name}\` requires a value.`,
+      );
+    }
+
+    return undefined;
+  }
+
+  return mode === 'strict' ? value : trimmed;
+}
+
+export function readOptionalLooseStringFlag(
+  flags: Record<string, unknown>,
+  name: string,
+): string | undefined {
+  return readOptionalCliStringFlagValue(flags, name, 'loose');
+}
+
+export function readOptionalStrictStringFlag(
+  flags: Record<string, unknown>,
+  name: string,
+): string | undefined {
+  return readOptionalCliStringFlagValue(flags, name, 'strict');
+}
+
+export function requireStrictStringFlag(
+  flags: Record<string, unknown>,
+  name: string,
+  message: string,
+): string {
+  const value = readOptionalStrictStringFlag(flags, name);
+  if (!value) {
+    throw createCliDiagnosticCodeError(
+      CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
+      message,
+    );
+  }
+
+  return value;
+}
+
+export function readOptionalPairedStrictStringFlags(
+  flags: Record<string, unknown>,
+  leftName: string,
+  rightName: string,
+  message: string,
+): readonly [string | undefined, string | undefined] {
+  const leftValue = readOptionalStrictStringFlag(flags, leftName);
+  const rightValue = readOptionalStrictStringFlag(flags, rightName);
+  if (Boolean(leftValue) !== Boolean(rightValue)) {
+    throw createCliDiagnosticCodeError(
+      CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
+      message,
+    );
+  }
+
+  return [leftValue, rightValue] as const;
+}

--- a/packages/wp-typia/src/external-layer-prompt-options.ts
+++ b/packages/wp-typia/src/external-layer-prompt-options.ts
@@ -1,0 +1,30 @@
+export type ExternalLayerSelectOption = {
+  description?: string;
+  extends: string[];
+  id: string;
+};
+
+export function formatExternalLayerSelectHint(
+  option: ExternalLayerSelectOption,
+): string | undefined {
+  const details = [
+    option.description,
+    option.extends.length > 0
+      ? `extends ${option.extends.join(', ')}`
+      : undefined,
+  ].filter(
+    (value): value is string => typeof value === 'string' && value.length > 0,
+  );
+
+  return details.length > 0 ? details.join(' · ') : undefined;
+}
+
+export function toExternalLayerPromptOptions(
+  options: ExternalLayerSelectOption[],
+) {
+  return options.map((option) => ({
+    hint: formatExternalLayerSelectHint(option),
+    label: option.id,
+    value: option.id,
+  }));
+}

--- a/packages/wp-typia/src/runtime-bridge-output.ts
+++ b/packages/wp-typia/src/runtime-bridge-output.ts
@@ -13,6 +13,10 @@ import {
   type OutputMarkerOptions,
   stripLeadingOutputMarker,
 } from './output-markers';
+import {
+  toExternalLayerPromptOptions,
+  type ExternalLayerSelectOption,
+} from './external-layer-prompt-options';
 
 type PrintLine = (line: string) => void;
 type PackageManagerId = 'bun' | 'npm' | 'pnpm' | 'yarn';
@@ -101,12 +105,6 @@ export type SerializableCompletionPayload = {
   summaryLines?: string[];
   title: string;
   warningLines?: string[];
-};
-
-type ExternalLayerSelectOption = {
-  description?: string;
-  extends: string[];
-  id: string;
 };
 
 /**
@@ -695,33 +693,10 @@ export function printBlock(lines: string[], printLine: PrintLine): void {
   }
 }
 
-function formatExternalLayerSelectHint(
-  option: ExternalLayerSelectOption,
-): string | undefined {
-  const details = [
-    option.description,
-    option.extends.length > 0
-      ? `extends ${option.extends.join(', ')}`
-      : undefined,
-  ].filter(
-    (value): value is string => typeof value === 'string' && value.length > 0,
-  );
-
-  return details.length > 0 ? details.join(' · ') : undefined;
-}
-
 /**
  * Converts external layer options into prompt-compatible select items.
  *
  * @param options External layer options returned by the block generator.
  * @returns Prompt select options with labels and hints.
  */
-export function toExternalLayerPromptOptions(
-  options: ExternalLayerSelectOption[],
-) {
-  return options.map((option) => ({
-    hint: formatExternalLayerSelectHint(option),
-    label: option.id,
-    value: option.id,
-  }));
-}
+export { toExternalLayerPromptOptions } from './external-layer-prompt-options';

--- a/packages/wp-typia/src/runtime-bridge.ts
+++ b/packages/wp-typia/src/runtime-bridge.ts
@@ -29,6 +29,7 @@ import {
   toExternalLayerPromptOptions,
 } from './runtime-bridge-output';
 import { isInteractiveTerminal } from './runtime-capabilities';
+import { readOptionalLooseStringFlag } from './cli-string-flags';
 export {
   buildCreateCompletionPayload,
   buildCreateDryRunPayload,
@@ -126,24 +127,6 @@ function shouldWrapCliCommandError(options: {
   }
 
   return true;
-}
-
-function readOptionalLooseStringFlag(
-  flags: Record<string, unknown>,
-  name: string,
-): string | undefined {
-  const value = flags[name];
-  if (value === undefined || value === null) {
-    return undefined;
-  }
-  if (typeof value !== 'string') {
-    throw createCliDiagnosticCodeError(
-      CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
-      `\`--${name}\` requires a value.`,
-    );
-  }
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : undefined;
 }
 
 function pushFlag(argv: string[], name: string, value: unknown): void {

--- a/packages/wp-typia/tests/cli-string-flags.test.ts
+++ b/packages/wp-typia/tests/cli-string-flags.test.ts
@@ -1,0 +1,77 @@
+import { expect, test } from 'bun:test';
+
+import { CLI_DIAGNOSTIC_CODES } from '@wp-typia/project-tools/cli-diagnostics';
+
+import {
+  readOptionalLooseStringFlag,
+  readOptionalPairedStrictStringFlags,
+  readOptionalStrictStringFlag,
+  requireStrictStringFlag,
+} from '../src/cli-string-flags';
+
+test('strict optional string flags preserve values and reject empty strings', () => {
+  expect(readOptionalStrictStringFlag({ template: ' basic ' }, 'template')).toBe(
+    ' basic ',
+  );
+
+  try {
+    readOptionalStrictStringFlag({ template: '   ' }, 'template');
+    throw new Error('Expected strict flag reader to throw.');
+  } catch (error) {
+    expect((error as { code?: string }).code).toBe(
+      CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
+    );
+    expect((error as Error).message).toContain('`--template` requires a value.');
+  }
+});
+
+test('loose optional string flags trim values and collapse empty strings to undefined', () => {
+  expect(readOptionalLooseStringFlag({ namespace: ' demo-space/v1 ' }, 'namespace')).toBe(
+    'demo-space/v1',
+  );
+  expect(readOptionalLooseStringFlag({ namespace: '   ' }, 'namespace')).toBeUndefined();
+  expect(readOptionalLooseStringFlag({}, 'namespace')).toBeUndefined();
+});
+
+test('paired and required strict string flags keep current missing-argument diagnostics', () => {
+  expect(
+    readOptionalPairedStrictStringFlags(
+      { block: 'counter-card', attribute: 'hero' },
+      'block',
+      'attribute',
+      'paired flag message',
+    ),
+  ).toEqual(['counter-card', 'hero']);
+  expect(
+    requireStrictStringFlag(
+      { anchor: 'core/post-content' },
+      'anchor',
+      'missing anchor message',
+    ),
+  ).toBe('core/post-content');
+
+  try {
+    readOptionalPairedStrictStringFlags(
+      { block: 'counter-card' },
+      'block',
+      'attribute',
+      'paired flag message',
+    );
+    throw new Error('Expected paired strict flag reader to throw.');
+  } catch (error) {
+    expect((error as { code?: string }).code).toBe(
+      CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
+    );
+    expect((error as Error).message).toContain('paired flag message');
+  }
+
+  try {
+    requireStrictStringFlag({}, 'anchor', 'missing anchor message');
+    throw new Error('Expected required strict flag reader to throw.');
+  } catch (error) {
+    expect((error as { code?: string }).code).toBe(
+      CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
+    );
+    expect((error as Error).message).toContain('missing anchor message');
+  }
+});

--- a/packages/wp-typia/tests/external-layer-prompt-options.test.ts
+++ b/packages/wp-typia/tests/external-layer-prompt-options.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from 'bun:test';
+
+import {
+  formatExternalLayerSelectHint,
+  toExternalLayerPromptOptions,
+} from '../src/external-layer-prompt-options';
+
+test('formats external layer hints from descriptions and extends lists', () => {
+  expect(
+    formatExternalLayerSelectHint({
+      description: 'Workspace-ready metrics layer',
+      extends: ['acme/base', 'acme/tokens'],
+      id: 'acme/metrics',
+    }),
+  ).toBe('Workspace-ready metrics layer · extends acme/base, acme/tokens');
+  expect(
+    formatExternalLayerSelectHint({
+      extends: [],
+      id: 'acme/minimal',
+    }),
+  ).toBeUndefined();
+});
+
+test('maps external layer options into prompt-compatible labels and hints', () => {
+  expect(
+    toExternalLayerPromptOptions([
+      {
+        description: 'Workspace-ready metrics layer',
+        extends: ['acme/base'],
+        id: 'acme/metrics',
+      },
+      {
+        extends: [],
+        id: 'acme/minimal',
+      },
+    ]),
+  ).toEqual([
+    {
+      hint: 'Workspace-ready metrics layer · extends acme/base',
+      label: 'acme/metrics',
+      value: 'acme/metrics',
+    },
+    {
+      hint: undefined,
+      label: 'acme/minimal',
+      value: 'acme/minimal',
+    },
+  ]);
+});


### PR DESCRIPTION
## Summary
- extract shared strict/loose CLI string flag readers for add-command parsing
- centralize external-layer prompt hint formatting and shared scaffold collision checks
- add focused regression coverage for the new helper paths while preserving existing diagnostics

## Why
A few small helper duplications were still hanging around after the larger add-command refactors. They were not breaking runtime behavior, but they made new add kinds easier to implement inconsistently and spread identical collision/flag parsing rules across multiple files.

## Impact
This keeps the current CLI messages and diagnostic codes intact while making the shared helper path clearer for future add kinds and follow-up refactors.

## Validation
- `node scripts/check-repo-format.mjs`
- `./node_modules/.bin/tsc --noEmit`
- `PATH=/Users/imjlk/.bun/bin:$PATH bun test packages/wp-typia/tests/cli-string-flags.test.ts packages/wp-typia/tests/external-layer-prompt-options.test.ts packages/wp-typia/tests/add-kind-registry.test.ts`
- `PATH=/Users/imjlk/.bun/bin:$PATH bun test packages/wp-typia-project-tools/tests/cli-add-shared.test.ts packages/wp-typia-project-tools/tests/workspace-add.test.ts packages/wp-typia-project-tools/tests/external-layer-selection.test.ts`
- `PATH=/Users/imjlk/.bun/bin:$PATH bun run --filter wp-typia build`
- `PATH=/Users/imjlk/.bun/bin:$PATH bun run --filter @wp-typia/project-tools build`
- `node scripts/validate-sampo-changesets.mjs`

Closes #675.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated duplicate collision detection logic across add-command helpers.
  * Externalized CLI string flag parsing into reusable utilities.
  * Centralized external layer prompt option formatting logic.

* **Tests**
  * Added test coverage for scaffold collision detection.
  * Added test coverage for CLI string flag parsing.
  * Added test coverage for external layer prompt options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->