### PR TITLE
fix(ai): document script-module compatibility

### DIFF
--- a/.sampo/changesets/691-ai-script-module-compat.md
+++ b/.sampo/changesets/691-ai-script-module-compat.md
@@ -1,0 +1,7 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Document and test that generated server-only AI feature PHP avoids WordPress
+script-module enqueue APIs, keeping older WordPress sites from loading an
+unguarded script-module call.

--- a/.sampo/changesets/691-ai-script-module-compat.md
+++ b/.sampo/changesets/691-ai-script-module-compat.md
@@ -1,7 +1,9 @@
 ---
 npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
 ---
 
 Document and test that generated server-only AI feature PHP avoids WordPress
 script-module enqueue APIs, keeping older WordPress sites from loading an
-unguarded script-module call.
+unguarded script-module call. Keep the CLI package in the same release lane as
+its exact `@wp-typia/project-tools` dependency.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai-templates.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai-templates.ts
@@ -50,6 +50,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * - ${quotePhpString(adminNoticeMessageFilterHook)} filters the wp-admin notice shown when AI support is unavailable.
  * - ${quotePhpString(unavailableMessageFilterHook)} filters REST-facing unavailable messages by reason code.
  * - ${quotePhpString(telemetryFilterHook)} filters the response telemetry array before schema validation. Return a schema-compatible array.
+ *
+ * Compatibility note: this server-only endpoint avoids WordPress script-module enqueue APIs so older sites can load the generated feature file safely.
  */
 
 if ( ! function_exists( '${loadSchemaFunctionName}' ) ) {

--- a/packages/wp-typia-project-tools/tests/cli-add-workspace-ai.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-add-workspace-ai.test.ts
@@ -236,6 +236,10 @@ describe("@wp-typia/project-tools cli-add-workspace ai-feature", () => {
 		expect(phpSource).toContain("generate_text_result");
 		expect(phpSource).toContain("using_model_preference");
 		expect(phpSource).toContain("is_wp_error( $permission )");
+		expect(phpSource).toContain(
+			"this server-only endpoint avoids WordPress script-module enqueue APIs",
+		);
+		expect(phpSource).not.toContain("wp_enqueue_script_module(");
 		expect(phpSource).toContain("admin_notices");
 		expect(phpSource).toContain("sprintf(");
 		expect(phpSource).toContain("The %s AI feature is optional");


### PR DESCRIPTION
## Summary
- document that generated server-only AI feature PHP avoids WordPress script-module enqueue APIs
- add generated-output coverage so AI feature PHP does not introduce an unguarded `wp_enqueue_script_module(` call
- add Sampo changeset for `@wp-typia/project-tools`

Closes #691

## Verification
- `node scripts/check-repo-format.mjs`
- `./node_modules/.bin/tsc --noEmit`
- `bun run --filter @wp-typia/project-tools build`
- `bun test packages/wp-typia-project-tools/tests/cli-add-workspace-ai.test.ts`
- `node scripts/validate-sampo-changesets.mjs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility of AI-generated PHP features with older WordPress installations by preventing certain API calls that may not be supported.

* **Tests**
  * Updated tests to verify generated endpoints maintain compatibility with legacy WordPress versions.

* **Chores**
  * Added documentation of compatibility behavior for generated server-only features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->