### PR TITLE
fix(cli): validate output format values

### DIFF
--- a/.sampo/changesets/690-validate-format-values.md
+++ b/.sampo/changesets/690-validate-format-values.md
@@ -1,0 +1,7 @@
+---
+npm/wp-typia: patch
+---
+
+Validate CLI `--format` values before command execution so typoed formats fail
+clearly with the supported `json` and `toon` values instead of silently falling
+back to human-readable output.

--- a/packages/wp-typia/src/cli-diagnostic-output.ts
+++ b/packages/wp-typia/src/cli-diagnostic-output.ts
@@ -4,6 +4,7 @@ import {
   type CliDiagnosticCode,
 } from '@wp-typia/project-tools/cli-diagnostics';
 import { COMMAND_ROUTING_METADATA } from './command-option-metadata';
+import { isSupportedCliOutputFormat } from './cli-output-format';
 import { findFirstPositional } from '../bin/argv-walker.js';
 
 type CliStructuredOutputArgs = {
@@ -64,7 +65,9 @@ export function prefersStructuredCliOutput(
   args: CliStructuredOutputArgs,
 ): boolean {
   return (
-    (args.formatExplicit && args.format !== 'toon') ||
+    (args.formatExplicit &&
+      args.format === 'json' &&
+      isSupportedCliOutputFormat(args.format)) ||
     Boolean(args.agent) ||
     Boolean(args.context?.store?.isAIAgent)
   );

--- a/packages/wp-typia/src/cli-output-format.ts
+++ b/packages/wp-typia/src/cli-output-format.ts
@@ -1,0 +1,72 @@
+import {
+  CLI_DIAGNOSTIC_CODES,
+  createCliCommandError,
+} from '@wp-typia/project-tools/cli-diagnostics';
+import { COMMAND_ROUTING_METADATA } from './command-option-metadata';
+import { findFirstPositional } from '../bin/argv-walker.js';
+
+export const SUPPORTED_CLI_OUTPUT_FORMATS = ['json', 'toon'] as const;
+
+export type CliOutputFormat = (typeof SUPPORTED_CLI_OUTPUT_FORMATS)[number];
+
+export function formatSupportedCliOutputFormats(): string {
+  return SUPPORTED_CLI_OUTPUT_FORMATS.join(', ');
+}
+
+export function isSupportedCliOutputFormat(
+  value: string | undefined,
+): value is CliOutputFormat {
+  return SUPPORTED_CLI_OUTPUT_FORMATS.includes(value as CliOutputFormat);
+}
+
+export function formatInvalidCliOutputFormatMessage(value: string): string {
+  return `Invalid --format value "${value}". Supported values: ${formatSupportedCliOutputFormats()}.`;
+}
+
+function resolveEntrypointCliCommand(argv: string[]): string {
+  return findFirstPositional(argv, COMMAND_ROUTING_METADATA) ?? 'wp-typia';
+}
+
+function assertSupportedCliOutputFormat(
+  value: string,
+  argv: string[],
+): void {
+  if (isSupportedCliOutputFormat(value)) {
+    return;
+  }
+
+  throw createCliCommandError({
+    code: CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
+    command: resolveEntrypointCliCommand(argv),
+    detailLines: [formatInvalidCliOutputFormatMessage(value)],
+  });
+}
+
+export function validateCliOutputFormatArgv(argv: string[]): void {
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg) {
+      continue;
+    }
+
+    if (arg === '--') {
+      return;
+    }
+
+    if (arg === '--format') {
+      const next = argv[index + 1];
+      if (next && !next.startsWith('-')) {
+        assertSupportedCliOutputFormat(next, argv);
+        index += 1;
+      }
+      continue;
+    }
+
+    if (arg.startsWith('--format=')) {
+      const value = arg.slice('--format='.length);
+      if (value) {
+        assertSupportedCliOutputFormat(value, argv);
+      }
+    }
+  }
+}

--- a/packages/wp-typia/src/cli.ts
+++ b/packages/wp-typia/src/cli.ts
@@ -11,6 +11,7 @@ import { skillsPlugin } from "@bunli/plugin-skills";
 import packageJson from "../package.json";
 import { bunliConfig } from "../bunli.config";
 import { writeStructuredCliDiagnosticError } from "./cli-diagnostic-output";
+import { validateCliOutputFormatArgv } from "./cli-output-format";
 import { normalizeWpTypiaArgv } from "./command-contract";
 import { WP_TYPIA_CONFIG_SOURCES } from "./config";
 import { extractWpTypiaConfigOverride } from "./config-override";
@@ -110,6 +111,7 @@ export async function createWpTypiaCli(options: {
 export async function main(argv = process.argv.slice(2)): Promise<void> {
 	const normalizedArgv = normalizeWpTypiaArgv(argv);
 	const { argv: cliArgv, configOverridePath } = extractWpTypiaConfigOverride(normalizedArgv);
+	validateCliOutputFormatArgv(cliArgv);
 	const cli = await createWpTypiaCli({ configOverridePath });
 	await cli.run(cliArgv);
 }

--- a/packages/wp-typia/src/command-option-metadata.ts
+++ b/packages/wp-typia/src/command-option-metadata.ts
@@ -314,7 +314,7 @@ export const SYNC_OPTION_METADATA = {
  */
 export const DOCTOR_OPTION_METADATA = {
   format: {
-    description: 'Use `json` for machine-readable doctor check output.',
+    description: 'Use `json` for machine-readable doctor check output or `toon` for human-readable output.',
     type: 'string',
   },
 } as const satisfies CommandOptionMetadataMap;
@@ -339,7 +339,7 @@ export const GLOBAL_OPTION_METADATA = {
     type: 'string',
   },
   format: {
-    description: 'Output format for supported commands.',
+    description: 'Output format for supported commands (`json` or `toon`).',
     type: 'string',
   },
   id: {

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -22,6 +22,7 @@ import {
   TEMPLATES_OPTION_METADATA,
 } from './command-option-metadata';
 import { prefersStructuredCliArgv } from './cli-diagnostic-output';
+import { validateCliOutputFormatArgv } from './cli-output-format';
 import {
   getTemplateById,
   listTemplates,
@@ -659,6 +660,7 @@ export async function runNodeCli(argv = process.argv.slice(2)): Promise<void> {
   const normalizedArgv = normalizeWpTypiaArgv(argv);
   const { argv: argvWithoutConfigOverride, configOverridePath } =
     extractWpTypiaConfigOverride(normalizedArgv);
+  validateCliOutputFormatArgv(argvWithoutConfigOverride);
   const { argv: cliArgv, flags } = parseGlobalFlags(argvWithoutConfigOverride);
   const { flags: commandFlags, positionals } = parseArgv(cliArgv);
   const rawMergedFlags: Record<string, unknown> = {

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -1846,6 +1846,28 @@ describe('wp-typia package', () => {
     expect(parsed.error?.code).toBe('invalid-command');
   });
 
+  test('rejects invalid output formats before Node fallback command execution', () => {
+    const cases = [
+      ['create', 'demo-format', '--dry-run', '--format', 'jso'],
+      ['add', 'block', 'promo-card', '--dry-run', '--format', 'jso'],
+      ['init', '--format', 'jso'],
+      ['doctor', '--format', 'jso'],
+      ['templates', 'list', '--format', 'jso'],
+      ['sync', '--format', 'jso'],
+    ];
+
+    for (const args of cases) {
+      const result = runCapturedCommand(process.execPath, [entryPath, ...args], {
+        env: withoutLocalBunEnv(),
+      });
+
+      expect(result.status).toBe(1);
+      expect(result.stdout).toBe('');
+      expect(result.stderr).toContain('Invalid --format value "jso".');
+      expect(result.stderr).toContain('Supported values: json, toon.');
+    }
+  });
+
   test('preserves command metadata for invalid templates subcommands in Node fallback JSON mode', async () => {
     await expect(
       runNodeCli(['templates', 'unknown', '--format', 'json']),
@@ -2124,6 +2146,28 @@ describe('wp-typia package', () => {
       expect(parsed.error?.code).toBe('outside-project-root');
     } finally {
       fs.rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('rejects invalid output formats before Bun runtime command execution', () => {
+    const cases = [
+      ['create', 'demo-format', '--dry-run', '--format', 'jso'],
+      ['add', 'block', 'promo-card', '--dry-run', '--format', 'jso'],
+      ['init', '--format', 'jso'],
+      ['doctor', '--format', 'jso'],
+      ['templates', 'list', '--format', 'jso'],
+      ['sync', '--format', 'jso'],
+    ];
+
+    for (const args of cases) {
+      const result = runCapturedCommand('bun', [fullRuntimeEntrypoint, ...args], {
+        env: withoutAIAgentEnv(),
+      });
+
+      expect(result.status).toBe(1);
+      expect(result.stdout).toBe('');
+      expect(result.stderr).toContain('Invalid --format value "jso".');
+      expect(result.stderr).toContain('Supported values: json, toon.');
     }
   });
 


### PR DESCRIPTION
## Summary
- add a shared CLI output format validator for the supported `json` and `toon` values
- run validation before Node fallback and Bun runtime command execution so typos like `--format jso` fail clearly
- keep structured output tied to explicit valid `--format json` requests and add coverage across create/add/init/doctor/templates/sync

Closes #690

## Tests
- `bun run --filter wp-typia build`
- `bun test packages/wp-typia/tests/cli-package.test.ts --test-name-pattern "invalid output formats"`
- `bun test packages/wp-typia/tests/cli-package.test.ts`
- `bun run --filter wp-typia test`
- `node scripts/check-repo-format.mjs`
- `bun run typecheck`
- `node scripts/validate-sampo-changesets.mjs`
- `node scripts/validate-runtime-package-coupling.mjs`
- `git diff --check`