### PR TITLE
fix(cli): centralize package manager inference

### DIFF
--- a/.sampo/changesets/689-central-package-manager-inference.md
+++ b/.sampo/changesets/689-central-package-manager-inference.md
@@ -1,0 +1,8 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Centralize CLI package-manager inference so completion guidance and sync flows
+share support for packageManager fields, Bun/pnpm/Yarn/npm lockfiles, Yarn PnP
+markers, npm shrinkwrap files, and npm fallback behavior.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-block.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-block.ts
@@ -65,6 +65,7 @@ import {
 } from "./template-layers.js";
 import {
 	formatInstallCommand,
+	type PackageManagerId,
 } from "./package-managers.js";
 import { parseCompoundInnerBlocksPreset } from "./compound-inner-blocks.js";
 import {
@@ -158,7 +159,7 @@ function hasInstalledWorkspaceDependencies(projectDir: string): boolean {
 }
 
 function assertWorkspaceDependenciesInstalled(workspace: {
-	packageManager: "bun" | "npm" | "pnpm" | "yarn";
+	packageManager: PackageManagerId;
 	projectDir: string;
 }): void {
 	if (hasInstalledWorkspaceDependencies(workspace.projectDir)) {

--- a/packages/wp-typia-project-tools/src/runtime/migration-utils.ts
+++ b/packages/wp-typia-project-tools/src/runtime/migration-utils.ts
@@ -2,7 +2,11 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { execSync } from 'node:child_process';
 
-import { formatRunScript } from './package-managers.js';
+import {
+  formatRunScript,
+  parsePackageManagerField,
+  type PackageManagerId,
+} from './package-managers.js';
 import type {
   JsonValue,
   ManifestAttribute,
@@ -195,17 +199,11 @@ export function runProjectScriptIfPresent(
 
 export function detectPackageManagerId(
   projectDir: string,
-): 'bun' | 'npm' | 'pnpm' | 'yarn' {
+): PackageManagerId {
   const packageJson = readJson<{ packageManager?: string }>(
     path.join(projectDir, 'package.json'),
   );
-  const field = String(packageJson.packageManager ?? '');
-
-  if (field.startsWith('bun@')) return 'bun';
-  if (field.startsWith('npm@')) return 'npm';
-  if (field.startsWith('pnpm@')) return 'pnpm';
-  if (field.startsWith('yarn@')) return 'yarn';
-  return 'bun';
+  return parsePackageManagerField(packageJson.packageManager) ?? 'bun';
 }
 
 export function getLocalTsxBinary(projectDir: string): string {

--- a/packages/wp-typia-project-tools/src/runtime/migration-utils.ts
+++ b/packages/wp-typia-project-tools/src/runtime/migration-utils.ts
@@ -4,6 +4,7 @@ import { execSync } from 'node:child_process';
 
 import {
   formatRunScript,
+  inferPackageManagerId,
   parsePackageManagerField,
   type PackageManagerId,
 } from './package-managers.js';
@@ -203,7 +204,10 @@ export function detectPackageManagerId(
   const packageJson = readJson<{ packageManager?: string }>(
     path.join(projectDir, 'package.json'),
   );
-  return parsePackageManagerField(packageJson.packageManager) ?? 'bun';
+  return (
+    parsePackageManagerField(packageJson.packageManager) ??
+    inferPackageManagerId(projectDir)
+  );
 }
 
 export function getLocalTsxBinary(projectDir: string): string {

--- a/packages/wp-typia-project-tools/src/runtime/package-managers.ts
+++ b/packages/wp-typia-project-tools/src/runtime/package-managers.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs";
+import path from "node:path";
+
 export type PackageManagerId = "bun" | "npm" | "pnpm" | "yarn";
 
 export interface PackageManagerDefinition {
@@ -39,6 +42,19 @@ const PACKAGE_MANAGER_DATA: PackageManagerDefinition[] = [
 	},
 ];
 
+const PACKAGE_MANAGER_LOCKFILE_SIGNALS = [
+	{ id: "bun", filenames: ["bun.lock", "bun.lockb"] },
+	{ id: "pnpm", filenames: ["pnpm-lock.yaml"] },
+	{
+		id: "yarn",
+		filenames: ["yarn.lock", ".pnp.cjs", ".pnp.loader.mjs", ".yarnrc.yml"],
+	},
+	{ id: "npm", filenames: ["package-lock.json", "npm-shrinkwrap.json"] },
+] as const satisfies Array<{
+	filenames: string[];
+	id: PackageManagerId;
+}>;
+
 export const PACKAGE_MANAGER_IDS = PACKAGE_MANAGER_DATA.map((manager) => manager.id) as PackageManagerId[];
 export const PACKAGE_MANAGERS = Object.freeze(
 	Object.fromEntries(
@@ -63,6 +79,74 @@ export function getPackageManager(id: string): PackageManagerDefinition {
 		);
 	}
 	return manager;
+}
+
+/**
+ * Parse a normalized package-manager id from a package.json `packageManager` field.
+ *
+ * @param packageManagerField Raw field value such as `pnpm@8.3.1`.
+ * @returns A supported package manager id, or null when the field is missing or unsupported.
+ */
+export function parsePackageManagerField(
+	packageManagerField: string | undefined,
+): PackageManagerId | null {
+	const packageManagerId = packageManagerField?.split("@", 1)[0];
+	return PACKAGE_MANAGER_IDS.includes(packageManagerId as PackageManagerId)
+		? (packageManagerId as PackageManagerId)
+		: null;
+}
+
+function readPackageManagerField(projectDir: string): string | undefined {
+	try {
+		const packageJsonPath = path.join(projectDir, "package.json");
+		if (!fs.existsSync(packageJsonPath)) {
+			return undefined;
+		}
+
+		const manifest = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as {
+			packageManager?: unknown;
+		};
+		return typeof manifest.packageManager === "string"
+			? manifest.packageManager
+			: undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Infer the package manager used by a project from package.json and lockfile signals.
+ *
+ * `packageManager` fields take precedence over lockfiles, then lockfile and PnP
+ * markers are checked in Bun, pnpm, Yarn, npm order. npm remains the fallback so
+ * generated projects without explicit metadata keep the historical CLI default.
+ *
+ * @param projectDir Project root to inspect.
+ * @param packageManagerField Optional already-read package.json field.
+ * @returns The inferred package manager id.
+ */
+export function inferPackageManagerId(
+	projectDir: string,
+	packageManagerField?: string,
+): PackageManagerId {
+	const fieldPackageManager =
+		parsePackageManagerField(packageManagerField) ??
+		parsePackageManagerField(readPackageManagerField(projectDir));
+	if (fieldPackageManager) {
+		return fieldPackageManager;
+	}
+
+	for (const signal of PACKAGE_MANAGER_LOCKFILE_SIGNALS) {
+		if (
+			signal.filenames.some((filename) =>
+				fs.existsSync(path.join(projectDir, filename)),
+			)
+		) {
+			return signal.id;
+		}
+	}
+
+	return "npm";
 }
 
 export function getPackageManagerSelectOptions(): Array<{

--- a/packages/wp-typia-project-tools/src/runtime/workspace-project.ts
+++ b/packages/wp-typia-project-tools/src/runtime/workspace-project.ts
@@ -1,7 +1,10 @@
 import fs from "node:fs";
 import path from "node:path";
 
-import type { PackageManagerId } from "./package-managers.js";
+import {
+	parsePackageManagerField,
+	type PackageManagerId,
+} from "./package-managers.js";
 
 export const WORKSPACE_TEMPLATE_PACKAGE = "@wp-typia/create-workspace-template";
 
@@ -124,16 +127,7 @@ export function getInvalidWorkspaceProjectReason(startDir: string): string | nul
 export function parseWorkspacePackageManagerId(
 	packageManagerField: string | undefined,
 ): PackageManagerId {
-	const packageManagerId = packageManagerField?.split("@", 1)[0];
-	switch (packageManagerId) {
-		case "bun":
-		case "npm":
-		case "pnpm":
-		case "yarn":
-			return packageManagerId;
-		default:
-			return "npm";
-	}
+	return parsePackageManagerField(packageManagerField) ?? "npm";
 }
 
 /**

--- a/packages/wp-typia-project-tools/tests/package-managers.test.ts
+++ b/packages/wp-typia-project-tools/tests/package-managers.test.ts
@@ -7,6 +7,7 @@ import {
 	inferPackageManagerId,
 	parsePackageManagerField,
 } from "../src/runtime/package-managers.js";
+import { detectPackageManagerId } from "../src/runtime/migration-utils.js";
 
 const tempRoot = fs.mkdtempSync(
 	path.join(os.tmpdir(), "wp-typia-package-managers-"),
@@ -116,5 +117,19 @@ describe("package manager inference", () => {
 		const projectDir = writeProjectFixture({ name: "fallback-npm" });
 
 		expect(inferPackageManagerId(projectDir)).toBe("npm");
+	});
+
+	test("keeps migration helper fallback aligned with shared inference", () => {
+		const npmProjectDir = writeProjectFixture({
+			files: ["package-lock.json"],
+			name: "migration-npm-lock",
+		});
+		const pnpProjectDir = writeProjectFixture({
+			files: [".pnp.cjs"],
+			name: "migration-yarn-pnp",
+		});
+
+		expect(detectPackageManagerId(npmProjectDir)).toBe("npm");
+		expect(detectPackageManagerId(pnpProjectDir)).toBe("yarn");
 	});
 });

--- a/packages/wp-typia-project-tools/tests/package-managers.test.ts
+++ b/packages/wp-typia-project-tools/tests/package-managers.test.ts
@@ -1,0 +1,120 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+	inferPackageManagerId,
+	parsePackageManagerField,
+} from "../src/runtime/package-managers.js";
+
+const tempRoot = fs.mkdtempSync(
+	path.join(os.tmpdir(), "wp-typia-package-managers-"),
+);
+
+function writeProjectFixture(options: {
+	files?: string[];
+	name: string;
+	packageManager?: string;
+}): string {
+	const projectDir = path.join(tempRoot, options.name);
+	fs.mkdirSync(projectDir, { recursive: true });
+	fs.writeFileSync(
+		path.join(projectDir, "package.json"),
+		`${JSON.stringify(
+			{
+				name: options.name,
+				...(options.packageManager
+					? { packageManager: options.packageManager }
+					: {}),
+			},
+			null,
+			2,
+		)}\n`,
+		"utf8",
+	);
+	for (const file of options.files ?? []) {
+		fs.writeFileSync(path.join(projectDir, file), "", "utf8");
+	}
+	return projectDir;
+}
+
+afterAll(() => {
+	fs.rmSync(tempRoot, { force: true, recursive: true });
+});
+
+describe("package manager inference", () => {
+	test("parses supported packageManager fields", () => {
+		expect(parsePackageManagerField("bun@1.3.11")).toBe("bun");
+		expect(parsePackageManagerField("npm@11.6.1")).toBe("npm");
+		expect(parsePackageManagerField("pnpm@8.3.1")).toBe("pnpm");
+		expect(parsePackageManagerField("yarn@3.2.4")).toBe("yarn");
+		expect(parsePackageManagerField("deno@2.0.0")).toBeNull();
+		expect(parsePackageManagerField(undefined)).toBeNull();
+	});
+
+	test("prefers the packageManager field over lockfile signals", () => {
+		const projectDir = writeProjectFixture({
+			files: ["pnpm-lock.yaml"],
+			name: "field-wins",
+			packageManager: "bun@1.3.11",
+		});
+
+		expect(inferPackageManagerId(projectDir)).toBe("bun");
+	});
+
+	test("detects Yarn PnP markers as Yarn", () => {
+		const cjsProjectDir = writeProjectFixture({
+			files: [".pnp.cjs"],
+			name: "yarn-pnp-cjs",
+		});
+		const loaderProjectDir = writeProjectFixture({
+			files: [".pnp.loader.mjs"],
+			name: "yarn-pnp-loader",
+		});
+
+		expect(inferPackageManagerId(cjsProjectDir)).toBe("yarn");
+		expect(inferPackageManagerId(loaderProjectDir)).toBe("yarn");
+	});
+
+	test("detects npm lockfiles as npm", () => {
+		const lockProjectDir = writeProjectFixture({
+			files: ["package-lock.json"],
+			name: "npm-lock",
+		});
+		const shrinkwrapProjectDir = writeProjectFixture({
+			files: ["npm-shrinkwrap.json"],
+			name: "npm-shrinkwrap",
+		});
+
+		expect(inferPackageManagerId(lockProjectDir)).toBe("npm");
+		expect(inferPackageManagerId(shrinkwrapProjectDir)).toBe("npm");
+	});
+
+	test("detects bun, pnpm, and yarn lockfile signals", () => {
+		expect(
+			inferPackageManagerId(
+				writeProjectFixture({ files: ["bun.lock"], name: "bun-lock" }),
+			),
+		).toBe("bun");
+		expect(
+			inferPackageManagerId(
+				writeProjectFixture({
+					files: ["pnpm-lock.yaml"],
+					name: "pnpm-lock",
+				}),
+			),
+		).toBe("pnpm");
+		expect(
+			inferPackageManagerId(
+				writeProjectFixture({ files: ["yarn.lock"], name: "yarn-lock" }),
+			),
+		).toBe("yarn");
+	});
+
+	test("falls back to npm when no package-manager signal exists", () => {
+		const projectDir = writeProjectFixture({ name: "fallback-npm" });
+
+		expect(inferPackageManagerId(projectDir)).toBe("npm");
+	});
+});

--- a/packages/wp-typia/src/runtime-bridge-output.ts
+++ b/packages/wp-typia/src/runtime-bridge-output.ts
@@ -1,8 +1,9 @@
-import fs from 'node:fs';
-import path from 'node:path';
-
 import packageJson from '../package.json';
-import { formatPackageExecCommand } from '@wp-typia/project-tools/package-managers';
+import {
+  formatPackageExecCommand,
+  inferPackageManagerId,
+  type PackageManagerId,
+} from '@wp-typia/project-tools/package-managers';
 import {
   buildAddKindCompletionDetails,
   type AddKindId,
@@ -19,7 +20,6 @@ import {
 } from './external-layer-prompt-options';
 
 type PrintLine = (line: string) => void;
-type PackageManagerId = 'bun' | 'npm' | 'pnpm' | 'yarn';
 
 export type CreateProgressPayload = {
   detail: string;
@@ -497,39 +497,6 @@ export function buildInitCompletionPayload(
   };
 }
 
-function inferProjectPackageManager(projectDir: string): PackageManagerId {
-  try {
-    const packageJsonPath = path.join(projectDir, 'package.json');
-    if (fs.existsSync(packageJsonPath)) {
-      const manifest = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as {
-        packageManager?: string;
-      };
-      if (manifest.packageManager?.startsWith('bun@')) return 'bun';
-      if (manifest.packageManager?.startsWith('pnpm@')) return 'pnpm';
-      if (manifest.packageManager?.startsWith('yarn@')) return 'yarn';
-      if (manifest.packageManager?.startsWith('npm@')) return 'npm';
-    }
-  } catch {}
-
-  if (
-    fs.existsSync(path.join(projectDir, 'bun.lock')) ||
-    fs.existsSync(path.join(projectDir, 'bun.lockb'))
-  ) {
-    return 'bun';
-  }
-  if (fs.existsSync(path.join(projectDir, 'pnpm-lock.yaml'))) {
-    return 'pnpm';
-  }
-  if (
-    fs.existsSync(path.join(projectDir, 'yarn.lock')) ||
-    fs.existsSync(path.join(projectDir, '.yarnrc.yml'))
-  ) {
-    return 'yarn';
-  }
-
-  return 'npm';
-}
-
 /**
  * Builds the completion payload shown after a migrate command succeeds.
  *
@@ -573,7 +540,7 @@ export function buildAddCompletionPayload(
 ): AlternateBufferCompletionPayload {
   const verificationLines = [
     formatPackageExecCommand(
-      options.packageManager ?? inferProjectPackageManager(options.projectDir),
+      options.packageManager ?? inferPackageManagerId(options.projectDir),
       `wp-typia@${packageJson.version}`,
       'doctor',
     ),

--- a/packages/wp-typia/src/runtime-bridge-sync.ts
+++ b/packages/wp-typia/src/runtime-bridge-sync.ts
@@ -5,8 +5,13 @@ import {
   CLI_DIAGNOSTIC_CODES,
   createCliDiagnosticCodeError,
 } from '@wp-typia/project-tools/cli-diagnostics';
+import {
+  formatInstallCommand,
+  formatRunScript,
+  inferPackageManagerId,
+  type PackageManagerId,
+} from '@wp-typia/project-tools/package-managers';
 
-type PackageManagerId = 'bun' | 'npm' | 'pnpm' | 'yarn';
 type SyncScriptName = 'sync' | 'sync-ai' | 'sync-rest' | 'sync-types';
 type SyncScriptKey = SyncScriptName | 'sync-wordpress-ai';
 export type SyncExecutionTarget = 'ai' | 'default';
@@ -80,79 +85,11 @@ export function resolveSyncExecutionTarget(
   );
 }
 
-function formatRunScript(
-  packageManagerId: PackageManagerId,
-  scriptName: string,
-  extraArgs = '',
-) {
-  const args = extraArgs.trim();
-  if (packageManagerId === 'bun') {
-    return args ? `bun run ${scriptName} ${args}` : `bun run ${scriptName}`;
-  }
-  if (packageManagerId === 'npm') {
-    return args ? `npm run ${scriptName} -- ${args}` : `npm run ${scriptName}`;
-  }
-  if (packageManagerId === 'pnpm') {
-    return args ? `pnpm run ${scriptName} ${args}` : `pnpm run ${scriptName}`;
-  }
-  return args ? `yarn run ${scriptName} ${args}` : `yarn run ${scriptName}`;
-}
-
-function formatInstallCommand(packageManagerId: PackageManagerId): string {
-  switch (packageManagerId) {
-    case 'bun':
-      return 'bun install';
-    case 'pnpm':
-      return 'pnpm install';
-    case 'yarn':
-      return 'yarn install';
-    default:
-      return 'npm install';
-  }
-}
-
 function getSyncRootError(cwd: string): Error {
   return createCliDiagnosticCodeError(
     CLI_DIAGNOSTIC_CODES.OUTSIDE_PROJECT_ROOT,
     `No generated wp-typia project root was found at ${cwd}. Run \`wp-typia sync\` from a scaffolded project or official workspace root that already contains generated sync scripts. If you expected this directory to work, cd into the scaffold root first or rerun the scaffold before syncing.`,
   );
-}
-
-function inferSyncPackageManager(
-  cwd: string,
-  packageManagerField?: string,
-): PackageManagerId {
-  const field = String(packageManagerField ?? '');
-  if (field.startsWith('bun@')) return 'bun';
-  if (field.startsWith('npm@')) return 'npm';
-  if (field.startsWith('pnpm@')) return 'pnpm';
-  if (field.startsWith('yarn@')) return 'yarn';
-
-  if (
-    fs.existsSync(path.join(cwd, 'bun.lock')) ||
-    fs.existsSync(path.join(cwd, 'bun.lockb'))
-  ) {
-    return 'bun';
-  }
-  if (fs.existsSync(path.join(cwd, 'pnpm-lock.yaml'))) {
-    return 'pnpm';
-  }
-  if (
-    fs.existsSync(path.join(cwd, 'yarn.lock')) ||
-    fs.existsSync(path.join(cwd, '.pnp.cjs')) ||
-    fs.existsSync(path.join(cwd, '.pnp.loader.mjs')) ||
-    fs.existsSync(path.join(cwd, '.yarnrc.yml'))
-  ) {
-    return 'yarn';
-  }
-  if (
-    fs.existsSync(path.join(cwd, 'package-lock.json')) ||
-    fs.existsSync(path.join(cwd, 'npm-shrinkwrap.json'))
-  ) {
-    return 'npm';
-  }
-
-  return 'npm';
 }
 
 function resolveSyncProjectContext(cwd: string): SyncProjectContext {
@@ -205,7 +142,7 @@ function resolveSyncProjectContext(cwd: string): SyncProjectContext {
   return {
     cwd,
     packageJsonPath,
-    packageManager: inferSyncPackageManager(cwd, packageJson.packageManager),
+    packageManager: inferPackageManagerId(cwd, packageJson.packageManager),
     scripts: syncScripts,
   };
 }

--- a/packages/wp-typia/tests/completion-output.test.ts
+++ b/packages/wp-typia/tests/completion-output.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, test } from 'bun:test';
+import { afterAll, describe, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import packageJson from '../package.json';
 
 import {
@@ -21,6 +24,30 @@ const UNICODE_MARKER_OPTIONS = {
     LANG: 'en_US.UTF-8',
   },
 } as const;
+const tempRoot = fs.mkdtempSync(
+  path.join(os.tmpdir(), 'wp-typia-completion-output-'),
+);
+
+function writeCompletionProjectFixture(options: {
+  files?: string[];
+  name: string;
+}): string {
+  const projectDir = path.join(tempRoot, options.name);
+  fs.mkdirSync(projectDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(projectDir, 'package.json'),
+    `${JSON.stringify({ name: options.name }, null, 2)}\n`,
+    'utf8',
+  );
+  for (const file of options.files ?? []) {
+    fs.writeFileSync(path.join(projectDir, file), '', 'utf8');
+  }
+  return projectDir;
+}
+
+afterAll(() => {
+  fs.rmSync(tempRoot, { force: true, recursive: true });
+});
 
 describe('alternate-buffer completion output helpers', () => {
   test('create completion payload preserves reviewable next steps and optional onboarding', () => {
@@ -278,6 +305,28 @@ describe('alternate-buffer completion output helpers', () => {
     expect(payload.optionalNote).toContain(
       'inventory and generated-artifact check',
     );
+  });
+
+  test('add completion payload infers Yarn PnP doctor guidance without an explicit package manager', () => {
+    const projectDir = writeCompletionProjectFixture({
+      files: ['.pnp.loader.mjs'],
+      name: 'demo-yarn-pnp-workspace',
+    });
+    const payload = buildAddCompletionPayload(
+      {
+        kind: 'block',
+        projectDir,
+        values: {
+          blockSlugs: 'promo-card',
+          templateId: 'basic',
+        },
+      },
+      UNICODE_MARKER_OPTIONS,
+    );
+
+    expect(payload.optionalLines).toEqual([
+      `yarn dlx wp-typia@${packageJson.version} doctor`,
+    ]);
   });
 
   test('dry-run add payload preserves the richer add completion guidance', () => {

--- a/packages/wp-typia/tests/runtime-bridge-sync.test.ts
+++ b/packages/wp-typia/tests/runtime-bridge-sync.test.ts
@@ -10,7 +10,9 @@ const tempRoot = fs.mkdtempSync(
 );
 
 function writeSyncFixture(options: {
+  files?: string[];
   name: string;
+  packageManager?: string | null;
   scripts: Record<string, string>;
   withInstallMarker?: boolean;
 }) {
@@ -21,7 +23,9 @@ function writeSyncFixture(options: {
     JSON.stringify(
       {
         name: options.name,
-        packageManager: 'npm@10.9.0',
+        ...(options.packageManager === null
+          ? {}
+          : { packageManager: options.packageManager ?? 'npm@10.9.0' }),
         scripts: options.scripts,
       },
       null,
@@ -33,6 +37,9 @@ function writeSyncFixture(options: {
     fs.mkdirSync(path.join(projectDir, 'node_modules'), {
       recursive: true,
     });
+  }
+  for (const file of options.files ?? []) {
+    fs.writeFileSync(path.join(projectDir, file), '', 'utf8');
   }
   return projectDir;
 }
@@ -83,6 +90,76 @@ test('dry-run sync previews commands without requiring installed dependencies', 
       scriptName: 'sync',
     },
   ]);
+});
+
+test('sync infers package manager from shared lockfile and PnP signals', async () => {
+  const cases = [
+    {
+      command: 'yarn',
+      displayCommand: 'yarn run sync --check',
+      files: ['.pnp.cjs'],
+      name: 'demo-sync-yarn-pnp',
+      packageManager: 'yarn',
+    },
+    {
+      command: 'npm',
+      displayCommand: 'npm run sync -- --check',
+      files: ['package-lock.json'],
+      name: 'demo-sync-npm-lock',
+      packageManager: 'npm',
+    },
+    {
+      command: 'npm',
+      displayCommand: 'npm run sync -- --check',
+      files: ['npm-shrinkwrap.json'],
+      name: 'demo-sync-npm-shrinkwrap',
+      packageManager: 'npm',
+    },
+    {
+      command: 'pnpm',
+      displayCommand: 'pnpm run sync --check',
+      files: ['pnpm-lock.yaml'],
+      name: 'demo-sync-pnpm-lock',
+      packageManager: 'pnpm',
+    },
+    {
+      command: 'bun',
+      displayCommand: 'bun run sync --check',
+      files: ['bun.lockb'],
+      name: 'demo-sync-bun-lock',
+      packageManager: 'bun',
+    },
+    {
+      command: 'npm',
+      displayCommand: 'npm run sync -- --check',
+      files: [],
+      name: 'demo-sync-npm-fallback',
+      packageManager: 'npm',
+    },
+  ] as const;
+
+  for (const testCase of cases) {
+    const projectDir = writeSyncFixture({
+      files: [...testCase.files],
+      name: testCase.name,
+      packageManager: null,
+      scripts: {
+        sync: 'node scripts/record.mjs sync',
+      },
+    });
+    const result = await executeSyncCommand({
+      check: true,
+      cwd: projectDir,
+      dryRun: true,
+    });
+
+    expect(result.packageManager).toBe(testCase.packageManager);
+    expect(result.plannedCommands[0]).toMatchObject({
+      command: testCase.command,
+      displayCommand: testCase.displayCommand,
+      scriptName: 'sync',
+    });
+  }
 });
 
 test('sync can capture executed script output for structured callers', async () => {


### PR DESCRIPTION
## Summary
- add shared package-manager inference in `@wp-typia/project-tools/package-managers`
- route sync execution and add completion doctor guidance through the same inference helper
- detect Yarn PnP markers plus npm lockfiles/shrinkwrap while preserving Bun, pnpm, Yarn, packageManager fields, and npm fallback behavior
- deduplicate CLI package-manager type usage around the shared `PackageManagerId`

Closes #689

## Tests
- `bun test packages/wp-typia-project-tools/tests/package-managers.test.ts`
- `bun test packages/wp-typia/tests/runtime-bridge-sync.test.ts packages/wp-typia/tests/completion-output.test.ts`
- `bun run --filter @wp-typia/project-tools build`
- `bun run --filter wp-typia build`
- `bun run --filter @wp-typia/project-tools test:quick`
- `bun run --filter wp-typia test`
- `bun run typecheck`
- `node scripts/check-repo-format.mjs`
- `node scripts/validate-sampo-changesets.mjs`
- `node scripts/validate-runtime-package-coupling.mjs`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized package manager detection across CLI features, now consistently supporting Bun, pnpm, Yarn, npm, and their respective lockfiles/markers (including Yarn Plug'n'Play detection).

* **Tests**
  * Added comprehensive test coverage for package manager inference, lockfile detection, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->