### PR TITLE
refactor(project-tools): share TypeScript source masking

### DIFF
--- a/.sampo/changesets/692-ts-source-masking.md
+++ b/.sampo/changesets/692-ts-source-masking.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Extract shared TypeScript source masking utilities so add and doctor runtime
+checks use the same comment, literal, and executable-pattern detection logic.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace.ts
@@ -27,6 +27,13 @@ import {
 	type WorkspaceMutationSnapshot,
 	snapshotWorkspaceFiles,
 } from "./cli-add-shared.js";
+import {
+	findExecutablePatternMatch,
+	hasExecutablePattern,
+	hasUncommentedPattern,
+	maskTypeScriptCommentsAndLiterals,
+	type SourceRange,
+} from "./ts-source-masking.js";
 
 const VARIATIONS_IMPORT_LINE = "import { registerWorkspaceVariations } from './variations';";
 const VARIATIONS_IMPORT_PATTERN =
@@ -48,121 +55,6 @@ const BLOCK_TRANSFORMS_CALL_PATTERN =
 const SCAFFOLD_REGISTRATION_SETTINGS_CALL_PATTERN =
 	/registerScaffoldBlockType\s*\(\s*registration\s*\.\s*name\s*,\s*registration\s*\.\s*settings\s*\)\s*;?/u;
 const FULL_BLOCK_NAME_PATTERN = /^[a-z0-9-]+\/[a-z0-9-]+$/u;
-
-interface SourceRange {
-	end: number;
-	start: number;
-}
-
-function maskSourceSegment(segment: string): string {
-	return segment.replace(/[^\n\r]/gu, " ");
-}
-
-function maskTypeScriptComments(source: string): string {
-	return source
-		.replace(/\/\*[\s\S]*?\*\//gu, maskSourceSegment)
-		.replace(/\/\/[^\n\r]*/gu, maskSourceSegment);
-}
-
-// Preserve source offsets so executable-code match indexes still map to the original file.
-function maskTypeScriptCommentsAndLiterals(source: string): string {
-	let maskedSource = "";
-	let index = 0;
-
-	while (index < source.length) {
-		const current = source[index];
-		const next = source[index + 1];
-
-		if (current === "/" && next === "/") {
-			const start = index;
-			index += 2;
-
-			while (
-				index < source.length &&
-				source[index] !== "\n" &&
-				source[index] !== "\r"
-			) {
-				index += 1;
-			}
-
-			maskedSource += maskSourceSegment(source.slice(start, index));
-			continue;
-		}
-
-		if (current === "/" && next === "*") {
-			const start = index;
-			index += 2;
-
-			while (
-				index < source.length &&
-				!(source[index] === "*" && source[index + 1] === "/")
-			) {
-				index += 1;
-			}
-
-			index = Math.min(index + 2, source.length);
-			maskedSource += maskSourceSegment(source.slice(start, index));
-			continue;
-		}
-
-		if (current === "'" || current === '"' || current === "`") {
-			const start = index;
-			const quote = current;
-			index += 1;
-
-			while (index < source.length) {
-				const char = source[index];
-
-				if (char === "\\") {
-					index += 2;
-					continue;
-				}
-
-				index += 1;
-
-				if (char === quote) {
-					break;
-				}
-			}
-
-			maskedSource += maskSourceSegment(source.slice(start, index));
-			continue;
-		}
-
-		maskedSource += current;
-		index += 1;
-	}
-
-	return maskedSource;
-}
-
-function hasExecutablePattern(source: string, pattern: RegExp): boolean {
-	return pattern.test(maskTypeScriptCommentsAndLiterals(source));
-}
-
-function hasUncommentedPattern(source: string, pattern: RegExp): boolean {
-	return pattern.test(maskTypeScriptComments(source));
-}
-
-function findExecutablePatternMatch(
-	source: string,
-	patterns: readonly RegExp[],
-): SourceRange | undefined {
-	const maskedSource = maskTypeScriptCommentsAndLiterals(source);
-
-	for (const pattern of patterns) {
-		const match = pattern.exec(maskedSource);
-
-		if (match && match.index !== undefined) {
-			return {
-				end: match.index + match[0].length,
-				start: match.index,
-			};
-		}
-	}
-
-	return undefined;
-}
 
 function isIdentifierBoundary(source: string, index: number): boolean {
 	if (index < 0 || index >= source.length) {

--- a/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace-blocks.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace-blocks.ts
@@ -13,6 +13,11 @@ import {
 	HOOKED_BLOCK_ANCHOR_PATTERN,
 	HOOKED_BLOCK_POSITION_SET,
 } from "./hooked-blocks.js";
+import {
+	hasExecutablePattern,
+	hasUncommentedPattern,
+	maskTypeScriptCommentsAndLiterals,
+} from "./ts-source-masking.js";
 
 import type { DoctorCheck } from "./cli-doctor.js";
 import type { WorkspaceInventory } from "./workspace-inventory.js";
@@ -73,96 +78,6 @@ type WorkspaceBlockIframeMetadata = Record<string, unknown> & {
 interface WorkspaceBlockEditorSource {
 	relativePath: string;
 	source: string;
-}
-
-function maskSourceSegment(segment: string): string {
-	return segment.replace(/[^\n\r]/gu, " ");
-}
-
-function maskTypeScriptComments(source: string): string {
-	return source
-		.replace(/\/\*[\s\S]*?\*\//gu, maskSourceSegment)
-		.replace(/\/\/[^\n\r]*/gu, maskSourceSegment);
-}
-
-// Preserve offsets while hiding non-executable text from hook checks.
-function maskTypeScriptCommentsAndLiterals(source: string): string {
-	let maskedSource = "";
-	let index = 0;
-
-	while (index < source.length) {
-		const current = source[index];
-		const next = source[index + 1];
-
-		if (current === "/" && next === "/") {
-			const start = index;
-			index += 2;
-
-			while (
-				index < source.length &&
-				source[index] !== "\n" &&
-				source[index] !== "\r"
-			) {
-				index += 1;
-			}
-
-			maskedSource += maskSourceSegment(source.slice(start, index));
-			continue;
-		}
-
-		if (current === "/" && next === "*") {
-			const start = index;
-			index += 2;
-
-			while (
-				index < source.length &&
-				!(source[index] === "*" && source[index + 1] === "/")
-			) {
-				index += 1;
-			}
-
-			index = Math.min(index + 2, source.length);
-			maskedSource += maskSourceSegment(source.slice(start, index));
-			continue;
-		}
-
-		if (current === "'" || current === '"' || current === "`") {
-			const start = index;
-			const quote = current;
-			index += 1;
-
-			while (index < source.length) {
-				const char = source[index];
-
-				if (char === "\\") {
-					index += 2;
-					continue;
-				}
-
-				index += 1;
-
-				if (char === quote) {
-					break;
-				}
-			}
-
-			maskedSource += maskSourceSegment(source.slice(start, index));
-			continue;
-		}
-
-		maskedSource += current;
-		index += 1;
-	}
-
-	return maskedSource;
-}
-
-function hasUncommentedPattern(source: string, pattern: RegExp): boolean {
-	return pattern.test(maskTypeScriptComments(source));
-}
-
-function hasExecutablePattern(source: string, pattern: RegExp): boolean {
-	return pattern.test(maskTypeScriptCommentsAndLiterals(source));
 }
 
 function normalizePathSeparators(relativePath: string): string {

--- a/packages/wp-typia-project-tools/src/runtime/ts-source-masking.ts
+++ b/packages/wp-typia-project-tools/src/runtime/ts-source-masking.ts
@@ -1,0 +1,141 @@
+/** Original-source range returned from a masked-source pattern match. */
+export interface SourceRange {
+	end: number;
+	start: number;
+}
+
+function maskSourceSegment(segment: string): string {
+	return segment.replace(/[^\n\r]/gu, " ");
+}
+
+function testPattern(source: string, pattern: RegExp): boolean {
+	pattern.lastIndex = 0;
+	const matched = pattern.test(source);
+	pattern.lastIndex = 0;
+	return matched;
+}
+
+/**
+ * Masks TypeScript comments with spaces while preserving newlines and offsets.
+ */
+export function maskTypeScriptComments(source: string): string {
+	return source
+		.replace(/\/\*[\s\S]*?\*\//gu, maskSourceSegment)
+		.replace(/\/\/[^\n\r]*/gu, maskSourceSegment);
+}
+
+/**
+ * Masks TypeScript comments and quoted/template literals with spaces while
+ * preserving source offsets. This is a lightweight lexer for runtime checks,
+ * not a full TypeScript parser, so template interpolation and regex/division
+ * ambiguity are intentionally left to callers that need deeper syntax analysis.
+ */
+export function maskTypeScriptCommentsAndLiterals(source: string): string {
+	let maskedSource = "";
+	let index = 0;
+
+	while (index < source.length) {
+		const current = source[index];
+		const next = source[index + 1];
+
+		if (current === "/" && next === "/") {
+			const start = index;
+			index += 2;
+
+			while (
+				index < source.length &&
+				source[index] !== "\n" &&
+				source[index] !== "\r"
+			) {
+				index += 1;
+			}
+
+			maskedSource += maskSourceSegment(source.slice(start, index));
+			continue;
+		}
+
+		if (current === "/" && next === "*") {
+			const start = index;
+			index += 2;
+
+			while (
+				index < source.length &&
+				!(source[index] === "*" && source[index + 1] === "/")
+			) {
+				index += 1;
+			}
+
+			index = Math.min(index + 2, source.length);
+			maskedSource += maskSourceSegment(source.slice(start, index));
+			continue;
+		}
+
+		if (current === "'" || current === '"' || current === "`") {
+			const start = index;
+			const quote = current;
+			index += 1;
+
+			while (index < source.length) {
+				const char = source[index];
+
+				if (char === "\\") {
+					index += 2;
+					continue;
+				}
+
+				index += 1;
+
+				if (char === quote) {
+					break;
+				}
+			}
+
+			maskedSource += maskSourceSegment(source.slice(start, index));
+			continue;
+		}
+
+		maskedSource += current;
+		index += 1;
+	}
+
+	return maskedSource;
+}
+
+/**
+ * Tests for a pattern after hiding comments and quoted/template literals.
+ */
+export function hasExecutablePattern(source: string, pattern: RegExp): boolean {
+	return testPattern(maskTypeScriptCommentsAndLiterals(source), pattern);
+}
+
+/**
+ * Tests for a pattern after hiding comments while leaving literals intact.
+ */
+export function hasUncommentedPattern(source: string, pattern: RegExp): boolean {
+	return testPattern(maskTypeScriptComments(source), pattern);
+}
+
+/**
+ * Finds the first masked-source match that maps back to the original source.
+ */
+export function findExecutablePatternMatch(
+	source: string,
+	patterns: readonly RegExp[],
+): SourceRange | undefined {
+	const maskedSource = maskTypeScriptCommentsAndLiterals(source);
+
+	for (const pattern of patterns) {
+		pattern.lastIndex = 0;
+		const match = pattern.exec(maskedSource);
+		pattern.lastIndex = 0;
+
+		if (match && match.index !== undefined) {
+			return {
+				end: match.index + match[0].length,
+				start: match.index,
+			};
+		}
+	}
+
+	return undefined;
+}

--- a/packages/wp-typia-project-tools/tests/ts-source-masking.test.ts
+++ b/packages/wp-typia-project-tools/tests/ts-source-masking.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+	findExecutablePatternMatch,
+	hasExecutablePattern,
+	hasUncommentedPattern,
+	maskTypeScriptComments,
+	maskTypeScriptCommentsAndLiterals,
+} from "../src/runtime/ts-source-masking.js";
+
+describe("TypeScript source masking", () => {
+	test("masks comments while preserving offsets and newlines", () => {
+		const source = [
+			"const before = true;",
+			"// registerWorkspaceVariations();",
+			"const after = true; /* applyWorkspaceBlockTransforms(registration.settings); */",
+		].join("\n");
+
+		const masked = maskTypeScriptComments(source);
+
+		expect(masked).toHaveLength(source.length);
+		expect(masked.split("\n")).toHaveLength(source.split("\n").length);
+		expect(masked).toContain("const before = true;");
+		expect(masked).toContain("const after = true;");
+		expect(masked).not.toContain("registerWorkspaceVariations");
+		expect(masked).not.toContain("applyWorkspaceBlockTransforms");
+	});
+
+	test("distinguishes uncommented imports from commented imports", () => {
+		const importPattern =
+			/^\s*import\s*\{\s*registerWorkspaceVariations\s*\}\s*from\s*["']\.\/variations["']\s*;?\s*$/mu;
+		const commentedSource = [
+			"// import { registerWorkspaceVariations } from './variations';",
+			"const marker = true;",
+		].join("\n");
+		const activeSource = [
+			"import { registerWorkspaceVariations } from './variations';",
+			"const marker = true;",
+		].join("\n");
+
+		expect(hasUncommentedPattern(commentedSource, importPattern)).toBe(false);
+		expect(hasUncommentedPattern(activeSource, importPattern)).toBe(true);
+	});
+
+	test("ignores string and template literal text for executable pattern checks", () => {
+		const callPattern = /registerWorkspaceBlockStyles\s*\(\s*\)\s*;?/u;
+		const source = [
+			"const stringText = 'registerWorkspaceBlockStyles();';",
+			'const doubleQuoted = "registerWorkspaceBlockStyles();";',
+			"const templateText = `registerWorkspaceBlockStyles();`; ",
+			"// registerWorkspaceBlockStyles();",
+		].join("\n");
+
+		expect(hasExecutablePattern(source, callPattern)).toBe(false);
+	});
+
+	test("detects executable source patterns after masking non-executable text", () => {
+		const callPattern = /registerWorkspaceBlockStyles\s*\(\s*\)\s*;?/u;
+		const source = [
+			"const stringText = 'registerWorkspaceBlockStyles();';",
+			"registerWorkspaceBlockStyles();",
+		].join("\n");
+
+		expect(hasExecutablePattern(source, callPattern)).toBe(true);
+		expect(findExecutablePatternMatch(source, [callPattern])).toEqual({
+			end: source.length,
+			start: source.lastIndexOf("registerWorkspaceBlockStyles();"),
+		});
+	});
+
+	test("masks escaped quotes inside literals without losing following executable source", () => {
+		const callPattern = /applyWorkspaceBlockTransforms\s*\(\s*registration\s*\.\s*settings\s*\)\s*;?/u;
+		const source = [
+			`const quoted = "ignore \\"applyWorkspaceBlockTransforms(registration.settings);\\"";`,
+			"applyWorkspaceBlockTransforms(registration.settings);",
+		].join("\n");
+
+		const masked = maskTypeScriptCommentsAndLiterals(source);
+
+		expect(masked).toHaveLength(source.length);
+		expect(hasExecutablePattern(source, callPattern)).toBe(true);
+		expect(findExecutablePatternMatch(source, [callPattern])?.start).toBe(
+			source.lastIndexOf("applyWorkspaceBlockTransforms"),
+		);
+	});
+});


### PR DESCRIPTION
## Summary

- Add a shared TypeScript source masking utility for comment/literal masking and executable-pattern checks.
- Replace duplicated add and doctor runtime masking helpers with shared imports.
- Cover comments, strings, template literals, offset-preserving matches, and executable source patterns.

Fixes #692.

## Validation

- bun run --filter @wp-typia/project-tools build
- bun test packages/wp-typia-project-tools/tests/ts-source-masking.test.ts packages/wp-typia-project-tools/tests/workspace-add.test.ts packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
- bun run typecheck
- node scripts/check-repo-format.mjs
- node scripts/validate-sampo-changesets.mjs
- git diff --check