### PR TITLE
refactor(add): share workspace mutation orchestration

### DIFF
--- a/.sampo/changesets/693-workspace-mutation-orchestration.md
+++ b/.sampo/changesets/693-workspace-mutation-orchestration.md
@@ -1,0 +1,7 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Centralize workspace add mutation snapshot and rollback orchestration so
+ability, AI feature, and admin view scaffolds share the same mutation executor
+and PHP snippet insertion helpers.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ability-scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ability-scaffold.ts
@@ -32,10 +32,12 @@ import {
 import {
 	getWorkspaceBootstrapPath,
 	patchFile,
-	rollbackWorkspaceMutation,
-	snapshotWorkspaceFiles,
-	type WorkspaceMutationSnapshot,
 } from "./cli-add-shared.js";
+import {
+	appendPhpSnippetBeforeClosingTag,
+	executeWorkspaceMutationPlan,
+	insertPhpSnippetBeforeWorkspaceAnchors,
+} from "./cli-add-workspace-mutation.js";
 import {
 	updatePluginHeaderCompatibility,
 } from "./scaffold-compatibility.js";
@@ -194,34 +196,14 @@ function ${enqueueFunctionName}() {
 \t);
 }
 `;
-		const insertionAnchors = [
-			/add_action\(\s*["']init["']\s*,\s*["'][^"']+_load_textdomain["']\s*\);\s*\n/u,
-			/\?>\s*$/u,
-		];
-		const insertPhpSnippet = (snippet: string): void => {
-			for (const anchor of insertionAnchors) {
-				const candidate = nextSource.replace(anchor, (match) => `${snippet}\n${match}`);
-				if (candidate !== nextSource) {
-					nextSource = candidate;
-					return;
-				}
-			}
-			nextSource = `${nextSource.trimEnd()}\n${snippet}\n`;
-		};
-		const appendPhpSnippet = (snippet: string): void => {
-			const closingTagPattern = /\?>\s*$/u;
-			if (closingTagPattern.test(nextSource)) {
-				nextSource = nextSource.replace(closingTagPattern, `${snippet}\n?>`);
-				return;
-			}
-			nextSource = `${nextSource.trimEnd()}\n${snippet}\n`;
-		};
-
 		if (!hasPhpFunctionDefinition(nextSource, loadFunctionName)) {
-			insertPhpSnippet(loadFunction);
+			nextSource = insertPhpSnippetBeforeWorkspaceAnchors(nextSource, loadFunction);
 		}
 		if (!hasPhpFunctionDefinition(nextSource, enqueueFunctionName)) {
-			insertPhpSnippet(enqueueFunction);
+			nextSource = insertPhpSnippetBeforeWorkspaceAnchors(
+				nextSource,
+				enqueueFunction,
+			);
 		} else if (
 			!findPhpFunctionRange(nextSource, enqueueFunctionName)?.source.includes(
 				"wp_enqueue_script_module",
@@ -237,13 +219,13 @@ function ${enqueueFunctionName}() {
 		}
 
 		if (!nextSource.includes(loadHook)) {
-			appendPhpSnippet(loadHook);
+			nextSource = appendPhpSnippetBeforeClosingTag(nextSource, loadHook);
 		}
 		if (!nextSource.includes(adminEnqueueHook)) {
-			appendPhpSnippet(adminEnqueueHook);
+			nextSource = appendPhpSnippetBeforeClosingTag(nextSource, adminEnqueueHook);
 		}
 		if (!nextSource.includes(editorEnqueueHook)) {
-			appendPhpSnippet(editorEnqueueHook);
+			nextSource = appendPhpSnippetBeforeClosingTag(nextSource, editorEnqueueHook);
 		}
 
 		return nextSource;
@@ -519,8 +501,8 @@ export async function scaffoldAbilityWorkspace({
 		"abilities",
 		`${abilitySlug}.php`,
 	);
-	const mutationSnapshot: WorkspaceMutationSnapshot = {
-		fileSources: await snapshotWorkspaceFiles([
+	await executeWorkspaceMutationPlan({
+		filePaths: [
 			blockConfigPath,
 			bootstrapPath,
 			buildScriptPath,
@@ -529,58 +511,53 @@ export async function scaffoldAbilityWorkspace({
 			syncProjectScriptPath,
 			webpackConfigPath,
 			abilitiesIndexPath,
-		]),
-		snapshotDirs: [],
+		],
 		targetPaths: [abilityDir, phpFilePath, syncAbilitiesScriptPath],
-	};
+		run: async () => {
+			await fsp.mkdir(abilityDir, { recursive: true });
+			await fsp.mkdir(path.dirname(phpFilePath), { recursive: true });
+			await ensureAbilityBootstrapAnchors(workspace);
+			await patchFile(bootstrapPath, (source) =>
+				updatePluginHeaderCompatibility(source, compatibilityPolicy),
+			);
+			await ensureAbilityPackageScripts(workspace);
+			await ensureAbilitySyncProjectAnchors(workspace);
+			await ensureAbilityBuildScriptAnchors(workspace);
+			await ensureAbilityWebpackAnchors(workspace);
+			await fsp.writeFile(syncAbilitiesScriptPath, buildAbilitySyncScriptSource(), "utf8");
+			await fsp.writeFile(
+				configFilePath,
+				buildAbilityConfigSource(abilitySlug, workspace.workspace.namespace),
+				"utf8",
+			);
+			await fsp.writeFile(typesFilePath, buildAbilityTypesSource(abilitySlug), "utf8");
+			await fsp.writeFile(dataFilePath, buildAbilityDataSource(abilitySlug), "utf8");
+			await fsp.writeFile(clientFilePath, buildAbilityClientSource(abilitySlug), "utf8");
+			await fsp.writeFile(
+				phpFilePath,
+				buildAbilityPhpSource(abilitySlug, workspace),
+				"utf8",
+			);
 
-	try {
-		await fsp.mkdir(abilityDir, { recursive: true });
-		await fsp.mkdir(path.dirname(phpFilePath), { recursive: true });
-		await ensureAbilityBootstrapAnchors(workspace);
-		await patchFile(bootstrapPath, (source) =>
-			updatePluginHeaderCompatibility(source, compatibilityPolicy),
-		);
-		await ensureAbilityPackageScripts(workspace);
-		await ensureAbilitySyncProjectAnchors(workspace);
-		await ensureAbilityBuildScriptAnchors(workspace);
-		await ensureAbilityWebpackAnchors(workspace);
-		await fsp.writeFile(syncAbilitiesScriptPath, buildAbilitySyncScriptSource(), "utf8");
-		await fsp.writeFile(
-			configFilePath,
-			buildAbilityConfigSource(abilitySlug, workspace.workspace.namespace),
-			"utf8",
-		);
-		await fsp.writeFile(typesFilePath, buildAbilityTypesSource(abilitySlug), "utf8");
-		await fsp.writeFile(dataFilePath, buildAbilityDataSource(abilitySlug), "utf8");
-		await fsp.writeFile(clientFilePath, buildAbilityClientSource(abilitySlug), "utf8");
-		await fsp.writeFile(
-			phpFilePath,
-			buildAbilityPhpSource(abilitySlug, workspace),
-			"utf8",
-		);
-
-		const pascalCase = toPascalCase(abilitySlug);
-		await syncTypeSchemas({
-			jsonSchemaFile: `src/abilities/${abilitySlug}/input.schema.json`,
-			projectRoot: workspace.projectDir,
-			sourceTypeName: `${pascalCase}AbilityInput`,
-			typesFile: `src/abilities/${abilitySlug}/types.ts`,
-		});
-		await syncTypeSchemas({
-			jsonSchemaFile: `src/abilities/${abilitySlug}/output.schema.json`,
-			projectRoot: workspace.projectDir,
-			sourceTypeName: `${pascalCase}AbilityOutput`,
-			typesFile: `src/abilities/${abilitySlug}/types.ts`,
-		});
-		await writeAbilityRegistry(workspace.projectDir, abilitySlug);
-		await appendWorkspaceInventoryEntries(workspace.projectDir, {
-			abilityEntries: [
-				buildAbilityConfigEntry(abilitySlug, compatibilityPolicy),
-			],
-		});
-	} catch (error) {
-		await rollbackWorkspaceMutation(mutationSnapshot);
-		throw error;
-	}
+			const pascalCase = toPascalCase(abilitySlug);
+			await syncTypeSchemas({
+				jsonSchemaFile: `src/abilities/${abilitySlug}/input.schema.json`,
+				projectRoot: workspace.projectDir,
+				sourceTypeName: `${pascalCase}AbilityInput`,
+				typesFile: `src/abilities/${abilitySlug}/types.ts`,
+			});
+			await syncTypeSchemas({
+				jsonSchemaFile: `src/abilities/${abilitySlug}/output.schema.json`,
+				projectRoot: workspace.projectDir,
+				sourceTypeName: `${pascalCase}AbilityOutput`,
+				typesFile: `src/abilities/${abilitySlug}/types.ts`,
+			});
+			await writeAbilityRegistry(workspace.projectDir, abilitySlug);
+			await appendWorkspaceInventoryEntries(workspace.projectDir, {
+				abilityEntries: [
+					buildAbilityConfigEntry(abilitySlug, compatibilityPolicy),
+				],
+			});
+		},
+	});
 }

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-admin-view-scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-admin-view-scaffold.ts
@@ -31,10 +31,12 @@ import {
 import {
   getWorkspaceBootstrapPath,
   patchFile,
-  rollbackWorkspaceMutation,
-  snapshotWorkspaceFiles,
-  type WorkspaceMutationSnapshot,
 } from './cli-add-shared.js';
+import {
+  appendPhpSnippetBeforeClosingTag,
+  executeWorkspaceMutationPlan,
+  insertPhpSnippetBeforeWorkspaceAnchors,
+} from './cli-add-workspace-mutation.js';
 import {
   DEFAULT_WORDPRESS_CORE_DATA_VERSION,
   DEFAULT_WORDPRESS_DATA_VERSION,
@@ -141,34 +143,8 @@ function ${loadFunctionName}() {
 \t}
 }
 `;
-    const insertionAnchors = [
-      /add_action\(\s*["']init["']\s*,\s*["'][^"']+_load_textdomain["']\s*\);\s*\n/u,
-      /\?>\s*$/u,
-    ];
-    const insertPhpSnippet = (snippet: string): void => {
-      for (const anchor of insertionAnchors) {
-        const candidate = nextSource.replace(
-          anchor,
-          (match) => `${snippet}\n${match}`,
-        );
-        if (candidate !== nextSource) {
-          nextSource = candidate;
-          return;
-        }
-      }
-      nextSource = `${nextSource.trimEnd()}\n${snippet}\n`;
-    };
-    const appendPhpSnippet = (snippet: string): void => {
-      const closingTagPattern = /\?>\s*$/u;
-      if (closingTagPattern.test(nextSource)) {
-        nextSource = nextSource.replace(closingTagPattern, `${snippet}\n?>`);
-        return;
-      }
-      nextSource = `${nextSource.trimEnd()}\n${snippet}\n`;
-    };
-
     if (!hasPhpFunctionDefinition(nextSource, loadFunctionName)) {
-      insertPhpSnippet(loadFunction);
+      nextSource = insertPhpSnippetBeforeWorkspaceAnchors(nextSource, loadFunction);
     } else {
       const functionRange = findPhpFunctionRange(nextSource, loadFunctionName);
       const functionSource = functionRange
@@ -190,7 +166,7 @@ function ${loadFunctionName}() {
     }
 
     if (!loadHookPattern.test(nextSource)) {
-      appendPhpSnippet(loadHook);
+      nextSource = appendPhpSnippetBeforeClosingTag(nextSource, loadHook);
     }
 
     return nextSource;
@@ -385,86 +361,81 @@ export async function scaffoldAdminViewWorkspace(options: {
     'admin-views',
     `${adminViewSlug}.php`,
   );
-  const mutationSnapshot: WorkspaceMutationSnapshot = {
-    fileSources: await snapshotWorkspaceFiles([
+  await executeWorkspaceMutationPlan({
+    filePaths: [
       adminViewsIndexPath,
       blockConfigPath,
       bootstrapPath,
       buildScriptPath,
       packageJsonPath,
       webpackConfigPath,
-    ]),
-    snapshotDirs: [],
+    ],
     targetPaths: [adminViewDir, adminViewPhpPath],
-  };
-
-  try {
-    await fsp.mkdir(adminViewDir, { recursive: true });
-    await fsp.mkdir(path.dirname(adminViewPhpPath), { recursive: true });
-    await ensureAdminViewPackageDependencies(workspace, parsedSource);
-    await ensureAdminViewBootstrapAnchors(workspace);
-    await ensureAdminViewBuildScriptAnchors(workspace);
-    await ensureAdminViewWebpackAnchors(workspace);
-    await fsp.writeFile(
-      path.join(adminViewDir, 'types.ts'),
-      buildAdminViewTypesSource(adminViewSlug, restResource, coreDataSource),
-      'utf8',
-    );
-    await fsp.writeFile(
-      path.join(adminViewDir, 'config.ts'),
-      buildAdminViewConfigSource(
-        adminViewSlug,
-        workspace.workspace.textDomain,
-        parsedSource,
-        restResource,
-      ),
-      'utf8',
-    );
-    await fsp.writeFile(
-      path.join(adminViewDir, 'data.ts'),
-      coreDataSource
-        ? buildCoreDataAdminViewDataSource(adminViewSlug, coreDataSource)
-        : restResource
-          ? buildRestAdminViewDataSource(adminViewSlug, restResource)
-          : buildDefaultAdminViewDataSource(adminViewSlug),
-      'utf8',
-    );
-    await fsp.writeFile(
-      path.join(adminViewDir, 'Screen.tsx'),
-      coreDataSource
-        ? buildCoreDataAdminViewScreenSource(
-            adminViewSlug,
-            workspace.workspace.textDomain,
-          )
-        : buildAdminViewScreenSource(
-            adminViewSlug,
-            workspace.workspace.textDomain,
-          ),
-      'utf8',
-    );
-    await fsp.writeFile(
-      path.join(adminViewDir, 'index.tsx'),
-      buildAdminViewEntrySource(adminViewSlug),
-      'utf8',
-    );
-    await fsp.writeFile(
-      path.join(adminViewDir, 'style.scss'),
-      buildAdminViewStyleSource(),
-      'utf8',
-    );
-    await fsp.writeFile(
-      adminViewPhpPath,
-      buildAdminViewPhpSource(adminViewSlug, workspace),
-      'utf8',
-    );
-    await writeAdminViewRegistry(workspace.projectDir, adminViewSlug);
-    await appendWorkspaceInventoryEntries(workspace.projectDir, {
-      adminViewEntries: [
-        buildAdminViewConfigEntry(adminViewSlug, parsedSource),
-      ],
-    });
-  } catch (error) {
-    await rollbackWorkspaceMutation(mutationSnapshot);
-    throw error;
-  }
+    run: async () => {
+      await fsp.mkdir(adminViewDir, { recursive: true });
+      await fsp.mkdir(path.dirname(adminViewPhpPath), { recursive: true });
+      await ensureAdminViewPackageDependencies(workspace, parsedSource);
+      await ensureAdminViewBootstrapAnchors(workspace);
+      await ensureAdminViewBuildScriptAnchors(workspace);
+      await ensureAdminViewWebpackAnchors(workspace);
+      await fsp.writeFile(
+        path.join(adminViewDir, 'types.ts'),
+        buildAdminViewTypesSource(adminViewSlug, restResource, coreDataSource),
+        'utf8',
+      );
+      await fsp.writeFile(
+        path.join(adminViewDir, 'config.ts'),
+        buildAdminViewConfigSource(
+          adminViewSlug,
+          workspace.workspace.textDomain,
+          parsedSource,
+          restResource,
+        ),
+        'utf8',
+      );
+      await fsp.writeFile(
+        path.join(adminViewDir, 'data.ts'),
+        coreDataSource
+          ? buildCoreDataAdminViewDataSource(adminViewSlug, coreDataSource)
+          : restResource
+            ? buildRestAdminViewDataSource(adminViewSlug, restResource)
+            : buildDefaultAdminViewDataSource(adminViewSlug),
+        'utf8',
+      );
+      await fsp.writeFile(
+        path.join(adminViewDir, 'Screen.tsx'),
+        coreDataSource
+          ? buildCoreDataAdminViewScreenSource(
+              adminViewSlug,
+              workspace.workspace.textDomain,
+            )
+          : buildAdminViewScreenSource(
+              adminViewSlug,
+              workspace.workspace.textDomain,
+            ),
+        'utf8',
+      );
+      await fsp.writeFile(
+        path.join(adminViewDir, 'index.tsx'),
+        buildAdminViewEntrySource(adminViewSlug),
+        'utf8',
+      );
+      await fsp.writeFile(
+        path.join(adminViewDir, 'style.scss'),
+        buildAdminViewStyleSource(),
+        'utf8',
+      );
+      await fsp.writeFile(
+        adminViewPhpPath,
+        buildAdminViewPhpSource(adminViewSlug, workspace),
+        'utf8',
+      );
+      await writeAdminViewRegistry(workspace.projectDir, adminViewSlug);
+      await appendWorkspaceInventoryEntries(workspace.projectDir, {
+        adminViewEntries: [
+          buildAdminViewConfigEntry(adminViewSlug, parsedSource),
+        ],
+      });
+    },
+  });
 }

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai-scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai-scaffold.ts
@@ -21,10 +21,8 @@ import { appendWorkspaceInventoryEntries } from "./workspace-inventory.js";
 import {
 	getWorkspaceBootstrapPath,
 	patchFile,
-	rollbackWorkspaceMutation,
-	snapshotWorkspaceFiles,
-	type WorkspaceMutationSnapshot,
 } from "./cli-add-shared.js";
+import { executeWorkspaceMutationPlan } from "./cli-add-workspace-mutation.js";
 import { updatePluginHeaderCompatibility } from "./scaffold-compatibility.js";
 import { toPascalCase, toTitleCase } from "./string-case.js";
 import {
@@ -81,88 +79,83 @@ export async function scaffoldAiFeatureWorkspace({
 		"ai-features",
 		`${aiFeatureSlug}.php`,
 	);
-	const mutationSnapshot: WorkspaceMutationSnapshot = {
-		fileSources: await snapshotWorkspaceFiles([
+	return executeWorkspaceMutationPlan({
+		filePaths: [
 			blockConfigPath,
 			bootstrapPath,
 			packageJsonPath,
 			syncAiScriptPath,
 			syncProjectScriptPath,
 			syncRestScriptPath,
-		]),
-		snapshotDirs: [],
+		],
 		targetPaths: [aiFeatureDir, phpFilePath, syncAiScriptPath],
-	};
+		run: async () => {
+			await fsp.mkdir(aiFeatureDir, { recursive: true });
+			await fsp.mkdir(path.dirname(phpFilePath), { recursive: true });
+			await ensureAiFeatureBootstrapAnchors(workspace);
+			await patchFile(bootstrapPath, (source) =>
+				updatePluginHeaderCompatibility(source, compatibilityPolicy),
+			);
+			const packageScriptChanges = await ensureAiFeaturePackageScripts(workspace);
+			await ensureAiFeatureSyncProjectAnchors(workspace);
+			await ensureAiFeatureSyncRestAnchors(workspace);
+			await fsp.writeFile(
+				syncAiScriptPath,
+				buildAiFeatureSyncScriptSource(),
+				"utf8",
+			);
+			await fsp.writeFile(typesFilePath, buildAiFeatureTypesSource(aiFeatureSlug), "utf8");
+			await fsp.writeFile(
+				validatorsFilePath,
+				buildAiFeatureValidatorsSource(aiFeatureSlug),
+				"utf8",
+			);
+			await fsp.writeFile(apiFilePath, buildAiFeatureApiSource(aiFeatureSlug), "utf8");
+			await fsp.writeFile(dataFilePath, buildAiFeatureDataSource(aiFeatureSlug), "utf8");
+			await fsp.writeFile(
+				phpFilePath,
+				buildAiFeaturePhpSource(
+					aiFeatureSlug,
+					namespace,
+					workspace.workspace.phpPrefix,
+					workspace.workspace.textDomain,
+				),
+				"utf8",
+			);
 
-	try {
-		await fsp.mkdir(aiFeatureDir, { recursive: true });
-		await fsp.mkdir(path.dirname(phpFilePath), { recursive: true });
-		await ensureAiFeatureBootstrapAnchors(workspace);
-		await patchFile(bootstrapPath, (source) =>
-			updatePluginHeaderCompatibility(source, compatibilityPolicy),
-		);
-		const packageScriptChanges = await ensureAiFeaturePackageScripts(workspace);
-		await ensureAiFeatureSyncProjectAnchors(workspace);
-		await ensureAiFeatureSyncRestAnchors(workspace);
-		await fsp.writeFile(
-			syncAiScriptPath,
-			buildAiFeatureSyncScriptSource(),
-			"utf8",
-		);
-		await fsp.writeFile(typesFilePath, buildAiFeatureTypesSource(aiFeatureSlug), "utf8");
-		await fsp.writeFile(
-			validatorsFilePath,
-			buildAiFeatureValidatorsSource(aiFeatureSlug),
-			"utf8",
-		);
-		await fsp.writeFile(apiFilePath, buildAiFeatureApiSource(aiFeatureSlug), "utf8");
-		await fsp.writeFile(dataFilePath, buildAiFeatureDataSource(aiFeatureSlug), "utf8");
-		await fsp.writeFile(
-			phpFilePath,
-			buildAiFeaturePhpSource(
-				aiFeatureSlug,
-				namespace,
-				workspace.workspace.phpPrefix,
-				workspace.workspace.textDomain,
-			),
-			"utf8",
-		);
+			const pascalCase = toPascalCase(aiFeatureSlug);
+			await syncAiFeatureRestArtifacts({
+				clientFile: `src/ai-features/${aiFeatureSlug}/api-client.ts`,
+				outputDir: path.join("src", "ai-features", aiFeatureSlug),
+				projectDir: workspace.projectDir,
+				typesFile: `src/ai-features/${aiFeatureSlug}/api-types.ts`,
+				validatorsFile: `src/ai-features/${aiFeatureSlug}/api-validators.ts`,
+				variables: {
+					namespace,
+					pascalCase,
+					slugKebabCase: aiFeatureSlug,
+					title: toTitleCase(aiFeatureSlug),
+				},
+			});
+			await syncAiFeatureSchemaArtifact({
+				aiSchemaFile: `src/ai-features/${aiFeatureSlug}/ai-schemas/feature-result.ai.schema.json`,
+				outputDir: path.join("src", "ai-features", aiFeatureSlug),
+				projectDir: workspace.projectDir,
+			});
+			await appendWorkspaceInventoryEntries(workspace.projectDir, {
+				aiFeatureEntries: [
+					buildAiFeatureConfigEntry(aiFeatureSlug, namespace),
+				],
+				transformSource: ensureBlockConfigCanAddRestManifests,
+			});
 
-		const pascalCase = toPascalCase(aiFeatureSlug);
-		await syncAiFeatureRestArtifacts({
-			clientFile: `src/ai-features/${aiFeatureSlug}/api-client.ts`,
-			outputDir: path.join("src", "ai-features", aiFeatureSlug),
-			projectDir: workspace.projectDir,
-			typesFile: `src/ai-features/${aiFeatureSlug}/api-types.ts`,
-			validatorsFile: `src/ai-features/${aiFeatureSlug}/api-validators.ts`,
-			variables: {
-				namespace,
-				pascalCase,
-				slugKebabCase: aiFeatureSlug,
-				title: toTitleCase(aiFeatureSlug),
-			},
-		});
-		await syncAiFeatureSchemaArtifact({
-			aiSchemaFile: `src/ai-features/${aiFeatureSlug}/ai-schemas/feature-result.ai.schema.json`,
-			outputDir: path.join("src", "ai-features", aiFeatureSlug),
-			projectDir: workspace.projectDir,
-		});
-		await appendWorkspaceInventoryEntries(workspace.projectDir, {
-			aiFeatureEntries: [
-				buildAiFeatureConfigEntry(aiFeatureSlug, namespace),
-			],
-			transformSource: ensureBlockConfigCanAddRestManifests,
-		});
-
-		return {
-			warnings: packageScriptChanges.addedProjectToolsDependency
-				? [
-						"Added `@wp-typia/project-tools` to devDependencies for `sync-ai`. If this workspace was already installed, rerun your package manager install command before the first `wp-typia sync ai`.",
-					]
-				: [],
-		};
-	} catch (error) {
-		await rollbackWorkspaceMutation(mutationSnapshot);
-		throw error;
-	}
+			return {
+				warnings: packageScriptChanges.addedProjectToolsDependency
+					? [
+							"Added `@wp-typia/project-tools` to devDependencies for `sync-ai`. If this workspace was already installed, rerun your package manager install command before the first `wp-typia sync ai`.",
+						]
+					: [],
+			};
+		},
+	});
 }

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-mutation.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-mutation.ts
@@ -20,6 +20,21 @@ const DEFAULT_PHP_SNIPPET_INSERTION_ANCHORS = [
 ] as const;
 
 /**
+ * Error thrown when the mutation and its rollback both fail.
+ */
+export class WorkspaceMutationRollbackError extends Error {
+	readonly mutationError: unknown;
+	readonly rollbackError: unknown;
+
+	constructor(mutationError: unknown, rollbackError: unknown) {
+		super("Workspace mutation failed and rollback also failed.");
+		this.name = "WorkspaceMutationRollbackError";
+		this.mutationError = mutationError;
+		this.rollbackError = rollbackError;
+	}
+}
+
+/**
  * Execute a workspace add mutation with rollback on any failure.
  */
 export async function executeWorkspaceMutationPlan<TResult>({
@@ -37,7 +52,11 @@ export async function executeWorkspaceMutationPlan<TResult>({
 	try {
 		return await run();
 	} catch (error) {
-		await rollbackWorkspaceMutation(mutationSnapshot);
+		try {
+			await rollbackWorkspaceMutation(mutationSnapshot);
+		} catch (rollbackError) {
+			throw new WorkspaceMutationRollbackError(error, rollbackError);
+		}
 		throw error;
 	}
 }

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-mutation.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-mutation.ts
@@ -1,0 +1,75 @@
+import {
+	rollbackWorkspaceMutation,
+	snapshotWorkspaceFiles,
+} from "./cli-add-shared.js";
+
+export interface WorkspaceMutationPlan<TResult> {
+	/** Files to capture before the mutation starts. Missing files are restored as absent. */
+	filePaths: string[];
+	/** Snapshot directories created by the mutation, usually migration fixtures. */
+	snapshotDirs?: string[];
+	/** Created files or directories to remove if the mutation fails. */
+	targetPaths?: string[];
+	/** Mutating work to execute after the snapshot is captured. */
+	run: () => Promise<TResult>;
+}
+
+const DEFAULT_PHP_SNIPPET_INSERTION_ANCHORS = [
+	/add_action\(\s*["']init["']\s*,\s*["'][^"']+_load_textdomain["']\s*\);\s*\n/u,
+	/\?>\s*$/u,
+] as const;
+
+/**
+ * Execute a workspace add mutation with rollback on any failure.
+ */
+export async function executeWorkspaceMutationPlan<TResult>({
+	filePaths,
+	run,
+	snapshotDirs = [],
+	targetPaths = [],
+}: WorkspaceMutationPlan<TResult>): Promise<TResult> {
+	const mutationSnapshot = {
+		fileSources: await snapshotWorkspaceFiles(filePaths),
+		snapshotDirs: [...snapshotDirs],
+		targetPaths: [...targetPaths],
+	};
+
+	try {
+		return await run();
+	} catch (error) {
+		await rollbackWorkspaceMutation(mutationSnapshot);
+		throw error;
+	}
+}
+
+/**
+ * Insert a PHP snippet before the workspace textdomain hook or closing tag.
+ */
+export function insertPhpSnippetBeforeWorkspaceAnchors(
+	source: string,
+	snippet: string,
+): string {
+	for (const anchor of DEFAULT_PHP_SNIPPET_INSERTION_ANCHORS) {
+		const candidate = source.replace(anchor, (match) => `${snippet}\n${match}`);
+		if (candidate !== source) {
+			return candidate;
+		}
+	}
+
+	return `${source.trimEnd()}\n${snippet}\n`;
+}
+
+/**
+ * Append a PHP snippet before the closing tag when one is present.
+ */
+export function appendPhpSnippetBeforeClosingTag(
+	source: string,
+	snippet: string,
+): string {
+	const closingTagPattern = /\?>\s*$/u;
+	if (closingTagPattern.test(source)) {
+		return source.replace(closingTagPattern, `${snippet}\n?>`);
+	}
+
+	return `${source.trimEnd()}\n${snippet}\n`;
+}

--- a/packages/wp-typia-project-tools/tests/cli-add-workspace-boundaries.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-add-workspace-boundaries.test.ts
@@ -37,6 +37,14 @@ test('cli-add-workspace delegates asset, rest-resource, ai-feature, and admin-vi
     path.join(runtimeRoot, 'cli-add-workspace-ai-source-emitters.ts'),
     'utf8',
   );
+  const aiScaffoldSource = fs.readFileSync(
+    path.join(runtimeRoot, 'cli-add-workspace-ai-scaffold.ts'),
+    'utf8',
+  );
+  const abilityScaffoldSource = fs.readFileSync(
+    path.join(runtimeRoot, 'cli-add-workspace-ability-scaffold.ts'),
+    'utf8',
+  );
   const adminViewSource = fs.readFileSync(
     path.join(runtimeRoot, 'cli-add-workspace-admin-view.ts'),
     'utf8',
@@ -149,15 +157,17 @@ test('cli-add-workspace delegates asset, rest-resource, ai-feature, and admin-vi
   expect(restAnchorsSource).toContain(
     'async function ensureRestResourceSyncScriptAnchors(',
   );
-  expect(aiSource).toContain('from "./cli-add-workspace-ai-anchors.js"');
-  expect(aiSource).toContain(
+  expect(aiScaffoldSource).toContain('from "./cli-add-workspace-ai-anchors.js"');
+  expect(aiScaffoldSource).toContain(
     'from "./cli-add-workspace-ai-source-emitters.js"',
   );
-  expect(aiSource).not.toContain('function buildAiFeatureTypesSource(');
-  expect(aiSource).not.toContain(
+  expect(aiScaffoldSource).not.toContain('function buildAiFeatureTypesSource(');
+  expect(aiScaffoldSource).not.toContain(
     'async function ensureAiFeatureBootstrapAnchors(',
   );
-  expect(aiSource).toContain('function buildAiFeaturePhpSource(');
+  expect(aiScaffoldSource).toContain(
+    'from "./cli-add-workspace-ai-templates.js"',
+  );
   expect(aiSource).toContain('export async function runAddAiFeatureCommand(');
   expect(aiSourceEmittersSource).toContain(
     'function buildAiFeatureTypesSource(',
@@ -210,4 +220,13 @@ test('cli-add-workspace delegates asset, rest-resource, ai-feature, and admin-vi
   expect(adminViewTemplatesSource).not.toContain(
     'export async function runAddAdminViewCommand(',
   );
+  for (const scaffoldSource of [
+    abilityScaffoldSource,
+    adminViewScaffoldSource,
+    aiScaffoldSource,
+  ]) {
+    expect(scaffoldSource).toContain('executeWorkspaceMutationPlan');
+    expect(scaffoldSource).not.toContain('rollbackWorkspaceMutation');
+    expect(scaffoldSource).not.toContain('snapshotWorkspaceFiles');
+  }
 });

--- a/packages/wp-typia-project-tools/tests/cli-add-workspace-mutation.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-add-workspace-mutation.test.ts
@@ -8,6 +8,7 @@ import {
 	appendPhpSnippetBeforeClosingTag,
 	executeWorkspaceMutationPlan,
 	insertPhpSnippetBeforeWorkspaceAnchors,
+	WorkspaceMutationRollbackError,
 } from "../src/runtime/cli-add-workspace-mutation.js";
 
 const tempRoot = fs.mkdtempSync(
@@ -68,6 +69,37 @@ describe("workspace add mutation executor", () => {
 		expect(await fsp.readFile(existingPath, "utf8")).toBe("before");
 		expect(fs.existsSync(generatedFilePath)).toBe(false);
 		expect(fs.existsSync(targetDir)).toBe(false);
+	});
+
+	test("preserves mutation and rollback failures together", async () => {
+		const projectDir = path.join(tempRoot, "rollback-failure");
+		const nestedDir = path.join(projectDir, "nested");
+		const existingPath = path.join(nestedDir, "existing.txt");
+		await fsp.mkdir(nestedDir, { recursive: true });
+		await fsp.writeFile(existingPath, "before", "utf8");
+
+		let caughtError: unknown;
+		try {
+			await executeWorkspaceMutationPlan({
+				filePaths: [existingPath],
+				run: async () => {
+					await fsp.rm(nestedDir, { force: true, recursive: true });
+					await fsp.writeFile(nestedDir, "not a directory", "utf8");
+					throw new Error("mutation failed");
+				},
+			});
+		} catch (error) {
+			caughtError = error;
+		}
+
+		expect(caughtError).toBeInstanceOf(WorkspaceMutationRollbackError);
+		const rollbackError = caughtError as WorkspaceMutationRollbackError;
+		expect(rollbackError.message).toBe(
+			"Workspace mutation failed and rollback also failed.",
+		);
+		expect(rollbackError.mutationError).toBeInstanceOf(Error);
+		expect((rollbackError.mutationError as Error).message).toBe("mutation failed");
+		expect(rollbackError.rollbackError).toBeInstanceOf(Error);
 	});
 });
 

--- a/packages/wp-typia-project-tools/tests/cli-add-workspace-mutation.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-add-workspace-mutation.test.ts
@@ -1,0 +1,106 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { promises as fsp } from "node:fs";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+	appendPhpSnippetBeforeClosingTag,
+	executeWorkspaceMutationPlan,
+	insertPhpSnippetBeforeWorkspaceAnchors,
+} from "../src/runtime/cli-add-workspace-mutation.js";
+
+const tempRoot = fs.mkdtempSync(
+	path.join(os.tmpdir(), "wp-typia-add-mutation-"),
+);
+
+afterAll(() => {
+	fs.rmSync(tempRoot, { force: true, recursive: true });
+});
+
+describe("workspace add mutation executor", () => {
+	test("keeps successful workspace mutation results", async () => {
+		const projectDir = path.join(tempRoot, "success");
+		const existingPath = path.join(projectDir, "existing.txt");
+		const createdDir = path.join(projectDir, "created");
+		const createdFile = path.join(createdDir, "file.txt");
+		await fsp.mkdir(projectDir, { recursive: true });
+		await fsp.writeFile(existingPath, "before", "utf8");
+
+		const result = await executeWorkspaceMutationPlan({
+			filePaths: [existingPath, createdFile],
+			targetPaths: [createdDir],
+			run: async () => {
+				await fsp.writeFile(existingPath, "after", "utf8");
+				await fsp.mkdir(createdDir, { recursive: true });
+				await fsp.writeFile(createdFile, "created", "utf8");
+				return "ok";
+			},
+		});
+
+		expect(result).toBe("ok");
+		expect(await fsp.readFile(existingPath, "utf8")).toBe("after");
+		expect(await fsp.readFile(createdFile, "utf8")).toBe("created");
+	});
+
+	test("rolls back changed files, missing snapshots, and target paths on failure", async () => {
+		const projectDir = path.join(tempRoot, "rollback");
+		const existingPath = path.join(projectDir, "existing.txt");
+		const generatedFilePath = path.join(projectDir, "generated.txt");
+		const targetDir = path.join(projectDir, "target");
+		await fsp.mkdir(projectDir, { recursive: true });
+		await fsp.writeFile(existingPath, "before", "utf8");
+
+		await expect(
+			executeWorkspaceMutationPlan({
+				filePaths: [existingPath, generatedFilePath],
+				targetPaths: [targetDir],
+				run: async () => {
+					await fsp.writeFile(existingPath, "after", "utf8");
+					await fsp.writeFile(generatedFilePath, "generated", "utf8");
+					await fsp.mkdir(targetDir, { recursive: true });
+					await fsp.writeFile(path.join(targetDir, "file.txt"), "target", "utf8");
+					throw new Error("boom");
+				},
+			}),
+		).rejects.toThrow("boom");
+
+		expect(await fsp.readFile(existingPath, "utf8")).toBe("before");
+		expect(fs.existsSync(generatedFilePath)).toBe(false);
+		expect(fs.existsSync(targetDir)).toBe(false);
+	});
+});
+
+describe("workspace PHP snippet helpers", () => {
+	test("inserts snippets before textdomain anchors", () => {
+		const source = [
+			"<?php",
+			"add_action( 'init', 'demo_load_textdomain' );",
+			"do_action( 'demo_ready' );",
+			"",
+		].join("\n");
+
+		expect(
+			insertPhpSnippetBeforeWorkspaceAnchors(source, "function demo_load() {}"),
+		).toBe(
+			[
+				"<?php",
+				"function demo_load() {}",
+				"add_action( 'init', 'demo_load_textdomain' );",
+				"do_action( 'demo_ready' );",
+				"",
+			].join("\n"),
+		);
+	});
+
+	test("appends snippets before closing tags", () => {
+		const source = "<?php\n?>\n";
+
+		expect(
+			appendPhpSnippetBeforeClosingTag(
+				source,
+				"add_action( 'plugins_loaded', 'demo_load' );",
+			),
+		).toBe("<?php\nadd_action( 'plugins_loaded', 'demo_load' );\n?>");
+	});
+});


### PR DESCRIPTION
## Summary

- Add a shared workspace mutation executor that snapshots files and rolls back target paths on scaffold failures.
- Move ability, AI feature, and admin view scaffolds onto the shared mutation path.
- Share PHP snippet insertion helpers used by ability/admin-view bootstrap patching.
- Add focused success/rollback tests plus boundary coverage that keeps complex add kinds on the shared executor.

Fixes #693.

## Validation

- bun run --filter @wp-typia/project-tools build
- bun test packages/wp-typia-project-tools/tests/cli-add-workspace-mutation.test.ts packages/wp-typia-project-tools/tests/cli-add-workspace-boundaries.test.ts
- bun run --filter @wp-typia/project-tools test:workspace
- bun run typecheck
- node scripts/check-repo-format.mjs
- node scripts/validate-sampo-changesets.mjs
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved workspace scaffolding reliability through centralized mutation orchestration with automatic rollback capabilities when operations fail.
  * Standardized PHP code insertion across workspace generation, ensuring consistent behavior across all scaffold types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->