### PR TITLE
refactor(inventory): drive section repair from descriptors

### DIFF
--- a/.sampo/changesets/695-data-driven-inventory-sections.md
+++ b/.sampo/changesets/695-data-driven-inventory-sections.md
@@ -1,0 +1,7 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Drive workspace inventory section creation from shared descriptors so adding
+new generated inventory sections no longer requires duplicating interface and
+constant insertion checks.

--- a/packages/wp-typia-project-tools/src/runtime/workspace-inventory.ts
+++ b/packages/wp-typia-project-tools/src/runtime/workspace-inventory.ts
@@ -383,6 +383,122 @@ export const EDITOR_PLUGINS: WorkspaceEditorPluginConfig[] = [
 ];
 `;
 
+type InventorySectionDescriptor = {
+	/** Optional exported interface that backs the inventory section entries. */
+	interface?: {
+		name: string;
+		section: string;
+	};
+	/** Optional exported const array that stores the inventory section entries. */
+	value?: {
+		name: string;
+		section: string;
+	};
+};
+
+const INVENTORY_SECTIONS: readonly InventorySectionDescriptor[] = [
+	{
+		interface: {
+			name: "WorkspaceVariationConfig",
+			section: VARIATIONS_INTERFACE_SECTION,
+		},
+		value: {
+			name: "VARIATIONS",
+			section: VARIATIONS_CONST_SECTION,
+		},
+	},
+	{
+		interface: {
+			name: "WorkspaceBlockStyleConfig",
+			section: BLOCK_STYLES_INTERFACE_SECTION,
+		},
+		value: {
+			name: "BLOCK_STYLES",
+			section: BLOCK_STYLES_CONST_SECTION,
+		},
+	},
+	{
+		interface: {
+			name: "WorkspaceBlockTransformConfig",
+			section: BLOCK_TRANSFORMS_INTERFACE_SECTION,
+		},
+		value: {
+			name: "BLOCK_TRANSFORMS",
+			section: BLOCK_TRANSFORMS_CONST_SECTION,
+		},
+	},
+	{
+		interface: {
+			name: "WorkspacePatternConfig",
+			section: PATTERNS_INTERFACE_SECTION,
+		},
+		value: {
+			name: "PATTERNS",
+			section: PATTERNS_CONST_SECTION,
+		},
+	},
+	{
+		interface: {
+			name: "WorkspaceBindingSourceConfig",
+			section: BINDING_SOURCES_INTERFACE_SECTION,
+		},
+		value: {
+			name: "BINDING_SOURCES",
+			section: BINDING_SOURCES_CONST_SECTION,
+		},
+	},
+	{
+		interface: {
+			name: "WorkspaceRestResourceConfig",
+			section: REST_RESOURCES_INTERFACE_SECTION,
+		},
+		value: {
+			name: "REST_RESOURCES",
+			section: REST_RESOURCES_CONST_SECTION,
+		},
+	},
+	{
+		interface: {
+			name: "WorkspaceAbilityConfig",
+			section: ABILITIES_INTERFACE_SECTION,
+		},
+		value: {
+			name: "ABILITIES",
+			section: ABILITIES_CONST_SECTION,
+		},
+	},
+	{
+		interface: {
+			name: "WorkspaceAiFeatureConfig",
+			section: AI_FEATURES_INTERFACE_SECTION,
+		},
+		value: {
+			name: "AI_FEATURES",
+			section: AI_FEATURES_CONST_SECTION,
+		},
+	},
+	{
+		interface: {
+			name: "WorkspaceAdminViewConfig",
+			section: ADMIN_VIEWS_INTERFACE_SECTION,
+		},
+		value: {
+			name: "ADMIN_VIEWS",
+			section: ADMIN_VIEWS_CONST_SECTION,
+		},
+	},
+	{
+		interface: {
+			name: "WorkspaceEditorPluginConfig",
+			section: EDITOR_PLUGINS_INTERFACE_SECTION,
+		},
+		value: {
+			name: "EDITOR_PLUGINS",
+			section: EDITOR_PLUGINS_CONST_SECTION,
+		},
+	},
+];
+
 function getPropertyNameText(name: ts.PropertyName): string | null {
 	if (ts.isIdentifier(name) || ts.isStringLiteral(name)) {
 		return name.text;
@@ -972,70 +1088,32 @@ export function getWorkspaceBlockSelectOptions(projectDir: string): Array<{
 function ensureWorkspaceInventorySections(source: string): string {
 	let nextSource = source.trimEnd();
 
-	if (!/export\s+interface\s+WorkspaceVariationConfig\b/u.test(nextSource)) {
-		nextSource += VARIATIONS_INTERFACE_SECTION;
-	}
-	if (!/export\s+const\s+VARIATIONS\b/u.test(nextSource)) {
-		nextSource += VARIATIONS_CONST_SECTION;
-	}
-	if (!/export\s+interface\s+WorkspaceBlockStyleConfig\b/u.test(nextSource)) {
-		nextSource += BLOCK_STYLES_INTERFACE_SECTION;
-	}
-	if (!/export\s+const\s+BLOCK_STYLES\b/u.test(nextSource)) {
-		nextSource += BLOCK_STYLES_CONST_SECTION;
-	}
-	if (!/export\s+interface\s+WorkspaceBlockTransformConfig\b/u.test(nextSource)) {
-		nextSource += BLOCK_TRANSFORMS_INTERFACE_SECTION;
-	}
-	if (!/export\s+const\s+BLOCK_TRANSFORMS\b/u.test(nextSource)) {
-		nextSource += BLOCK_TRANSFORMS_CONST_SECTION;
-	}
-
-	if (!/export\s+interface\s+WorkspacePatternConfig\b/u.test(nextSource)) {
-		nextSource += PATTERNS_INTERFACE_SECTION;
-	}
-	if (!/export\s+const\s+PATTERNS\b/u.test(nextSource)) {
-		nextSource += PATTERNS_CONST_SECTION;
-	}
-
-	if (!/export\s+interface\s+WorkspaceBindingSourceConfig\b/u.test(nextSource)) {
-		nextSource += BINDING_SOURCES_INTERFACE_SECTION;
-	}
-	if (!/export\s+const\s+BINDING_SOURCES\b/u.test(nextSource)) {
-		nextSource += BINDING_SOURCES_CONST_SECTION;
-	}
-	if (!/export\s+interface\s+WorkspaceRestResourceConfig\b/u.test(nextSource)) {
-		nextSource += REST_RESOURCES_INTERFACE_SECTION;
-	}
-	if (!/export\s+const\s+REST_RESOURCES\b/u.test(nextSource)) {
-		nextSource += REST_RESOURCES_CONST_SECTION;
-	}
-	if (!/export\s+interface\s+WorkspaceAbilityConfig\b/u.test(nextSource)) {
-		nextSource += ABILITIES_INTERFACE_SECTION;
-	}
-	if (!/export\s+const\s+ABILITIES\b/u.test(nextSource)) {
-		nextSource += ABILITIES_CONST_SECTION;
-	}
-	if (!/export\s+interface\s+WorkspaceAiFeatureConfig\b/u.test(nextSource)) {
-		nextSource += AI_FEATURES_INTERFACE_SECTION;
-	}
-	if (!/export\s+const\s+AI_FEATURES\b/u.test(nextSource)) {
-		nextSource += AI_FEATURES_CONST_SECTION;
-	}
-	if (!/export\s+interface\s+WorkspaceAdminViewConfig\b/u.test(nextSource)) {
-		nextSource += ADMIN_VIEWS_INTERFACE_SECTION;
-	}
-	if (!/export\s+const\s+ADMIN_VIEWS\b/u.test(nextSource)) {
-		nextSource += ADMIN_VIEWS_CONST_SECTION;
-	}
-	if (!/export\s+interface\s+WorkspaceEditorPluginConfig\b/u.test(nextSource)) {
-		nextSource += EDITOR_PLUGINS_INTERFACE_SECTION;
-	}
-	if (!/export\s+const\s+EDITOR_PLUGINS\b/u.test(nextSource)) {
-		nextSource += EDITOR_PLUGINS_CONST_SECTION;
+	for (const section of INVENTORY_SECTIONS) {
+		if (
+			section.interface &&
+			!hasExportedInterface(nextSource, section.interface.name)
+		) {
+			nextSource += section.interface.section;
+		}
+		if (section.value && !hasExportedConst(nextSource, section.value.name)) {
+			nextSource += section.value.section;
+		}
 	}
 
 	return `${nextSource}\n`;
+}
+
+function hasExportedInterface(source: string, interfaceName: string): boolean {
+	return new RegExp(
+		`export\\s+interface\\s+${escapeRegex(interfaceName)}\\b`,
+		"u",
+	).test(source);
+}
+
+function hasExportedConst(source: string, constName: string): boolean {
+	return new RegExp(`export\\s+const\\s+${escapeRegex(constName)}\\b`, "u").test(
+		source,
+	);
 }
 
 function appendEntriesAtMarker(source: string, marker: string, entries: string[]): string {

--- a/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
@@ -454,6 +454,106 @@ test("binding source workflow repairs missing bootstrap functions even when hook
   expect(repairedBootstrap).toContain("build/bindings/index.js");
 }, 15_000);
 
+test("workspace inventory repair creates every descriptor-backed section", () => {
+  const repairedSource = updateWorkspaceInventorySource(`export interface WorkspaceBlockConfig {
+\tslug: string;
+\ttypesFile: string;
+}
+
+export const BLOCKS: WorkspaceBlockConfig[] = [
+\t// wp-typia add block entries
+];
+`);
+  const expectedSections = [
+    {
+      constName: "VARIATIONS",
+      interfaceName: "WorkspaceVariationConfig",
+      marker: "\t// wp-typia add variation entries",
+    },
+    {
+      constName: "BLOCK_STYLES",
+      interfaceName: "WorkspaceBlockStyleConfig",
+      marker: "\t// wp-typia add style entries",
+    },
+    {
+      constName: "BLOCK_TRANSFORMS",
+      interfaceName: "WorkspaceBlockTransformConfig",
+      marker: "\t// wp-typia add transform entries",
+    },
+    {
+      constName: "PATTERNS",
+      interfaceName: "WorkspacePatternConfig",
+      marker: "\t// wp-typia add pattern entries",
+    },
+    {
+      constName: "BINDING_SOURCES",
+      interfaceName: "WorkspaceBindingSourceConfig",
+      marker: "\t// wp-typia add binding-source entries",
+    },
+    {
+      constName: "REST_RESOURCES",
+      interfaceName: "WorkspaceRestResourceConfig",
+      marker: "\t// wp-typia add rest-resource entries",
+    },
+    {
+      constName: "ABILITIES",
+      interfaceName: "WorkspaceAbilityConfig",
+      marker: "\t// wp-typia add ability entries",
+    },
+    {
+      constName: "AI_FEATURES",
+      interfaceName: "WorkspaceAiFeatureConfig",
+      marker: "\t// wp-typia add ai-feature entries",
+    },
+    {
+      constName: "ADMIN_VIEWS",
+      interfaceName: "WorkspaceAdminViewConfig",
+      marker: "\t// wp-typia add admin-view entries",
+    },
+    {
+      constName: "EDITOR_PLUGINS",
+      interfaceName: "WorkspaceEditorPluginConfig",
+      marker: "\t// wp-typia add editor-plugin entries",
+    },
+  ];
+
+  let previousSectionIndex = -1;
+  for (const { constName, interfaceName, marker } of expectedSections) {
+    const interfacePattern = new RegExp(
+      `export interface ${interfaceName}\\b`,
+      "gu"
+    );
+    const constPattern = new RegExp(`export const ${constName}\\b`, "gu");
+    expect(repairedSource.match(interfacePattern)?.length).toBe(1);
+    expect(repairedSource.match(constPattern)?.length).toBe(1);
+    expect(repairedSource).toContain(marker);
+
+    const sectionIndex = repairedSource.indexOf(`export interface ${interfaceName}`);
+    expect(sectionIndex).toBeGreaterThan(previousSectionIndex);
+    expect(repairedSource.indexOf(`export const ${constName}`)).toBeGreaterThan(
+      sectionIndex
+    );
+    previousSectionIndex = sectionIndex;
+  }
+});
+
+test("workspace inventory section descriptors support optional interface and const halves", () => {
+  const inventorySource = fs.readFileSync(
+    path.join(import.meta.dir, "..", "src", "runtime", "workspace-inventory.ts"),
+    "utf8"
+  );
+
+  expect(inventorySource).toContain(
+    "const INVENTORY_SECTIONS: readonly InventorySectionDescriptor[]"
+  );
+  expect(inventorySource).toContain("interface?: {");
+  expect(inventorySource).toContain("value?: {");
+  expect(inventorySource).toContain("for (const section of INVENTORY_SECTIONS)");
+  expect(inventorySource).not.toContain(
+    "if (!/export\\s+interface\\s+WorkspaceVariationConfig\\b/u.test(nextSource))"
+  );
+});
+
 test("workspace inventory repair avoids duplicating existing section constants", () => {
   const repairedSource = updateWorkspaceInventorySource(
     `export const VARIATIONS: WorkspaceVariationConfig[] = [


### PR DESCRIPTION
## Summary
- drive workspace inventory section creation from a shared descriptor list
- keep generated inventory interfaces and constants in the existing stable order
- add tests that cover every current descriptor-backed inventory section and descriptor optionality

Closes #695

## Validation
- bun test packages/wp-typia-project-tools/tests/workspace-doctor.test.ts --test-name-pattern "workspace inventory"
- bun run --filter @wp-typia/project-tools build
- bun run typecheck
- node scripts/check-repo-format.mjs
- node scripts/validate-sampo-changesets.mjs && git diff --check
- bun run --filter @wp-typia/project-tools test:workspace