### PR TITLE
test(cli): cover core fallback and config contracts

### DIFF
--- a/.sampo/changesets/696-cli-core-coverage.md
+++ b/.sampo/changesets/696-cli-core-coverage.md
@@ -1,0 +1,6 @@
+---
+npm/wp-typia: patch
+---
+
+Add focused CLI core tests for Node fallback routing, command registry metadata,
+configuration merging and overrides, and structured diagnostic output.

--- a/packages/wp-typia/tests/cli-diagnostic-output.test.ts
+++ b/packages/wp-typia/tests/cli-diagnostic-output.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import { CLI_DIAGNOSTIC_CODES } from '@wp-typia/project-tools/cli-diagnostics';
+
+import {
+  emitCliDiagnosticFailure,
+  prefersStructuredCliArgv,
+  prefersStructuredCliOutput,
+  writeStructuredCliDiagnosticError,
+} from '../src/cli-diagnostic-output';
+import { validateCliOutputFormatArgv } from '../src/cli-output-format';
+
+function captureStderr(callback: () => void): {
+  exitCode: string | number | undefined;
+  stderr: string;
+} {
+  const originalExitCode = process.exitCode;
+  const originalWrite = process.stderr.write;
+  let stderr = '';
+
+  process.exitCode = undefined;
+  process.stderr.write = ((chunk: unknown) => {
+    stderr += String(chunk);
+    return true;
+  }) as typeof process.stderr.write;
+
+  try {
+    callback();
+    return {
+      exitCode: process.exitCode,
+      stderr,
+    };
+  } finally {
+    process.stderr.write = originalWrite;
+    process.exitCode = originalExitCode;
+  }
+}
+
+describe('CLI structured diagnostic output', () => {
+  afterEach(() => {
+    process.exitCode = 0;
+  });
+
+  test('detects explicit structured format requests before argv terminators', () => {
+    expect(prefersStructuredCliArgv(['doctor', '--format', 'json'])).toBe(true);
+    expect(prefersStructuredCliArgv(['doctor', '--format=json'])).toBe(true);
+    expect(prefersStructuredCliArgv(['doctor', '--format', 'toon'])).toBe(false);
+    expect(
+      prefersStructuredCliArgv(['doctor', '--', '--format', 'json']),
+    ).toBe(false);
+  });
+
+  test('prefers structured output for explicit JSON and agent contexts', () => {
+    expect(
+      prefersStructuredCliOutput({
+        format: 'json',
+        formatExplicit: true,
+        output: () => {},
+      }),
+    ).toBe(true);
+    expect(
+      prefersStructuredCliOutput({
+        format: 'json',
+        formatExplicit: false,
+        output: () => {},
+      }),
+    ).toBe(false);
+    expect(
+      prefersStructuredCliOutput({
+        context: {
+          store: {
+            isAIAgent: true,
+          },
+        },
+        output: () => {},
+      }),
+    ).toBe(true);
+  });
+
+  test('writes structured command failures to stderr and leaves stdout callbacks unused', () => {
+    let outputCalls = 0;
+    const captured = captureStderr(() => {
+      const handled = emitCliDiagnosticFailure(
+        {
+          format: 'json',
+          formatExplicit: true,
+          output: () => {
+            outputCalls += 1;
+          },
+        },
+        {
+          code: CLI_DIAGNOSTIC_CODES.INVALID_COMMAND,
+          command: 'templates',
+          detailLines: ['Unknown templates subcommand "wat".'],
+        },
+      );
+
+      expect(handled).toBe(true);
+    });
+    const parsed = JSON.parse(captured.stderr) as {
+      error?: { code?: string; command?: string };
+      ok?: boolean;
+    };
+
+    expect(outputCalls).toBe(0);
+    expect(captured.exitCode).toBe(1);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error?.code).toBe(CLI_DIAGNOSTIC_CODES.INVALID_COMMAND);
+    expect(parsed.error?.command).toBe('templates');
+  });
+
+  test('returns false for human output and serializes structured argv errors to stderr', () => {
+    expect(
+      writeStructuredCliDiagnosticError(['doctor'], new Error('boom')),
+    ).toBe(false);
+
+    const captured = captureStderr(() => {
+      const handled = writeStructuredCliDiagnosticError(
+        ['doctor', '--format', 'json'],
+        new Error('doctor exploded'),
+      );
+
+      expect(handled).toBe(true);
+    });
+    const parsed = JSON.parse(captured.stderr) as {
+      error?: { command?: string; kind?: string; message?: string };
+      ok?: boolean;
+    };
+
+    expect(captured.exitCode).toBe(1);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error?.command).toBe('doctor');
+    expect(parsed.error?.kind).toBe('command-execution');
+    expect(parsed.error?.message).toContain('doctor exploded');
+  });
+
+  test('throws human diagnostics and validates unsupported output formats before dispatch', () => {
+    expect(() =>
+      emitCliDiagnosticFailure(
+        {
+          format: 'toon',
+          formatExplicit: true,
+          output: () => {},
+        },
+        {
+          code: CLI_DIAGNOSTIC_CODES.INVALID_COMMAND,
+          command: 'sync',
+          detailLines: ['Unknown sync target.'],
+        },
+      ),
+    ).toThrow('wp-typia sync failed');
+
+    try {
+      validateCliOutputFormatArgv(['sync', '--format', 'jso']);
+      throw new Error('Expected invalid output format validation to throw.');
+    } catch (error) {
+      expect(error).toMatchObject({
+        code: CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
+        command: 'sync',
+      });
+    }
+  });
+});

--- a/packages/wp-typia/tests/command-registry.test.ts
+++ b/packages/wp-typia/tests/command-registry.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from 'bun:test';
+
+import { COMMAND_OPTION_METADATA_BY_GROUP } from '../src/command-option-metadata';
+import {
+  WP_TYPIA_BUN_REQUIRED_TOP_LEVEL_COMMAND_NAMES,
+  WP_TYPIA_COMMAND_OPTION_GROUP_NAMES_BY_TOP_LEVEL_COMMAND,
+  WP_TYPIA_COMMAND_REGISTRY,
+  WP_TYPIA_FUTURE_COMMAND_TREE,
+  WP_TYPIA_NODE_FALLBACK_TOP_LEVEL_COMMAND_NAMES,
+  WP_TYPIA_RESERVED_TOP_LEVEL_COMMAND_NAMES,
+  WP_TYPIA_TOP_LEVEL_COMMAND_NAMES,
+} from '../src/command-registry';
+
+describe('wp-typia command registry metadata', () => {
+  test('keeps top-level command names unique and derived lists in sync', () => {
+    const commandNames = WP_TYPIA_COMMAND_REGISTRY.map(
+      (command) => command.name,
+    );
+    const commandTreeNames = WP_TYPIA_COMMAND_REGISTRY.filter(
+      (command) => command.commandTree,
+    ).map((command) => command.name);
+    const nodeFallbackNames = WP_TYPIA_COMMAND_REGISTRY.filter(
+      (command) => command.nodeFallback,
+    ).map((command) => command.name);
+    const bunRequiredNames = WP_TYPIA_COMMAND_REGISTRY.filter(
+      (command) => command.requiresBunRuntime,
+    ).map((command) => command.name);
+
+    expect(new Set(commandNames).size).toBe(commandNames.length);
+    expect(WP_TYPIA_RESERVED_TOP_LEVEL_COMMAND_NAMES).toEqual(commandNames);
+    expect(WP_TYPIA_TOP_LEVEL_COMMAND_NAMES).toEqual(commandTreeNames);
+    expect(WP_TYPIA_NODE_FALLBACK_TOP_LEVEL_COMMAND_NAMES).toEqual(
+      nodeFallbackNames,
+    );
+    expect(WP_TYPIA_BUN_REQUIRED_TOP_LEVEL_COMMAND_NAMES).toEqual(
+      bunRequiredNames,
+    );
+  });
+
+  test('keeps every command option group backed by shared option metadata', () => {
+    for (const command of WP_TYPIA_COMMAND_REGISTRY) {
+      expect(
+        WP_TYPIA_COMMAND_OPTION_GROUP_NAMES_BY_TOP_LEVEL_COMMAND[command.name],
+      ).toEqual(command.optionGroups);
+
+      for (const groupName of command.optionGroups) {
+        expect(COMMAND_OPTION_METADATA_BY_GROUP[groupName]).toBeDefined();
+      }
+    }
+  });
+
+  test('derives the public command tree from command-tree registry entries', () => {
+    const commandTreeEntries = WP_TYPIA_COMMAND_REGISTRY.filter(
+      (command) => command.commandTree,
+    );
+
+    expect(WP_TYPIA_FUTURE_COMMAND_TREE).toEqual(
+      commandTreeEntries.map((command) => ({
+        description: command.description,
+        name: command.name,
+        subcommands:
+          'subcommands' in command ? command.subcommands : undefined,
+      })),
+    );
+
+    for (const command of WP_TYPIA_FUTURE_COMMAND_TREE) {
+      expect(command.description).toBeTruthy();
+      expect(WP_TYPIA_TOP_LEVEL_COMMAND_NAMES).toContain(command.name);
+    }
+  });
+});

--- a/packages/wp-typia/tests/config.test.ts
+++ b/packages/wp-typia/tests/config.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  loadWpTypiaUserConfig,
+  loadWpTypiaUserConfigFromSource,
+  mergeWpTypiaUserConfig,
+  type WpTypiaUserConfig,
+} from '../src/config';
+import { extractWpTypiaConfigOverride } from '../src/config-override';
+
+function writeJson(filePath: string, value: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+describe('wp-typia user config loading', () => {
+  test('deep merges objects while replacing arrays from later config sources', () => {
+    const base: WpTypiaUserConfig = {
+      create: {
+        namespace: 'base-space',
+        template: 'basic',
+        yes: true,
+      },
+      mcp: {
+        schemaSources: [
+          {
+            namespace: 'base',
+            path: './base.ts',
+          },
+        ],
+      },
+    };
+    const incoming: WpTypiaUserConfig = {
+      create: {
+        'package-manager': 'pnpm',
+        template: 'persistence',
+      },
+      mcp: {
+        schemaSources: [
+          {
+            namespace: 'incoming',
+            path: './incoming.ts',
+          },
+        ],
+      },
+    };
+
+    const merged = mergeWpTypiaUserConfig(base, incoming);
+
+    expect(merged.create).toEqual({
+      namespace: 'base-space',
+      'package-manager': 'pnpm',
+      template: 'persistence',
+      yes: true,
+    });
+    expect(merged.mcp?.schemaSources).toEqual([
+      {
+        namespace: 'incoming',
+        path: './incoming.ts',
+      },
+    ]);
+    expect(merged.mcp?.schemaSources).not.toBe(incoming.mcp?.schemaSources);
+  });
+
+  test('loads explicit config sources relative to the requested working directory', async () => {
+    const tempRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'wp-typia-config-source-'),
+    );
+
+    try {
+      writeJson(path.join(tempRoot, 'nested', 'override.json'), {
+        create: {
+          'package-manager': 'yarn',
+          template: 'compound',
+        },
+      });
+
+      await expect(
+        loadWpTypiaUserConfigFromSource(tempRoot, './nested/override.json'),
+      ).resolves.toEqual({
+        create: {
+          'package-manager': 'yarn',
+          template: 'compound',
+        },
+      });
+    } finally {
+      fs.rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('loads default config sources in precedence order', async () => {
+    const tempRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'wp-typia-config-precedence-'),
+    );
+    const cwd = path.join(tempRoot, 'project');
+
+    try {
+      writeJson(path.join(cwd, '.wp-typiarc'), {
+        create: {
+          namespace: 'project-space',
+          'package-manager': 'npm',
+          template: 'interactivity',
+        },
+      });
+      writeJson(path.join(cwd, '.wp-typiarc.json'), {
+        create: {
+          'data-storage': 'post-meta',
+        },
+        mcp: {
+          schemaSources: [
+            {
+              namespace: 'project',
+              path: './project.ts',
+            },
+          ],
+        },
+      });
+      writeJson(path.join(cwd, 'package.json'), {
+        name: 'demo-config-project',
+        'wp-typia': {
+          create: {
+            template: 'persistence',
+          },
+        },
+      });
+
+      const config = await loadWpTypiaUserConfig(cwd);
+
+      expect(config).toEqual({
+        create: {
+          namespace: 'project-space',
+          'package-manager': 'npm',
+          'data-storage': 'post-meta',
+          template: 'persistence',
+        },
+        mcp: {
+          schemaSources: [
+            {
+              namespace: 'project',
+              path: './project.ts',
+            },
+          ],
+        },
+      });
+    } finally {
+      fs.rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+});
+
+describe('wp-typia config override argv extraction', () => {
+  test('extracts long and short config overrides without disturbing command argv', () => {
+    expect(
+      extractWpTypiaConfigOverride([
+        '--config',
+        './override.json',
+        'create',
+        'demo',
+        '--template',
+        'basic',
+      ]),
+    ).toEqual({
+      argv: ['create', 'demo', '--template', 'basic'],
+      configOverridePath: './override.json',
+    });
+
+    expect(
+      extractWpTypiaConfigOverride([
+        'templates',
+        '-c',
+        './templates.json',
+        'inspect',
+        '--',
+        '--config',
+      ]),
+    ).toEqual({
+      argv: ['templates', 'inspect', '--', '--config'],
+      configOverridePath: './templates.json',
+    });
+  });
+
+  test('preserves missing-value diagnostics for config override flags', () => {
+    expect(() => extractWpTypiaConfigOverride(['--config'])).toThrow(
+      '`--config` requires a value.',
+    );
+    expect(() => extractWpTypiaConfigOverride(['-c'])).toThrow(
+      '`-c` requires a value.',
+    );
+  });
+});

--- a/packages/wp-typia/tests/node-cli-core.test.ts
+++ b/packages/wp-typia/tests/node-cli-core.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import packageJson from '../package.json';
+import { runNodeCli } from '../src/node-cli';
+
+async function captureNodeCli(argv: string[]): Promise<{
+  error: unknown;
+  exitCode: string | number;
+  stdout: string;
+}> {
+  const originalExitCode = process.exitCode;
+  const originalLog = console.log;
+  const lines: string[] = [];
+  let error: unknown;
+
+  process.exitCode = 0;
+  console.log = (line = '') => {
+    lines.push(String(line));
+  };
+
+  try {
+    try {
+      await runNodeCli(argv);
+    } catch (caught) {
+      error = caught;
+    }
+
+    return {
+      error,
+      exitCode: process.exitCode ?? 0,
+      stdout: lines.join('\n'),
+    };
+  } finally {
+    console.log = originalLog;
+    process.exitCode = originalExitCode;
+  }
+}
+
+describe('Node fallback CLI core routing', () => {
+  afterEach(() => {
+    process.exitCode = 0;
+  });
+
+  test('prints general help and marks no-command invocations as errors', async () => {
+    const result = await captureNodeCli([]);
+
+    expect(result.error).toBeUndefined();
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toContain(`wp-typia ${packageJson.version}`);
+    expect(result.stdout).toContain(
+      'Canonical CLI package for wp-typia scaffolding',
+    );
+    expect(result.stdout).toContain('Runtime: Node fallback');
+    expect(result.stdout).toContain('Commands:');
+  });
+
+  test('routes explicit help flags and help targets to the fallback help renderers', async () => {
+    const generalHelp = await captureNodeCli(['--help']);
+    const createHelp = await captureNodeCli(['--help', 'create']);
+    const commandHelp = await captureNodeCli(['help', 'templates']);
+
+    expect(generalHelp.error).toBeUndefined();
+    expect(generalHelp.exitCode).toBe(0);
+    expect(generalHelp.stdout).toContain('Commands:');
+    expect(generalHelp.stdout).toContain('standalone wp-typia binary');
+
+    expect(createHelp.error).toBeUndefined();
+    expect(createHelp.exitCode).toBe(0);
+    expect(createHelp.stdout).toContain('Usage: wp-typia create <project-dir>');
+    expect(createHelp.stdout).toContain('--template');
+
+    expect(commandHelp.error).toBeUndefined();
+    expect(commandHelp.exitCode).toBe(0);
+    expect(commandHelp.stdout).toContain('wp-typia templates <list|inspect>');
+    expect(commandHelp.stdout).toContain('--id');
+  });
+
+  test('falls back to general help for unknown help targets without dispatching commands', async () => {
+    const result = await captureNodeCli(['help', 'definitely-not-a-command']);
+
+    expect(result.error).toBeUndefined();
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Commands:');
+    expect(result.stdout).toContain(
+      'Canonical CLI package for wp-typia scaffolding',
+    );
+    expect(result.stdout).not.toContain('Usage: wp-typia create <project-dir>');
+  });
+
+  test('prints human and structured version output from the fallback runtime', async () => {
+    const human = await captureNodeCli(['--version']);
+    const structured = await captureNodeCli(['version', '--format', 'json']);
+    const parsed = JSON.parse(structured.stdout) as {
+      data?: { name?: string; type?: string; version?: string };
+      ok?: boolean;
+    };
+
+    expect(human.error).toBeUndefined();
+    expect(human.exitCode).toBe(0);
+    expect(human.stdout.trim()).toBe(`wp-typia ${packageJson.version}`);
+
+    expect(structured.error).toBeUndefined();
+    expect(structured.exitCode).toBe(0);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.data?.name).toBe('wp-typia');
+    expect(parsed.data?.type).toBe('version');
+    expect(parsed.data?.version).toBe(packageJson.version);
+  });
+
+  test('keeps Bun-only top-level commands on the unsupported-command diagnostic path', async () => {
+    const result = await captureNodeCli(['skills', 'list']);
+
+    expect(result.stdout).toBe('');
+    expect(result.error).toMatchObject({
+      code: 'unsupported-command',
+      command: 'skills',
+    });
+  });
+});

--- a/packages/wp-typia/tests/node-cli-core.test.ts
+++ b/packages/wp-typia/tests/node-cli-core.test.ts
@@ -14,8 +14,8 @@ async function captureNodeCli(argv: string[]): Promise<{
   let error: unknown;
 
   process.exitCode = 0;
-  console.log = (line = '') => {
-    lines.push(String(line));
+  console.log = (...args: unknown[]) => {
+    lines.push(args.map(String).join(' '));
   };
 
   try {


### PR DESCRIPTION
## Summary
- add focused Node fallback tests for no-command, help routing, version output, and Bun-only command diagnostics
- add command registry invariant tests for derived command lists, option groups, and command-tree metadata
- add config merge/loading and config override extraction tests
- add structured diagnostic output and invalid --format handling tests

Closes #696

## Validation
- bun test packages/wp-typia/tests/node-cli-core.test.ts packages/wp-typia/tests/command-registry.test.ts packages/wp-typia/tests/config.test.ts packages/wp-typia/tests/cli-diagnostic-output.test.ts
- bun run --filter wp-typia test
- bun run typecheck
- node scripts/check-repo-format.mjs
- node scripts/validate-sampo-changesets.mjs
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded CLI core test coverage for Node fallback routing, command registry metadata validation, configuration discovery and merge/override behavior, and structured diagnostic output with proper error serialization and exit code handling.

* **Chores**
  * Updated changeset for patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->