### PR TITLE
fix(add): validate block template ids

### DIFF
--- a/.sampo/changesets/697-rest-cache-clock.md
+++ b/.sampo/changesets/697-rest-cache-clock.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/rest: patch
+---
+
+Ensure React query cache invalidation uses monotonically increasing timestamps so same-millisecond invalidations refetch reliably.

--- a/.sampo/changesets/697-rest-cache-clock.md
+++ b/.sampo/changesets/697-rest-cache-clock.md
@@ -2,4 +2,4 @@
 npm/@wp-typia/rest: patch
 ---
 
-Ensure React query cache invalidation uses monotonically increasing timestamps so same-millisecond invalidations refetch reliably.
+Ensure React query cache invalidation uses monotonic cache revisions so same-millisecond invalidations refetch reliably without skewing stale-time timestamps.

--- a/.sampo/changesets/697-validate-add-block-template-id.md
+++ b/.sampo/changesets/697-validate-add-block-template-id.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Validate `wp-typia add block --template` ids through the shared add-block template runtime guard before preparing execution.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add.ts
@@ -12,6 +12,7 @@ export {
 	ADD_KIND_IDS,
 	EDITOR_PLUGIN_SLOT_IDS,
 	formatAddHelpText,
+	isAddBlockTemplateId,
 } from "./cli-add-shared.js";
 export type {
 	AddBlockTemplateId,

--- a/packages/wp-typia-rest/src/react-client-state.ts
+++ b/packages/wp-typia-rest/src/react-client-state.ts
@@ -18,8 +18,10 @@ const EMPTY_SNAPSHOT: EndpointDataSnapshot = {
   data: undefined,
   error: null,
   invalidatedAt: 0,
+  invalidatedRevision: 0,
   isFetching: false,
   updatedAt: 0,
+  updatedRevision: 0,
   validation: null,
 };
 
@@ -48,8 +50,10 @@ function syncSnapshot(entry: EndpointDataCacheEntry) {
     data: entry.data,
     error: entry.error,
     invalidatedAt: entry.invalidatedAt,
+    invalidatedRevision: entry.invalidatedRevision,
     isFetching: entry.isFetching,
     updatedAt: entry.updatedAt,
+    updatedRevision: entry.updatedRevision,
     validation: entry.validation,
   };
 }
@@ -62,7 +66,7 @@ function isEntryStale(
     return true;
   }
 
-  if (entry.invalidatedAt > entry.updatedAt) {
+  if (entry.invalidatedRevision > entry.updatedRevision) {
     return true;
   }
 
@@ -91,11 +95,12 @@ function castEndpointValidationPromise<Req, Res>(
  */
 export function createEndpointDataClient(): EndpointDataClient {
   const entries = new Map<CacheKey, EndpointDataCacheEntry>();
-  let logicalClock = Date.now();
+  // Revisions preserve same-millisecond ordering without skewing staleTime clocks.
+  let revision = 0;
 
-  function nextTimestamp(): number {
-    logicalClock = Math.max(Date.now(), logicalClock + 1);
-    return logicalClock;
+  function nextRevision(): number {
+    revision += 1;
+    return revision;
   }
 
   function notify(cacheKey: CacheKey) {
@@ -118,7 +123,8 @@ export function createEndpointDataClient(): EndpointDataClient {
           return;
         }
 
-        entry.invalidatedAt = nextTimestamp();
+        entry.invalidatedAt = Date.now();
+        entry.invalidatedRevision = nextRevision();
         syncSnapshot(entry);
         notify(cacheKey);
         return;
@@ -130,7 +136,8 @@ export function createEndpointDataClient(): EndpointDataClient {
           continue;
         }
 
-        entry.invalidatedAt = nextTimestamp();
+        entry.invalidatedAt = Date.now();
+        entry.invalidatedRevision = nextRevision();
         syncSnapshot(entry);
         notify(cacheKey);
       }
@@ -170,7 +177,8 @@ export function createEndpointDataClient(): EndpointDataClient {
 
       entry.data = resolvedNext;
       entry.error = null;
-      entry.updatedAt = nextTimestamp();
+      entry.updatedAt = Date.now();
+      entry.updatedRevision = nextRevision();
       entry.validation = toEndpointResponseValidationResult({
         data: resolvedNext,
         errors: [],
@@ -191,6 +199,7 @@ export function createEndpointDataClient(): EndpointDataClient {
       const entry = getOrCreateEntry(entries, cacheKey);
       entry.error = null;
       entry.updatedAt = Date.now();
+      entry.updatedRevision = nextRevision();
       entry.validation = validation;
       if (validation.isValid) {
         entry.data = validation.data;
@@ -223,12 +232,13 @@ export function createEndpointDataClient(): EndpointDataClient {
       syncSnapshot(entry);
       notify(cacheKey);
 
-      const startedAt = nextTimestamp();
+      const startedRevision = revision;
       const promise = execute()
         .then((validation) => {
           entry.error = null;
-          if (entry.invalidatedAt <= startedAt) {
-            entry.updatedAt = nextTimestamp();
+          if (entry.invalidatedRevision <= startedRevision) {
+            entry.updatedAt = Date.now();
+            entry.updatedRevision = nextRevision();
             entry.validation = validation;
             if (validation.isValid) {
               entry.data = validation.data;
@@ -239,8 +249,9 @@ export function createEndpointDataClient(): EndpointDataClient {
         })
         .catch((error: unknown) => {
           entry.error = error;
-          if (entry.invalidatedAt <= startedAt) {
-            entry.updatedAt = nextTimestamp();
+          if (entry.invalidatedRevision <= startedRevision) {
+            entry.updatedAt = Date.now();
+            entry.updatedRevision = nextRevision();
           }
           syncSnapshot(entry);
           throw error;
@@ -263,7 +274,8 @@ export function createEndpointDataClient(): EndpointDataClient {
 
       entry.data = data;
       entry.error = null;
-      entry.updatedAt = nextTimestamp();
+      entry.updatedAt = Date.now();
+      entry.updatedRevision = nextRevision();
       entry.validation = toEndpointResponseValidationResult({
         data,
         errors: [],

--- a/packages/wp-typia-rest/src/react-client-state.ts
+++ b/packages/wp-typia-rest/src/react-client-state.ts
@@ -91,6 +91,12 @@ function castEndpointValidationPromise<Req, Res>(
  */
 export function createEndpointDataClient(): EndpointDataClient {
   const entries = new Map<CacheKey, EndpointDataCacheEntry>();
+  let logicalClock = Date.now();
+
+  function nextTimestamp(): number {
+    logicalClock = Math.max(Date.now(), logicalClock + 1);
+    return logicalClock;
+  }
 
   function notify(cacheKey: CacheKey) {
     const entry = entries.get(cacheKey);
@@ -112,7 +118,7 @@ export function createEndpointDataClient(): EndpointDataClient {
           return;
         }
 
-        entry.invalidatedAt = Date.now();
+        entry.invalidatedAt = nextTimestamp();
         syncSnapshot(entry);
         notify(cacheKey);
         return;
@@ -124,7 +130,7 @@ export function createEndpointDataClient(): EndpointDataClient {
           continue;
         }
 
-        entry.invalidatedAt = Date.now();
+        entry.invalidatedAt = nextTimestamp();
         syncSnapshot(entry);
         notify(cacheKey);
       }
@@ -164,7 +170,7 @@ export function createEndpointDataClient(): EndpointDataClient {
 
       entry.data = resolvedNext;
       entry.error = null;
-      entry.updatedAt = Date.now();
+      entry.updatedAt = nextTimestamp();
       entry.validation = toEndpointResponseValidationResult({
         data: resolvedNext,
         errors: [],
@@ -217,12 +223,12 @@ export function createEndpointDataClient(): EndpointDataClient {
       syncSnapshot(entry);
       notify(cacheKey);
 
-      const startedAt = Date.now();
+      const startedAt = nextTimestamp();
       const promise = execute()
         .then((validation) => {
           entry.error = null;
           if (entry.invalidatedAt <= startedAt) {
-            entry.updatedAt = Date.now();
+            entry.updatedAt = nextTimestamp();
             entry.validation = validation;
             if (validation.isValid) {
               entry.data = validation.data;
@@ -234,7 +240,7 @@ export function createEndpointDataClient(): EndpointDataClient {
         .catch((error: unknown) => {
           entry.error = error;
           if (entry.invalidatedAt <= startedAt) {
-            entry.updatedAt = Date.now();
+            entry.updatedAt = nextTimestamp();
           }
           syncSnapshot(entry);
           throw error;
@@ -257,7 +263,7 @@ export function createEndpointDataClient(): EndpointDataClient {
 
       entry.data = data;
       entry.error = null;
-      entry.updatedAt = Date.now();
+      entry.updatedAt = nextTimestamp();
       entry.validation = toEndpointResponseValidationResult({
         data,
         errors: [],

--- a/packages/wp-typia-rest/src/react-client-types.ts
+++ b/packages/wp-typia-rest/src/react-client-types.ts
@@ -15,8 +15,10 @@ export interface EndpointDataSnapshot {
   data: unknown;
   error: unknown;
   invalidatedAt: number;
+  invalidatedRevision: number;
   isFetching: boolean;
   updatedAt: number;
+  updatedRevision: number;
   validation: AnyEndpointValidationResult | null;
 }
 
@@ -28,12 +30,14 @@ export interface EndpointDataCacheEntry {
   data: unknown;
   error: unknown;
   invalidatedAt: number;
+  invalidatedRevision: number;
   isFetching: boolean;
   listeners: Set<EndpointDataListener>;
   promise: Promise<AnyEndpointValidationResult> | null;
   refetchers: Set<QueryRefetcher>;
   snapshot: EndpointDataSnapshot;
   updatedAt: number;
+  updatedRevision: number;
   validation: AnyEndpointValidationResult | null;
 }
 

--- a/packages/wp-typia-rest/src/react-query.ts
+++ b/packages/wp-typia-rest/src/react-query.ts
@@ -184,9 +184,9 @@ export function useEndpointQuery<Req, Res, Selected = Res>(
     }
 
     const shouldFetch =
-      snapshot.updatedAt === 0
+      snapshot.updatedRevision === 0
         ? initialData === undefined
-        : snapshot.invalidatedAt > snapshot.updatedAt
+        : snapshot.invalidatedRevision > snapshot.updatedRevision
           ? true
           : snapshot.error !== null
             ? false
@@ -211,8 +211,9 @@ export function useEndpointQuery<Req, Res, Selected = Res>(
     prepared.requestValidation.isValid,
     snapshot.isFetching,
     refetch,
-    snapshot.invalidatedAt,
+    snapshot.invalidatedRevision,
     snapshot.updatedAt,
+    snapshot.updatedRevision,
     staleTime,
   ]);
 

--- a/packages/wp-typia/src/add-kind-registry.ts
+++ b/packages/wp-typia/src/add-kind-registry.ts
@@ -243,6 +243,31 @@ export function isAddPersistenceTemplate(template?: string): boolean {
   return template === 'persistence' || template === 'compound';
 }
 
+function formatAddBlockTemplateIds(addRuntime: AddRuntime): string {
+  return addRuntime.ADD_BLOCK_TEMPLATE_IDS.join(', ');
+}
+
+function assertAddBlockTemplateId(
+  context: AddKindExecutionContext,
+  templateId: string,
+): CliAddRuntime.AddBlockTemplateId {
+  if (context.addRuntime.isAddBlockTemplateId(templateId)) {
+    return templateId;
+  }
+
+  if (templateId === 'query-loop') {
+    throw createCliDiagnosticCodeError(
+      CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
+      '`wp-typia add block --template query-loop` is not supported. Query Loop is a create-time `core/query` variation scaffold, so use `wp-typia create <project-dir> --template query-loop` instead.',
+    );
+  }
+
+  throw createCliDiagnosticCodeError(
+    CLI_DIAGNOSTIC_CODES.UNKNOWN_TEMPLATE,
+    `Unknown add-block template "${templateId}". Expected one of: ${formatAddBlockTemplateIds(context.addRuntime)}. Run \`wp-typia templates list\` to inspect available templates.`,
+  );
+}
+
 export const ADD_KIND_REGISTRY = {
   'admin-view': defineAddKindRegistryEntry<AddAdminViewResult>({
     completion: {
@@ -400,10 +425,13 @@ export const ADD_KIND_REGISTRY = {
         context.flags,
         'persistence-policy',
       );
-      let resolvedTemplateId = readOptionalStrictStringFlag(
+      const requestedTemplateId = readOptionalStrictStringFlag(
         context.flags,
         'template',
-      ) as CliAddRuntime.AddBlockTemplateId | undefined;
+      );
+      let resolvedTemplateId = requestedTemplateId
+        ? assertAddBlockTemplateId(context, requestedTemplateId)
+        : undefined;
       if (!resolvedTemplateId && context.isInteractiveSession) {
         const templatePrompt = await context.getOrCreatePrompt();
         resolvedTemplateId = await templatePrompt.select(

--- a/packages/wp-typia/tests/add-command.test.ts
+++ b/packages/wp-typia/tests/add-command.test.ts
@@ -4,6 +4,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 
 import type { ReadlinePrompt } from '@wp-typia/project-tools/cli-prompt';
+import { CLI_DIAGNOSTIC_CODES } from '@wp-typia/project-tools/cli-diagnostics';
 import { ADD_KIND_IDS, supportsAddKindDryRun } from '../src/add-kind-registry';
 import { WP_TYPIA_COMMAND_REGISTRY } from '../src/command-registry';
 import { executeAddCommand } from '../src/runtime-bridge';
@@ -21,9 +22,12 @@ describe('wp-typia add command bridge', () => {
     fs.rmSync(tempRoot, { force: true, recursive: true });
   });
 
-  async function expectInvalidAddBlockTemplate(options: {
+  async function expectRejectedAddBlockTemplate(options: {
+    code: string;
     interactive: boolean;
+    message: string;
     prompt?: ReadlinePrompt;
+    template: string;
   }) {
     let error: unknown;
 
@@ -32,7 +36,7 @@ describe('wp-typia add command bridge', () => {
         cwd: tempRoot,
         emitOutput: false,
         flags: {
-          template: 'unknown',
+          template: options.template,
         },
         interactive: options.interactive,
         kind: 'block',
@@ -44,13 +48,8 @@ describe('wp-typia add command bridge', () => {
     }
 
     expect(error).toBeInstanceOf(Error);
-    expect((error as { code?: string }).code).toBe('unknown-template');
-    expect((error as Error).message).toContain(
-      'Unknown add-block template "unknown". Expected one of: basic, interactivity, persistence, compound.',
-    );
-    expect((error as Error).message).toContain(
-      'Run `wp-typia templates list` to inspect available templates.',
-    );
+    expect((error as { code?: string }).code).toBe(options.code);
+    expect((error as Error).message).toContain(options.message);
   }
 
   test('defaults add block to the basic template in non-interactive runs', async () => {
@@ -184,8 +183,22 @@ describe('wp-typia add command bridge', () => {
   }, 15_000);
 
   test('rejects invalid block template ids before workspace mutation', async () => {
-    await expectInvalidAddBlockTemplate({
+    await expectRejectedAddBlockTemplate({
+      code: CLI_DIAGNOSTIC_CODES.UNKNOWN_TEMPLATE,
       interactive: false,
+      message:
+        'Unknown add-block template "unknown". Expected one of: basic, interactivity, persistence, compound.',
+      template: 'unknown',
+    });
+  });
+
+  test('rejects query-loop add block templates with create-time guidance', async () => {
+    await expectRejectedAddBlockTemplate({
+      code: CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
+      interactive: false,
+      message:
+        '`wp-typia add block --template query-loop` is not supported. Query Loop is a create-time `core/query` variation scaffold',
+      template: 'query-loop',
     });
   });
 
@@ -202,9 +215,13 @@ describe('wp-typia add command bridge', () => {
       },
     };
 
-    await expectInvalidAddBlockTemplate({
+    await expectRejectedAddBlockTemplate({
+      code: CLI_DIAGNOSTIC_CODES.UNKNOWN_TEMPLATE,
       interactive: true,
+      message:
+        'Unknown add-block template "unknown". Expected one of: basic, interactivity, persistence, compound.',
       prompt,
+      template: 'unknown',
     });
     expect(selectedPrompts).toEqual([]);
   });

--- a/packages/wp-typia/tests/add-command.test.ts
+++ b/packages/wp-typia/tests/add-command.test.ts
@@ -21,6 +21,38 @@ describe('wp-typia add command bridge', () => {
     fs.rmSync(tempRoot, { force: true, recursive: true });
   });
 
+  async function expectInvalidAddBlockTemplate(options: {
+    interactive: boolean;
+    prompt?: ReadlinePrompt;
+  }) {
+    let error: unknown;
+
+    try {
+      await executeAddCommand({
+        cwd: tempRoot,
+        emitOutput: false,
+        flags: {
+          template: 'unknown',
+        },
+        interactive: options.interactive,
+        kind: 'block',
+        name: 'promo-card',
+        ...(options.prompt ? { prompt: options.prompt } : {}),
+      });
+    } catch (caughtError) {
+      error = caughtError;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as { code?: string }).code).toBe('unknown-template');
+    expect((error as Error).message).toContain(
+      'Unknown add-block template "unknown". Expected one of: basic, interactivity, persistence, compound.',
+    );
+    expect((error as Error).message).toContain(
+      'Run `wp-typia templates list` to inspect available templates.',
+    );
+  }
+
   test('defaults add block to the basic template in non-interactive runs', async () => {
     const projectDir = path.join(tempRoot, 'demo-add-basic-default');
 
@@ -150,6 +182,32 @@ describe('wp-typia add command bridge', () => {
     );
     expect(generatedSave).toContain('data-wp-on--click={clickActionDirective}');
   }, 15_000);
+
+  test('rejects invalid block template ids before workspace mutation', async () => {
+    await expectInvalidAddBlockTemplate({
+      interactive: false,
+    });
+  });
+
+  test('interactive add block rejects invalid explicit templates before prompting', async () => {
+    const selectedPrompts: string[] = [];
+    const prompt: ReadlinePrompt = {
+      close() {},
+      async select(message: string) {
+        selectedPrompts.push(message);
+        throw new Error('select() should not be called for invalid templates');
+      },
+      async text() {
+        throw new Error('text() should not be called for invalid templates');
+      },
+    };
+
+    await expectInvalidAddBlockTemplate({
+      interactive: true,
+      prompt,
+    });
+    expect(selectedPrompts).toEqual([]);
+  });
 
   test('passes binding-source target flags through the add bridge', async () => {
     const projectDir = path.join(tempRoot, 'demo-add-binding-target');


### PR DESCRIPTION
## Summary

- expose the shared `isAddBlockTemplateId` runtime guard through the public add facade
- validate explicit `wp-typia add block --template` values before preparing block execution
- cover invalid interactive and non-interactive template input while preserving valid template behavior

Closes #697

## Validation

- `bun test packages/wp-typia/tests/add-command.test.ts`
- `bun test packages/wp-typia-project-tools/tests/cli-entry.test.ts --test-name-pattern "unknown add-block templates"`
- `bun run --filter wp-typia test`
- `bun run --filter @wp-typia/project-tools test`
- `bun run typecheck`
- `node scripts/check-repo-format.mjs`
- `node scripts/validate-sampo-changesets.mjs`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Template IDs for `wp-typia add block --template` are now validated before execution. Invalid template IDs are rejected with clear error messages indicating valid options. This validation applies to both interactive and non-interactive modes, preventing incomplete workspace mutations from invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->