### PR TITLE
fix(typia-llm): guard schema artifacts

### DIFF
--- a/.sampo/changesets/698-typia-llm-schema-guards.md
+++ b/.sampo/changesets/698-typia-llm-schema-guards.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Validate typia.llm artifact schema objects before applying OpenAPI-backed constraint restoration.

--- a/packages/wp-typia-project-tools/src/runtime/typia-llm.ts
+++ b/packages/wp-typia-project-tools/src/runtime/typia-llm.ts
@@ -1085,6 +1085,10 @@ export function applyOpenApiConstraintsToTypiaLlmFunctionArtifact({
   }
 
   if (constrainedArtifact.output) {
+    const outputSchema = assertJsonSchemaObject(
+      constrainedArtifact.output,
+      `typia.llm output for "${constrainedArtifact.name}"`,
+    );
     const responseSchema = resolveOpenApiSuccessResponseSchema(
       operation,
       openApiDocument,
@@ -1092,10 +1096,7 @@ export function applyOpenApiConstraintsToTypiaLlmFunctionArtifact({
     if (responseSchema) {
       mergeJsonSchemaConstraintProperties(
         openApiDocument,
-        assertJsonSchemaObject(
-          constrainedArtifact.output,
-          `typia.llm output for "${constrainedArtifact.name}"`,
-        ),
+        outputSchema,
         responseSchema,
       );
     }

--- a/packages/wp-typia-project-tools/src/runtime/typia-llm.ts
+++ b/packages/wp-typia-project-tools/src/runtime/typia-llm.ts
@@ -338,6 +338,24 @@ function isJsonSchemaObject(value: unknown): value is JsonSchemaObject {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
+/**
+ * Narrow a `typia.llm` artifact field before applying JSON Schema mutations.
+ *
+ * @param value Candidate schema value emitted by `typia.llm`.
+ * @param context Human-readable artifact path for diagnostics.
+ * @returns The value narrowed to the shared JSON Schema object shape.
+ */
+export function assertJsonSchemaObject(
+  value: unknown,
+  context: string,
+): JsonSchemaObject {
+  if (isJsonSchemaObject(value)) {
+    return value;
+  }
+
+  throw new Error(`${context} must be a JSON Schema object.`);
+}
+
 function decodeJsonPointerSegment(segment: string): string {
   return segment.replace(/~1/g, '/').replace(/~0/g, '~');
 }
@@ -1035,21 +1053,22 @@ export function applyOpenApiConstraintsToTypiaLlmFunctionArtifact({
     operation,
     openApiDocument,
   );
+  const parameterSchema = assertJsonSchemaObject(
+    constrainedArtifact.parameters,
+    `typia.llm parameters for "${constrainedArtifact.name}"`,
+  );
 
   if (requestBodySchema) {
     if (hasQueryParameters) {
       mergeJsonSchemaConstraintProperties(
         openApiDocument,
-        getOrCreateObjectProperty(
-          constrainedArtifact.parameters as unknown as JsonSchemaObject,
-          'body',
-        ),
+        getOrCreateObjectProperty(parameterSchema, 'body'),
         requestBodySchema,
       );
     } else {
       mergeJsonSchemaConstraintProperties(
         openApiDocument,
-        constrainedArtifact.parameters as unknown as JsonSchemaObject,
+        parameterSchema,
         requestBodySchema,
       );
     }
@@ -1058,11 +1077,8 @@ export function applyOpenApiConstraintsToTypiaLlmFunctionArtifact({
   if (hasQueryParameters) {
     applyOpenApiQueryParameterConstraints(
       requestBodySchema
-        ? getOrCreateObjectProperty(
-            constrainedArtifact.parameters as unknown as JsonSchemaObject,
-            'query',
-          )
-        : (constrainedArtifact.parameters as unknown as JsonSchemaObject),
+        ? getOrCreateObjectProperty(parameterSchema, 'query')
+        : parameterSchema,
       operation,
       openApiDocument,
     );
@@ -1076,7 +1092,10 @@ export function applyOpenApiConstraintsToTypiaLlmFunctionArtifact({
     if (responseSchema) {
       mergeJsonSchemaConstraintProperties(
         openApiDocument,
-        constrainedArtifact.output as unknown as JsonSchemaObject,
+        assertJsonSchemaObject(
+          constrainedArtifact.output,
+          `typia.llm output for "${constrainedArtifact.name}"`,
+        ),
         responseSchema,
       );
     }

--- a/packages/wp-typia-project-tools/tests/typia-llm.test.ts
+++ b/packages/wp-typia-project-tools/tests/typia-llm.test.ts
@@ -751,6 +751,39 @@ describe('typia.llm adapter emitter', () => {
     });
   });
 
+  test('rejects malformed typia.llm parameter artifacts before OpenAPI constraint projection', () => {
+    expect(() =>
+      applyOpenApiConstraintsToTypiaLlmFunctionArtifact({
+        functionArtifact: {
+          description: 'Increment the counter.',
+          name: 'incrementCounter',
+          parameters: [] as unknown as ILlmSchema.IParameters,
+        },
+        openApiDocument: COUNTER_OPENAPI,
+        operationId: 'incrementCounter',
+      }),
+    ).toThrow(
+      'typia.llm parameters for "incrementCounter" must be a JSON Schema object.',
+    );
+  });
+
+  test('rejects malformed typia.llm output artifacts before OpenAPI constraint projection', () => {
+    expect(() =>
+      applyOpenApiConstraintsToTypiaLlmFunctionArtifact({
+        functionArtifact: {
+          description: 'Increment the counter.',
+          name: 'incrementCounter',
+          output: [] as unknown as ILlmSchema.IParameters,
+          parameters: EMPTY_LLM_PARAMETERS,
+        },
+        openApiDocument: COUNTER_OPENAPI,
+        operationId: 'incrementCounter',
+      }),
+    ).toThrow(
+      'typia.llm output for "incrementCounter" must be a JSON Schema object.',
+    );
+  });
+
   test('restores canonical OpenAPI constraints for mixed body/query tool inputs', () => {
     const applicationArtifact = projectTypiaLlmApplicationArtifact({
       application: {

--- a/packages/wp-typia-project-tools/tests/typia-llm.test.ts
+++ b/packages/wp-typia-project-tools/tests/typia-llm.test.ts
@@ -784,6 +784,39 @@ describe('typia.llm adapter emitter', () => {
     );
   });
 
+  test('rejects malformed typia.llm output artifacts when no OpenAPI response schema exists', () => {
+    const noResponseOpenApi = {
+      info: {
+        title: 'No-response API',
+        version: '1.0.0',
+      },
+      openapi: '3.1.0',
+      paths: {
+        '/stub': {
+          post: {
+            operationId: 'stubOp',
+            responses: {},
+            summary: 'Stub with no success response.',
+            tags: [],
+          },
+        },
+      },
+    } as const as unknown as OpenApiDocument;
+
+    expect(() =>
+      applyOpenApiConstraintsToTypiaLlmFunctionArtifact({
+        functionArtifact: {
+          description: 'Stub.',
+          name: 'stubOp',
+          output: [] as unknown as ILlmSchema.IParameters,
+          parameters: EMPTY_LLM_PARAMETERS,
+        },
+        openApiDocument: noResponseOpenApi,
+        operationId: 'stubOp',
+      }),
+    ).toThrow('typia.llm output for "stubOp" must be a JSON Schema object.');
+  });
+
   test('restores canonical OpenAPI constraints for mixed body/query tool inputs', () => {
     const applicationArtifact = projectTypiaLlmApplicationArtifact({
       application: {


### PR DESCRIPTION
## Summary
- Add a runtime JSON Schema object guard for typia.llm artifact fields before OpenAPI constraint restoration mutates them.
- Replace unsafe double casts in the typia-llm OpenAPI projection path.
- Cover malformed parameters and output artifacts while preserving existing valid projection behavior.

## Validation
- bun test packages/wp-typia-project-tools/tests/typia-llm.test.ts
- bun run --filter @wp-typia/project-tools test
- bun test tests/unit/typia-llm-helper.test.ts tests/unit/typia-llm-evaluation.test.ts
- bun run typecheck
- node scripts/check-repo-format.mjs
- node scripts/validate-sampo-changesets.mjs
- git diff --check

Closes #698

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for schema objects before applying OpenAPI constraints to function artifacts, ensuring invalid structures are properly rejected with clear error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->