### PR TITLE
feat(cache): prune external template cache entries

### DIFF
--- a/.sampo/changesets/699-template-cache-pruning.md
+++ b/.sampo/changesets/699-template-cache-pruning.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Add opt-in TTL pruning for external template cache entries and document the cleanup controls.

--- a/README.md
+++ b/README.md
@@ -233,7 +233,12 @@ resolvable remote revisions are cached under a private per-user local temp cache
 so repeated scaffolds can reuse the same unpacked source. Set
 `WP_TYPIA_EXTERNAL_TEMPLATE_CACHE=0` to force a refresh, or
 `WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR=/path/to/cache` to place the cache in a
-project- or CI-managed directory.
+project- or CI-managed directory. Cache pruning is disabled by default; set
+`WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_TTL_DAYS=7` to remove stale completed cache
+entries older than the configured TTL during cache access, or call the exported
+`pruneExternalTemplateCache()` helper from `@wp-typia/project-tools` for an
+explicit cleanup pass. Pruning only removes guarded cache entry directories under
+the configured cache root.
 
 Remote template examples:
 

--- a/packages/wp-typia-project-tools/src/runtime/index.ts
+++ b/packages/wp-typia-project-tools/src/runtime/index.ts
@@ -154,6 +154,14 @@ export {
 	listTemplates,
 } from "./template-registry.js";
 export {
+	EXTERNAL_TEMPLATE_CACHE_TTL_DAYS_ENV,
+	pruneExternalTemplateCache,
+} from "./template-source-cache.js";
+export type {
+	ExternalTemplateCachePruneOptions,
+	ExternalTemplateCachePruneResult,
+} from "./template-source-cache.js";
+export {
 	STALE_TEMP_ROOT_MAX_AGE_MS,
 	WP_TYPIA_TEMP_ROOT_PREFIX,
 	cleanupManagedTempRoot,

--- a/packages/wp-typia-project-tools/src/runtime/template-source-cache.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-cache.ts
@@ -18,9 +18,22 @@ export const EXTERNAL_TEMPLATE_CACHE_DIR_ENV =
   'WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR'
 
 /**
+ * Environment variable that enables TTL-based external template cache pruning.
+ *
+ * Unset, empty, zero, negative, and non-numeric values keep pruning disabled.
+ */
+export const EXTERNAL_TEMPLATE_CACHE_TTL_DAYS_ENV =
+  'WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_TTL_DAYS'
+
+/**
  * Marker file written after a cache entry is fully populated.
  */
 const CACHE_MARKER_FILE = 'wp-typia-template-cache.json'
+
+/**
+ * Milliseconds in one TTL day.
+ */
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000
 
 /**
  * Private directory mode used for cache roots and entries on POSIX platforms.
@@ -62,6 +75,11 @@ const URL_LIKE_METADATA_KEY = /(url|uri|registry|tarball)/iu
  * Cache namespaces must stay within one path segment under the cache root.
  */
 const SAFE_CACHE_NAMESPACE_SEGMENT = /^[A-Za-z0-9_.-]+$/u
+
+/**
+ * Cache entries are deterministic SHA-256 digest directory names.
+ */
+const SAFE_CACHE_ENTRY_SEGMENT = /^[a-f0-9]{64}$/u
 
 /**
  * Serializable metadata recorded in the cache marker for diagnostics.
@@ -122,6 +140,56 @@ export interface ExternalTemplateCacheLookupDescriptor {
 }
 
 /**
+ * Options for best-effort external template cache pruning.
+ */
+export interface ExternalTemplateCachePruneOptions {
+  /**
+   * Environment object to inspect, defaulting to `process.env`.
+   */
+  env?: NodeJS.ProcessEnv
+
+  /**
+   * Clock override for deterministic tests.
+   */
+  now?: Date | number
+
+  /**
+   * TTL override in days. When omitted, the TTL environment variable is used.
+   */
+  ttlDays?: number
+}
+
+/**
+ * Summary returned after external template cache pruning.
+ */
+export interface ExternalTemplateCachePruneResult {
+  /**
+   * Absolute cache root inspected by the pruning helper.
+   */
+  cacheRoot: string
+
+  /**
+   * Entries removed because their marker timestamp exceeded the TTL.
+   */
+  prunedEntries: number
+
+  /**
+   * Candidate cache entry directories inspected.
+   */
+  scannedEntries: number
+
+  /**
+   * Candidate directories skipped because they were malformed or unsafe.
+   */
+  skippedEntries: number
+
+  /**
+   * Resolved TTL in milliseconds, or `null` when pruning was disabled.
+   */
+  ttlMs: number | null
+}
+
+/**
  * Checks whether remote external template source caching is enabled.
  *
  * Caching is enabled by default. Set `WP_TYPIA_EXTERNAL_TEMPLATE_CACHE` to
@@ -163,6 +231,37 @@ export function getExternalTemplateCacheRoot(
     os.tmpdir(),
     `wp-typia-template-source-cache-${getCurrentUserCacheSegment()}`,
   )
+}
+
+function parseExternalTemplateCacheTtlDays(value: unknown): number | null {
+  if (typeof value !== 'string' && typeof value !== 'number') {
+    return null
+  }
+
+  const ttlDays = typeof value === 'number' ? value : Number(value.trim())
+  if (!Number.isFinite(ttlDays) || ttlDays <= 0) {
+    return null
+  }
+
+  return ttlDays
+}
+
+function resolveExternalTemplateCacheTtlMs(
+  options: Pick<ExternalTemplateCachePruneOptions, 'env' | 'ttlDays'> = {},
+): number | null {
+  const ttlDays =
+    options.ttlDays === undefined
+      ? parseExternalTemplateCacheTtlDays(
+          options.env?.[EXTERNAL_TEMPLATE_CACHE_TTL_DAYS_ENV] ??
+            process.env[EXTERNAL_TEMPLATE_CACHE_TTL_DAYS_ENV],
+        )
+      : parseExternalTemplateCacheTtlDays(options.ttlDays)
+  if (ttlDays === null) {
+    return null
+  }
+
+  const ttlMs = ttlDays * MILLISECONDS_PER_DAY
+  return Number.isFinite(ttlMs) ? ttlMs : null
 }
 
 /**
@@ -424,6 +523,156 @@ function cacheMetadataMatches(
   return Object.entries(expected).every(([key, value]) => actual[key] === value)
 }
 
+function getExternalTemplateCacheNowMs(now: Date | number | undefined): number {
+  const nowMs =
+    now instanceof Date
+      ? now.getTime()
+      : typeof now === 'number'
+        ? now
+        : Date.now()
+
+  return Number.isFinite(nowMs) ? nowMs : Date.now()
+}
+
+function isPathInsideDirectory(
+  directory: string,
+  candidatePath: string,
+): boolean {
+  const relativePath = path.relative(directory, candidatePath)
+  return (
+    relativePath.length > 0 &&
+    !relativePath.startsWith('..') &&
+    !path.isAbsolute(relativePath)
+  )
+}
+
+async function removeCacheEntryWithinRoot(
+  cacheRoot: string,
+  entryDir: string,
+): Promise<boolean> {
+  if (!isPathInsideDirectory(cacheRoot, entryDir)) {
+    return false
+  }
+
+  try {
+    await fsp.rm(entryDir, { force: true, recursive: true })
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Removes stale external template cache entries when a positive TTL is configured.
+ *
+ * The helper is best-effort: malformed cache directories are skipped, cache
+ * roots must remain private and non-symlinked, and deletes are constrained to
+ * deterministic entry directories under the configured cache root.
+ *
+ * @param options Optional TTL, clock, and environment overrides.
+ * @returns Pruning summary with counts for inspected, skipped, and removed entries.
+ */
+export async function pruneExternalTemplateCache(
+  options: ExternalTemplateCachePruneOptions = {},
+): Promise<ExternalTemplateCachePruneResult> {
+  const env = options.env ?? process.env
+  const cacheRoot = getExternalTemplateCacheRoot(env)
+  const ttlMs = resolveExternalTemplateCacheTtlMs({
+    env,
+    ttlDays: options.ttlDays,
+  })
+  const result: ExternalTemplateCachePruneResult = {
+    cacheRoot,
+    prunedEntries: 0,
+    scannedEntries: 0,
+    skippedEntries: 0,
+    ttlMs,
+  }
+
+  if (ttlMs === null || !(await isPrivateCacheDirectory(cacheRoot))) {
+    return result
+  }
+
+  let namespaceEntries: fs.Dirent[]
+  try {
+    namespaceEntries = await fsp.readdir(cacheRoot, { withFileTypes: true })
+  } catch {
+    return result
+  }
+
+  const expiresBeforeMs = getExternalTemplateCacheNowMs(options.now) - ttlMs
+  for (const namespaceEntry of namespaceEntries) {
+    if (!namespaceEntry.isDirectory()) {
+      continue
+    }
+
+    const namespaceDir = resolveCacheNamespaceDir(
+      cacheRoot,
+      namespaceEntry.name,
+    )
+    if (!namespaceDir || !(await isPrivateCacheDirectory(namespaceDir))) {
+      result.skippedEntries += 1
+      continue
+    }
+
+    let cacheEntries: fs.Dirent[]
+    try {
+      cacheEntries = await fsp.readdir(namespaceDir, { withFileTypes: true })
+    } catch {
+      result.skippedEntries += 1
+      continue
+    }
+
+    for (const cacheEntry of cacheEntries) {
+      if (!cacheEntry.isDirectory()) {
+        continue
+      }
+      if (!SAFE_CACHE_ENTRY_SEGMENT.test(cacheEntry.name)) {
+        result.skippedEntries += 1
+        continue
+      }
+
+      const entryDir = path.join(namespaceDir, cacheEntry.name)
+      result.scannedEntries += 1
+      if (!isPathInsideDirectory(cacheRoot, entryDir)) {
+        result.skippedEntries += 1
+        continue
+      }
+
+      const markerPath = path.join(entryDir, CACHE_MARKER_FILE)
+      const sourceDir = path.join(entryDir, 'source')
+      if (!(await isReusableCacheEntry(entryDir, markerPath, sourceDir))) {
+        result.skippedEntries += 1
+        continue
+      }
+
+      let markerText: string
+      try {
+        markerText = await fsp.readFile(markerPath, 'utf8')
+      } catch {
+        result.skippedEntries += 1
+        continue
+      }
+
+      const marker = parseCacheMarkerMetadata(markerText)
+      if (!marker) {
+        result.skippedEntries += 1
+        continue
+      }
+
+      if (marker.createdAtMs < expiresBeforeMs) {
+        if (await removeCacheEntryWithinRoot(cacheRoot, entryDir)) {
+          result.prunedEntries += 1
+        } else {
+          result.skippedEntries += 1
+        }
+      }
+    }
+  }
+
+  return result
+}
+
 /**
  * Finds a reusable cache entry whose marker metadata includes the expected fields.
  *
@@ -455,6 +704,7 @@ export async function findReusableExternalTemplateSourceCache(
   ) {
     return null
   }
+  await pruneExternalTemplateCache()
 
   let entries: fs.Dirent[]
   try {
@@ -535,6 +785,7 @@ export async function resolveExternalTemplateSourceCache(
   ) {
     return null
   }
+  await pruneExternalTemplateCache()
 
   if (await isReusableCacheEntry(entryDir, markerPath, sourceDir)) {
     return {

--- a/packages/wp-typia-project-tools/src/runtime/template-source-cache.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-cache.ts
@@ -249,11 +249,11 @@ function parseExternalTemplateCacheTtlDays(value: unknown): number | null {
 function resolveExternalTemplateCacheTtlMs(
   options: Pick<ExternalTemplateCachePruneOptions, 'env' | 'ttlDays'> = {},
 ): number | null {
+  const env = options.env ?? process.env
   const ttlDays =
     options.ttlDays === undefined
       ? parseExternalTemplateCacheTtlDays(
-          options.env?.[EXTERNAL_TEMPLATE_CACHE_TTL_DAYS_ENV] ??
-            process.env[EXTERNAL_TEMPLATE_CACHE_TTL_DAYS_ENV],
+          env[EXTERNAL_TEMPLATE_CACHE_TTL_DAYS_ENV],
         )
       : parseExternalTemplateCacheTtlDays(options.ttlDays)
   if (ttlDays === null) {

--- a/packages/wp-typia-project-tools/tests/template-source.test.ts
+++ b/packages/wp-typia-project-tools/tests/template-source.test.ts
@@ -568,6 +568,54 @@ test("external template cache prune helper stays inside the configured cache roo
   }
 });
 
+test("external template cache prune helper respects provided env TTL lookup", async () => {
+  const originalCache = process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE;
+  const originalCacheDir = process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR;
+  const originalCacheTtl = process.env[EXTERNAL_TEMPLATE_CACHE_TTL_DAYS_ENV];
+  const cacheDir = path.join(tempRoot, "ttl-explicit-env-cache");
+
+  process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR = cacheDir;
+  process.env[EXTERNAL_TEMPLATE_CACHE_TTL_DAYS_ENV] = "1";
+  delete process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE;
+
+  try {
+    const staleResolution = await resolveExternalTemplateSourceCache(
+      {
+        keyParts: ["ttl-explicit-env", "stale"],
+        metadata: { name: "stale" },
+        namespace: "npm",
+      },
+      async (sourceDir) => {
+        fs.writeFileSync(path.join(sourceDir, "package.json"), "{}", "utf8");
+      }
+    );
+
+    if (!staleResolution) {
+      throw new Error("Expected a populated external template cache entry.");
+    }
+
+    setCacheMarkerCreatedAt(
+      staleResolution.sourceDir,
+      new Date("2026-01-01T00:00:00.000Z")
+    );
+
+    const pruneResult = await pruneExternalTemplateCache({
+      env: {
+        WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR: cacheDir,
+      },
+      now: new Date("2026-01-10T00:00:00.000Z"),
+    });
+
+    expect(pruneResult.ttlMs).toBeNull();
+    expect(pruneResult.prunedEntries).toBe(0);
+    expect(fs.existsSync(path.dirname(staleResolution.sourceDir))).toBe(true);
+  } finally {
+    restoreEnvValue("WP_TYPIA_EXTERNAL_TEMPLATE_CACHE", originalCache);
+    restoreEnvValue("WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR", originalCacheDir);
+    restoreEnvValue(EXTERNAL_TEMPLATE_CACHE_TTL_DAYS_ENV, originalCacheTtl);
+  }
+});
+
 test("getTemplateVariables rejects slugs that normalize to an empty identifier", () => {
   expect(() =>
     getTemplateVariables("basic", {

--- a/packages/wp-typia-project-tools/tests/template-source.test.ts
+++ b/packages/wp-typia-project-tools/tests/template-source.test.ts
@@ -7,7 +7,9 @@ import { blockTypesPackageVersion, cleanupScaffoldTempRoot, createBlockExternalF
 import { getTemplateVariables, scaffoldProject } from "../src/runtime/index.js";
 import { resolveTemplateId } from "../src/runtime/scaffold.js";
 import {
+  EXTERNAL_TEMPLATE_CACHE_TTL_DAYS_ENV,
   findReusableExternalTemplateSourceCache,
+  pruneExternalTemplateCache,
   resolveExternalTemplateSourceCache,
 } from "../src/runtime/template-source-cache.js";
 import { copyRenderedDirectory } from "../src/runtime/template-render.js";
@@ -109,6 +111,30 @@ describe("@wp-typia/project-tools template sources", () => {
     }
 
     return null;
+  }
+
+  function setCacheMarkerCreatedAt(sourceDir: string, createdAt: Date): void {
+    const markerPath = path.join(
+      path.dirname(sourceDir),
+      "wp-typia-template-cache.json"
+    );
+    const marker = JSON.parse(fs.readFileSync(markerPath, "utf8")) as Record<
+      string,
+      unknown
+    >;
+
+    fs.writeFileSync(
+      markerPath,
+      `${JSON.stringify(
+        {
+          ...marker,
+          createdAt: createdAt.toISOString(),
+        },
+        null,
+        2
+      )}\n`,
+      "utf8"
+    );
   }
 
 test("external template cache rejects unsafe namespaces before populating", async () => {
@@ -392,6 +418,153 @@ test("external template cache can find reusable entries by metadata", async () =
   } finally {
     restoreEnvValue("WP_TYPIA_EXTERNAL_TEMPLATE_CACHE", originalCache);
     restoreEnvValue("WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR", originalCacheDir);
+  }
+});
+
+test("external template cache TTL prunes stale entries before reuse", async () => {
+  const originalCache = process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE;
+  const originalCacheDir = process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR;
+  const originalCacheTtl = process.env[EXTERNAL_TEMPLATE_CACHE_TTL_DAYS_ENV];
+  const cacheDir = path.join(tempRoot, "ttl-reuse-cache");
+  const descriptor = {
+    keyParts: ["ttl-reuse"],
+    metadata: {
+      package: "@demo/ttl-reuse",
+      version: "1.0.0",
+    },
+    namespace: "npm",
+  };
+  let populateCount = 0;
+
+  process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR = cacheDir;
+  process.env[EXTERNAL_TEMPLATE_CACHE_TTL_DAYS_ENV] = "7";
+  delete process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE;
+
+  try {
+    const firstResolution = await resolveExternalTemplateSourceCache(
+      descriptor,
+      async (sourceDir) => {
+        populateCount += 1;
+        fs.writeFileSync(
+          path.join(sourceDir, "package.json"),
+          JSON.stringify({ refreshed: false }),
+          "utf8"
+        );
+      }
+    );
+
+    expect(firstResolution?.cacheHit).toBe(false);
+    if (!firstResolution) {
+      throw new Error("Expected a populated external template cache entry.");
+    }
+
+    setCacheMarkerCreatedAt(
+      firstResolution.sourceDir,
+      new Date(Date.now() - 10 * 24 * 60 * 60 * 1000)
+    );
+
+    const secondResolution = await resolveExternalTemplateSourceCache(
+      descriptor,
+      async (sourceDir) => {
+        populateCount += 1;
+        fs.writeFileSync(
+          path.join(sourceDir, "package.json"),
+          JSON.stringify({ refreshed: true }),
+          "utf8"
+        );
+      }
+    );
+
+    expect(secondResolution?.cacheHit).toBe(false);
+    expect(secondResolution?.sourceDir).toBe(firstResolution.sourceDir);
+    expect(populateCount).toBe(2);
+    expect(
+      fs.readFileSync(
+        path.join(firstResolution.sourceDir, "package.json"),
+        "utf8"
+      )
+    ).toContain('"refreshed":true');
+  } finally {
+    restoreEnvValue("WP_TYPIA_EXTERNAL_TEMPLATE_CACHE", originalCache);
+    restoreEnvValue("WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR", originalCacheDir);
+    restoreEnvValue(EXTERNAL_TEMPLATE_CACHE_TTL_DAYS_ENV, originalCacheTtl);
+  }
+});
+
+test("external template cache prune helper stays inside the configured cache root", async () => {
+  const originalCache = process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE;
+  const originalCacheDir = process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR;
+  const originalCacheTtl = process.env[EXTERNAL_TEMPLATE_CACHE_TTL_DAYS_ENV];
+  const cacheDir = path.join(tempRoot, "ttl-helper-cache");
+  const outsideDir = path.join(tempRoot, "ttl-helper-outside-target");
+  const outsideFile = path.join(outsideDir, "keep.txt");
+  const now = new Date("2026-01-10T00:00:00.000Z");
+
+  process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR = cacheDir;
+  delete process.env.WP_TYPIA_EXTERNAL_TEMPLATE_CACHE;
+  delete process.env[EXTERNAL_TEMPLATE_CACHE_TTL_DAYS_ENV];
+  fs.mkdirSync(outsideDir, { recursive: true });
+  fs.writeFileSync(outsideFile, "keep", "utf8");
+
+  try {
+    const staleResolution = await resolveExternalTemplateSourceCache(
+      {
+        keyParts: ["ttl-helper", "stale"],
+        metadata: { name: "stale" },
+        namespace: "npm",
+      },
+      async (sourceDir) => {
+        fs.writeFileSync(path.join(sourceDir, "package.json"), "{}", "utf8");
+      }
+    );
+    const freshResolution = await resolveExternalTemplateSourceCache(
+      {
+        keyParts: ["ttl-helper", "fresh"],
+        metadata: { name: "fresh" },
+        namespace: "npm",
+      },
+      async (sourceDir) => {
+        fs.writeFileSync(path.join(sourceDir, "package.json"), "{}", "utf8");
+      }
+    );
+
+    if (!staleResolution || !freshResolution) {
+      throw new Error("Expected populated external template cache entries.");
+    }
+
+    setCacheMarkerCreatedAt(
+      staleResolution.sourceDir,
+      new Date("2026-01-01T00:00:00.000Z")
+    );
+    setCacheMarkerCreatedAt(
+      freshResolution.sourceDir,
+      new Date("2026-01-09T00:00:00.000Z")
+    );
+
+    if (process.platform !== "win32") {
+      fs.symlinkSync(
+        outsideDir,
+        path.join(
+          path.dirname(path.dirname(staleResolution.sourceDir)),
+          "f".repeat(64)
+        ),
+        "dir"
+      );
+    }
+
+    const pruneResult = await pruneExternalTemplateCache({
+      now,
+      ttlDays: 7,
+    });
+
+    expect(pruneResult.prunedEntries).toBe(1);
+    expect(fs.existsSync(path.dirname(staleResolution.sourceDir))).toBe(false);
+    expect(fs.existsSync(path.dirname(freshResolution.sourceDir))).toBe(true);
+    expect(fs.readFileSync(outsideFile, "utf8")).toBe("keep");
+  } finally {
+    restoreEnvValue("WP_TYPIA_EXTERNAL_TEMPLATE_CACHE", originalCache);
+    restoreEnvValue("WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR", originalCacheDir);
+    restoreEnvValue(EXTERNAL_TEMPLATE_CACHE_TTL_DAYS_ENV, originalCacheTtl);
   }
 });
 


### PR DESCRIPTION
## Summary
- add opt-in `WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_TTL_DAYS` pruning for completed external template cache entries
- export `pruneExternalTemplateCache()` and pruning result/options types from the project-tools runtime barrel
- add stale cleanup and cache-root safety tests, plus README and changeset documentation

## Validation
- `bun test packages/wp-typia-project-tools/tests/template-source.test.ts`
- `bun run --filter @wp-typia/project-tools test:scaffold-core`
- `bun run typecheck`
- `node scripts/check-repo-format.mjs`
- `node scripts/validate-sampo-changesets.mjs`
- `git diff --check`

Closes #699

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional TTL-based cache pruning for external templates—configure cache expiration via environment variable
  * Introduced helper function for manual cache cleanup

* **Documentation**
  * Enhanced "Remote templates" section with cache management guidance, including default behavior and cleanup options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->