### PR TITLE
docs(config): document array replacement semantics

### DIFF
--- a/apps/docs/src/content/docs/reference/cli.md
+++ b/apps/docs/src/content/docs/reference/cli.md
@@ -27,6 +27,43 @@ shell `completions` require Bun 1.3.11+ or the standalone release binary.
 Status markers honor `WP_TYPIA_ASCII=1`, `WP_TYPIA_ASCII=0`, and `NO_COLOR` in
 the same way as generated project onboarding output.
 
+## Configuration Files
+
+`wp-typia` loads user config from `~/.config/wp-typia/config.json`,
+`.wp-typiarc`, `.wp-typiarc.json`, the `wp-typia` key in `package.json`, and
+then the optional `--config <path>` override. Later sources take precedence.
+
+Config objects are merged recursively, but arrays are replaced instead of
+concatenated. This keeps list-like options deterministic: the later source owns
+the full array value, and users should repeat any earlier entries they still
+want to preserve. This matters for options such as `mcp.schemaSources`.
+
+For example, this project config:
+
+```json
+{
+  "mcp": {
+    "schemaSources": [{ "namespace": "base", "path": "./base.ts" }]
+  }
+}
+```
+
+combined with this later `package.json` override:
+
+```json
+{
+  "wp-typia": {
+    "mcp": {
+      "schemaSources": [{ "namespace": "app", "path": "./app.ts" }]
+    }
+  }
+}
+```
+
+resolves to only the `app` source. To keep both entries, include both in the
+later array. Additive array merging is intentionally out of scope for the
+current config contract.
+
 ## Machine-readable diagnostics
 
 Commands that support `--format json` emit stable failure envelopes for CI, IDE,

--- a/packages/wp-typia/tests/config.test.ts
+++ b/packages/wp-typia/tests/config.test.ts
@@ -104,6 +104,14 @@ describe('wp-typia user config loading', () => {
           'package-manager': 'npm',
           template: 'interactivity',
         },
+        mcp: {
+          schemaSources: [
+            {
+              namespace: 'rc',
+              path: './rc.ts',
+            },
+          ],
+        },
       });
       writeJson(path.join(cwd, '.wp-typiarc.json'), {
         create: {
@@ -124,6 +132,14 @@ describe('wp-typia user config loading', () => {
           create: {
             template: 'persistence',
           },
+          mcp: {
+            schemaSources: [
+              {
+                namespace: 'package',
+                path: './package.ts',
+              },
+            ],
+          },
         },
       });
 
@@ -139,8 +155,8 @@ describe('wp-typia user config loading', () => {
         mcp: {
           schemaSources: [
             {
-              namespace: 'project',
-              path: './project.ts',
+              namespace: 'package',
+              path: './package.ts',
             },
           ],
         },


### PR DESCRIPTION
## Summary
- document wp-typia config source precedence and deep-merge semantics
- clarify that arrays such as mcp.schemaSources are replaced by later sources rather than concatenated
- extend config loading coverage so later source arrays replace earlier source arrays

Closes #700

## Validation
- bun test packages/wp-typia/tests/config.test.ts
- bun run --filter wp-typia test
- bun run typecheck
- node scripts/check-repo-format.mjs
- node scripts/validate-sampo-changesets.mjs
- git diff --check