### PR TITLE
refactor(cli): share entrypoint command resolution

### DIFF
--- a/.sampo/changesets/715-cli-command-resolution.md
+++ b/.sampo/changesets/715-cli-command-resolution.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Share CLI entrypoint command resolution between output-format validation and diagnostic output.

--- a/packages/wp-typia/src/cli-command-resolution.ts
+++ b/packages/wp-typia/src/cli-command-resolution.ts
@@ -1,6 +1,9 @@
 import { findFirstPositional } from '../bin/argv-walker.js';
 import { COMMAND_ROUTING_METADATA } from './command-option-metadata';
 
+/**
+ * Resolve the first routed CLI command from entrypoint argv.
+ */
 export function resolveEntrypointCliCommand(argv: string[]): string {
   return findFirstPositional(argv, COMMAND_ROUTING_METADATA) ?? 'wp-typia';
 }

--- a/packages/wp-typia/src/cli-command-resolution.ts
+++ b/packages/wp-typia/src/cli-command-resolution.ts
@@ -1,0 +1,6 @@
+import { findFirstPositional } from '../bin/argv-walker.js';
+import { COMMAND_ROUTING_METADATA } from './command-option-metadata';
+
+export function resolveEntrypointCliCommand(argv: string[]): string {
+  return findFirstPositional(argv, COMMAND_ROUTING_METADATA) ?? 'wp-typia';
+}

--- a/packages/wp-typia/src/cli-diagnostic-output.ts
+++ b/packages/wp-typia/src/cli-diagnostic-output.ts
@@ -3,9 +3,8 @@ import {
   serializeCliDiagnosticError,
   type CliDiagnosticCode,
 } from '@wp-typia/project-tools/cli-diagnostics';
-import { COMMAND_ROUTING_METADATA } from './command-option-metadata';
+import { resolveEntrypointCliCommand } from './cli-command-resolution';
 import { isSupportedCliOutputFormat } from './cli-output-format';
-import { findFirstPositional } from '../bin/argv-walker.js';
 
 type CliStructuredOutputArgs = {
   agent?: unknown;
@@ -27,10 +26,6 @@ type EmitCliDiagnosticFailureOptions = {
   extraOutput?: Record<string, unknown>;
   summary?: string;
 };
-
-function resolveEntrypointCliCommand(argv: string[]): string {
-  return findFirstPositional(argv, COMMAND_ROUTING_METADATA) ?? 'wp-typia';
-}
 
 function writeStructuredCliJsonToStderr(
   payload: Record<string, unknown>,

--- a/packages/wp-typia/src/cli-output-format.ts
+++ b/packages/wp-typia/src/cli-output-format.ts
@@ -2,8 +2,7 @@ import {
   CLI_DIAGNOSTIC_CODES,
   createCliCommandError,
 } from '@wp-typia/project-tools/cli-diagnostics';
-import { COMMAND_ROUTING_METADATA } from './command-option-metadata';
-import { findFirstPositional } from '../bin/argv-walker.js';
+import { resolveEntrypointCliCommand } from './cli-command-resolution';
 
 export const SUPPORTED_CLI_OUTPUT_FORMATS = ['json', 'toon'] as const;
 
@@ -21,10 +20,6 @@ export function isSupportedCliOutputFormat(
 
 export function formatInvalidCliOutputFormatMessage(value: string): string {
   return `Invalid --format value "${value}". Supported values: ${formatSupportedCliOutputFormats()}.`;
-}
-
-function resolveEntrypointCliCommand(argv: string[]): string {
-  return findFirstPositional(argv, COMMAND_ROUTING_METADATA) ?? 'wp-typia';
 }
 
 function assertSupportedCliOutputFormat(


### PR DESCRIPTION
## Summary
- add a shared CLI entrypoint command resolution helper
- reuse it from output-format validation and diagnostic output
- add a Sampo changeset for the wp-typia package

Closes #715

## Validation
- bun run --filter wp-typia test
- bun run typecheck
- node scripts/check-repo-format.mjs
- node scripts/validate-sampo-changesets.mjs
- git diff --check

Note: a direct raw test run before the package build failed only on version assertions because the release bump had updated package.json to 0.22.4 while stale local built artifacts still reported 0.22.3. The package test script rebuilds first and passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated CLI command resolution logic for improved consistency in diagnostic output and output formatting across the CLI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->