### PR TITLE
ux(cli): advertise text output format

### DIFF
--- a/.sampo/changesets/719-cli-format-text.md
+++ b/.sampo/changesets/719-cli-format-text.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Advertise `--format text` for human-readable CLI output while preserving the legacy `toon` alias.

--- a/apps/docs/src/content/docs/reference/cli.md
+++ b/apps/docs/src/content/docs/reference/cli.md
@@ -17,15 +17,19 @@ shell `completions` require Bun 1.3.11+ or the standalone release binary.
 
 ## Global flags
 
-| Flag              | Description                                                               |
-| ----------------- | ------------------------------------------------------------------------- |
-| `--help`          | Show top-level or command-specific help.                                  |
-| `--version`       | Print the installed `wp-typia` version.                                   |
-| `--config <path>` | Load a config override file for the current invocation.                   |
-| `--format json`   | Emit machine-readable output for commands that support structured output. |
+| Flag                      | Description                                                                                                        |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `--help`                  | Show top-level or command-specific help.                                                                           |
+| `--version`               | Print the installed `wp-typia` version.                                                                            |
+| `--config <path>`         | Load a config override file for the current invocation.                                                            |
+| `--format <json \| text>` | Select command output for supported commands; `json` is machine-readable and `text` is the human-readable default. |
 
 Status markers honor `WP_TYPIA_ASCII=1`, `WP_TYPIA_ASCII=0`, and `NO_COLOR` in
 the same way as generated project onboarding output.
+
+The legacy internal value `toon` remains accepted as a compatibility alias for
+human-readable output, but help and invalid-format guidance advertise the public
+`text` spelling instead.
 
 ## Configuration Files
 

--- a/packages/wp-typia/src/cli-diagnostic-output.ts
+++ b/packages/wp-typia/src/cli-diagnostic-output.ts
@@ -59,10 +59,11 @@ export function prefersStructuredCliArgv(argv: string[]): boolean {
 export function prefersStructuredCliOutput(
   args: CliStructuredOutputArgs,
 ): boolean {
+  if (args.formatExplicit) {
+    return args.format === 'json' && isSupportedCliOutputFormat(args.format);
+  }
+
   return (
-    (args.formatExplicit &&
-      args.format === 'json' &&
-      isSupportedCliOutputFormat(args.format)) ||
     Boolean(args.agent) ||
     Boolean(args.context?.store?.isAIAgent)
   );

--- a/packages/wp-typia/src/cli-output-format.ts
+++ b/packages/wp-typia/src/cli-output-format.ts
@@ -4,18 +4,67 @@ import {
 } from '@wp-typia/project-tools/cli-diagnostics';
 import { resolveEntrypointCliCommand } from './cli-command-resolution';
 
-export const SUPPORTED_CLI_OUTPUT_FORMATS = ['json', 'toon'] as const;
+export const PUBLIC_CLI_OUTPUT_FORMATS = ['json', 'text'] as const;
+
+// `toon` was the original internal spelling for human output. Keep accepting it
+// for old automation, but do not advertise it in user-facing supported lists.
+const LEGACY_CLI_OUTPUT_FORMAT_ALIASES = ['toon'] as const;
+
+export const SUPPORTED_CLI_OUTPUT_FORMATS = [
+  ...PUBLIC_CLI_OUTPUT_FORMATS,
+  ...LEGACY_CLI_OUTPUT_FORMAT_ALIASES,
+] as const;
+
+const SUPPORTED_CLI_OUTPUT_FORMAT_VALUES: readonly string[] =
+  SUPPORTED_CLI_OUTPUT_FORMATS;
 
 export type CliOutputFormat = (typeof SUPPORTED_CLI_OUTPUT_FORMATS)[number];
 
 export function formatSupportedCliOutputFormats(): string {
-  return SUPPORTED_CLI_OUTPUT_FORMATS.join(', ');
+  return PUBLIC_CLI_OUTPUT_FORMATS.join(', ');
 }
 
 export function isSupportedCliOutputFormat(
   value: string | undefined,
 ): value is CliOutputFormat {
-  return SUPPORTED_CLI_OUTPUT_FORMATS.includes(value as CliOutputFormat);
+  return (
+    typeof value === 'string' &&
+    SUPPORTED_CLI_OUTPUT_FORMAT_VALUES.includes(value)
+  );
+}
+
+export function normalizeCliOutputFormatArgv(argv: string[]): string[] {
+  let normalized: string[] | undefined;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg) {
+      continue;
+    }
+
+    if (arg === '--') {
+      break;
+    }
+
+    if (arg === '--format') {
+      const next = argv[index + 1];
+      if (next === 'text') {
+        normalized ??= [...argv];
+        normalized[index + 1] = 'toon';
+      }
+      if (next && !next.startsWith('-')) {
+        index += 1;
+      }
+      continue;
+    }
+
+    if (arg === '--format=text') {
+      normalized ??= [...argv];
+      normalized[index] = '--format=toon';
+    }
+  }
+
+  return normalized ?? argv;
 }
 
 export function formatInvalidCliOutputFormatMessage(value: string): string {

--- a/packages/wp-typia/src/cli.ts
+++ b/packages/wp-typia/src/cli.ts
@@ -11,7 +11,10 @@ import { skillsPlugin } from "@bunli/plugin-skills";
 import packageJson from "../package.json";
 import { bunliConfig } from "../bunli.config";
 import { writeStructuredCliDiagnosticError } from "./cli-diagnostic-output";
-import { validateCliOutputFormatArgv } from "./cli-output-format";
+import {
+	normalizeCliOutputFormatArgv,
+	validateCliOutputFormatArgv,
+} from "./cli-output-format";
 import { normalizeWpTypiaArgv } from "./command-contract";
 import { WP_TYPIA_CONFIG_SOURCES } from "./config";
 import { extractWpTypiaConfigOverride } from "./config-override";
@@ -113,7 +116,7 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
 	const { argv: cliArgv, configOverridePath } = extractWpTypiaConfigOverride(normalizedArgv);
 	validateCliOutputFormatArgv(cliArgv);
 	const cli = await createWpTypiaCli({ configOverridePath });
-	await cli.run(cliArgv);
+	await cli.run(normalizeCliOutputFormatArgv(cliArgv));
 }
 
 export async function runCliEntrypoint(argv = process.argv.slice(2)): Promise<void> {

--- a/packages/wp-typia/src/command-option-metadata.ts
+++ b/packages/wp-typia/src/command-option-metadata.ts
@@ -314,7 +314,8 @@ export const SYNC_OPTION_METADATA = {
  */
 export const DOCTOR_OPTION_METADATA = {
   format: {
-    description: 'Use `json` for machine-readable doctor check output or `toon` for human-readable output.',
+    description:
+      'Use `json` for machine-readable doctor check output or `text` for human-readable output.',
     type: 'string',
   },
 } as const satisfies CommandOptionMetadataMap;
@@ -339,7 +340,7 @@ export const GLOBAL_OPTION_METADATA = {
     type: 'string',
   },
   format: {
-    description: 'Output format for supported commands (`json` or `toon`).',
+    description: 'Output format for supported commands (`json` or `text`).',
     type: 'string',
   },
   id: {

--- a/packages/wp-typia/tests/cli-diagnostic-output.test.ts
+++ b/packages/wp-typia/tests/cli-diagnostic-output.test.ts
@@ -8,7 +8,12 @@ import {
   prefersStructuredCliOutput,
   writeStructuredCliDiagnosticError,
 } from '../src/cli-diagnostic-output';
-import { validateCliOutputFormatArgv } from '../src/cli-output-format';
+import {
+  formatInvalidCliOutputFormatMessage,
+  isSupportedCliOutputFormat,
+  normalizeCliOutputFormatArgv,
+  validateCliOutputFormatArgv,
+} from '../src/cli-output-format';
 
 function captureStderr(callback: () => void): {
   exitCode: string | number | undefined;
@@ -44,6 +49,7 @@ describe('CLI structured diagnostic output', () => {
   test('detects explicit structured format requests before argv terminators', () => {
     expect(prefersStructuredCliArgv(['doctor', '--format', 'json'])).toBe(true);
     expect(prefersStructuredCliArgv(['doctor', '--format=json'])).toBe(true);
+    expect(prefersStructuredCliArgv(['doctor', '--format', 'text'])).toBe(false);
     expect(prefersStructuredCliArgv(['doctor', '--format', 'toon'])).toBe(false);
     expect(
       prefersStructuredCliArgv(['doctor', '--', '--format', 'json']),
@@ -62,6 +68,14 @@ describe('CLI structured diagnostic output', () => {
       prefersStructuredCliOutput({
         format: 'json',
         formatExplicit: false,
+        output: () => {},
+      }),
+    ).toBe(false);
+    expect(
+      prefersStructuredCliOutput({
+        agent: {},
+        format: 'text',
+        formatExplicit: true,
         output: () => {},
       }),
     ).toBe(false);
@@ -159,5 +173,40 @@ describe('CLI structured diagnostic output', () => {
         command: 'sync',
       });
     }
+  });
+
+  test('advertises text output while accepting the legacy toon alias', () => {
+    expect(formatInvalidCliOutputFormatMessage('jso')).toBe(
+      'Invalid --format value "jso". Supported values: json, text.',
+    );
+    expect(isSupportedCliOutputFormat('json')).toBe(true);
+    expect(isSupportedCliOutputFormat('text')).toBe(true);
+    expect(isSupportedCliOutputFormat('toon')).toBe(true);
+
+    expect(() =>
+      validateCliOutputFormatArgv(['sync', '--format', 'text']),
+    ).not.toThrow();
+    expect(() =>
+      validateCliOutputFormatArgv(['sync', '--format', 'toon']),
+    ).not.toThrow();
+    expect(() =>
+      validateCliOutputFormatArgv(['sync', '--format', 'jso']),
+    ).toThrow('Supported values: json, text.');
+  });
+
+  test('normalizes public text format to the internal runtime alias', () => {
+    expect(normalizeCliOutputFormatArgv(['doctor', '--format', 'text'])).toEqual(
+      ['doctor', '--format', 'toon'],
+    );
+    expect(normalizeCliOutputFormatArgv(['doctor', '--format=text'])).toEqual([
+      'doctor',
+      '--format=toon',
+    ]);
+    expect(
+      normalizeCliOutputFormatArgv(['doctor', '--', '--format', 'text']),
+    ).toEqual(['doctor', '--', '--format', 'text']);
+    expect(
+      normalizeCliOutputFormatArgv(['doctor', '--format', '--', '--format=text']),
+    ).toEqual(['doctor', '--format', '--', '--format=text']);
   });
 });

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -457,6 +457,11 @@ describe('wp-typia package', () => {
       '--help',
     ]);
     const addHelpOutput = runUtf8Command('node', [entryPath, 'add', '--help']);
+    const doctorHelpOutput = runUtf8Command('node', [
+      entryPath,
+      'doctor',
+      '--help',
+    ]);
 
     for (const commandName of WP_TYPIA_TOP_LEVEL_COMMAND_NAMES) {
       expect(helpOutput).toContain(commandName);
@@ -481,6 +486,10 @@ describe('wp-typia package', () => {
     expect(addHelpOutput).toContain('ability');
     expect(addHelpOutput).toContain('ai-feature');
     expect(addHelpOutput).toContain('editor-plugin');
+    expect(doctorHelpOutput).toContain(
+      '`json` for machine-readable doctor check output or `text` for human-readable output',
+    );
+    expect(doctorHelpOutput).not.toContain('toon');
   });
 
   test('prints structured init plans through the canonical bin', () => {
@@ -1864,7 +1873,7 @@ describe('wp-typia package', () => {
       expect(result.status).toBe(1);
       expect(result.stdout).toBe('');
       expect(result.stderr).toContain('Invalid --format value "jso".');
-      expect(result.stderr).toContain('Supported values: json, toon.');
+      expect(result.stderr).toContain('Supported values: json, text.');
     }
   });
 
@@ -2167,8 +2176,24 @@ describe('wp-typia package', () => {
       expect(result.status).toBe(1);
       expect(result.stdout).toBe('');
       expect(result.stderr).toContain('Invalid --format value "jso".');
-      expect(result.stderr).toContain('Supported values: json, toon.');
+      expect(result.stderr).toContain('Supported values: json, text.');
     }
+  });
+
+  test('accepts text as the public human-readable format in Bun runtime', () => {
+    const result = runCapturedCommand(
+      'bun',
+      [fullRuntimeEntrypoint, 'create', '--format', 'text'],
+      {
+        env: withoutAIAgentEnv(),
+      },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain('Error: wp-typia create failed');
+    expect(result.stderr).not.toContain('Invalid --format value "text".');
+    expect(result.stderr).not.toContain('Supported values:');
   });
 
   test('emits a machine-readable missing-argument error code for top-level config parsing in Bun runtime JSON mode', () => {

--- a/packages/wp-typia/tests/node-cli-core.test.ts
+++ b/packages/wp-typia/tests/node-cli-core.test.ts
@@ -89,6 +89,8 @@ describe('Node fallback CLI core routing', () => {
 
   test('prints human and structured version output from the fallback runtime', async () => {
     const human = await captureNodeCli(['--version']);
+    const text = await captureNodeCli(['version', '--format', 'text']);
+    const legacyToon = await captureNodeCli(['version', '--format', 'toon']);
     const structured = await captureNodeCli(['version', '--format', 'json']);
     const parsed = JSON.parse(structured.stdout) as {
       data?: { name?: string; type?: string; version?: string };
@@ -98,6 +100,14 @@ describe('Node fallback CLI core routing', () => {
     expect(human.error).toBeUndefined();
     expect(human.exitCode).toBe(0);
     expect(human.stdout.trim()).toBe(`wp-typia ${packageJson.version}`);
+
+    expect(text.error).toBeUndefined();
+    expect(text.exitCode).toBe(0);
+    expect(text.stdout.trim()).toBe(`wp-typia ${packageJson.version}`);
+
+    expect(legacyToon.error).toBeUndefined();
+    expect(legacyToon.exitCode).toBe(0);
+    expect(legacyToon.stdout.trim()).toBe(`wp-typia ${packageJson.version}`);
 
     expect(structured.error).toBeUndefined();
     expect(structured.exitCode).toBe(0);


### PR DESCRIPTION
## Summary

- advertise `--format text` as the public human-readable CLI output spelling while keeping `toon` as a legacy compatibility alias
- keep invalid-format diagnostics and Node fallback help focused on `json, text`
- normalize public `text` to Bunli's internal `toon` runtime format and let explicit human format override automatic agent JSON output
- document the legacy alias policy in the CLI reference and add a patch changeset

Closes #719.

## Validation

- `bun test packages/wp-typia/tests/cli-diagnostic-output.test.ts packages/wp-typia/tests/cli-package.test.ts`
- `bun run --filter wp-typia test`
- `bun run typecheck`
- `node scripts/check-repo-format.mjs`
- `node scripts/validate-sampo-changesets.mjs`
- `git diff --check`
- `bun run docs:build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `--format text` option for CLI commands to generate human-readable output. The `--format` flag now globally supports both `text` and `json` output formats, with environment variables controlling status marker display.

* **Documentation**
  * Updated CLI reference documentation to document the `--format` global flag options and their respective output formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->