### PR TITLE
refactor(cli): consolidate node help rendering

### DIFF
--- a/.sampo/changesets/717-node-help-renderer.md
+++ b/.sampo/changesets/717-node-help-renderer.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Consolidate Node fallback command help rendering around shared command metadata.

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -11,6 +11,7 @@ import {
   ADD_OPTION_METADATA,
   buildCommandOptionParser,
   CREATE_OPTION_METADATA,
+  type CommandOptionMetadataMap,
   DOCTOR_OPTION_METADATA,
   extractKnownOptionValuesFromArgv,
   formatNodeFallbackOptionHelp,
@@ -79,6 +80,11 @@ type NodeFallbackDispatchContext = {
   cwd: string;
   mergedFlags: Record<string, unknown>;
   positionals: string[];
+};
+type NodeFallbackCommandHelpConfig = {
+  bodyLines?: string[];
+  heading: string;
+  optionMetadata: CommandOptionMetadataMap;
 };
 
 const NODE_FALLBACK_OPTION_PARSER = buildCommandOptionParser(
@@ -219,98 +225,65 @@ function renderGeneralHelp() {
   ]);
 }
 
-function renderTemplatesHelp() {
+/**
+ * Render one Node fallback command help screen from shared command metadata.
+ */
+function renderNodeFallbackCommandHelp(config: NodeFallbackCommandHelpConfig) {
   printBlock([
-    'wp-typia templates <list|inspect>',
+    config.heading,
     '',
     ...NODE_FALLBACK_RUNTIME_SUMMARY_LINES,
     '',
+    ...(config.bodyLines ? [...config.bodyLines, ''] : []),
     'Supported flags:',
-    ...formatNodeFallbackOptionHelp(TEMPLATES_OPTION_METADATA),
+    ...formatNodeFallbackOptionHelp(config.optionMetadata),
   ]);
 }
 
-function renderCreateHelp() {
-  printBlock([
-    `Usage: ${WP_TYPIA_CANONICAL_CREATE_USAGE}`,
-    '',
-    ...NODE_FALLBACK_RUNTIME_SUMMARY_LINES,
-    '',
-    'Supported flags:',
-    ...formatNodeFallbackOptionHelp(CREATE_OPTION_METADATA),
-  ]);
-}
+const NODE_FALLBACK_COMMAND_HELP_CONFIG = {
+  add: {
+    bodyLines: [`Supported kinds: ${formatAddKindList()}`],
+    heading: 'Usage: wp-typia add <kind> <name>',
+    optionMetadata: ADD_OPTION_METADATA,
+  },
+  create: {
+    heading: `Usage: ${WP_TYPIA_CANONICAL_CREATE_USAGE}`,
+    optionMetadata: CREATE_OPTION_METADATA,
+  },
+  doctor: {
+    bodyLines: [
+      'Runs read-only environment readiness checks. Official wp-typia workspace roots also get inventory, source-tree drift, iframe/API v3 compatibility, and shared convention checks.',
+    ],
+    heading: 'Usage: wp-typia doctor [--format json]',
+    optionMetadata: DOCTOR_OPTION_METADATA,
+  },
+  init: {
+    bodyLines: [
+      'Preview-by-default retrofit planner for existing WordPress block or plugin projects. Re-run with --apply to write package.json updates and helper scripts.',
+    ],
+    heading: 'Usage: wp-typia init [project-dir]',
+    optionMetadata: INIT_OPTION_METADATA,
+  },
+  migrate: {
+    heading: `Usage: ${WP_TYPIA_CANONICAL_MIGRATE_USAGE}`,
+    optionMetadata: MIGRATE_OPTION_METADATA,
+  },
+  sync: {
+    heading: 'Usage: wp-typia sync [ai]',
+    optionMetadata: SYNC_OPTION_METADATA,
+  },
+  templates: {
+    heading: 'wp-typia templates <list|inspect>',
+    optionMetadata: TEMPLATES_OPTION_METADATA,
+  },
+} satisfies Record<NodeFallbackExecutableCommandName, NodeFallbackCommandHelpConfig>;
 
-function renderInitHelp() {
-  printBlock([
-    'Usage: wp-typia init [project-dir]',
-    '',
-    ...NODE_FALLBACK_RUNTIME_SUMMARY_LINES,
-    '',
-    'Preview-by-default retrofit planner for existing WordPress block or plugin projects. Re-run with --apply to write package.json updates and helper scripts.',
-    '',
-    'Supported flags:',
-    ...formatNodeFallbackOptionHelp(INIT_OPTION_METADATA),
-  ]);
-}
-
-function renderAddHelp() {
-  printBlock([
-    'Usage: wp-typia add <kind> <name>',
-    '',
-    ...NODE_FALLBACK_RUNTIME_SUMMARY_LINES,
-    '',
-    `Supported kinds: ${formatAddKindList()}`,
-    '',
-    'Supported flags:',
-    ...formatNodeFallbackOptionHelp(ADD_OPTION_METADATA),
-  ]);
-}
-
-function renderMigrateHelp() {
-  printBlock([
-    `Usage: ${WP_TYPIA_CANONICAL_MIGRATE_USAGE}`,
-    '',
-    ...NODE_FALLBACK_RUNTIME_SUMMARY_LINES,
-    '',
-    'Supported flags:',
-    ...formatNodeFallbackOptionHelp(MIGRATE_OPTION_METADATA),
-  ]);
-}
-
-function renderSyncHelp() {
-  printBlock([
-    'Usage: wp-typia sync [ai]',
-    '',
-    ...NODE_FALLBACK_RUNTIME_SUMMARY_LINES,
-    '',
-    'Supported flags:',
-    ...formatNodeFallbackOptionHelp(SYNC_OPTION_METADATA),
-  ]);
-}
-
-function renderDoctorHelp() {
-  printBlock([
-    'Usage: wp-typia doctor [--format json]',
-    '',
-    ...NODE_FALLBACK_RUNTIME_SUMMARY_LINES,
-    '',
-    'Runs read-only environment readiness checks. Official wp-typia workspace roots also get inventory, source-tree drift, iframe/API v3 compatibility, and shared convention checks.',
-    '',
-    'Supported flags:',
-    ...formatNodeFallbackOptionHelp(DOCTOR_OPTION_METADATA),
-  ]);
-}
-
-const NODE_FALLBACK_HELP_RENDERERS = {
-  add: renderAddHelp,
-  create: renderCreateHelp,
-  doctor: renderDoctorHelp,
-  init: renderInitHelp,
-  migrate: renderMigrateHelp,
-  sync: renderSyncHelp,
-  templates: renderTemplatesHelp,
-} satisfies Record<NodeFallbackExecutableCommandName, () => void>;
+const NODE_FALLBACK_HELP_RENDERERS = Object.fromEntries(
+  Object.entries(NODE_FALLBACK_COMMAND_HELP_CONFIG).map(([command, config]) => [
+    command,
+    () => renderNodeFallbackCommandHelp(config),
+  ]),
+) as Record<NodeFallbackExecutableCommandName, () => void>;
 
 function renderVersion(
   options: {

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -992,26 +992,27 @@ describe('wp-typia package', () => {
       'buildCommandOptions(TEMPLATES_OPTION_METADATA)',
     );
     expect(nodeCliSource).toMatch(/from ['"]\.\/command-option-metadata['"]/);
+    expect(nodeCliSource).toContain('renderNodeFallbackCommandHelp(config)');
     expect(nodeCliSource).toContain(
-      'formatNodeFallbackOptionHelp(CREATE_OPTION_METADATA)',
+      'optionMetadata: CREATE_OPTION_METADATA',
     );
     expect(nodeCliSource).toContain(
-      'formatNodeFallbackOptionHelp(INIT_OPTION_METADATA)',
+      'optionMetadata: INIT_OPTION_METADATA',
     );
     expect(nodeCliSource).toContain(
-      'formatNodeFallbackOptionHelp(ADD_OPTION_METADATA)',
+      'optionMetadata: ADD_OPTION_METADATA',
     );
     expect(nodeCliSource).toContain(
-      'formatNodeFallbackOptionHelp(SYNC_OPTION_METADATA)',
+      'optionMetadata: SYNC_OPTION_METADATA',
     );
     expect(nodeCliSource).toContain(
-      'formatNodeFallbackOptionHelp(DOCTOR_OPTION_METADATA)',
+      'optionMetadata: DOCTOR_OPTION_METADATA',
     );
     expect(nodeCliSource).toContain(
-      'formatNodeFallbackOptionHelp(MIGRATE_OPTION_METADATA)',
+      'optionMetadata: MIGRATE_OPTION_METADATA',
     );
     expect(nodeCliSource).toContain(
-      'formatNodeFallbackOptionHelp(TEMPLATES_OPTION_METADATA)',
+      'optionMetadata: TEMPLATES_OPTION_METADATA',
     );
   });
 

--- a/packages/wp-typia/tests/node-cli-core.test.ts
+++ b/packages/wp-typia/tests/node-cli-core.test.ts
@@ -67,11 +67,15 @@ describe('Node fallback CLI core routing', () => {
     expect(createHelp.error).toBeUndefined();
     expect(createHelp.exitCode).toBe(0);
     expect(createHelp.stdout).toContain('Usage: wp-typia create <project-dir>');
+    expect(createHelp.stdout).toContain('Runtime: Node fallback');
+    expect(createHelp.stdout).toContain('Supported flags:');
     expect(createHelp.stdout).toContain('--template');
 
     expect(commandHelp.error).toBeUndefined();
     expect(commandHelp.exitCode).toBe(0);
     expect(commandHelp.stdout).toContain('wp-typia templates <list|inspect>');
+    expect(commandHelp.stdout).toContain('Runtime: Node fallback');
+    expect(commandHelp.stdout).toContain('Supported flags:');
     expect(commandHelp.stdout).toContain('--id');
   });
 


### PR DESCRIPTION
## Summary
- add a shared Node fallback command help renderer/config
- preserve command help content while keeping runtime guidance and option metadata visible
- update representative help tests and add a patch changeset

Closes #717.

## Validation
- bun test packages/wp-typia/tests/node-cli-core.test.ts packages/wp-typia/tests/cli-package.test.ts
- bun run --filter wp-typia test
- bun run typecheck
- node scripts/check-repo-format.mjs
- node scripts/validate-sampo-changesets.mjs
- git diff --check