### PR TITLE
test(cli): expand node fallback core coverage

### DIFF
--- a/.sampo/changesets/716-node-cli-core-coverage.md
+++ b/.sampo/changesets/716-node-cli-core-coverage.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Expand Node fallback CLI core coverage for dispatch, format, config, and stderr handling.

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -102,7 +102,7 @@ const NODE_FALLBACK_RUNTIME_SUMMARY_LINES = [
   'Output markers: WP_TYPIA_ASCII=1 forces ASCII markers, WP_TYPIA_ASCII=0 opts back into Unicode markers, and non-empty NO_COLOR requests ASCII markers when WP_TYPIA_ASCII is unset.',
 ];
 
-const printLine: PrintLine = (line = '') => {
+const printLine: PrintLine = (line) => {
   console.log(line);
 };
 

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -40,6 +40,7 @@ import {
   mergeWpTypiaUserConfig,
 } from './config';
 import { extractWpTypiaConfigOverride } from './config-override';
+import type { PrintLine } from './print-line';
 import {
   executeAddCommand,
   executeCreateCommand,
@@ -101,9 +102,9 @@ const NODE_FALLBACK_RUNTIME_SUMMARY_LINES = [
   'Output markers: WP_TYPIA_ASCII=1 forces ASCII markers, WP_TYPIA_ASCII=0 opts back into Unicode markers, and non-empty NO_COLOR requests ASCII markers when WP_TYPIA_ASCII is unset.',
 ];
 
-function printLine(line = '') {
+const printLine: PrintLine = (line = '') => {
   console.log(line);
-}
+};
 
 function printBlock(lines: string[]) {
   for (const line of lines) {

--- a/packages/wp-typia/tests/node-cli-core.test.ts
+++ b/packages/wp-typia/tests/node-cli-core.test.ts
@@ -1,26 +1,64 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
 import { afterEach, describe, expect, test } from 'bun:test';
 
 import packageJson from '../package.json';
-import { runNodeCli } from '../src/node-cli';
+import { runNodeCli, runNodeCliEntrypoint } from '../src/node-cli';
 
-async function captureNodeCli(argv: string[]): Promise<{
+async function captureNodeCli(
+  argv: string[],
+  options: {
+    cwd?: string;
+    entrypoint?: boolean;
+  } = {},
+): Promise<{
   error: unknown;
   exitCode: string | number;
+  stderr: string;
   stdout: string;
 }> {
+  const originalCwd = process.cwd();
   const originalExitCode = process.exitCode;
+  const originalError = console.error;
   const originalLog = console.log;
-  const lines: string[] = [];
+  const originalStderrWrite = process.stderr.write;
+  const originalWarn = console.warn;
+  const stderr: string[] = [];
+  const stdout: string[] = [];
   let error: unknown;
 
   process.exitCode = 0;
   console.log = (...args: unknown[]) => {
-    lines.push(args.map(String).join(' '));
+    stdout.push(args.map(String).join(' '));
   };
+  console.error = (...args: unknown[]) => {
+    stderr.push(args.map(String).join(' '));
+  };
+  console.warn = (...args: unknown[]) => {
+    stderr.push(args.map(String).join(' '));
+  };
+  process.stderr.write = ((chunk: unknown, ...args: unknown[]) => {
+    stderr.push(Buffer.isBuffer(chunk) ? chunk.toString('utf8') : String(chunk));
+    const callback = args.find(
+      (arg): arg is (error?: Error | null) => void =>
+        typeof arg === 'function',
+    );
+    callback?.();
+    return true;
+  }) as typeof process.stderr.write;
 
   try {
+    if (options.cwd) {
+      process.chdir(options.cwd);
+    }
     try {
-      await runNodeCli(argv);
+      if (options.entrypoint) {
+        await runNodeCliEntrypoint(argv);
+      } else {
+        await runNodeCli(argv);
+      }
     } catch (caught) {
       error = caught;
     }
@@ -28,12 +66,31 @@ async function captureNodeCli(argv: string[]): Promise<{
     return {
       error,
       exitCode: process.exitCode ?? 0,
-      stdout: lines.join('\n'),
+      stderr: stderr.join('\n'),
+      stdout: stdout.join('\n'),
     };
   } finally {
+    if (options.cwd) {
+      process.chdir(originalCwd);
+    }
+    console.error = originalError;
     console.log = originalLog;
+    console.warn = originalWarn;
+    process.stderr.write = originalStderrWrite;
     process.exitCode = originalExitCode;
   }
+}
+
+function createTempRoot(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function removeTempRoot(tempRoot: string): void {
+  fs.rmSync(tempRoot, { force: true, recursive: true });
+}
+
+function writeJson(filePath: string, value: unknown): void {
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
 }
 
 describe('Node fallback CLI core routing', () => {
@@ -119,6 +176,191 @@ describe('Node fallback CLI core routing', () => {
     expect(parsed.data?.name).toBe('wp-typia');
     expect(parsed.data?.type).toBe('version');
     expect(parsed.data?.version).toBe(packageJson.version);
+  });
+
+  test('dispatches create dry-runs through the Node fallback runtime', async () => {
+    const tempRoot = createTempRoot('wp-typia-node-create-');
+
+    try {
+      const result = await captureNodeCli(
+        ['create', 'demo-card', '--dry-run', '--template', 'basic', '--yes'],
+        { cwd: tempRoot },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).toBe('');
+      expect(result.stdout).toContain('Dry run for Demo Card');
+      expect(result.stdout).toContain('Template: basic');
+      expect(result.stdout).toContain('No files were written');
+      expect(fs.existsSync(path.join(tempRoot, 'demo-card'))).toBe(false);
+    } finally {
+      removeTempRoot(tempRoot);
+    }
+  });
+
+  test('keeps add dispatch on stdout help and command diagnostics for missing kinds', async () => {
+    const result = await captureNodeCli(['add']);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toContain('Usage:');
+    expect(result.stdout).toContain('wp-typia add block <name>');
+    expect(result.error).toMatchObject({
+      code: 'missing-argument',
+      command: 'add',
+    });
+  });
+
+  test('dispatches init structured previews from the Node fallback runtime', async () => {
+    const tempRoot = createTempRoot('wp-typia-node-init-');
+
+    try {
+      const result = await captureNodeCli(['init', '--format', 'json'], {
+        cwd: tempRoot,
+      });
+      const parsed = JSON.parse(result.stdout) as {
+        data?: {
+          command?: string;
+          detectedLayout?: { kind?: string };
+          mode?: string;
+          packageManager?: string;
+        };
+        ok?: boolean;
+      };
+
+      expect(result.error).toBeUndefined();
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).toBe('');
+      expect(parsed.ok).toBe(true);
+      expect(parsed.data?.command).toBe('init');
+      expect(parsed.data?.mode).toBe('preview');
+      expect(parsed.data?.packageManager).toBe('npm');
+      expect(parsed.data?.detectedLayout?.kind).toBe('unsupported');
+    } finally {
+      removeTempRoot(tempRoot);
+    }
+  });
+
+  test('rejects invalid output formats before Node fallback dispatch', async () => {
+    const result = await captureNodeCli(['templates', 'list', '--format', 'jso']);
+
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toBe('');
+    expect(result.error).toMatchObject({
+      code: 'invalid-argument',
+      command: 'templates',
+    });
+    expect(result.error).toBeInstanceOf(Error);
+    expect((result.error as Error).message).toContain(
+      'Invalid --format value "jso". Supported values: json, text.',
+    );
+  });
+
+  test('emits structured command output when --format json is explicit', async () => {
+    const tempRoot = createTempRoot('wp-typia-node-json-create-');
+
+    try {
+      const result = await captureNodeCli(
+        [
+          'create',
+          'json-card',
+          '--dry-run',
+          '--template',
+          'basic',
+          '--yes',
+          '--format',
+          'json',
+        ],
+        { cwd: tempRoot },
+      );
+      const parsed = JSON.parse(result.stdout) as {
+        data?: {
+          command?: string;
+          dryRun?: boolean;
+          files?: string[];
+          template?: string;
+        };
+        ok?: boolean;
+      };
+
+      expect(result.error).toBeUndefined();
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).toBe('');
+      expect(parsed.ok).toBe(true);
+      expect(parsed.data?.command).toBe('create');
+      expect(parsed.data?.dryRun).toBe(true);
+      expect(parsed.data?.template).toBe('basic');
+      expect(parsed.data?.files).toContain('src/block.json');
+    } finally {
+      removeTempRoot(tempRoot);
+    }
+  });
+
+  test('applies --config overrides before dispatching create defaults', async () => {
+    const tempRoot = createTempRoot('wp-typia-node-config-create-');
+    writeJson(path.join(tempRoot, 'wp-typia.config.json'), {
+      create: {
+        'dry-run': true,
+        'package-manager': 'pnpm',
+        template: 'interactivity',
+        yes: true,
+      },
+    });
+
+    try {
+      const result = await captureNodeCli(
+        [
+          'create',
+          'config-card',
+          '--config',
+          'wp-typia.config.json',
+          '--format',
+          'json',
+        ],
+        { cwd: tempRoot },
+      );
+      const parsed = JSON.parse(result.stdout) as {
+        data?: {
+          completion?: { summaryLines?: string[] };
+          dryRun?: boolean;
+          files?: string[];
+          template?: string;
+        };
+        ok?: boolean;
+      };
+
+      expect(result.error).toBeUndefined();
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).toBe('');
+      expect(parsed.ok).toBe(true);
+      expect(parsed.data?.dryRun).toBe(true);
+      expect(parsed.data?.template).toBe('interactivity');
+      expect(parsed.data?.completion?.summaryLines).toContain(
+        'Package manager: pnpm',
+      );
+      expect(parsed.data?.files).toContain('src/interactivity.ts');
+    } finally {
+      removeTempRoot(tempRoot);
+    }
+  });
+
+  test('captures structured entrypoint errors on stderr', async () => {
+    const result = await captureNodeCli(['create', '--format', 'json'], {
+      entrypoint: true,
+    });
+    const parsed = JSON.parse(result.stderr) as {
+      error?: { code?: string; command?: string; kind?: string };
+      ok?: boolean;
+    };
+
+    expect(result.error).toBeUndefined();
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe('');
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error?.kind).toBe('command-execution');
+    expect(parsed.error?.command).toBe('create');
+    expect(parsed.error?.code).toBe('missing-argument');
   });
 
   test('keeps Bun-only top-level commands on the unsupported-command diagnostic path', async () => {


### PR DESCRIPTION
## Summary
- extend the Node fallback CLI capture helper to collect stdout and stderr
- add focused core tests for create/add/init dispatch, invalid format handling, structured JSON output, config overrides, and entrypoint stderr errors
- wire node-cli output through the shared PrintLine type and add a patch changeset

Closes #716.

## Validation
- bun test packages/wp-typia/tests/node-cli-core.test.ts
- bun run --filter wp-typia test
- bun run typecheck
- node scripts/check-repo-format.mjs
- node scripts/validate-sampo-changesets.mjs
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded Node CLI core test coverage to validate command behaviors including dry-runs, structured output formatting, configuration overrides, and error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->