### PR TITLE
refactor(add): reuse php snippet mutation helpers

### DIFF
--- a/.sampo/changesets/714-php-snippet-mutation-helpers.md
+++ b/.sampo/changesets/714-php-snippet-mutation-helpers.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Route workspace add PHP bootstrap patching through shared snippet mutation helpers.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai-anchors.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai-anchors.ts
@@ -6,6 +6,10 @@ import {
 	getWorkspaceBootstrapPath,
 	patchFile,
 } from "./cli-add-shared.js";
+import {
+	appendPhpSnippetBeforeClosingTag,
+	insertPhpSnippetBeforeWorkspaceAnchors,
+} from "./cli-add-workspace-mutation.js";
 import { hasPhpFunctionDefinition } from "./php-utils.js";
 import type { WorkspaceProject } from "./workspace-project.js";
 
@@ -31,31 +35,8 @@ function ${registerFunctionName}() {
 \t}
 }
 `;
-		const insertionAnchors = [
-			/add_action\(\s*["']init["']\s*,\s*["'][^"']+_load_textdomain["']\s*\);\s*\n/u,
-			/\?>\s*$/u,
-		];
-		const insertPhpSnippet = (snippet: string): void => {
-			for (const anchor of insertionAnchors) {
-				const candidate = nextSource.replace(anchor, (match) => `${snippet}\n${match}`);
-				if (candidate !== nextSource) {
-					nextSource = candidate;
-					return;
-				}
-			}
-			nextSource = `${nextSource.trimEnd()}\n${snippet}\n`;
-		};
-		const appendPhpSnippet = (snippet: string): void => {
-			const closingTagPattern = /\?>\s*$/u;
-			if (closingTagPattern.test(nextSource)) {
-				nextSource = nextSource.replace(closingTagPattern, `${snippet}\n?>`);
-				return;
-			}
-			nextSource = `${nextSource.trimEnd()}\n${snippet}\n`;
-		};
-
 		if (!hasPhpFunctionDefinition(nextSource, registerFunctionName)) {
-			insertPhpSnippet(registerFunction);
+			nextSource = insertPhpSnippetBeforeWorkspaceAnchors(nextSource, registerFunction);
 		} else if (!nextSource.includes(AI_FEATURE_SERVER_GLOB)) {
 			throw new Error(
 				[
@@ -67,7 +48,7 @@ function ${registerFunctionName}() {
 		}
 
 		if (!nextSource.includes(registerHook)) {
-			appendPhpSnippet(registerHook);
+			nextSource = appendPhpSnippetBeforeClosingTag(nextSource, registerHook);
 		}
 
 		return nextSource;

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-assets.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-assets.ts
@@ -41,6 +41,10 @@ import {
 	type WorkspaceMutationSnapshot,
 	snapshotWorkspaceFiles,
 } from "./cli-add-shared.js";
+import {
+	appendPhpSnippetBeforeClosingTag,
+	insertPhpSnippetBeforeWorkspaceAnchors,
+} from "./cli-add-workspace-mutation.js";
 import { normalizeOptionalCliString } from "./cli-validation.js";
 
 const PATTERN_BOOTSTRAP_CATEGORY = "register_block_pattern_category";
@@ -783,41 +787,30 @@ function ${bindingEditorEnqueueFunctionName}() {
 }
 `;
 
-		const insertionAnchors = [
-			/add_action\(\s*["']init["']\s*,\s*["'][^"']+_load_textdomain["']\s*\);\s*\n/u,
-			/\?>\s*$/u,
-		];
-		const insertPhpSnippet = (snippet: string): void => {
-			for (const anchor of insertionAnchors) {
-				const candidate = nextSource.replace(anchor, (match) => `${snippet}\n${match}`);
-				if (candidate !== nextSource) {
-					nextSource = candidate;
-					return;
-				}
-			}
-			nextSource = `${nextSource.trimEnd()}\n${snippet}\n`;
-		};
-		const appendPhpSnippet = (snippet: string): void => {
-			const closingTagPattern = /\?>\s*$/u;
-			if (closingTagPattern.test(nextSource)) {
-				nextSource = nextSource.replace(closingTagPattern, `${snippet}\n?>`);
-				return;
-			}
-			nextSource = `${nextSource.trimEnd()}\n${snippet}\n`;
-		};
-
 		if (!hasPhpFunctionDefinition(nextSource, bindingRegistrationFunctionName)) {
-			insertPhpSnippet(bindingRegistrationFunction);
+			nextSource = insertPhpSnippetBeforeWorkspaceAnchors(
+				nextSource,
+				bindingRegistrationFunction,
+			);
 		}
 		if (!hasPhpFunctionDefinition(nextSource, bindingEditorEnqueueFunctionName)) {
-			insertPhpSnippet(bindingEditorEnqueueFunction);
+			nextSource = insertPhpSnippetBeforeWorkspaceAnchors(
+				nextSource,
+				bindingEditorEnqueueFunction,
+			);
 		}
 
 		if (!nextSource.includes(bindingRegistrationHook)) {
-			appendPhpSnippet(bindingRegistrationHook);
+			nextSource = appendPhpSnippetBeforeClosingTag(
+				nextSource,
+				bindingRegistrationHook,
+			);
 		}
 		if (!nextSource.includes(bindingEditorEnqueueHook)) {
-			appendPhpSnippet(bindingEditorEnqueueHook);
+			nextSource = appendPhpSnippetBeforeClosingTag(
+				nextSource,
+				bindingEditorEnqueueHook,
+			);
 		}
 
 		return nextSource;
@@ -871,31 +864,8 @@ function ${enqueueFunctionName}() {
 }
 `;
 
-		const insertionAnchors = [
-			/add_action\(\s*["']init["']\s*,\s*["'][^"']+_load_textdomain["']\s*\);\s*\n/u,
-			/\?>\s*$/u,
-		];
-		const insertPhpSnippet = (snippet: string): void => {
-			for (const anchor of insertionAnchors) {
-				const candidate = nextSource.replace(anchor, (match) => `${snippet}\n${match}`);
-				if (candidate !== nextSource) {
-					nextSource = candidate;
-					return;
-				}
-			}
-			nextSource = `${nextSource.trimEnd()}\n${snippet}\n`;
-		};
-		const appendPhpSnippet = (snippet: string): void => {
-			const closingTagPattern = /\?>\s*$/u;
-			if (closingTagPattern.test(nextSource)) {
-				nextSource = nextSource.replace(closingTagPattern, `${snippet}\n?>`);
-				return;
-			}
-			nextSource = `${nextSource.trimEnd()}\n${snippet}\n`;
-		};
-
 		if (!hasPhpFunctionDefinition(nextSource, enqueueFunctionName)) {
-			insertPhpSnippet(enqueueFunction);
+			nextSource = insertPhpSnippetBeforeWorkspaceAnchors(nextSource, enqueueFunction);
 		} else {
 			const requiredReferences = [
 				EDITOR_PLUGIN_EDITOR_SCRIPT,
@@ -927,7 +897,7 @@ function ${enqueueFunctionName}() {
 		}
 
 		if (!nextSource.includes(enqueueHook)) {
-			appendPhpSnippet(enqueueHook);
+			nextSource = appendPhpSnippetBeforeClosingTag(nextSource, enqueueHook);
 		}
 
 		return nextSource;

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest-anchors.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest-anchors.ts
@@ -4,6 +4,10 @@ import {
 	getWorkspaceBootstrapPath,
 	patchFile,
 } from "./cli-add-shared.js";
+import {
+	appendPhpSnippetBeforeClosingTag,
+	insertPhpSnippetBeforeWorkspaceAnchors,
+} from "./cli-add-workspace-mutation.js";
 import { hasPhpFunctionDefinition } from "./php-utils.js";
 import type { WorkspaceProject } from "./workspace-project.js";
 
@@ -26,31 +30,8 @@ function ${registerFunctionName}() {
 \t}
 }
 `;
-		const insertionAnchors = [
-			/add_action\(\s*["']init["']\s*,\s*["'][^"']+_load_textdomain["']\s*\);\s*\n/u,
-			/\?>\s*$/u,
-		];
-		const insertPhpSnippet = (snippet: string): void => {
-			for (const anchor of insertionAnchors) {
-				const candidate = nextSource.replace(anchor, (match) => `${snippet}\n${match}`);
-				if (candidate !== nextSource) {
-					nextSource = candidate;
-					return;
-				}
-			}
-			nextSource = `${nextSource.trimEnd()}\n${snippet}\n`;
-		};
-		const appendPhpSnippet = (snippet: string): void => {
-			const closingTagPattern = /\?>\s*$/u;
-			if (closingTagPattern.test(nextSource)) {
-				nextSource = nextSource.replace(closingTagPattern, `${snippet}\n?>`);
-				return;
-			}
-			nextSource = `${nextSource.trimEnd()}\n${snippet}\n`;
-		};
-
 		if (!hasPhpFunctionDefinition(nextSource, registerFunctionName)) {
-			insertPhpSnippet(registerFunction);
+			nextSource = insertPhpSnippetBeforeWorkspaceAnchors(nextSource, registerFunction);
 		} else if (!nextSource.includes(REST_RESOURCE_SERVER_GLOB)) {
 			throw new Error(
 				[
@@ -62,7 +43,7 @@ function ${registerFunctionName}() {
 		}
 
 		if (!nextSource.includes(registerHook)) {
-			appendPhpSnippet(registerHook);
+			nextSource = appendPhpSnippetBeforeClosingTag(nextSource, registerHook);
 		}
 
 		return nextSource;

--- a/packages/wp-typia-project-tools/tests/cli-add-workspace-boundaries.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-add-workspace-boundaries.test.ts
@@ -61,6 +61,10 @@ test('cli-add-workspace delegates asset, rest-resource, ai-feature, and admin-vi
     path.join(runtimeRoot, 'cli-add-workspace-admin-view-scaffold.ts'),
     'utf8',
   );
+  const mutationSource = fs.readFileSync(
+    path.join(runtimeRoot, 'cli-add-workspace-mutation.ts'),
+    'utf8',
+  );
 
   expect(addWorkspaceSource).toContain(
     'from "./cli-add-workspace-admin-view.js"',
@@ -228,5 +232,19 @@ test('cli-add-workspace delegates asset, rest-resource, ai-feature, and admin-vi
     expect(scaffoldSource).toContain('executeWorkspaceMutationPlan');
     expect(scaffoldSource).not.toContain('rollbackWorkspaceMutation');
     expect(scaffoldSource).not.toContain('snapshotWorkspaceFiles');
+  }
+  expect(mutationSource).toContain('insertPhpSnippetBeforeWorkspaceAnchors');
+  expect(mutationSource).toContain('appendPhpSnippetBeforeClosingTag');
+  for (const bootstrapAnchorSource of [
+    aiAnchorsSource,
+    restAnchorsSource,
+    assetsSource,
+  ]) {
+    expect(bootstrapAnchorSource).toContain(
+      'insertPhpSnippetBeforeWorkspaceAnchors',
+    );
+    expect(bootstrapAnchorSource).toContain('appendPhpSnippetBeforeClosingTag');
+    expect(bootstrapAnchorSource).not.toContain('const insertPhpSnippet');
+    expect(bootstrapAnchorSource).not.toContain('const appendPhpSnippet');
   }
 });

--- a/packages/wp-typia-project-tools/tests/cli-add-workspace-mutation.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-add-workspace-mutation.test.ts
@@ -125,6 +125,17 @@ describe("workspace PHP snippet helpers", () => {
 		);
 	});
 
+	test("inserts snippets before closing tags when textdomain anchors are absent", () => {
+		const source = "<?php\n?>\n";
+
+		expect(
+			insertPhpSnippetBeforeWorkspaceAnchors(
+				source,
+				"function demo_register_rest_resources() {}",
+			),
+		).toBe("<?php\nfunction demo_register_rest_resources() {}\n?>\n");
+	});
+
 	test("appends snippets before closing tags", () => {
 		const source = "<?php\n?>\n";
 


### PR DESCRIPTION
## Summary
- migrate AI and REST workspace bootstrap patchers to the shared PHP snippet mutation helpers
- migrate binding-source and editor-plugin bootstrap patchers away from local snippet closures
- add boundary/helper coverage so anchor insertion and closing-tag append behavior stay centralized
- add a project-tools patch changeset

Closes #714.

## Validation
- bun test packages/wp-typia-project-tools/tests/cli-add-workspace-mutation.test.ts packages/wp-typia-project-tools/tests/cli-add-workspace-boundaries.test.ts
- bun test packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
- bun run --filter @wp-typia/project-tools test
- bun run typecheck
- node scripts/check-repo-format.mjs
- node scripts/validate-sampo-changesets.mjs
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated PHP code snippet injection logic into shared helper functions for improved consistency and maintainability across workspace bootstrap operations.

* **Tests**
  * Added test coverage to verify proper usage of shared PHP mutation helpers and prevent duplication of injection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->