### PR TITLE
ci(release): publish dataviews through oidc

### DIFF
--- a/.sampo/changesets/747-dataviews-oidc-publish.md
+++ b/.sampo/changesets/747-dataviews-oidc-publish.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/dataviews: patch
+---
+
+Include @wp-typia/dataviews in the automated npm OIDC publish workflow.

--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ If you want to see the “everything included” shape of `wp-typia`, start with
 - [`@wp-typia/block-types`](https://www.npmjs.com/package/@wp-typia/block-types)
 - [`@wp-typia/rest`](https://www.npmjs.com/package/@wp-typia/rest)
 - [`@wp-typia/api-client`](https://www.npmjs.com/package/@wp-typia/api-client)
+- [`@wp-typia/dataviews`](https://www.npmjs.com/package/@wp-typia/dataviews) as the opt-in DataViews compatibility contract for generated admin screens
 - [`@wp-typia/block-runtime`](https://www.npmjs.com/package/@wp-typia/block-runtime) as the current graduation prototype for defaults/editor/validation helpers
 
 ## Project Structure
@@ -333,6 +334,7 @@ wp-typia/
 │   ├── create-workspace-template/ # Official empty workspace template package
 │   ├── wp-typia-api-client/    # Backend-neutral generated API client runtime
 │   ├── wp-typia-block-runtime/ # Prototype block runtime facade package
+│   ├── wp-typia-dataviews/     # Opt-in DataViews compatibility contract
 │   ├── wp-typia-rest/          # Typed REST client helpers
 │   └── wp-typia-block-types/   # Shared semantic block types
 ├── examples/

--- a/apps/docs/src/content/docs/guides/architecture.md
+++ b/apps/docs/src/content/docs/guides/architecture.md
@@ -18,6 +18,8 @@ title: 'Architecture'
   Shared WordPress semantic types for generated projects.
 - `packages/wp-typia-rest`
   Shared TypeScript REST helpers for data-backed blocks.
+- `packages/wp-typia-dataviews`
+  Opt-in DataViews compatibility contracts for generated admin screens.
 
 ### 2. Reference app
 

--- a/apps/docs/src/content/docs/maintainers/package-graduation.md
+++ b/apps/docs/src/content/docs/maintainers/package-graduation.md
@@ -12,6 +12,8 @@ This document records the current package-boundary recommendation.
   Programmatic project orchestration package.
 - `@wp-typia/block-runtime`
   Normative generated-project runtime helper package.
+- `@wp-typia/dataviews`
+  Opt-in DataViews compatibility contract package for generated admin screens.
 
 ## Why this split
 
@@ -49,4 +51,5 @@ Kept in `@wp-typia/block-runtime`:
 The old `@wp-typia/create` and `create-wp-typia` package shells are no longer
 kept in-repo. Current package-boundary docs should point directly at
 `wp-typia`, `@wp-typia/project-tools`, `@wp-typia/block-runtime`, and
-`@wp-typia/create-workspace-template`.
+`@wp-typia/create-workspace-template`, with `@wp-typia/dataviews` as the
+opt-in admin screen compatibility package.

--- a/apps/docs/src/content/docs/reference/api.md
+++ b/apps/docs/src/content/docs/reference/api.md
@@ -68,6 +68,9 @@ secondary imports compared with the core package roots and primary subpaths.
   React-facing inspector helpers for manifest-driven editor controls.
 - `@wp-typia/block-runtime/json-utils`
   JSON cloning helpers used by manifest and projection utilities.
+- `@wp-typia/dataviews`
+  Opt-in generated admin screen compatibility contracts for WordPress
+  DataViews and DataForm integrations.
 - `@wp-typia/api-client/internal/runtime-primitives`
   Advanced/internal validation normalization helpers shared by transport
   adapters.

--- a/packages/wp-typia-project-tools/tests/package-versions.test.ts
+++ b/packages/wp-typia-project-tools/tests/package-versions.test.ts
@@ -192,6 +192,12 @@ describe('package version cache invalidation', () => {
         'utf8',
       ),
     ) as { version?: string };
+    expect(typeof dataViewsPackageJson.version).toBe('string');
+    if (typeof dataViewsPackageJson.version !== 'string') {
+      throw new Error(
+        'packages/wp-typia-dataviews/package.json is missing a string "version".',
+      );
+    }
 
     expect(DEFAULT_WORDPRESS_ABILITIES_VERSION).toBe('^0.10.0');
     expect(DEFAULT_WORDPRESS_CORE_ABILITIES_VERSION).toBe('^0.9.0');

--- a/packages/wp-typia-project-tools/tests/package-versions.test.ts
+++ b/packages/wp-typia-project-tools/tests/package-versions.test.ts
@@ -180,13 +180,27 @@ describe('package version cache invalidation', () => {
       ),
       'utf8',
     );
+    const dataViewsPackageJson = JSON.parse(
+      fs.readFileSync(
+        path.join(
+          import.meta.dir,
+          '..',
+          '..',
+          'wp-typia-dataviews',
+          'package.json',
+        ),
+        'utf8',
+      ),
+    ) as { version?: string };
 
     expect(DEFAULT_WORDPRESS_ABILITIES_VERSION).toBe('^0.10.0');
     expect(DEFAULT_WORDPRESS_CORE_ABILITIES_VERSION).toBe('^0.9.0');
     expect(DEFAULT_WORDPRESS_CORE_DATA_VERSION).toBe('^7.44.0');
     expect(DEFAULT_WORDPRESS_DATA_VERSION).toBe('^9.28.0');
     expect(DEFAULT_WORDPRESS_DATAVIEWS_VERSION).toBe('^14.1.0');
-    expect(DEFAULT_WP_TYPIA_DATAVIEWS_VERSION).toBe('^0.1.0');
+    expect(DEFAULT_WP_TYPIA_DATAVIEWS_VERSION).toBe(
+      `^${dataViewsPackageJson.version}`,
+    );
     expect(abilityScaffoldSource).not.toContain(
       'const WP_ABILITIES_PACKAGE_VERSION',
     );

--- a/scripts/publish-oidc.sh
+++ b/scripts/publish-oidc.sh
@@ -7,6 +7,7 @@ DRY_RUN="${DRY_RUN:-0}"
 
 PACKAGES=(
   "packages/wp-typia-block-types"
+  "packages/wp-typia-dataviews"
   "packages/wp-typia-api-client"
   "packages/wp-typia-rest"
   "packages/wp-typia-block-runtime"

--- a/scripts/run-publish-install-smoke.mjs
+++ b/scripts/run-publish-install-smoke.mjs
@@ -19,6 +19,7 @@ const PACKAGE_CHAIN = [
 	["packages/wp-typia-api-client", "@wp-typia/api-client"],
 	["packages/wp-typia-rest", "@wp-typia/rest"],
 	["packages/wp-typia-block-types", "@wp-typia/block-types"],
+	["packages/wp-typia-dataviews", "@wp-typia/dataviews"],
 	["packages/wp-typia-block-runtime", "@wp-typia/block-runtime"],
 	["packages/wp-typia-project-tools", "@wp-typia/project-tools"],
 	["packages/wp-typia", "wp-typia"],
@@ -27,6 +28,7 @@ const GENERATED_PROJECT_OVERRIDE_PACKAGES = [
 	"@wp-typia/api-client",
 	"@wp-typia/rest",
 	"@wp-typia/block-types",
+	"@wp-typia/dataviews",
 	"@wp-typia/block-runtime",
 ];
 const npmCommand = getNpmCommand();
@@ -197,6 +199,7 @@ withTempDir("wp-typia-publish-install-smoke-", (tempRoot) => {
 	fs.mkdirSync(projectDir, { recursive: true });
 	writeJson(path.join(projectDir, "package.json"), {
 		dependencies: {
+			"@wp-typia/dataviews": `file:${tarballs.get("@wp-typia/dataviews")}`,
 			"wp-typia": `file:${tarballs.get("wp-typia")}`,
 		},
 		name: "wp-typia-publish-install-smoke",
@@ -275,6 +278,23 @@ withTempDir("wp-typia-publish-install-smoke-", (tempRoot) => {
 			'\tif (typeof value !== "function") {',
 			'\t\tthrow new Error(`Expected ${name} to be a function export.`);',
 			"\t}",
+			"}",
+			"",
+		].join("\n"),
+	);
+
+	runScript(
+		projectDir,
+		"node",
+		"dataviews-export-smoke.mjs",
+		[
+			'import { DATAVIEWS_FIELD_TYPES, DATAVIEWS_LAYOUT_TYPES } from "@wp-typia/dataviews";',
+			"",
+			'if (!DATAVIEWS_LAYOUT_TYPES.includes("table")) {',
+			'\tthrow new Error("Expected @wp-typia/dataviews to publish DataViews layout constants.");',
+			"}",
+			'if (!DATAVIEWS_FIELD_TYPES.includes("text")) {',
+			'\tthrow new Error("Expected @wp-typia/dataviews to publish DataViews field constants.");',
 			"}",
 			"",
 		].join("\n"),
@@ -431,7 +451,7 @@ withTempDir("wp-typia-publish-install-smoke-", (tempRoot) => {
 	typecheckGeneratedProject(compoundDir);
 
 	process.stdout.write(
-		`Verified published-install smoke for wp-typia ${parsed.data.version}, bundled Bunli metadata, runtime wrapper exports, block-runtime metadata sync, project-tools runtime paths, and generated basic/compound scaffold installs.\n`,
+		`Verified published-install smoke for wp-typia ${parsed.data.version}, bundled Bunli metadata, dataviews exports, runtime wrapper exports, block-runtime metadata sync, project-tools runtime paths, and generated basic/compound scaffold installs.\n`,
 	);
 });
 


### PR DESCRIPTION
## Summary
- add @wp-typia/dataviews to the npm OIDC publish package list
- include dataviews in the publish/install smoke path and verify runtime exports
- align generated admin-view fallback dependency checks with the dataviews package version
- document dataviews in manual package maps and add a dataviews patch changeset

Closes #747

## Validation
- node scripts/validate-publish-oidc-packages.mjs
- bun test packages/wp-typia-project-tools/tests/package-versions.test.ts
- node scripts/validate-sampo-changesets.mjs
- npm view @wp-typia/dataviews version --json --registry https://registry.npmjs.org/
- bun run test:publish-install-smoke
- node scripts/check-repo-format.mjs
- git diff --check
- bun run typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `@wp-typia/dataviews` package is now included in the automated npm OIDC publish workflow for releases.

* **Documentation**
  * Updated documentation across architecture guides, API reference, and package graduation materials to reflect the new DataViews compatibility package for generated admin screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->