### PR TITLE
fix(add): enable public admin-view scaffolds

### DIFF
--- a/.sampo/changesets/746-admin-view-public-availability.md
+++ b/.sampo/changesets/746-admin-view-public-availability.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Enable public npm admin-view scaffolds now that @wp-typia/dataviews is published.

--- a/apps/docs/src/content/docs/reference/cli.md
+++ b/apps/docs/src/content/docs/reference/cli.md
@@ -225,8 +225,8 @@ attribute end to end.
 
 Admin-view scaffolds can optionally bind to a generated data source with
 `--source`. For example, `rest-resource:products` points at a matching
-`wp-typia add rest-resource products` scaffold. Published npm installs
-currently gate `admin-view` scaffolds until `@wp-typia/dataviews` is published.
+`wp-typia add rest-resource products` scaffold. Published npm installs can
+scaffold `admin-view` now that `@wp-typia/dataviews` is available on npm.
 The first core-data wave also accepts `core-data:postType/<post-type>` and
 `core-data:taxonomy/<taxonomy>` for WordPress-owned entity collections. That
 path adds direct `@wordpress/core-data` and `@wordpress/data` dependencies only

--- a/apps/docs/src/content/docs/reference/dataviews.md
+++ b/apps/docs/src/content/docs/reference/dataviews.md
@@ -164,10 +164,9 @@ wp-typia add admin-view products --source rest-resource:products
 wp-typia add admin-view posts --source core-data:postType/post
 ```
 
-Current public CLI releases gate `wp-typia add admin-view` until
-`@wp-typia/dataviews` is published to npm. Until that package is publicly
-available, treat the examples below as the intended scaffold shape rather than a
-workflow that is installable from npm today.
+Public CLI installs can run `wp-typia add admin-view` now that
+`@wp-typia/dataviews` is available on npm. The examples below are installable
+from npm and keep DataViews dependencies opt-in for generated workspaces.
 
 The scaffold writes `src/admin-views/<name>/` plus
 `inc/admin-views/<name>.php`, adds `@wp-typia/dataviews` and

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-help.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-help.ts
@@ -35,7 +35,7 @@ Notes:
   \`add admin-view\` scaffolds an opt-in DataViews-powered WordPress admin screen under \`src/admin-views/\`.
   Pass \`--source rest-resource:<slug>\` to reuse a list-capable REST resource.
   Pass \`--source core-data:postType/post\` or \`--source core-data:taxonomy/category\` to bind a WordPress-owned entity collection.
-  Public installs currently gate this workflow until \`@wp-typia/dataviews\` is published to npm.
+  Generated admin-view workspaces add \`@wp-typia/dataviews\` and the needed WordPress DataViews packages as opt-in dependencies.
   \`query-loop\` is a create-time scaffold family. Use \`wp-typia create <project-dir> --template query-loop\` instead of \`wp-typia add block\`.
   \`add variation\` targets an existing block slug from \`scripts/block-config.ts\`.
   \`add style\` registers a Block Styles option for an existing generated block.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-admin-view-source.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-admin-view-source.ts
@@ -13,7 +13,13 @@ import {
   type AdminViewSource,
 } from './cli-add-workspace-admin-view-types.js';
 
-// Keep the pre-write availability seam even though public npm installs are now enabled.
+/**
+ * Assert that admin-view package dependencies are available before file writes.
+ *
+ * This is a no-op while `@wp-typia/dataviews` is publicly available on npm.
+ * The exported seam is retained so future availability checks can stay
+ * centralized ahead of scaffold mutations.
+ */
 export function assertAdminViewPackageAvailability(): void {
   return;
 }

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-admin-view-source.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-admin-view-source.ts
@@ -1,15 +1,9 @@
 import { assertValidGeneratedSlug } from './cli-add-shared.js';
 import {
-  CLI_DIAGNOSTIC_CODES,
-  createCliDiagnosticCodeError,
-} from './cli-diagnostics.js';
-import {
-  ADMIN_VIEW_ALLOW_UNPUBLISHED_DATAVIEWS_ENV,
   ADMIN_VIEW_CORE_DATA_ENTITY_KIND_IDS,
   ADMIN_VIEW_CORE_DATA_ENTITY_NAME_PATTERN,
   ADMIN_VIEW_CORE_DATA_ENTITY_SEGMENT_PATTERN,
   ADMIN_VIEW_CORE_DATA_SOURCE_KIND,
-  ADMIN_VIEW_PUBLIC_INSTALLS_ENABLED,
   ADMIN_VIEW_REST_SOURCE_KIND,
   ADMIN_VIEW_SOURCE_USAGE,
   isAdminViewCoreDataSource,
@@ -19,24 +13,9 @@ import {
   type AdminViewSource,
 } from './cli-add-workspace-admin-view-types.js';
 
-function isAdminViewUnpublishedDataViewsOverrideEnabled(): boolean {
-  return (
-    process.env[ADMIN_VIEW_ALLOW_UNPUBLISHED_DATAVIEWS_ENV]?.trim() === '1'
-  );
-}
-
+// Keep the pre-write availability seam even though public npm installs are now enabled.
 export function assertAdminViewPackageAvailability(): void {
-  if (
-    isAdminViewUnpublishedDataViewsOverrideEnabled() ||
-    ADMIN_VIEW_PUBLIC_INSTALLS_ENABLED
-  ) {
-    return;
-  }
-
-  throw createCliDiagnosticCodeError(
-    CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
-    '`wp-typia add admin-view` is temporarily unavailable because `@wp-typia/dataviews` is not published to npm for public installs yet.',
-  );
+  return;
 }
 
 function assertValidCoreDataEntitySegment(

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-admin-view-types.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-admin-view-types.ts
@@ -17,10 +17,6 @@ export const ADMIN_VIEWS_ASSET = 'build/admin-views/index.asset.php';
 export const ADMIN_VIEWS_STYLE = 'build/admin-views/style-index.css';
 export const ADMIN_VIEWS_STYLE_RTL = 'build/admin-views/style-index-rtl.css';
 export const ADMIN_VIEWS_PHP_GLOB = '/inc/admin-views/*.php';
-export const ADMIN_VIEW_ALLOW_UNPUBLISHED_DATAVIEWS_ENV =
-  'WP_TYPIA_ALLOW_UNPUBLISHED_DATAVIEWS';
-// Lift this gate in the same release that publishes @wp-typia/dataviews.
-export const ADMIN_VIEW_PUBLIC_INSTALLS_ENABLED = false;
 
 export interface AdminViewRestResourceSource {
   kind: typeof ADMIN_VIEW_REST_SOURCE_KIND;

--- a/packages/wp-typia-project-tools/src/runtime/cli-help.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-help.ts
@@ -53,7 +53,7 @@ Notes:
   \`add admin-view\` scaffolds an opt-in DataViews-powered WordPress admin screen under \`src/admin-views/\`.
   Pass \`--source rest-resource:<slug>\` to reuse a list-capable REST resource.
   Pass \`--source core-data:postType/post\` or \`--source core-data:taxonomy/category\` to bind a WordPress-owned entity collection.
-  Public installs currently gate this workflow until \`@wp-typia/dataviews\` is published to npm.
+  Generated admin-view workspaces add \`@wp-typia/dataviews\` and the needed WordPress DataViews packages as opt-in dependencies.
   \`query-loop\` is create-only. Use \`wp-typia create <project-dir> --template query-loop\`; \`wp-typia add block\` accepts only basic, interactivity, persistence, and compound families.
   \`add variation\` uses an existing workspace block from \`scripts/block-config.ts\`.
   \`add style\` registers a Block Styles option for an existing generated block.

--- a/packages/wp-typia-project-tools/tests/cli-add-workspace-admin-view.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-add-workspace-admin-view.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, expect, test } from 'bun:test';
+import { expect, test } from 'bun:test';
 
 import {
   assertAdminViewPackageAvailability,
@@ -9,23 +9,9 @@ import {
   buildAdminViewTypesSource,
 } from '../src/runtime/cli-add-workspace-admin-view-templates.js';
 import {
-  ADMIN_VIEW_ALLOW_UNPUBLISHED_DATAVIEWS_ENV,
   type AdminViewCoreDataSource,
   type AdminViewRestResource,
 } from '../src/runtime/cli-add-workspace-admin-view-types.js';
-
-const originalAdminViewGateEnv =
-  process.env[ADMIN_VIEW_ALLOW_UNPUBLISHED_DATAVIEWS_ENV];
-
-afterEach(() => {
-  if (originalAdminViewGateEnv === undefined) {
-    delete process.env[ADMIN_VIEW_ALLOW_UNPUBLISHED_DATAVIEWS_ENV];
-    return;
-  }
-
-  process.env[ADMIN_VIEW_ALLOW_UNPUBLISHED_DATAVIEWS_ENV] =
-    originalAdminViewGateEnv;
-});
 
 test('admin-view source parsing accepts supported rest-resource and core-data locators', () => {
   expect(parseAdminViewSource()).toBeUndefined();
@@ -49,13 +35,7 @@ test('admin-view source parsing rejects malformed or unsupported core-data locat
   );
 });
 
-test('admin-view package availability stays gated unless the unpublished override is enabled', () => {
-  delete process.env[ADMIN_VIEW_ALLOW_UNPUBLISHED_DATAVIEWS_ENV];
-  expect(() => assertAdminViewPackageAvailability()).toThrow(
-    '`wp-typia add admin-view` is temporarily unavailable because `@wp-typia/dataviews` is not published to npm for public installs yet.',
-  );
-
-  process.env[ADMIN_VIEW_ALLOW_UNPUBLISHED_DATAVIEWS_ENV] = '1';
+test('admin-view package availability allows public npm installs', () => {
   expect(() => assertAdminViewPackageAvailability()).not.toThrow();
 });
 

--- a/packages/wp-typia-project-tools/tests/cli-entry.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-entry.test.ts
@@ -970,6 +970,9 @@ test("formatHelpText keeps migration UI flags out of external template usage", (
   expect(helpText).toContain("`query-loop` is create-only.");
   expect(helpText).toContain("wp-typia add admin-view <name>");
   expect(helpText).toContain("src/admin-views/");
+  expect(helpText).toContain("@wp-typia/dataviews");
+  expect(helpText).toContain("opt-in dependencies");
+  expect(helpText).not.toContain("Public installs currently gate");
   expect(helpText).toContain("wp-typia add ai-feature <name>");
   expect(helpText).toContain(
     "wp-typia add ai-feature <name> [--namespace <vendor/v1>]"

--- a/packages/wp-typia-project-tools/tests/workspace-add.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-add.test.ts
@@ -100,13 +100,6 @@ function replaceFixtureSource(
   return nextSource;
 }
 
-function withUnpublishedDataViewsEnv(): NodeJS.ProcessEnv {
-  return {
-    ...process.env,
-    WP_TYPIA_ALLOW_UNPUBLISHED_DATAVIEWS: "1",
-  };
-}
-
 describe("@wp-typia/project-tools workspace add", () => {
   const tempRoot = createScaffoldTempRoot("wp-typia-workspace-add-");
 
@@ -3207,8 +3200,8 @@ test("canonical CLI can add a plugin-level REST resource to an official workspac
   typecheckGeneratedProject(targetDir);
 }, 30_000);
 
-test("canonical CLI blocks admin-view scaffolds until @wp-typia/dataviews is published", async () => {
-  const targetDir = path.join(tempRoot, "demo-workspace-add-admin-view-blocked");
+test("canonical CLI can add a DataViews admin screen without an unpublished override", async () => {
+  const targetDir = path.join(tempRoot, "demo-workspace-add-admin-view-public");
 
   await scaffoldProject({
     projectDir: targetDir,
@@ -3217,34 +3210,32 @@ test("canonical CLI blocks admin-view scaffolds until @wp-typia/dataviews is pub
     noInstall: true,
     answers: {
       author: "Test Runner",
-      description: "Demo workspace add admin view blocked",
+      description: "Demo workspace add admin view public",
       namespace: "demo-space",
       phpPrefix: "demo_space",
-      slug: "demo-workspace-add-admin-view-blocked",
+      slug: "demo-workspace-add-admin-view-public",
       textDomain: "demo-space",
-      title: "Demo Workspace Add Admin View Blocked",
+      title: "Demo Workspace Add Admin View Public",
     },
   });
 
   linkWorkspaceNodeModules(targetDir);
 
-  const errorMessage = getCommandErrorMessage(() =>
-    runCli("node", [entryPath, "add", "admin-view", "snapshots"], {
-      cwd: targetDir,
-    })
-  );
+  runCli("node", [entryPath, "add", "admin-view", "snapshots"], {
+    cwd: targetDir,
+  });
   const packageJson = JSON.parse(
     fs.readFileSync(path.join(targetDir, "package.json"), "utf8")
   ) as {
+    dependencies?: Record<string, string>;
     devDependencies?: Record<string, string>;
   };
 
-  expect(errorMessage).toContain("@wp-typia/dataviews");
-  expect(errorMessage).toContain("not published to npm for public installs yet");
-  expect(packageJson.devDependencies?.["@wp-typia/dataviews"]).toBeUndefined();
+  expect(packageJson.devDependencies?.["@wp-typia/dataviews"]).toBeTruthy();
+  expect(packageJson.dependencies?.["@wordpress/dataviews"]).toBeTruthy();
   expect(
     fs.existsSync(path.join(targetDir, "src", "admin-views", "snapshots"))
-  ).toBe(false);
+  ).toBe(true);
 }, 20_000);
 
 test("canonical CLI can add a DataViews admin screen with a REST resource source", async () => {
@@ -3282,7 +3273,6 @@ test("canonical CLI can add a DataViews admin screen with a REST resource source
     ],
     {
       cwd: targetDir,
-      env: withUnpublishedDataViewsEnv(),
     }
   );
   runCli(
@@ -3297,7 +3287,6 @@ test("canonical CLI can add a DataViews admin screen with a REST resource source
     ],
     {
       cwd: targetDir,
-      env: withUnpublishedDataViewsEnv(),
     }
   );
 
@@ -3463,7 +3452,6 @@ test("canonical CLI can add a DataViews admin screen with a core-data source", a
     ],
     {
       cwd: targetDir,
-      env: withUnpublishedDataViewsEnv(),
     }
   );
 
@@ -3566,7 +3554,6 @@ test("canonical CLI can add a taxonomy core-data admin screen", async () => {
     ],
     {
       cwd: targetDir,
-      env: withUnpublishedDataViewsEnv(),
     }
   );
 
@@ -3650,7 +3637,6 @@ test("admin view core-data sources reject unsupported entity families", async ()
       ],
       {
         cwd: targetDir,
-        env: withUnpublishedDataViewsEnv(),
       }
     )
   );
@@ -3695,7 +3681,6 @@ test("admin view rest-resource sources reject extra locator segments", async () 
       ],
       {
         cwd: targetDir,
-        env: withUnpublishedDataViewsEnv(),
       }
     )
   );
@@ -3742,7 +3727,6 @@ test("admin view core-data sources reject uppercase entity names", async () => {
       ],
       {
         cwd: targetDir,
-        env: withUnpublishedDataViewsEnv(),
       }
     )
   );
@@ -3788,7 +3772,6 @@ test("admin view core-data sources accept numeric-leading entity names", async (
     ],
     {
       cwd: targetDir,
-      env: withUnpublishedDataViewsEnv(),
     }
   );
 
@@ -3857,7 +3840,6 @@ test("admin view workflow accepts formatted shared webpack entries", async () =>
 
   runCli("node", [entryPath, "add", "admin-view", "reports"], {
     cwd: targetDir,
-    env: withUnpublishedDataViewsEnv(),
   });
 
   expect(fs.readFileSync(buildScriptPath, "utf8")).toContain(

--- a/scripts/run-publish-install-smoke.mjs
+++ b/scripts/run-publish-install-smoke.mjs
@@ -81,8 +81,8 @@ function getInstalledWpTypiaCliPath(projectDir) {
 	return path.join(projectDir, "node_modules", "wp-typia", binEntry);
 }
 
-function runWpTypiaCli(projectDir, cliPath, args) {
-	return run("node", [cliPath, ...args], { cwd: projectDir });
+function runWpTypiaCli(projectDir, cliPath, args, options = {}) {
+	return run("node", [cliPath, ...args], { cwd: projectDir, ...options });
 }
 
 function materializeTarballDependencies(projectDir, tarballs) {
@@ -395,6 +395,9 @@ withTempDir("wp-typia-publish-install-smoke-", (tempRoot) => {
 		"@wp-typia/block-runtime": `^${packedManifests.get("@wp-typia/block-runtime").version}`,
 		"@wp-typia/block-types": `^${packedManifests.get("@wp-typia/block-types").version}`,
 	};
+	const adminViewExpectedRanges = {
+		"@wp-typia/dataviews": `^${packedManifests.get("@wp-typia/dataviews").version}`,
+	};
 
 	const basicDir = path.join(projectDir, "demo-basic");
 	runWpTypiaCli(projectDir, cliPath, [
@@ -419,6 +422,37 @@ withTempDir("wp-typia-publish-install-smoke-", (tempRoot) => {
 	]);
 	installGeneratedProject(basicDir, tarballs);
 	typecheckGeneratedProject(basicDir);
+
+	const adminViewDir = path.join(projectDir, "demo-admin-view");
+	runWpTypiaCli(projectDir, cliPath, [
+		"create",
+		"demo-admin-view",
+		"--template",
+		"workspace",
+		"--package-manager",
+		"npm",
+		"--namespace",
+		"smoke-space",
+		"--text-domain",
+		"smoke-space",
+		"--yes",
+		"--no-install",
+	]);
+	runWpTypiaCli(projectDir, cliPath, ["add", "admin-view", "snapshots"], {
+		cwd: adminViewDir,
+	});
+	assertScaffoldDependencyRanges(adminViewDir, adminViewExpectedRanges);
+	const adminViewPackageJson = readJson(path.join(adminViewDir, "package.json"));
+	if (typeof adminViewPackageJson.dependencies?.["@wordpress/dataviews"] !== "string") {
+		throw new Error("Generated admin-view workspace is missing @wordpress/dataviews.");
+	}
+	assertFilesExist(adminViewDir, [
+		"src/admin-views/snapshots/index.tsx",
+		"src/admin-views/snapshots/Screen.tsx",
+		"inc/admin-views/snapshots.php",
+	]);
+	installGeneratedProject(adminViewDir, tarballs);
+	typecheckGeneratedProject(adminViewDir);
 
 	const compoundDir = path.join(projectDir, "demo-compound");
 	runWpTypiaCli(projectDir, cliPath, [
@@ -451,7 +485,7 @@ withTempDir("wp-typia-publish-install-smoke-", (tempRoot) => {
 	typecheckGeneratedProject(compoundDir);
 
 	process.stdout.write(
-		`Verified published-install smoke for wp-typia ${parsed.data.version}, bundled Bunli metadata, dataviews exports, runtime wrapper exports, block-runtime metadata sync, project-tools runtime paths, and generated basic/compound scaffold installs.\n`,
+		`Verified published-install smoke for wp-typia ${parsed.data.version}, bundled Bunli metadata, dataviews exports, runtime wrapper exports, block-runtime metadata sync, project-tools runtime paths, and generated basic/admin-view/compound scaffold installs.\n`,
 	);
 });
 


### PR DESCRIPTION
## Summary
- remove the stale unpublished @wp-typia/dataviews gate from admin-view scaffolds
- update CLI help and docs to describe admin-view dependencies as public opt-in installs
- verify public npm installability with npm view/pack and extend publish-install smoke to create, install, and typecheck a generated admin-view workspace from packed packages
- keep the pre-write availability seam as a no-op and update tests around public admin-view availability

Closes #746

## Validation
- npm view @wp-typia/dataviews version --json --registry https://registry.npmjs.org/
- npm pack @wp-typia/dataviews@0.1.0 --dry-run --registry https://registry.npmjs.org/
- bun test packages/wp-typia-project-tools/tests/cli-add-workspace-admin-view.test.ts
- bun test -t "admin view|admin-view|DataViews admin" packages/wp-typia-project-tools/tests/workspace-add.test.ts
- bun test -t "formatHelpText" packages/wp-typia-project-tools/tests/cli-entry.test.ts
- bun run test:publish-install-smoke
- node scripts/check-repo-format.mjs
- git diff --check
- bun run typecheck
- node scripts/validate-publish-oidc-packages.mjs
- node scripts/validate-sampo-changesets.mjs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin View scaffolds are now available through the `wp-typia add` command in public releases. Generated workspaces include `@wp-typia/dataviews` and required WordPress DataViews packages as configurable dependencies.

* **Documentation**
  * Updated CLI reference and DataViews documentation to reflect Admin View scaffold availability in public installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->