### PR TITLE
fix(php): make function range scanning string-aware

### DIFF
--- a/.sampo/changesets/731-php-function-range-strings.md
+++ b/.sampo/changesets/731-php-function-range-strings.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Ignore PHP string and heredoc braces when repairing generated workspace bootstrap functions.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ability-scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ability-scaffold.ts
@@ -48,6 +48,7 @@ import {
 import {
 	escapeRegex,
 	findPhpFunctionRange,
+	hasPhpFunctionCall,
 	hasPhpFunctionDefinition,
 	replacePhpFunctionDefinition,
 } from "./php-utils.js";
@@ -209,7 +210,7 @@ function ${enqueueFunctionName}() {
 			const functionSource = functionRange
 				? nextSource.slice(functionRange.start, functionRange.end)
 				: "";
-			if (!functionSource.includes("wp_enqueue_script_module")) {
+			if (!hasPhpFunctionCall(functionSource, "wp_enqueue_script_module")) {
 				const replacedSource = replacePhpFunctionDefinition(
 					nextSource,
 					enqueueFunctionName,

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ability-scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ability-scaffold.ts
@@ -204,18 +204,25 @@ function ${enqueueFunctionName}() {
 				nextSource,
 				enqueueFunction,
 			);
-		} else if (
-			!findPhpFunctionRange(nextSource, enqueueFunctionName)?.source.includes(
-				"wp_enqueue_script_module",
-			)
-		) {
-			nextSource =
-				replacePhpFunctionDefinition(
+		} else {
+			const functionRange = findPhpFunctionRange(nextSource, enqueueFunctionName);
+			const functionSource = functionRange
+				? nextSource.slice(functionRange.start, functionRange.end)
+				: "";
+			if (!functionSource.includes("wp_enqueue_script_module")) {
+				const replacedSource = replacePhpFunctionDefinition(
 					nextSource,
 					enqueueFunctionName,
 					enqueueFunction,
 					{ trimReplacementStart: true },
-				) ?? nextSource;
+				);
+				if (!replacedSource) {
+					throw new Error(
+						`Unable to repair ${path.basename(bootstrapPath)} for ${enqueueFunctionName}.`,
+					);
+				}
+				nextSource = replacedSource;
+			}
 		}
 
 		if (!nextSource.includes(loadHook)) {

--- a/packages/wp-typia-project-tools/src/runtime/php-utils.ts
+++ b/packages/wp-typia-project-tools/src/runtime/php-utils.ts
@@ -252,7 +252,7 @@ export function findPhpFunctionRange(
 			index += 2;
 			continue;
 		}
-		if (character === "#") {
+		if (character === "#" && source[index + 1] !== "[") {
 			mode = "line-comment";
 			index += 1;
 			continue;

--- a/packages/wp-typia-project-tools/src/runtime/php-utils.ts
+++ b/packages/wp-typia-project-tools/src/runtime/php-utils.ts
@@ -12,6 +12,19 @@ export type ReplacePhpFunctionDefinitionOptions = PhpFunctionRangeOptions & {
 	trimReplacementStart?: boolean;
 };
 
+type PhpFunctionScanMode =
+	| "block-comment"
+	| "code"
+	| "double-quoted"
+	| "heredoc"
+	| "line-comment"
+	| "single-quoted";
+
+type PhpHeredocStart = {
+	contentStart: number;
+	delimiter: string;
+};
+
 export function escapeRegex(value: string): string {
 	return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
 }
@@ -25,6 +38,123 @@ export function hasPhpFunctionDefinition(
 	functionName: string,
 ): boolean {
 	return new RegExp(`function\\s+${escapeRegex(functionName)}\\s*\\(`, "u").test(source);
+}
+
+function isPhpIdentifierStart(character: string | undefined): boolean {
+	return /^[A-Za-z_]$/u.test(character ?? "");
+}
+
+function isPhpIdentifierPart(character: string | undefined): boolean {
+	return /^[A-Za-z0-9_]$/u.test(character ?? "");
+}
+
+function isPhpLineStart(source: string, index: number): boolean {
+	return index === 0 || source[index - 1] === "\n";
+}
+
+function isPhpHorizontalWhitespace(character: string | undefined): boolean {
+	return character === " " || character === "\t";
+}
+
+function findPhpLineBoundary(
+	source: string,
+	index: number,
+): { contentEnd: number; nextStart: number } {
+	const newlineIndex = source.indexOf("\n", index);
+	if (newlineIndex === -1) {
+		return {
+			contentEnd: source.endsWith("\r") ? source.length - 1 : source.length,
+			nextStart: source.length,
+		};
+	}
+
+	return {
+		contentEnd: source[newlineIndex - 1] === "\r" ? newlineIndex - 1 : newlineIndex,
+		nextStart: newlineIndex + 1,
+	};
+}
+
+function parsePhpHeredocStart(source: string, index: number): PhpHeredocStart | null {
+	if (!source.startsWith("<<<", index)) {
+		return null;
+	}
+
+	let cursor = index + 3;
+	while (isPhpHorizontalWhitespace(source[cursor])) {
+		cursor += 1;
+	}
+
+	const quote = source[cursor] === "'" || source[cursor] === '"' ? source[cursor] : "";
+	if (quote) {
+		cursor += 1;
+	}
+
+	if (!isPhpIdentifierStart(source[cursor])) {
+		return null;
+	}
+
+	const delimiterStart = cursor;
+	cursor += 1;
+	while (isPhpIdentifierPart(source[cursor])) {
+		cursor += 1;
+	}
+	const delimiter = source.slice(delimiterStart, cursor);
+
+	if (quote) {
+		if (source[cursor] !== quote) {
+			return null;
+		}
+		cursor += 1;
+	}
+
+	const lineBoundary = findPhpLineBoundary(source, cursor);
+	if (source.slice(cursor, lineBoundary.contentEnd).trim() !== "") {
+		return null;
+	}
+
+	return {
+		contentStart: lineBoundary.nextStart,
+		delimiter,
+	};
+}
+
+function findPhpHeredocClosingEnd(
+	source: string,
+	index: number,
+	delimiter: string,
+): number | null {
+	if (!isPhpLineStart(source, index)) {
+		return null;
+	}
+
+	let cursor = index;
+	while (isPhpHorizontalWhitespace(source[cursor])) {
+		cursor += 1;
+	}
+
+	if (!source.startsWith(delimiter, cursor)) {
+		return null;
+	}
+	cursor += delimiter.length;
+
+	if (source[cursor] === ";") {
+		cursor += 1;
+	}
+	while (isPhpHorizontalWhitespace(source[cursor])) {
+		cursor += 1;
+	}
+
+	if (source[cursor] === "\r" && source[cursor + 1] === "\n") {
+		return cursor + 2;
+	}
+	if (source[cursor] === "\n") {
+		return cursor + 1;
+	}
+	if (cursor >= source.length) {
+		return source.length;
+	}
+
+	return null;
 }
 
 export function findPhpFunctionRange(
@@ -49,13 +179,106 @@ export function findPhpFunctionRange(
 	const openBraceIndex = functionStart + openBraceOffset;
 
 	let depth = 0;
-	for (let index = openBraceIndex; index < source.length; index += 1) {
+	let mode: PhpFunctionScanMode = "code";
+	let heredocDelimiter = "";
+	let index = openBraceIndex;
+	while (index < source.length) {
 		const character = source[index];
+
+		if (mode === "heredoc") {
+			const closingEnd = findPhpHeredocClosingEnd(
+				source,
+				index,
+				heredocDelimiter,
+			);
+			if (closingEnd !== null) {
+				mode = "code";
+				heredocDelimiter = "";
+				index = closingEnd;
+				continue;
+			}
+
+			const nextLineStart = findPhpLineBoundary(source, index).nextStart;
+			if (nextLineStart <= index) {
+				return null;
+			}
+			index = nextLineStart;
+			continue;
+		}
+
+		if (mode === "single-quoted" || mode === "double-quoted") {
+			const quote = mode === "single-quoted" ? "'" : '"';
+			if (character === "\\") {
+				index += 2;
+				continue;
+			}
+			if (character === quote) {
+				mode = "code";
+			}
+			index += 1;
+			continue;
+		}
+
+		if (mode === "line-comment") {
+			if (character === "\r" || character === "\n") {
+				mode = "code";
+			}
+			index += 1;
+			continue;
+		}
+
+		if (mode === "block-comment") {
+			if (character === "*" && source[index + 1] === "/") {
+				mode = "code";
+				index += 2;
+				continue;
+			}
+			index += 1;
+			continue;
+		}
+
+		if (character === "'") {
+			mode = "single-quoted";
+			index += 1;
+			continue;
+		}
+		if (character === '"') {
+			mode = "double-quoted";
+			index += 1;
+			continue;
+		}
+		if (character === "/" && source[index + 1] === "/") {
+			mode = "line-comment";
+			index += 2;
+			continue;
+		}
+		if (character === "#") {
+			mode = "line-comment";
+			index += 1;
+			continue;
+		}
+		if (character === "/" && source[index + 1] === "*") {
+			mode = "block-comment";
+			index += 2;
+			continue;
+		}
+		if (character === "<") {
+			const heredocStart = parsePhpHeredocStart(source, index);
+			if (heredocStart) {
+				mode = "heredoc";
+				heredocDelimiter = heredocStart.delimiter;
+				index = heredocStart.contentStart;
+				continue;
+			}
+		}
+
 		if (character === "{") {
 			depth += 1;
+			index += 1;
 			continue;
 		}
 		if (character !== "}") {
+			index += 1;
 			continue;
 		}
 		depth -= 1;
@@ -72,6 +295,7 @@ export function findPhpFunctionRange(
 				start: functionStart,
 			};
 		}
+		index += 1;
 	}
 
 	return null;

--- a/packages/wp-typia-project-tools/src/runtime/php-utils.ts
+++ b/packages/wp-typia-project-tools/src/runtime/php-utils.ts
@@ -56,6 +56,34 @@ function isPhpHorizontalWhitespace(character: string | undefined): boolean {
 	return character === " " || character === "\t";
 }
 
+function isPhpWhitespace(character: string | undefined): boolean {
+	return typeof character === "string" && /\s/u.test(character);
+}
+
+function isPhpHeredocContinuation(character: string | undefined): boolean {
+	return (
+		character === ";" ||
+		character === "," ||
+		character === ")" ||
+		character === "]" ||
+		character === "}" ||
+		character === "." ||
+		character === "?" ||
+		character === ":" ||
+		character === "+" ||
+		character === "-" ||
+		character === "*" ||
+		character === "/" ||
+		character === "%" ||
+		character === "|" ||
+		character === "&" ||
+		character === "^" ||
+		character === "=" ||
+		character === "<" ||
+		character === ">"
+	);
+}
+
 function findPhpLineBoundary(
 	source: string,
 	index: number,
@@ -137,26 +165,168 @@ function findPhpHeredocClosingEnd(
 	}
 	cursor += delimiter.length;
 
-	if (source[cursor] === ";") {
-		cursor += 1;
-	}
-	while (isPhpHorizontalWhitespace(source[cursor])) {
-		cursor += 1;
+	if (isPhpIdentifierPart(source[cursor])) {
+		return null;
 	}
 
-	if (source[cursor] === "\r" && source[cursor + 1] === "\n") {
-		return cursor + 2;
+	let continuationCursor = cursor;
+	while (isPhpHorizontalWhitespace(source[continuationCursor])) {
+		continuationCursor += 1;
 	}
-	if (source[cursor] === "\n") {
-		return cursor + 1;
-	}
-	if (cursor >= source.length) {
-		return source.length;
+	const continuation = source[continuationCursor];
+	if (
+		continuationCursor >= source.length ||
+		continuation === "\r" ||
+		continuation === "\n" ||
+		isPhpHeredocContinuation(continuation)
+	) {
+		return cursor;
 	}
 
 	return null;
 }
 
+function matchesPhpFunctionCallAt(
+	source: string,
+	index: number,
+	functionName: string,
+): boolean {
+	if (!source.startsWith(functionName, index)) {
+		return false;
+	}
+	if (isPhpIdentifierPart(source[index - 1])) {
+		return false;
+	}
+
+	let cursor = index + functionName.length;
+	if (isPhpIdentifierPart(source[cursor])) {
+		return false;
+	}
+	while (isPhpWhitespace(source[cursor])) {
+		cursor += 1;
+	}
+
+	return source[cursor] === "(";
+}
+
+/**
+ * Detect a PHP function call outside strings, comments, heredoc, and nowdoc blocks.
+ *
+ * @param source PHP source to scan.
+ * @param functionName Literal PHP function identifier to find.
+ * @returns Whether `source` contains a code-mode call to `functionName`.
+ */
+export function hasPhpFunctionCall(source: string, functionName: string): boolean {
+	let mode: PhpFunctionScanMode = "code";
+	let heredocDelimiter = "";
+	let index = 0;
+	while (index < source.length) {
+		const character = source[index];
+
+		if (mode === "heredoc") {
+			const closingEnd = findPhpHeredocClosingEnd(
+				source,
+				index,
+				heredocDelimiter,
+			);
+			if (closingEnd !== null) {
+				mode = "code";
+				heredocDelimiter = "";
+				index = closingEnd;
+				continue;
+			}
+
+			const nextLineStart = findPhpLineBoundary(source, index).nextStart;
+			if (nextLineStart <= index) {
+				return false;
+			}
+			index = nextLineStart;
+			continue;
+		}
+
+		if (mode === "single-quoted" || mode === "double-quoted") {
+			const quote = mode === "single-quoted" ? "'" : '"';
+			if (character === "\\") {
+				index += 2;
+				continue;
+			}
+			if (character === quote) {
+				mode = "code";
+			}
+			index += 1;
+			continue;
+		}
+
+		if (mode === "line-comment") {
+			if (character === "\r" || character === "\n") {
+				mode = "code";
+			}
+			index += 1;
+			continue;
+		}
+
+		if (mode === "block-comment") {
+			if (character === "*" && source[index + 1] === "/") {
+				mode = "code";
+				index += 2;
+				continue;
+			}
+			index += 1;
+			continue;
+		}
+
+		if (character === "'") {
+			mode = "single-quoted";
+			index += 1;
+			continue;
+		}
+		if (character === '"') {
+			mode = "double-quoted";
+			index += 1;
+			continue;
+		}
+		if (character === "/" && source[index + 1] === "/") {
+			mode = "line-comment";
+			index += 2;
+			continue;
+		}
+		if (character === "#" && source[index + 1] !== "[") {
+			mode = "line-comment";
+			index += 1;
+			continue;
+		}
+		if (character === "/" && source[index + 1] === "*") {
+			mode = "block-comment";
+			index += 2;
+			continue;
+		}
+		if (character === "<") {
+			const heredocStart = parsePhpHeredocStart(source, index);
+			if (heredocStart) {
+				mode = "heredoc";
+				heredocDelimiter = heredocStart.delimiter;
+				index = heredocStart.contentStart;
+				continue;
+			}
+		}
+		if (matchesPhpFunctionCallAt(source, index, functionName)) {
+			return true;
+		}
+
+		index += 1;
+	}
+
+	return false;
+}
+
+/**
+ * Locate a PHP function body without counting braces in non-code regions.
+ *
+ * @param source PHP source to scan.
+ * @param functionName Literal PHP function identifier to locate.
+ * @param options Range options such as trailing newline inclusion.
+ * @returns The matched {@link PhpFunctionRange}, or `null` when no safe range exists.
+ */
 export function findPhpFunctionRange(
 	source: string,
 	functionName: string,

--- a/packages/wp-typia-project-tools/src/runtime/php-utils.ts
+++ b/packages/wp-typia-project-tools/src/runtime/php-utils.ts
@@ -60,30 +60,6 @@ function isPhpWhitespace(character: string | undefined): boolean {
 	return typeof character === "string" && /\s/u.test(character);
 }
 
-function isPhpHeredocContinuation(character: string | undefined): boolean {
-	return (
-		character === ";" ||
-		character === "," ||
-		character === ")" ||
-		character === "]" ||
-		character === "}" ||
-		character === "." ||
-		character === "?" ||
-		character === ":" ||
-		character === "+" ||
-		character === "-" ||
-		character === "*" ||
-		character === "/" ||
-		character === "%" ||
-		character === "|" ||
-		character === "&" ||
-		character === "^" ||
-		character === "=" ||
-		character === "<" ||
-		character === ">"
-	);
-}
-
 function findPhpLineBoundary(
 	source: string,
 	index: number,
@@ -178,12 +154,44 @@ function findPhpHeredocClosingEnd(
 		continuationCursor >= source.length ||
 		continuation === "\r" ||
 		continuation === "\n" ||
-		isPhpHeredocContinuation(continuation)
+		!isPhpIdentifierPart(continuation)
 	) {
 		return cursor;
 	}
 
 	return null;
+}
+
+function skipPhpCallTrivia(source: string, index: number): number | null {
+	let cursor = index;
+	while (cursor < source.length) {
+		while (isPhpWhitespace(source[cursor])) {
+			cursor += 1;
+		}
+
+		if (source[cursor] === "/" && source[cursor + 1] === "*") {
+			const commentEnd = source.indexOf("*/", cursor + 2);
+			if (commentEnd === -1) {
+				return null;
+			}
+			cursor = commentEnd + 2;
+			continue;
+		}
+
+		if (source[cursor] === "/" && source[cursor + 1] === "/") {
+			cursor = findPhpLineBoundary(source, cursor + 2).nextStart;
+			continue;
+		}
+
+		if (source[cursor] === "#" && source[cursor + 1] !== "[") {
+			cursor = findPhpLineBoundary(source, cursor + 1).nextStart;
+			continue;
+		}
+
+		return cursor;
+	}
+
+	return cursor;
 }
 
 function matchesPhpFunctionCallAt(
@@ -202,11 +210,9 @@ function matchesPhpFunctionCallAt(
 	if (isPhpIdentifierPart(source[cursor])) {
 		return false;
 	}
-	while (isPhpWhitespace(source[cursor])) {
-		cursor += 1;
-	}
+	const callStart = skipPhpCallTrivia(source, cursor);
 
-	return source[cursor] === "(";
+	return callStart !== null && source[callStart] === "(";
 }
 
 /**

--- a/packages/wp-typia-project-tools/tests/cli-add-workspace-ability.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-add-workspace-ability.test.ts
@@ -103,6 +103,51 @@ describe("@wp-typia/project-tools cli-add-workspace ability", () => {
 		expect(readWorkspaceInventory(targetDir).abilities).toHaveLength(0);
 	}, 20_000);
 
+	test("ability add rolls back when legacy bootstrap function range is unsafe", async () => {
+		const targetDir = path.join(tempRoot, "demo-workspace-add-ability-unsafe-bootstrap");
+		const workspaceSlug = "demo-workspace-add-ability-unsafe-bootstrap";
+
+		await scaffoldAbilityWorkspace(
+			targetDir,
+			workspaceSlug,
+			"Demo Workspace Add Ability Unsafe Bootstrap",
+			"Demo workspace add ability unsafe bootstrap",
+		);
+
+		const bootstrapPath = path.join(targetDir, `${workspaceSlug}.php`);
+		fs.writeFileSync(
+			bootstrapPath,
+			`${fs.readFileSync(bootstrapPath, "utf8").trimEnd()}
+
+function demo_space_enqueue_workflow_abilities() {
+\t$payload = <<<JSON
+{
+\t"brace": "{"
+}
+`,
+			"utf8",
+		);
+
+		const errorMessage = getCommandErrorMessage(() =>
+			runCli("node", [entryPath, "add", "ability", "review-workflow"], {
+				cwd: targetDir,
+			}),
+		);
+
+		expect(errorMessage).toContain(
+			`Unable to repair ${workspaceSlug}.php for demo_space_enqueue_workflow_abilities.`,
+		);
+		expect(
+			fs.existsSync(path.join(targetDir, "src", "abilities", "review-workflow")),
+		).toBe(false);
+		expect(
+			fs.existsSync(
+				path.join(targetDir, "inc", "abilities", "review-workflow.php"),
+			),
+		).toBe(false);
+		expect(readWorkspaceInventory(targetDir).abilities).toHaveLength(0);
+	}, 20_000);
+
 	test("canonical CLI can add a typed workflow ability to an official workspace template", async () => {
 		const targetDir = path.join(tempRoot, "demo-workspace-add-ability");
 		const workspaceSlug = "demo-workspace-add-ability";

--- a/packages/wp-typia-project-tools/tests/cli-add-workspace-ability.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-add-workspace-ability.test.ts
@@ -55,6 +55,8 @@ function seedLegacyAbilityWorkspace(targetDir: string, workspaceSlug: string) {
 
 function demo_space_enqueue_workflow_abilities() {
 \t// Legacy ability enqueue marker.
+\t// wp_enqueue_script_module( is only mentioned here, not called.
+\t$legacy_note = 'wp_enqueue_script_module(';
 \twp_enqueue_script(
 \t\t'demo-space-legacy-abilities',
 \t\tplugins_url( 'build/abilities/index.js', __FILE__ ),

--- a/packages/wp-typia-project-tools/tests/php-utils.test.ts
+++ b/packages/wp-typia-project-tools/tests/php-utils.test.ts
@@ -111,6 +111,31 @@ function keep_me() {
 	expect(range?.source).not.toContain("function keep_me()");
 });
 
+test("findPhpFunctionRange preserves PHP 8 attributes instead of treating them as comments", () => {
+	const source = `<?php
+function wp_typia_demo() {
+\t#[ExampleAttribute] class LocalThing {
+\t\tpublic function value() {
+\t\t\treturn true;
+\t\t}
+\t}
+
+\treturn array();
+}
+
+function keep_me() {
+\treturn true;
+}
+`;
+
+	const range = findPhpFunctionRange(source, "wp_typia_demo");
+
+	expect(range).not.toBeNull();
+	expect(range?.source).toContain("#[ExampleAttribute] class LocalThing");
+	expect(range?.source).toContain("return array();");
+	expect(range?.source).not.toContain("function keep_me()");
+});
+
 test("findPhpFunctionRange returns null for unterminated heredoc content", () => {
 	const source = `<?php
 function wp_typia_demo() {

--- a/packages/wp-typia-project-tools/tests/php-utils.test.ts
+++ b/packages/wp-typia-project-tools/tests/php-utils.test.ts
@@ -59,6 +59,74 @@ function wp_typia_typed() : array {
 	);
 });
 
+test("findPhpFunctionRange ignores braces inside PHP string literals", () => {
+	const source = `<?php
+function wp_typia_demo() {
+\t$json = '{"key": {"nested": true}}';
+\t$template = "Hello {name}";
+\tif ( true ) {
+\t\treturn array( 'ok' => true );
+\t}
+}
+
+function keep_me() {
+\treturn true;
+}
+`;
+
+	const range = findPhpFunctionRange(source, "wp_typia_demo");
+
+	expect(range).not.toBeNull();
+	expect(range?.source).toContain(`$json = '{"key": {"nested": true}}';`);
+	expect(range?.source).toContain('$template = "Hello {name}";');
+	expect(range?.source).not.toContain("function keep_me()");
+});
+
+test("findPhpFunctionRange ignores braces inside heredoc and nowdoc content", () => {
+	const source = `<?php
+function wp_typia_demo() {
+\t$json = <<<JSON
+{
+\t"query": {"postType": "page"}
+}
+\tJSON;
+\t$raw = <<<'NOWDOC'
+{
+\t"literal": "{$notInterpolated}"
+}
+\tNOWDOC;
+\treturn array();
+}
+
+function keep_me() {
+\treturn true;
+}
+`;
+
+	const range = findPhpFunctionRange(source, "wp_typia_demo");
+
+	expect(range).not.toBeNull();
+	expect(range?.source).toContain("<<<JSON");
+	expect(range?.source).toContain("<<<'NOWDOC'");
+	expect(range?.source).not.toContain("function keep_me()");
+});
+
+test("findPhpFunctionRange returns null for unterminated heredoc content", () => {
+	const source = `<?php
+function wp_typia_demo() {
+\t$json = <<<JSON
+{
+\t"query": {"postType": "page"}
+}
+
+function keep_me() {
+\treturn true;
+}
+`;
+
+	expect(findPhpFunctionRange(source, "wp_typia_demo")).toBeNull();
+});
+
 test("replacePhpFunctionDefinition replaces only the targeted PHP function", () => {
 	const source = `<?php
 function wp_typia_demo() {

--- a/packages/wp-typia-project-tools/tests/php-utils.test.ts
+++ b/packages/wp-typia-project-tools/tests/php-utils.test.ts
@@ -127,8 +127,11 @@ function wp_typia_demo() {
 \t"label": "demo"
 }
 \tTEXT );
+\t$nonEmpty = <<<TEXT
+demo
+\tTEXT !== '';
 
-\treturn array( $values, $trimmed );
+\treturn array( $values, $trimmed, $nonEmpty );
 }
 
 function keep_me() {
@@ -141,7 +144,8 @@ function keep_me() {
 	expect(range).not.toBeNull();
 	expect(range?.source).toContain("JSON,");
 	expect(range?.source).toContain("TEXT );");
-	expect(range?.source).toContain("return array( $values, $trimmed );");
+	expect(range?.source).toContain("TEXT !== '';");
+	expect(range?.source).toContain("return array( $values, $trimmed, $nonEmpty );");
 	expect(range?.source).not.toContain("function keep_me()");
 });
 
@@ -203,6 +207,18 @@ TEXT;
 	expect(
 		hasPhpFunctionCall(
 			`${source}\nwp_enqueue_script_module( 'demo', 'url', array(), null );\n`,
+			"wp_enqueue_script_module",
+		),
+	).toBe(true);
+	expect(
+		hasPhpFunctionCall(
+			`${source}\nwp_enqueue_script_module/* reason */( 'demo', 'url', array(), null );\n`,
+			"wp_enqueue_script_module",
+		),
+	).toBe(true);
+	expect(
+		hasPhpFunctionCall(
+			`${source}\nwp_enqueue_script_module // reason\n( 'demo', 'url', array(), null );\n`,
 			"wp_enqueue_script_module",
 		),
 	).toBe(true);

--- a/packages/wp-typia-project-tools/tests/php-utils.test.ts
+++ b/packages/wp-typia-project-tools/tests/php-utils.test.ts
@@ -3,6 +3,7 @@ import { expect, test } from "bun:test";
 import {
 	escapeRegex,
 	findPhpFunctionRange,
+	hasPhpFunctionCall,
 	hasPhpFunctionDefinition,
 	quotePhpString,
 	replacePhpFunctionDefinition,
@@ -111,6 +112,39 @@ function keep_me() {
 	expect(range?.source).not.toContain("function keep_me()");
 });
 
+test("findPhpFunctionRange accepts heredoc expression continuations", () => {
+	const source = `<?php
+function wp_typia_demo() {
+\t$values = array(
+\t\t<<<JSON
+{
+\t"query": {"postType": "page"}
+}
+\t\tJSON,
+\t);
+\t$trimmed = trim( <<<TEXT
+{
+\t"label": "demo"
+}
+\tTEXT );
+
+\treturn array( $values, $trimmed );
+}
+
+function keep_me() {
+\treturn true;
+}
+`;
+
+	const range = findPhpFunctionRange(source, "wp_typia_demo");
+
+	expect(range).not.toBeNull();
+	expect(range?.source).toContain("JSON,");
+	expect(range?.source).toContain("TEXT );");
+	expect(range?.source).toContain("return array( $values, $trimmed );");
+	expect(range?.source).not.toContain("function keep_me()");
+});
+
 test("findPhpFunctionRange preserves PHP 8 attributes instead of treating them as comments", () => {
 	const source = `<?php
 function wp_typia_demo() {
@@ -150,6 +184,28 @@ function keep_me() {
 `;
 
 	expect(findPhpFunctionRange(source, "wp_typia_demo")).toBeNull();
+});
+
+test("hasPhpFunctionCall ignores comments, strings, heredoc, and nowdoc", () => {
+	const source = `<?php
+function wp_typia_demo() {
+\t// wp_enqueue_script_module(
+\t$single = 'wp_enqueue_script_module(';
+\t$double = "wp_enqueue_script_module(";
+\t$heredoc = <<<TEXT
+wp_enqueue_script_module(
+TEXT;
+\treturn true;
+}
+`;
+
+	expect(hasPhpFunctionCall(source, "wp_enqueue_script_module")).toBe(false);
+	expect(
+		hasPhpFunctionCall(
+			`${source}\nwp_enqueue_script_module( 'demo', 'url', array(), null );\n`,
+			"wp_enqueue_script_module",
+		),
+	).toBe(true);
 });
 
 test("replacePhpFunctionDefinition replaces only the targeted PHP function", () => {


### PR DESCRIPTION
## Summary
- ignore braces inside PHP single/double quoted strings, comments, heredoc, and nowdoc while finding function ranges
- return null for unterminated heredoc/nowdoc content so bootstrap patchers avoid unsafe replacement
- fail and roll back ability bootstrap repair when an existing function range cannot be safely found

## Tests
- bun test packages/wp-typia-project-tools/tests/php-utils.test.ts
- bun test packages/wp-typia-project-tools/tests/cli-add-workspace-ability.test.ts
- node scripts/check-repo-format.mjs
- git diff --check
- bun run typecheck
- node scripts/validate-sampo-changesets.mjs

Closes #731

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced PHP parsing to correctly handle string literals, heredoc syntax, and braces in PHP code during workspace operations.

* **New Features**
  * Improved error reporting for workspace bootstrap operations with more detailed failure messages.

* **Chores**
  * Patch version bump for project tools and core packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->