### PR TITLE
fix(cli): normalize --format text in Node fallback

### DIFF
--- a/.sampo/changesets/732-node-format-text-normalization.md
+++ b/.sampo/changesets/732-node-format-text-normalization.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Normalize `--format text` through the Node fallback CLI before command dispatch.

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -23,7 +23,10 @@ import {
   TEMPLATES_OPTION_METADATA,
 } from './command-option-metadata';
 import { prefersStructuredCliArgv } from './cli-diagnostic-output';
-import { validateCliOutputFormatArgv } from './cli-output-format';
+import {
+  normalizeCliOutputFormatArgv,
+  validateCliOutputFormatArgv,
+} from './cli-output-format';
 import {
   getTemplateById,
   listTemplates,
@@ -635,7 +638,10 @@ export async function runNodeCli(argv = process.argv.slice(2)): Promise<void> {
   const { argv: argvWithoutConfigOverride, configOverridePath } =
     extractWpTypiaConfigOverride(normalizedArgv);
   validateCliOutputFormatArgv(argvWithoutConfigOverride);
-  const { argv: cliArgv, flags } = parseGlobalFlags(argvWithoutConfigOverride);
+  const outputFormatArgv = normalizeCliOutputFormatArgv(
+    argvWithoutConfigOverride,
+  );
+  const { argv: cliArgv, flags } = parseGlobalFlags(outputFormatArgv);
   const { flags: commandFlags, positionals } = parseArgv(cliArgv);
   const rawMergedFlags: Record<string, unknown> = {
     ...commandFlags,

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -351,6 +351,8 @@ describe('wp-typia package', () => {
   test('derives fallback parsing and first-party initial values from shared metadata helpers', () => {
     expect(nodeCliSource).toContain('parseCommandArgvWithMetadata');
     expect(nodeCliSource).toContain('resolveCommandOptionValues');
+    expect(nodeCliSource).toContain('normalizeCliOutputFormatArgv');
+    expect(nodeCliSource).toContain('parseGlobalFlags(outputFormatArgv)');
     expect(nodeCliSource).not.toContain('const STRING_FLAG_NAMES = new Set([');
     expect(nodeCliSource).not.toContain('const BOOLEAN_FLAG_NAMES = new Set([');
     expect(nodeCliSource).not.toContain('const SHORT_FLAG_MAP = new Map<');

--- a/packages/wp-typia/tests/node-cli-core.test.ts
+++ b/packages/wp-typia/tests/node-cli-core.test.ts
@@ -194,6 +194,28 @@ describe('Node fallback CLI core routing', () => {
       expect(result.stdout).toContain('Template: basic');
       expect(result.stdout).toContain('No files were written');
       expect(fs.existsSync(path.join(tempRoot, 'demo-card'))).toBe(false);
+
+      const textResult = await captureNodeCli(
+        [
+          'create',
+          'text-card',
+          '--dry-run',
+          '--template',
+          'basic',
+          '--yes',
+          '--format',
+          'text',
+        ],
+        { cwd: tempRoot },
+      );
+
+      expect(textResult.error).toBeUndefined();
+      expect(textResult.exitCode).toBe(0);
+      expect(textResult.stderr).toBe('');
+      expect(textResult.stdout).toContain('Dry run for Text Card');
+      expect(textResult.stdout).toContain('Template: basic');
+      expect(textResult.stdout.trim()).not.toMatch(/^\{/u);
+      expect(fs.existsSync(path.join(tempRoot, 'text-card'))).toBe(false);
     } finally {
       removeTempRoot(tempRoot);
     }
@@ -254,6 +276,17 @@ describe('Node fallback CLI core routing', () => {
     expect(result.error).toBeInstanceOf(Error);
     expect((result.error as Error).message).toContain(
       'Invalid --format value "jso". Supported values: json, text.',
+    );
+  });
+
+  test('reports missing output format values before Node fallback dispatch', async () => {
+    const result = await captureNodeCli(['doctor', '--format']);
+
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toBe('');
+    expect(result.error).toBeInstanceOf(Error);
+    expect((result.error as Error).message).toContain(
+      '`--format` requires a value.',
     );
   });
 


### PR DESCRIPTION
## Summary\n- normalize Node fallback argv with the shared CLI output-format normalizer before parsing flags\n- cover Node fallback --format text dry-run behavior and missing --format diagnostics\n- add a Sampo changeset for wp-typia\n\n## Tests\n- bun test packages/wp-typia/tests/node-cli-core.test.ts\n- bun test packages/wp-typia/tests/cli-package.test.ts --test-name-pattern "derives fallback parsing"\n- bun test packages/wp-typia/tests/cli-diagnostic-output.test.ts\n- node scripts/check-repo-format.mjs\n- git diff --check\n- bun run typecheck\n- node scripts/validate-sampo-changesets.mjs\n- bun run --filter wp-typia build\n\nCloses #732

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed `--format text` output normalization to work correctly through Node fallback CLI dispatch
* Improved validation of the `--format` flag to ensure a value is provided

## Tests
* Extended test coverage for text format output handling and global flag parsing
* Added validation tests for format flag error cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->