### PR TITLE
fix(string-case): handle acronym runs in kebab case

### DIFF
--- a/.sampo/changesets/741-kebab-acronym-runs.md
+++ b/.sampo/changesets/741-kebab-acronym-runs.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Keep acronym runs together when deriving kebab-case generated identifiers.

--- a/packages/wp-typia-project-tools/src/runtime/string-case.ts
+++ b/packages/wp-typia-project-tools/src/runtime/string-case.ts
@@ -1,18 +1,65 @@
+const COMMON_ACRONYM_PREFIXES = [
+  'HTML',
+  'HTTP',
+  'JSON',
+  'REST',
+  'UUID',
+  'API',
+  'CSS',
+  'CTA',
+  'DOM',
+  'PHP',
+  'SQL',
+  'SVG',
+  'URL',
+  'XML',
+  'ID',
+  'JS',
+  'UI',
+  'WP',
+] as const;
+
+const COMMON_ACRONYM_PREFIX_SET = new Set<string>(COMMON_ACRONYM_PREFIXES);
+
 function capitalizeSegment(segment: string): string {
   return segment.charAt(0).toUpperCase() + segment.slice(1);
+}
+
+function splitAcronymBoundary(value: string): string {
+  return value.replace(/[A-Z]{2,}[a-z]+/g, (segment) => {
+    for (const prefix of COMMON_ACRONYM_PREFIXES) {
+      const suffix = segment.slice(prefix.length);
+      if (segment.startsWith(prefix) && /^[A-Z][a-z]/.test(suffix)) {
+        return `${prefix}-${suffix}`;
+      }
+    }
+
+    const uppercaseRun = /^[A-Z]+/.exec(segment)?.[0] ?? '';
+    if (
+      uppercaseRun.length < 4 ||
+      COMMON_ACRONYM_PREFIX_SET.has(uppercaseRun)
+    ) {
+      return segment;
+    }
+
+    return `${uppercaseRun.slice(0, -1)}-${uppercaseRun.slice(-1)}${segment.slice(
+      uppercaseRun.length,
+    )}`;
+  });
 }
 
 /**
  * Normalize arbitrary text into a kebab-case identifier.
  * Acronym runs stay grouped, with a boundary before the next capitalized word.
+ * Ambiguous acronym+lowercase inputs like `URLslug` intentionally stay as one
+ * word because there is no PascalCase boundary marker before the lowercase
+ * suffix.
  *
  * @param input Raw text that may contain spaces, punctuation, or camelCase.
  * @returns A lowercase kebab-case string with collapsed separators.
  */
 export function toKebabCase(input: string): string {
-  return input
-    .trim()
-    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1-$2')
+  return splitAcronymBoundary(input.trim())
     .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
     .replace(/[^A-Za-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')

--- a/packages/wp-typia-project-tools/src/runtime/string-case.ts
+++ b/packages/wp-typia-project-tools/src/runtime/string-case.ts
@@ -23,21 +23,30 @@ function capitalizeSegment(segment: string): string {
   return segment.charAt(0).toUpperCase() + segment.slice(1);
 }
 
+function findCommonAcronymPrefix(segment: string): string | undefined {
+  return COMMON_ACRONYM_PREFIXES.find((prefix) => segment.startsWith(prefix));
+}
+
 function splitKnownAcronymSegment(segment: string): string {
-  for (const prefix of COMMON_ACRONYM_PREFIXES) {
-    if (!segment.startsWith(prefix)) {
-      continue;
-    }
+  const prefixes: string[] = [];
+  let remaining = segment;
 
-    const suffix = segment.slice(prefix.length);
+  while (remaining.length > 0) {
+    const prefix = findCommonAcronymPrefix(remaining);
+    if (!prefix) {
+      break;
+    }
+    const suffix = remaining.slice(prefix.length);
     if (/^[A-Z][a-z]/.test(suffix)) {
-      return `${prefix}-${suffix}`;
+      return [...prefixes, prefix, suffix].join('-');
     }
 
-    const nested = splitKnownAcronymSegment(suffix);
-    if (nested !== suffix) {
-      return `${prefix}-${nested}`;
+    if (!findCommonAcronymPrefix(suffix)) {
+      break;
     }
+
+    prefixes.push(prefix);
+    remaining = suffix;
   }
 
   return segment;

--- a/packages/wp-typia-project-tools/src/runtime/string-case.ts
+++ b/packages/wp-typia-project-tools/src/runtime/string-case.ts
@@ -19,8 +19,6 @@ const COMMON_ACRONYM_PREFIXES = [
   'WP',
 ] as const;
 
-const COMMON_ACRONYM_PREFIX_SET = new Set<string>(COMMON_ACRONYM_PREFIXES);
-
 function capitalizeSegment(segment: string): string {
   return segment.charAt(0).toUpperCase() + segment.slice(1);
 }
@@ -34,23 +32,14 @@ function splitAcronymBoundary(value: string): string {
       }
     }
 
-    const uppercaseRun = /^[A-Z]+/.exec(segment)?.[0] ?? '';
-    if (
-      uppercaseRun.length < 4 ||
-      COMMON_ACRONYM_PREFIX_SET.has(uppercaseRun)
-    ) {
-      return segment;
-    }
-
-    return `${uppercaseRun.slice(0, -1)}-${uppercaseRun.slice(-1)}${segment.slice(
-      uppercaseRun.length,
-    )}`;
+    return segment;
   });
 }
 
 /**
  * Normalize arbitrary text into a kebab-case identifier.
- * Acronym runs stay grouped, with a boundary before the next capitalized word.
+ * Common acronym runs stay grouped, with a boundary before the next
+ * capitalized word.
  * Ambiguous acronym+lowercase inputs like `URLslug` intentionally stay as one
  * word because there is no PascalCase boundary marker before the lowercase
  * suffix.

--- a/packages/wp-typia-project-tools/src/runtime/string-case.ts
+++ b/packages/wp-typia-project-tools/src/runtime/string-case.ts
@@ -23,17 +23,28 @@ function capitalizeSegment(segment: string): string {
   return segment.charAt(0).toUpperCase() + segment.slice(1);
 }
 
-function splitAcronymBoundary(value: string): string {
-  return value.replace(/[A-Z]{2,}[a-z]+/g, (segment) => {
-    for (const prefix of COMMON_ACRONYM_PREFIXES) {
-      const suffix = segment.slice(prefix.length);
-      if (segment.startsWith(prefix) && /^[A-Z][a-z]/.test(suffix)) {
-        return `${prefix}-${suffix}`;
-      }
+function splitKnownAcronymSegment(segment: string): string {
+  for (const prefix of COMMON_ACRONYM_PREFIXES) {
+    if (!segment.startsWith(prefix)) {
+      continue;
     }
 
-    return segment;
-  });
+    const suffix = segment.slice(prefix.length);
+    if (/^[A-Z][a-z]/.test(suffix)) {
+      return `${prefix}-${suffix}`;
+    }
+
+    const nested = splitKnownAcronymSegment(suffix);
+    if (nested !== suffix) {
+      return `${prefix}-${nested}`;
+    }
+  }
+
+  return segment;
+}
+
+function splitAcronymBoundary(value: string): string {
+  return value.replace(/[A-Z]{2,}[a-z]+/g, splitKnownAcronymSegment);
 }
 
 /**

--- a/packages/wp-typia-project-tools/src/runtime/string-case.ts
+++ b/packages/wp-typia-project-tools/src/runtime/string-case.ts
@@ -4,6 +4,7 @@ function capitalizeSegment(segment: string): string {
 
 /**
  * Normalize arbitrary text into a kebab-case identifier.
+ * Acronym runs stay grouped, with a boundary before the next capitalized word.
  *
  * @param input Raw text that may contain spaces, punctuation, or camelCase.
  * @returns A lowercase kebab-case string with collapsed separators.
@@ -11,6 +12,7 @@ function capitalizeSegment(segment: string): string {
 export function toKebabCase(input: string): string {
   return input
     .trim()
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1-$2')
     .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
     .replace(/[^A-Za-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')

--- a/packages/wp-typia-project-tools/tests/string-case.test.ts
+++ b/packages/wp-typia-project-tools/tests/string-case.test.ts
@@ -13,6 +13,7 @@ const WORDPRESS_SAFE_SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/u;
 test("toKebabCase keeps acronym runs together", () => {
 	expect(toKebabCase("XMLParser")).toBe("xml-parser");
 	expect(toKebabCase("getURL")).toBe("get-url");
+	expect(toKebabCase("URLSlug")).toBe("url-slug");
 	expect(toKebabCase("parseJSONValue")).toBe("parse-json-value");
 	expect(toKebabCase("HeroCTABlock")).toBe("hero-cta-block");
 });
@@ -21,6 +22,8 @@ test("toKebabCase avoids inventing boundaries in acronym-lowercase words", () =>
 	expect(toKebabCase("URLslug")).toBe("urlslug");
 	expect(toKebabCase("HTTPserver")).toBe("httpserver");
 	expect(toKebabCase("XMLparser")).toBe("xmlparser");
+	expect(toKebabCase("GUIDe")).toBe("guide");
+	expect(toKebabCase("AABBcc")).toBe("aabbcc");
 });
 
 test("toKebabCase preserves common slug normalization behavior", () => {

--- a/packages/wp-typia-project-tools/tests/string-case.test.ts
+++ b/packages/wp-typia-project-tools/tests/string-case.test.ts
@@ -16,6 +16,8 @@ test("toKebabCase keeps acronym runs together", () => {
 	expect(toKebabCase("URLSlug")).toBe("url-slug");
 	expect(toKebabCase("parseJSONValue")).toBe("parse-json-value");
 	expect(toKebabCase("HeroCTABlock")).toBe("hero-cta-block");
+	expect(toKebabCase("JSONAPIResponse")).toBe("json-api-response");
+	expect(toKebabCase("XMLHTTPParser")).toBe("xml-http-parser");
 });
 
 test("toKebabCase avoids inventing boundaries in acronym-lowercase words", () => {

--- a/packages/wp-typia-project-tools/tests/string-case.test.ts
+++ b/packages/wp-typia-project-tools/tests/string-case.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "bun:test";
+
+import {
+	toCamelCase,
+	toKebabCase,
+	toPascalCase,
+	toSnakeCase,
+	toTitleCase,
+} from "../src/runtime/string-case.js";
+
+const WORDPRESS_SAFE_SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/u;
+
+test("toKebabCase keeps acronym runs together", () => {
+	expect(toKebabCase("XMLParser")).toBe("xml-parser");
+	expect(toKebabCase("getURL")).toBe("get-url");
+	expect(toKebabCase("parseJSONValue")).toBe("parse-json-value");
+	expect(toKebabCase("HeroCTABlock")).toBe("hero-cta-block");
+});
+
+test("toKebabCase preserves common slug normalization behavior", () => {
+	expect(toKebabCase("Demo Card")).toBe("demo-card");
+	expect(toKebabCase("demo_card")).toBe("demo-card");
+	expect(toKebabCase("demo/card")).toBe("demo-card");
+	expect(toKebabCase("demo--card")).toBe("demo-card");
+	expect(toKebabCase("  my cool block!  ")).toBe("my-cool-block");
+	expect(toKebabCase("Block Name 123")).toBe("block-name-123");
+});
+
+test("string case helpers continue to derive WordPress-safe identifiers", () => {
+	const slug = toKebabCase("Hero CTA Block!");
+
+	expect(slug).toBe("hero-cta-block");
+	expect(slug).toMatch(WORDPRESS_SAFE_SLUG);
+	expect(toSnakeCase("Hero CTA Block!")).toBe("hero_cta_block");
+	expect(toPascalCase("hero-cta-block")).toBe("HeroCtaBlock");
+	expect(toCamelCase("hero-cta-block")).toBe("heroCtaBlock");
+	expect(toTitleCase("hero-cta-block")).toBe("Hero Cta Block");
+});

--- a/packages/wp-typia-project-tools/tests/string-case.test.ts
+++ b/packages/wp-typia-project-tools/tests/string-case.test.ts
@@ -17,6 +17,12 @@ test("toKebabCase keeps acronym runs together", () => {
 	expect(toKebabCase("HeroCTABlock")).toBe("hero-cta-block");
 });
 
+test("toKebabCase avoids inventing boundaries in acronym-lowercase words", () => {
+	expect(toKebabCase("URLslug")).toBe("urlslug");
+	expect(toKebabCase("HTTPserver")).toBe("httpserver");
+	expect(toKebabCase("XMLparser")).toBe("xmlparser");
+});
+
 test("toKebabCase preserves common slug normalization behavior", () => {
 	expect(toKebabCase("Demo Card")).toBe("demo-card");
 	expect(toKebabCase("demo_card")).toBe("demo-card");

--- a/packages/wp-typia-project-tools/tests/string-case.test.ts
+++ b/packages/wp-typia-project-tools/tests/string-case.test.ts
@@ -18,6 +18,11 @@ test("toKebabCase keeps acronym runs together", () => {
 	expect(toKebabCase("HeroCTABlock")).toBe("hero-cta-block");
 	expect(toKebabCase("JSONAPIResponse")).toBe("json-api-response");
 	expect(toKebabCase("XMLHTTPParser")).toBe("xml-http-parser");
+
+	const repeatedIds = `${"ID".repeat(256)}Ab`;
+	expect(toKebabCase(repeatedIds)).toBe(
+		`${Array.from({ length: 256 }, () => "id").join("-")}-ab`,
+	);
 });
 
 test("toKebabCase avoids inventing boundaries in acronym-lowercase words", () => {


### PR DESCRIPTION
## Summary\n- keep uppercase acronym runs together when deriving kebab-case identifiers\n- document the acronym boundary behavior in the string-case helper\n- add regression coverage for XMLParser/getURL, common slug conversions, and WordPress-safe output\n\n## Tests\n- bun test packages/wp-typia-project-tools/tests/string-case.test.ts\n- node scripts/check-repo-format.mjs\n- git diff --check\n- node scripts/validate-sampo-changesets.mjs\n- bun run typecheck\n- bun run --filter @wp-typia/project-tools build\n- bun run --filter wp-typia build\n\nCloses #741

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of acronym sequences in kebab-case formatting (e.g., XMLParser now converts to xml-parser instead of separating each letter)

* **Tests**
  * Added test coverage for various string-case conversion scenarios, including acronym runs and WordPress slug compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->