### PR TITLE
refactor(add): single-source add kind ids

### DIFF
--- a/.sampo/changesets/734-single-source-add-kind-ids.md
+++ b/.sampo/changesets/734-single-source-add-kind-ids.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Single-source add kind ids through project-tools metadata so CLI routing and runtime add helpers cannot drift.

--- a/packages/wp-typia-project-tools/package.json
+++ b/packages/wp-typia-project-tools/package.json
@@ -17,6 +17,11 @@
       "import": "./dist/runtime/cli-add.js",
       "default": "./dist/runtime/cli-add.js"
     },
+    "./cli-add-kind-ids": {
+      "types": "./dist/runtime/cli-add-kind-ids.d.ts",
+      "import": "./dist/runtime/cli-add-kind-ids.js",
+      "default": "./dist/runtime/cli-add-kind-ids.js"
+    },
     "./cli-diagnostics": {
       "types": "./dist/runtime/cli-diagnostics.d.ts",
       "import": "./dist/runtime/cli-diagnostics.js",

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-kind-ids.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-kind-ids.ts
@@ -1,0 +1,25 @@
+/**
+ * Canonical top-level `wp-typia add` kind ids shared by the CLI command
+ * registry, routing metadata generation, and project-tools runtime helpers.
+ *
+ * Keep this order stable because it drives help output and command metadata.
+ */
+export const ADD_KIND_IDS = [
+	"admin-view",
+	"block",
+	"variation",
+	"style",
+	"transform",
+	"pattern",
+	"binding-source",
+	"rest-resource",
+	"ability",
+	"ai-feature",
+	"hooked-block",
+	"editor-plugin",
+] as const;
+
+/**
+ * Union of supported top-level `wp-typia add` kind ids.
+ */
+export type AddKindId = (typeof ADD_KIND_IDS)[number];

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-types.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-types.ts
@@ -1,24 +1,5 @@
-/**
- * Supported top-level `wp-typia add` kinds exposed by the canonical CLI.
- */
-export const ADD_KIND_IDS = [
-	"admin-view",
-	"block",
-	"variation",
-	"style",
-	"transform",
-	"pattern",
-	"binding-source",
-	"rest-resource",
-	"ability",
-	"ai-feature",
-	"hooked-block",
-	"editor-plugin",
-] as const;
-/**
- * Union of supported top-level `wp-typia add` kind ids.
- */
-export type AddKindId = (typeof ADD_KIND_IDS)[number];
+export { ADD_KIND_IDS } from "./cli-add-kind-ids.js";
+export type { AddKindId } from "./cli-add-kind-ids.js";
 
 /**
  * Supported plugin-level REST resource methods accepted by

--- a/packages/wp-typia-project-tools/src/runtime/php-utils.ts
+++ b/packages/wp-typia-project-tools/src/runtime/php-utils.ts
@@ -206,7 +206,7 @@ function matchesPhpFunctionCallAt(
 		return false;
 	}
 
-	let cursor = index + functionName.length;
+	const cursor = index + functionName.length;
 	if (isPhpIdentifierPart(source[cursor])) {
 		return false;
 	}

--- a/packages/wp-typia-project-tools/tests/cli-add-shared.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-add-shared.test.ts
@@ -93,6 +93,9 @@ test('focused add runtime modules own their helper categories', () => {
   expect(addKindIdsSource).toContain('export const ADD_KIND_IDS');
   expect(typesSource).toContain('export interface RunAddBlockCommandOptions');
   expect(typesSource).toContain('from "./cli-add-kind-ids.js"');
+  expect(typesSource).toContain(
+    'export type { AddKindId } from "./cli-add-kind-ids.js";',
+  );
   expect(typesSource).not.toContain('export const ADD_KIND_IDS = [');
   expect(validationSource).toContain('export function assertValidGeneratedSlug');
   expect(validationSource).toContain('export function assertValidRestResourceMethods');

--- a/packages/wp-typia-project-tools/tests/cli-add-shared.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-add-shared.test.ts
@@ -82,6 +82,7 @@ test('shared add runtime keeps compatibility exports around focused modules', ()
 });
 
 test('focused add runtime modules own their helper categories', () => {
+  const addKindIdsSource = readRuntimeSource('cli-add-kind-ids.ts');
   const typesSource = readRuntimeSource('cli-add-types.ts');
   const validationSource = readRuntimeSource('cli-add-validation.ts');
   const filesystemSource = readRuntimeSource('cli-add-filesystem.ts');
@@ -89,8 +90,10 @@ test('focused add runtime modules own their helper categories', () => {
   const collisionSource = readRuntimeSource('cli-add-collision.ts');
   const helpSource = readRuntimeSource('cli-add-help.ts');
 
+  expect(addKindIdsSource).toContain('export const ADD_KIND_IDS');
   expect(typesSource).toContain('export interface RunAddBlockCommandOptions');
-  expect(typesSource).toContain('export const ADD_KIND_IDS');
+  expect(typesSource).toContain('from "./cli-add-kind-ids.js"');
+  expect(typesSource).not.toContain('export const ADD_KIND_IDS = [');
   expect(validationSource).toContain('export function assertValidGeneratedSlug');
   expect(validationSource).toContain('export function assertValidRestResourceMethods');
   expect(validationSource).toContain('export function assertValidEditorPluginSlot');

--- a/packages/wp-typia/scripts/generate-routing-metadata.mjs
+++ b/packages/wp-typia/scripts/generate-routing-metadata.mjs
@@ -25,17 +25,35 @@ const commandRegistryModulePath = path.join(
   'command-registry.ts',
 );
 const addKindIdsModulePath = path.join(packageRoot, 'src', 'add-kind-ids.ts');
+const projectToolsAddKindIdsModulePath = path.join(
+  packageRoot,
+  '..',
+  'wp-typia-project-tools',
+  'src',
+  'runtime',
+  'cli-add-kind-ids.ts',
+);
 const checkOnly = process.argv.includes('--check');
 
 async function importTranspiledTypeScriptModule(
   modulePath,
   siblingModules = [],
+  externalModules = [],
 ) {
-  const [{ default: ts }, source, ...siblingSources] = await Promise.all([
+  const [
+    { default: ts },
+    source,
+    ...supportingSources
+  ] = await Promise.all([
     import('typescript'),
     fs.readFile(modulePath, 'utf8'),
     ...siblingModules.map((siblingPath) => fs.readFile(siblingPath, 'utf8')),
+    ...externalModules.map(({ modulePath: externalModulePath }) =>
+      fs.readFile(externalModulePath, 'utf8'),
+    ),
   ]);
+  const siblingSources = supportingSources.slice(0, siblingModules.length);
+  const externalSources = supportingSources.slice(siblingModules.length);
   const transpiled = ts.transpileModule(source, {
     compilerOptions: {
       module: ts.ModuleKind.CommonJS,
@@ -73,6 +91,45 @@ async function importTranspiledTypeScriptModule(
         'utf8',
       ),
     ),
+    ...externalModules.map(async (externalModule, index) => {
+      const parts = externalModule.specifier.split('/');
+      const packageName = externalModule.specifier.startsWith('@')
+        ? parts.slice(0, 2).join('/')
+        : parts[0];
+      const subpathParts = externalModule.specifier.startsWith('@')
+        ? parts.slice(2)
+        : parts.slice(1);
+      const packageDir = path.join(
+        tempDir,
+        'node_modules',
+        ...packageName.split('/'),
+      );
+      const moduleFile = path.join(
+        packageDir,
+        ...subpathParts.slice(0, -1),
+        `${subpathParts[subpathParts.length - 1]}.js`,
+      );
+
+      await fs.mkdir(path.dirname(moduleFile), { recursive: true });
+      await Promise.all([
+        fs.writeFile(
+          path.join(packageDir, 'package.json'),
+          JSON.stringify({ type: 'commonjs' }),
+          'utf8',
+        ),
+        fs.writeFile(
+          moduleFile,
+          ts.transpileModule(externalSources[index], {
+            compilerOptions: {
+              module: ts.ModuleKind.CommonJS,
+              target: ts.ScriptTarget.ES2020,
+            },
+            fileName: externalModule.modulePath,
+          }).outputText,
+          'utf8',
+        ),
+      ]);
+    }),
   ]);
   try {
     return require(tempFile);
@@ -150,9 +207,16 @@ const [
   },
 ] = await Promise.all([
   importTranspiledTypeScriptModule(commandOptionMetadataModulePath),
-  importTranspiledTypeScriptModule(commandRegistryModulePath, [
-    addKindIdsModulePath,
-  ]),
+  importTranspiledTypeScriptModule(
+    commandRegistryModulePath,
+    [addKindIdsModulePath],
+    [
+      {
+        modulePath: projectToolsAddKindIdsModulePath,
+        specifier: '@wp-typia/project-tools/cli-add-kind-ids',
+      },
+    ],
+  ),
 ]);
 
 const renderedFiles = renderRoutingMetadataFiles({

--- a/packages/wp-typia/scripts/runtime-build-dependencies.ts
+++ b/packages/wp-typia/scripts/runtime-build-dependencies.ts
@@ -39,6 +39,10 @@ export const PROJECT_TOOLS_ALIASES = {
 		projectToolsRuntimeDir,
 		"cli-add.js",
 	),
+	"@wp-typia/project-tools/cli-add-kind-ids": path.join(
+		projectToolsRuntimeDir,
+		"cli-add-kind-ids.js",
+	),
 	"@wp-typia/project-tools/cli-diagnostics": path.join(
 		projectToolsRuntimeDir,
 		"cli-diagnostics.js",

--- a/packages/wp-typia/src/add-kind-ids.ts
+++ b/packages/wp-typia/src/add-kind-ids.ts
@@ -1,16 +1,2 @@
-export const ADD_KIND_IDS = [
-  'admin-view',
-  'block',
-  'variation',
-  'style',
-  'transform',
-  'pattern',
-  'binding-source',
-  'rest-resource',
-  'ability',
-  'ai-feature',
-  'hooked-block',
-  'editor-plugin',
-] as const;
-
-export type AddKindId = (typeof ADD_KIND_IDS)[number];
+export { ADD_KIND_IDS } from '@wp-typia/project-tools/cli-add-kind-ids';
+export type { AddKindId } from '@wp-typia/project-tools/cli-add-kind-ids';

--- a/packages/wp-typia/src/add-kind-registry.ts
+++ b/packages/wp-typia/src/add-kind-registry.ts
@@ -10,10 +10,7 @@ import {
   readOptionalStrictStringFlag,
   requireStrictStringFlag,
 } from './cli-string-flags';
-import {
-  toExternalLayerPromptOptions,
-  type ExternalLayerSelectOption,
-} from './external-layer-prompt-options';
+import { toExternalLayerPromptOptions } from './external-layer-prompt-options';
 import type { PrintLine } from './print-line';
 
 export { ADD_KIND_IDS } from './add-kind-ids';

--- a/packages/wp-typia/src/runtime-bridge-output.ts
+++ b/packages/wp-typia/src/runtime-bridge-output.ts
@@ -14,10 +14,6 @@ import {
   type OutputMarkerOptions,
   stripLeadingOutputMarker,
 } from './output-markers';
-import {
-  toExternalLayerPromptOptions,
-  type ExternalLayerSelectOption,
-} from './external-layer-prompt-options';
 import type { PrintLine } from './print-line';
 
 export type CreateProgressPayload = {

--- a/packages/wp-typia/tests/add-kind-source.test.ts
+++ b/packages/wp-typia/tests/add-kind-source.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { ADD_KIND_IDS as PROJECT_TOOLS_ADD_KIND_IDS } from '@wp-typia/project-tools/cli-add-kind-ids';
+import { ADD_KIND_IDS } from '../src/add-kind-registry';
+import { WP_TYPIA_COMMAND_REGISTRY } from '../src/command-registry';
+
+const packageRoot = path.resolve(import.meta.dir, '..');
+
+test('single-sources add-kind ids from project-tools metadata', () => {
+  const cliAddKindIdsSource = fs.readFileSync(
+    path.join(packageRoot, 'src', 'add-kind-ids.ts'),
+    'utf8',
+  );
+  const addCommand = WP_TYPIA_COMMAND_REGISTRY.find(
+    (command) => command.name === 'add',
+  );
+
+  expect(cliAddKindIdsSource).toContain(
+    "'@wp-typia/project-tools/cli-add-kind-ids'",
+  );
+  expect(cliAddKindIdsSource).not.toContain('export const ADD_KIND_IDS = [');
+  expect(ADD_KIND_IDS).toEqual([...PROJECT_TOOLS_ADD_KIND_IDS]);
+  expect(addCommand?.subcommands).toEqual([...PROJECT_TOOLS_ADD_KIND_IDS]);
+});

--- a/packages/wp-typia/tests/bunli-prep.test.ts
+++ b/packages/wp-typia/tests/bunli-prep.test.ts
@@ -201,6 +201,9 @@ describe('wp-typia Bunli preparation', () => {
     expect(runtimeDependencyHelperSource).toContain(
       'dependencies: ["@wp-typia/api-client", "@wp-typia/block-runtime"]',
     );
+    expect(runtimeDependencyHelperSource).toContain(
+      '"@wp-typia/project-tools/cli-add-kind-ids": path.join(',
+    );
     expect(runtimeDependencyHelperSource).toContain('tsconfig.runtime.json');
     expect(runtimeDependencyHelperSource).toContain('tsconfig.build.json');
     expect(runtimeDependencyHelperSource).toContain(

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -303,6 +303,9 @@ describe('wp-typia package', () => {
     expect(projectToolsPackageManifest.exports['./cli']).toBeUndefined();
     expect(projectToolsPackageManifest.exports['./cli-add']).toBeDefined();
     expect(
+      projectToolsPackageManifest.exports['./cli-add-kind-ids'],
+    ).toBeDefined();
+    expect(
       projectToolsPackageManifest.exports['./cli-diagnostics'],
     ).toBeDefined();
     expect(projectToolsPackageManifest.exports['./cli-doctor']).toBeDefined();


### PR DESCRIPTION
## Summary
- Move canonical `ADD_KIND_IDS` into a project-tools metadata module and re-export it through the CLI package.
- Teach routing metadata generation and Bunli runtime aliases to consume that shared add-kind source.
- Add structural drift tests for CLI registry/runtime add-kind alignment.

## Verification
- `node packages/wp-typia/scripts/generate-routing-metadata.mjs --check`
- `bun test packages/wp-typia/tests/add-command.test.ts packages/wp-typia/tests/bunli-prep.test.ts packages/wp-typia/tests/cli-package.test.ts packages/wp-typia/tests/add-kind-source.test.ts packages/wp-typia/tests/add-kind-registry.test.ts packages/wp-typia-project-tools/tests/cli-add-shared.test.ts`
- `bun run format:check`
- `bun run lint:repo`
- `bun run typecheck`
- `bun run changesets:validate`
- `bun run manifest-policy:validate`
- `bun run runtime-coupling:validate`
- `bun run typescript-runtime:validate`
- `bun run publish:validate`
- `bun run --filter @wp-typia/project-tools build`
- `bun run --filter wp-typia build`

Closes #734

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Unified the source of add command kind IDs to ensure CLI and runtime helpers remain synchronized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->