### PR TITLE
fix(cli): code option parsing diagnostics

### DIFF
--- a/.sampo/changesets/736-diagnostic-coded-option-errors.md
+++ b/.sampo/changesets/736-diagnostic-coded-option-errors.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Emit diagnostic-coded CLI option parsing errors and preserve command context for structured Node fallback failures.

--- a/packages/wp-typia/src/command-contract.ts
+++ b/packages/wp-typia/src/command-contract.ts
@@ -99,7 +99,9 @@ function hasUnknownOptionBefore(argv: string[], endIndex: number): boolean {
       }
       if (
         !arg.includes('=') &&
-        SHARED_OPTION_PARSER.stringOptionNames.has(optionName)
+        SHARED_OPTION_PARSER.stringOptionNames.has(optionName) &&
+        argv[index + 1] &&
+        !argv[index + 1].startsWith('-')
       ) {
         index += 1;
       }
@@ -111,7 +113,11 @@ function hasUnknownOptionBefore(argv: string[], endIndex: number): boolean {
       if (!option) {
         return true;
       }
-      if (option.type === 'string') {
+      if (
+        option.type === 'string' &&
+        argv[index + 1] &&
+        !argv[index + 1].startsWith('-')
+      ) {
         index += 1;
       }
       continue;

--- a/packages/wp-typia/src/command-contract.ts
+++ b/packages/wp-typia/src/command-contract.ts
@@ -138,12 +138,12 @@ export function resolveCanonicalCommandContext(argv: string[]): string {
     return 'wp-typia';
   }
 
-  if (isReservedTopLevelCommandName(firstPositional)) {
-    return firstPositional;
-  }
-
   if (hasUnknownOptionBefore(argv, firstPositionalIndex)) {
     return 'wp-typia';
+  }
+
+  if (isReservedTopLevelCommandName(firstPositional)) {
+    return firstPositional;
   }
 
   return positionalIndexes.length === 1 ? 'create' : firstPositional;

--- a/packages/wp-typia/src/command-contract.ts
+++ b/packages/wp-typia/src/command-contract.ts
@@ -1,9 +1,5 @@
 import path from 'node:path';
 import {
-  CLI_DIAGNOSTIC_CODES,
-  createCliDiagnosticCodeError,
-} from '@wp-typia/project-tools/cli-diagnostics';
-import {
   collectPositionalIndexes,
   findFirstPositionalIndex,
 } from '../bin/argv-walker.js';
@@ -14,6 +10,7 @@ import {
   COMMAND_OPTION_METADATA_BY_GROUP,
   COMMAND_ROUTING_METADATA,
   GLOBAL_OPTION_METADATA,
+  createMissingOptionValueError,
 } from './command-option-metadata';
 export {
   WP_TYPIA_BUNLI_MIGRATION_DOC,
@@ -71,15 +68,6 @@ const SHORT_OPTION_NAMES_WITH_VALUES = new Set<string>(
     .filter(([, option]) => option.type === 'string')
     .map(([short]) => short),
 );
-
-function createMissingOptionValueError(
-  optionLabel: string,
-): ReturnType<typeof createCliDiagnosticCodeError> {
-  return createCliDiagnosticCodeError(
-    CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
-    `\`${optionLabel}\` requires a value.`,
-  );
-}
 
 export function isReservedTopLevelCommandName(value: string): boolean {
   return WP_TYPIA_RESERVED_TOP_LEVEL_COMMAND_NAMES.includes(

--- a/packages/wp-typia/src/command-contract.ts
+++ b/packages/wp-typia/src/command-contract.ts
@@ -75,6 +75,28 @@ export function isReservedTopLevelCommandName(value: string): boolean {
   );
 }
 
+export function resolveCanonicalCommandContext(argv: string[]): string {
+  const positionalIndexes = collectPositionalIndexes(
+    argv,
+    COMMAND_ROUTING_METADATA,
+  );
+  const firstPositionalIndex = positionalIndexes[0] ?? -1;
+  if (firstPositionalIndex === -1) {
+    return 'wp-typia';
+  }
+
+  const firstPositional = argv[firstPositionalIndex];
+  if (!firstPositional) {
+    return 'wp-typia';
+  }
+
+  if (isReservedTopLevelCommandName(firstPositional)) {
+    return firstPositional;
+  }
+
+  return positionalIndexes.length === 1 ? 'create' : firstPositional;
+}
+
 function assertStringOptionValues(argv: string[]): void {
   const firstPositionalIndex = findFirstPositionalIndex(
     argv,

--- a/packages/wp-typia/src/command-contract.ts
+++ b/packages/wp-typia/src/command-contract.ts
@@ -75,6 +75,54 @@ export function isReservedTopLevelCommandName(value: string): boolean {
   );
 }
 
+function getLongOptionName(arg: string): string {
+  return arg.slice(2).split('=', 1)[0] ?? '';
+}
+
+function hasUnknownOptionBefore(argv: string[], endIndex: number): boolean {
+  for (let index = 0; index < endIndex; index += 1) {
+    const arg = argv[index];
+    if (arg === '--') {
+      return false;
+    }
+    if (!arg.startsWith('-') || arg === '-') {
+      continue;
+    }
+
+    if (arg.startsWith('--')) {
+      const optionName = getLongOptionName(arg);
+      if (
+        !SHARED_OPTION_PARSER.booleanOptionNames.has(optionName) &&
+        !SHARED_OPTION_PARSER.stringOptionNames.has(optionName)
+      ) {
+        return true;
+      }
+      if (
+        !arg.includes('=') &&
+        SHARED_OPTION_PARSER.stringOptionNames.has(optionName)
+      ) {
+        index += 1;
+      }
+      continue;
+    }
+
+    if (arg.length === 2) {
+      const option = SHARED_OPTION_PARSER.shortFlagMap.get(arg.slice(1));
+      if (!option) {
+        return true;
+      }
+      if (option.type === 'string') {
+        index += 1;
+      }
+      continue;
+    }
+
+    return true;
+  }
+
+  return false;
+}
+
 export function resolveCanonicalCommandContext(argv: string[]): string {
   const positionalIndexes = collectPositionalIndexes(
     argv,
@@ -92,6 +140,10 @@ export function resolveCanonicalCommandContext(argv: string[]): string {
 
   if (isReservedTopLevelCommandName(firstPositional)) {
     return firstPositional;
+  }
+
+  if (hasUnknownOptionBefore(argv, firstPositionalIndex)) {
+    return 'wp-typia';
   }
 
   return positionalIndexes.length === 1 ? 'create' : firstPositional;

--- a/packages/wp-typia/src/command-contract.ts
+++ b/packages/wp-typia/src/command-contract.ts
@@ -1,5 +1,9 @@
 import path from 'node:path';
 import {
+  CLI_DIAGNOSTIC_CODES,
+  createCliDiagnosticCodeError,
+} from '@wp-typia/project-tools/cli-diagnostics';
+import {
   collectPositionalIndexes,
   findFirstPositionalIndex,
 } from '../bin/argv-walker.js';
@@ -68,6 +72,15 @@ const SHORT_OPTION_NAMES_WITH_VALUES = new Set<string>(
     .map(([short]) => short),
 );
 
+function createMissingOptionValueError(
+  optionLabel: string,
+): ReturnType<typeof createCliDiagnosticCodeError> {
+  return createCliDiagnosticCodeError(
+    CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
+    `\`${optionLabel}\` requires a value.`,
+  );
+}
+
 export function isReservedTopLevelCommandName(value: string): boolean {
   return WP_TYPIA_RESERVED_TOP_LEVEL_COMMAND_NAMES.includes(
     value as (typeof WP_TYPIA_RESERVED_TOP_LEVEL_COMMAND_NAMES)[number],
@@ -100,7 +113,7 @@ function assertStringOptionValues(argv: string[]): void {
       if (SHORT_OPTION_NAMES_WITH_VALUES.has(arg.slice(1))) {
         const next = argv[index + 1];
         if (!next || next.startsWith('-')) {
-          throw new Error(`\`${arg}\` requires a value.`);
+          throw createMissingOptionValueError(arg);
         }
         index += 1;
       }
@@ -117,14 +130,14 @@ function assertStringOptionValues(argv: string[]): void {
 
     if (arg.includes('=')) {
       if (!inlineValue) {
-        throw new Error(`\`--${rawName}\` requires a value.`);
+        throw createMissingOptionValueError(`--${rawName}`);
       }
       continue;
     }
 
     const next = argv[index + 1];
     if (!next || next.startsWith('-')) {
-      throw new Error(`\`--${rawName}\` requires a value.`);
+      throw createMissingOptionValueError(`--${rawName}`);
     }
     index += 1;
   }

--- a/packages/wp-typia/src/command-option-metadata.ts
+++ b/packages/wp-typia/src/command-option-metadata.ts
@@ -487,7 +487,7 @@ export const COMMAND_ROUTING_METADATA = buildArgvWalkerRoutingMetadata(
   ALL_COMMAND_OPTION_METADATA,
 );
 
-function createMissingOptionValueError(
+export function createMissingOptionValueError(
   optionLabel: string,
 ): ReturnType<typeof createCliDiagnosticCodeError> {
   return createCliDiagnosticCodeError(

--- a/packages/wp-typia/src/command-option-metadata.ts
+++ b/packages/wp-typia/src/command-option-metadata.ts
@@ -1,4 +1,8 @@
 import { z } from 'zod';
+import {
+  CLI_DIAGNOSTIC_CODES,
+  createCliDiagnosticCodeError,
+} from '@wp-typia/project-tools/cli-diagnostics';
 
 export type CommandOptionMetadata = {
   argumentKind?: 'flag';
@@ -483,6 +487,24 @@ export const COMMAND_ROUTING_METADATA = buildArgvWalkerRoutingMetadata(
   ALL_COMMAND_OPTION_METADATA,
 );
 
+function createMissingOptionValueError(
+  optionLabel: string,
+): ReturnType<typeof createCliDiagnosticCodeError> {
+  return createCliDiagnosticCodeError(
+    CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
+    `\`${optionLabel}\` requires a value.`,
+  );
+}
+
+function createUnknownOptionError(
+  optionLabel: string,
+): ReturnType<typeof createCliDiagnosticCodeError> {
+  return createCliDiagnosticCodeError(
+    CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
+    `Unknown option \`${optionLabel}\`.`,
+  );
+}
+
 export function extractKnownOptionValuesFromArgv(
   argv: string[],
   options: {
@@ -520,7 +542,7 @@ export function extractKnownOptionValuesFromArgv(
       }
       const next = argv[index + 1];
       if (!next || next.startsWith('-')) {
-        throw new Error(`\`${arg}\` requires a value.`);
+        throw createMissingOptionValueError(arg);
       }
       flags[shortFlag.name] = next;
       index += 1;
@@ -548,14 +570,14 @@ export function extractKnownOptionValuesFromArgv(
       }
       if (inlineValue !== undefined) {
         if (!inlineValue) {
-          throw new Error(`\`--${rawName}\` requires a value.`);
+          throw createMissingOptionValueError(`--${rawName}`);
         }
         flags[rawName] = inlineValue;
         continue;
       }
       const next = argv[index + 1];
       if (!next || next.startsWith('-')) {
-        throw new Error(`\`--${rawName}\` requires a value.`);
+        throw createMissingOptionValueError(`--${rawName}`);
       }
       flags[rawName] = next;
       index += 1;
@@ -600,7 +622,7 @@ export function parseCommandArgvWithMetadata(
     if (arg.length === 2 && arg.startsWith('-')) {
       const shortFlag = options.parser.shortFlagMap.get(arg.slice(1));
       if (!shortFlag) {
-        throw new Error(`Unknown option \`${arg}\`.`);
+        throw createUnknownOptionError(arg);
       }
       if (shortFlag.type === 'boolean') {
         flags[shortFlag.name] = true;
@@ -608,7 +630,7 @@ export function parseCommandArgvWithMetadata(
       }
       const next = argv[index + 1];
       if (!next || next.startsWith('-')) {
-        throw new Error(`\`${arg}\` requires a value.`);
+        throw createMissingOptionValueError(arg);
       }
       flags[shortFlag.name] = next;
       index += 1;
@@ -627,18 +649,18 @@ export function parseCommandArgvWithMetadata(
         continue;
       }
       if (!options.parser.stringOptionNames.has(rawName)) {
-        throw new Error(`Unknown option \`--${rawName}\`.`);
+        throw createUnknownOptionError(`--${rawName}`);
       }
       if (inlineValue !== undefined) {
         if (!inlineValue) {
-          throw new Error(`\`--${rawName}\` requires a value.`);
+          throw createMissingOptionValueError(`--${rawName}`);
         }
         flags[rawName] = inlineValue;
         continue;
       }
       const next = argv[index + 1];
       if (!next || next.startsWith('-')) {
-        throw new Error(`\`--${rawName}\` requires a value.`);
+        throw createMissingOptionValueError(`--${rawName}`);
       }
       flags[rawName] = next;
       index += 1;
@@ -646,7 +668,7 @@ export function parseCommandArgvWithMetadata(
     }
 
     if (arg.startsWith('-')) {
-      throw new Error(`Unknown option \`${arg}\`.`);
+      throw createUnknownOptionError(arg);
     }
 
     positionals.push(arg);

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -2,7 +2,6 @@ import packageJson from '../package.json';
 import {
   CLI_DIAGNOSTIC_CODES,
   createCliCommandError,
-  createCliDiagnosticCodeError,
   formatCliDiagnosticError,
   serializeCliDiagnosticError,
 } from '@wp-typia/project-tools/cli-diagnostics';
@@ -22,6 +21,7 @@ import {
   SYNC_OPTION_METADATA,
   TEMPLATES_OPTION_METADATA,
 } from './command-option-metadata';
+import { resolveEntrypointCliCommand } from './cli-command-resolution';
 import { prefersStructuredCliArgv } from './cli-diagnostic-output';
 import {
   normalizeCliOutputFormatArgv,
@@ -132,34 +132,18 @@ export function parseGlobalFlags(argv: string[]): {
   argv: string[];
   flags: GlobalFlags;
 } {
-  try {
-    const { argv: nextArgv, flags } = extractKnownOptionValuesFromArgv(argv, {
-      optionNames: ['format', 'id'],
-      parser: NODE_FALLBACK_OPTION_PARSER,
-    });
+  const { argv: nextArgv, flags } = extractKnownOptionValuesFromArgv(argv, {
+    optionNames: ['format', 'id'],
+    parser: NODE_FALLBACK_OPTION_PARSER,
+  });
 
-    return {
-      argv: nextArgv,
-      flags: {
-        format: typeof flags.format === 'string' ? flags.format : undefined,
-        id: typeof flags.id === 'string' ? flags.id : undefined,
-      },
-    };
-  } catch (error) {
-    if (
-      error instanceof Error &&
-      /\`--format\` requires a value\.|\`--id\` requires a value\./.test(
-        error.message,
-      )
-    ) {
-      throw createCliDiagnosticCodeError(
-        CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
-        error.message,
-      );
-    }
-
-    throw error;
-  }
+  return {
+    argv: nextArgv,
+    flags: {
+      format: typeof flags.format === 'string' ? flags.format : undefined,
+      id: typeof flags.id === 'string' ? flags.id : undefined,
+    },
+  };
 }
 
 async function applyNodeFallbackConfigDefaults(
@@ -726,11 +710,15 @@ export async function runNodeCliEntrypoint(
     await runNodeCli(argv);
   } catch (error) {
     if (prefersStructuredErrorOutput) {
+      const diagnostic = createCliCommandError({
+        command: resolveEntrypointCliCommand(argv),
+        error,
+      });
       process.stderr.write(
         `${JSON.stringify(
           {
             ok: false,
-            error: serializeCliDiagnosticError(error),
+            error: serializeCliDiagnosticError(diagnostic),
           },
           null,
           2,

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -21,7 +21,6 @@ import {
   SYNC_OPTION_METADATA,
   TEMPLATES_OPTION_METADATA,
 } from './command-option-metadata';
-import { resolveEntrypointCliCommand } from './cli-command-resolution';
 import { prefersStructuredCliArgv } from './cli-diagnostic-output';
 import {
   normalizeCliOutputFormatArgv,
@@ -68,6 +67,7 @@ import {
   WP_TYPIA_NODE_FALLBACK_TOP_LEVEL_COMMAND_NAMES,
   WP_TYPIA_POSITIONAL_ALIAS_USAGE,
   normalizeWpTypiaArgv,
+  resolveCanonicalCommandContext,
 } from './command-contract';
 
 type GlobalFlags = {
@@ -711,7 +711,7 @@ export async function runNodeCliEntrypoint(
   } catch (error) {
     if (prefersStructuredErrorOutput) {
       const diagnostic = createCliCommandError({
-        command: resolveEntrypointCliCommand(argv),
+        command: resolveCanonicalCommandContext(argv),
         error,
       });
       process.stderr.write(

--- a/packages/wp-typia/tests/bunli-prep.test.ts
+++ b/packages/wp-typia/tests/bunli-prep.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
+import { CLI_DIAGNOSTIC_CODES } from '@wp-typia/project-tools/cli-diagnostics';
 
 import { COMMAND_ROUTING_METADATA } from '../src/command-option-metadata';
 import {
@@ -33,6 +34,19 @@ const runtimeDependencyHelperSource = fs.readFileSync(
 );
 
 describe('wp-typia Bunli preparation', () => {
+  function expectMissingOptionValue(callback: () => unknown): void {
+    let caught: unknown;
+    try {
+      callback();
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toMatchObject({
+      code: CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
+    });
+  }
+
   test('checks in the Bunli prep tree while promoting a built CLI runtime', () => {
     expect(packageManifest.bin['wp-typia']).toBe('bin/wp-typia.js');
     expect(packageManifest.files).toContain('dist-bunli/');
@@ -340,11 +354,11 @@ describe('wp-typia Bunli preparation', () => {
       '--position',
       'after',
     ]);
-    expect(() =>
+    expectMissingOptionValue(() =>
       normalizeWpTypiaArgv(['templates', 'inspect', '--id']),
-    ).toThrow(/`--id` requires a value\./);
-    expect(() => normalizeWpTypiaArgv(['mcp', 'sync', '--output-dir'])).toThrow(
-      /`--output-dir` requires a value\./,
+    );
+    expectMissingOptionValue(() =>
+      normalizeWpTypiaArgv(['mcp', 'sync', '--output-dir']),
     );
     expect(
       normalizeWpTypiaArgv(['mcp', 'sync', '--output-dir=.bunli/custom-mcp']),

--- a/packages/wp-typia/tests/command-option-metadata.test.ts
+++ b/packages/wp-typia/tests/command-option-metadata.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import { CLI_DIAGNOSTIC_CODES } from '@wp-typia/project-tools/cli-diagnostics';
 
 import {
   ALL_COMMAND_OPTION_METADATA,
@@ -19,6 +20,24 @@ import {
 } from '../src/command-option-metadata';
 
 describe('command option metadata helpers', () => {
+  function expectDiagnosticCode(
+    callback: () => unknown,
+    code: string,
+    message: string,
+  ): void {
+    let caught: unknown;
+    try {
+      callback();
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toMatchObject({
+      code,
+      message,
+    });
+  }
+
   test('parses string and boolean flags from shared metadata', () => {
     const parsed = parseCommandArgvWithMetadata(
       ['--dry-run', '-t', 'basic', '-y', 'demo-project'],
@@ -248,5 +267,46 @@ describe('command option metadata helpers', () => {
       id: 'basic',
     });
     expect(extracted.argv).toEqual(['templates', 'inspect', '--', '--format']);
+  });
+
+  test('throws diagnostic-coded errors for parser option failures', () => {
+    const parser = buildCommandOptionParser(
+      GLOBAL_OPTION_METADATA,
+      DOCTOR_OPTION_METADATA,
+    );
+
+    expectDiagnosticCode(
+      () =>
+      parseCommandArgvWithMetadata(['doctor', '--format'], {
+        parser,
+      }),
+      CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
+      '`--format` requires a value.',
+    );
+    expectDiagnosticCode(
+      () =>
+      parseCommandArgvWithMetadata(['doctor', '--unknown'], {
+        parser,
+      }),
+      CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
+      'Unknown option `--unknown`.',
+    );
+  });
+
+  test('throws diagnostic-coded errors for missing extracted global option values', () => {
+    const parser = buildCommandOptionParser(ALL_COMMAND_OPTION_METADATA);
+
+    expectDiagnosticCode(
+      () =>
+      extractKnownOptionValuesFromArgv(
+        ['templates', '--id', '--format', 'json'],
+        {
+          optionNames: ['format', 'id'],
+          parser,
+        },
+      ),
+      CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
+      '`--id` requires a value.',
+    );
   });
 });

--- a/packages/wp-typia/tests/node-cli-core.test.ts
+++ b/packages/wp-typia/tests/node-cli-core.test.ts
@@ -366,6 +366,31 @@ describe('Node fallback CLI core routing', () => {
     expect(parsed.error?.detailLines).toContain('Unknown option `--unknown`.');
   });
 
+  test('keeps reserved commands after unknown options on the top-level structured context', async () => {
+    const result = await captureNodeCli(
+      ['--unknown', 'templates', '--format', 'json'],
+      { entrypoint: true },
+    );
+    const parsed = JSON.parse(result.stderr) as {
+      error?: {
+        code?: string;
+        command?: string;
+        detailLines?: string[];
+        kind?: string;
+      };
+      ok?: boolean;
+    };
+
+    expect(result.error).toBeUndefined();
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe('');
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error?.kind).toBe('command-execution');
+    expect(parsed.error?.code).toBe('invalid-argument');
+    expect(parsed.error?.command).toBe('wp-typia');
+    expect(parsed.error?.detailLines).toContain('Unknown option `--unknown`.');
+  });
+
   test('emits structured command output when --format json is explicit', async () => {
     const tempRoot = createTempRoot('wp-typia-node-json-create-');
 

--- a/packages/wp-typia/tests/node-cli-core.test.ts
+++ b/packages/wp-typia/tests/node-cli-core.test.ts
@@ -391,6 +391,31 @@ describe('Node fallback CLI core routing', () => {
     expect(parsed.error?.detailLines).toContain('Unknown option `--unknown`.');
   });
 
+  test('does not skip option-like tokens after missing pre-command option values', async () => {
+    const result = await captureNodeCli(
+      ['--id', '--unknown', 'templates', '--format', 'json'],
+      { entrypoint: true },
+    );
+    const parsed = JSON.parse(result.stderr) as {
+      error?: {
+        code?: string;
+        command?: string;
+        detailLines?: string[];
+        kind?: string;
+      };
+      ok?: boolean;
+    };
+
+    expect(result.error).toBeUndefined();
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe('');
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error?.kind).toBe('command-execution');
+    expect(parsed.error?.code).toBe('missing-argument');
+    expect(parsed.error?.command).toBe('wp-typia');
+    expect(parsed.error?.detailLines).toContain('`--id` requires a value.');
+  });
+
   test('emits structured command output when --format json is explicit', async () => {
     const tempRoot = createTempRoot('wp-typia-node-json-create-');
 

--- a/packages/wp-typia/tests/node-cli-core.test.ts
+++ b/packages/wp-typia/tests/node-cli-core.test.ts
@@ -285,9 +285,35 @@ describe('Node fallback CLI core routing', () => {
     expect(result.stdout).toBe('');
     expect(result.stderr).toBe('');
     expect(result.error).toBeInstanceOf(Error);
+    expect((result.error as { code?: string }).code).toBe('missing-argument');
     expect((result.error as Error).message).toContain(
       '`--format` requires a value.',
     );
+  });
+
+  test('emits structured missing option value diagnostics with command context', async () => {
+    const result = await captureNodeCli(
+      ['templates', '--id', '--format', 'json'],
+      { entrypoint: true },
+    );
+    const parsed = JSON.parse(result.stderr) as {
+      error?: {
+        code?: string;
+        command?: string;
+        detailLines?: string[];
+        kind?: string;
+      };
+      ok?: boolean;
+    };
+
+    expect(result.error).toBeUndefined();
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe('');
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error?.kind).toBe('command-execution');
+    expect(parsed.error?.code).toBe('missing-argument');
+    expect(parsed.error?.command).toBe('templates');
+    expect(parsed.error?.detailLines).toContain('`--id` requires a value.');
   });
 
   test('emits structured command output when --format json is explicit', async () => {

--- a/packages/wp-typia/tests/node-cli-core.test.ts
+++ b/packages/wp-typia/tests/node-cli-core.test.ts
@@ -341,6 +341,31 @@ describe('Node fallback CLI core routing', () => {
     expect(parsed.error?.detailLines).toContain('`--id` requires a value.');
   });
 
+  test('keeps pre-command unknown options on the top-level structured context', async () => {
+    const result = await captureNodeCli(
+      ['--unknown', 'alias-project', '--format', 'json'],
+      { entrypoint: true },
+    );
+    const parsed = JSON.parse(result.stderr) as {
+      error?: {
+        code?: string;
+        command?: string;
+        detailLines?: string[];
+        kind?: string;
+      };
+      ok?: boolean;
+    };
+
+    expect(result.error).toBeUndefined();
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe('');
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error?.kind).toBe('command-execution');
+    expect(parsed.error?.code).toBe('invalid-argument');
+    expect(parsed.error?.command).toBe('wp-typia');
+    expect(parsed.error?.detailLines).toContain('Unknown option `--unknown`.');
+  });
+
   test('emits structured command output when --format json is explicit', async () => {
     const tempRoot = createTempRoot('wp-typia-node-json-create-');
 

--- a/packages/wp-typia/tests/node-cli-core.test.ts
+++ b/packages/wp-typia/tests/node-cli-core.test.ts
@@ -316,6 +316,31 @@ describe('Node fallback CLI core routing', () => {
     expect(parsed.error?.detailLines).toContain('`--id` requires a value.');
   });
 
+  test('emits structured alias option diagnostics with create command context', async () => {
+    const result = await captureNodeCli(
+      ['alias-project', '--id', '--format', 'json'],
+      { entrypoint: true },
+    );
+    const parsed = JSON.parse(result.stderr) as {
+      error?: {
+        code?: string;
+        command?: string;
+        detailLines?: string[];
+        kind?: string;
+      };
+      ok?: boolean;
+    };
+
+    expect(result.error).toBeUndefined();
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe('');
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error?.kind).toBe('command-execution');
+    expect(parsed.error?.code).toBe('missing-argument');
+    expect(parsed.error?.command).toBe('create');
+    expect(parsed.error?.detailLines).toContain('`--id` requires a value.');
+  });
+
   test('emits structured command output when --format json is explicit', async () => {
     const tempRoot = createTempRoot('wp-typia-node-json-create-');
 


### PR DESCRIPTION
## Summary
- replace raw CLI option parsing errors with diagnostic-coded missing/invalid argument errors
- remove Node fallback regex matching against English missing-value messages
- wrap structured Node fallback entrypoint failures with command context before serialization
- add tests for missing string option values, unknown options, and structured JSON command metadata

## Tests
- bun test packages/wp-typia/tests/command-option-metadata.test.ts
- bun test packages/wp-typia/tests/node-cli-core.test.ts
- bun test packages/wp-typia/tests/bunli-prep.test.ts
- bun test packages/wp-typia-project-tools/tests/cli-entry.test.ts
- bun test packages/wp-typia/tests/cli-package.test.ts
- bun run --filter wp-typia build
- bun run format:check
- bun run typecheck
- bun run lint:repo
- bun run manifest-policy:validate
- bun run runtime-coupling:validate
- bun run typescript-runtime:validate
- bun run publish:validate
- bun run changesets:validate
- node packages/wp-typia/scripts/generate-routing-metadata.mjs --check
- git diff --check

Closes #736

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CLI option parsing now emits standardized diagnostic-coded errors for missing or unknown option values.
  * Structured error output for command failures preserves the relevant command context and diagnostic details.
  * Missing-option cases consistently report a clear diagnostic code and message across all CLI commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->