### PR TITLE
fix(scaffold): surface invalid compatibility floors

### DIFF
--- a/.sampo/changesets/742-compatibility-version-floor-diagnostics.md
+++ b/.sampo/changesets/742-compatibility-version-floor-diagnostics.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Surface malformed scaffold compatibility version floors instead of silently falling back, including CLI warnings for repaired plugin headers.

--- a/apps/docs/src/content/docs/reference/ai-scaffold-compatibility.md
+++ b/apps/docs/src/content/docs/reference/ai-scaffold-compatibility.md
@@ -19,6 +19,12 @@ The baseline also applies to optional AI features. Optional features must use
 runtime gates and graceful degradation instead of raising the plugin header
 floor.
 
+Compatibility floors must use dotted numeric segments, for example `6.7`,
+`7.0`, or `8.1.2`. Wildcards and ranges such as `6.x`, `^6.7`, or `>=6.7` are
+not accepted. Invalid internal policy values fail fast; malformed existing
+plugin header values are replaced with the resolved policy floor and surfaced as
+CLI warnings so maintainers can fix the source value deliberately.
+
 ## Feature Modes
 
 - `required`: raises the generated plugin header to the highest required

--- a/packages/wp-typia-project-tools/src/runtime/ai-feature-capability.ts
+++ b/packages/wp-typia-project-tools/src/runtime/ai-feature-capability.ts
@@ -151,6 +151,13 @@ function normalizeSelections(
   return [...normalized.values()];
 }
 
+function validateFeatureMinimumVersions(
+  definition: AiFeatureDefinition,
+): void {
+  pickHigherVersionFloor(definition.minimumVersions?.wordpress, undefined);
+  pickHigherVersionFloor(definition.minimumVersions?.php, undefined);
+}
+
 /**
  * Resolves a normalized AI feature capability plan from a list of selections.
  *
@@ -181,6 +188,7 @@ export function resolveAiFeatureCapabilityPlan(
         `Unknown AI feature capability "${selection.featureId}".`,
       );
     }
+    validateFeatureMinimumVersions(definition);
 
     const resolvedDefinition = {
       ...definition,

--- a/packages/wp-typia-project-tools/src/runtime/ai-feature-capability.ts
+++ b/packages/wp-typia-project-tools/src/runtime/ai-feature-capability.ts
@@ -154,8 +154,26 @@ function normalizeSelections(
 function validateFeatureMinimumVersions(
   definition: AiFeatureDefinition,
 ): void {
-  pickHigherVersionFloor(definition.minimumVersions?.wordpress, undefined);
-  pickHigherVersionFloor(definition.minimumVersions?.php, undefined);
+  for (const [platform, value] of [
+    ['wordpress', definition.minimumVersions?.wordpress],
+    ['php', definition.minimumVersions?.php],
+  ] as const) {
+    if (value === undefined) {
+      continue;
+    }
+
+    try {
+      pickHigherVersionFloor(value, undefined);
+    } catch (error) {
+      throw new Error(
+        [
+          `Invalid ${platform} minimum version floor for AI feature "${definition.id}": "${value}".`,
+          'Expected dotted numeric segments such as "6.7" or "8.1.2".',
+        ].join(' '),
+        { cause: error },
+      );
+    }
+  }
 }
 
 /**

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ability-scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ability-scaffold.ts
@@ -481,7 +481,10 @@ export async function scaffoldAbilityWorkspace({
 	abilitySlug,
 	compatibilityPolicy,
 	workspace,
-}: ScaffoldAbilityWorkspaceOptions): Promise<void> {
+}: ScaffoldAbilityWorkspaceOptions): Promise<{
+	warnings: string[];
+}> {
+	const compatibilityWarnings: string[] = [];
 	const blockConfigPath = path.join(workspace.projectDir, "scripts", "block-config.ts");
 	const bootstrapPath = getWorkspaceBootstrapPath(workspace);
 	const buildScriptPath = path.join(workspace.projectDir, "scripts", "build-workspace.mjs");
@@ -526,7 +529,11 @@ export async function scaffoldAbilityWorkspace({
 			await fsp.mkdir(path.dirname(phpFilePath), { recursive: true });
 			await ensureAbilityBootstrapAnchors(workspace);
 			await patchFile(bootstrapPath, (source) =>
-				updatePluginHeaderCompatibility(source, compatibilityPolicy),
+				updatePluginHeaderCompatibility(source, compatibilityPolicy, {
+					onWarning: (warning) => {
+						compatibilityWarnings.push(warning);
+					},
+				}),
 			);
 			await ensureAbilityPackageScripts(workspace);
 			await ensureAbilitySyncProjectAnchors(workspace);
@@ -568,4 +575,8 @@ export async function scaffoldAbilityWorkspace({
 			});
 		},
 	});
+
+	return {
+		warnings: compatibilityWarnings,
+	};
 }

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ability.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ability.ts
@@ -14,6 +14,9 @@ import {
 
 /**
  * Add one typed workflow ability scaffold to an official workspace project.
+ *
+ * @returns Generated ability metadata plus non-fatal scaffold warnings, such
+ * as repaired malformed existing plugin header floor values.
  */
 export async function runAddAbilityCommand({
 	abilityName,

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ability.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ability.ts
@@ -21,6 +21,7 @@ export async function runAddAbilityCommand({
 }: RunAddAbilityCommandOptions): Promise<{
 	abilitySlug: string;
 	projectDir: string;
+	warnings: string[];
 }> {
 	const workspace = resolveWorkspaceProject(cwd);
 	const abilitySlug = assertValidGeneratedSlug(
@@ -35,7 +36,7 @@ export async function runAddAbilityCommand({
 	const compatibilityPolicy = resolveScaffoldCompatibilityPolicy(
 		REQUIRED_WORKSPACE_ABILITY_COMPATIBILITY,
 	);
-	await scaffoldAbilityWorkspace({
+	const scaffoldResult = await scaffoldAbilityWorkspace({
 		abilitySlug,
 		compatibilityPolicy,
 		workspace,
@@ -44,5 +45,6 @@ export async function runAddAbilityCommand({
 	return {
 		abilitySlug,
 		projectDir: workspace.projectDir,
+		warnings: scaffoldResult.warnings,
 	};
 }

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai-scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai-scaffold.ts
@@ -57,6 +57,7 @@ export async function scaffoldAiFeatureWorkspace({
 }: ScaffoldAiFeatureWorkspaceOptions): Promise<{
 	warnings: string[];
 }> {
+	const compatibilityWarnings: string[] = [];
 	const blockConfigPath = path.join(workspace.projectDir, "scripts", "block-config.ts");
 	const bootstrapPath = getWorkspaceBootstrapPath(workspace);
 	const packageJsonPath = path.join(workspace.projectDir, "package.json");
@@ -94,7 +95,11 @@ export async function scaffoldAiFeatureWorkspace({
 			await fsp.mkdir(path.dirname(phpFilePath), { recursive: true });
 			await ensureAiFeatureBootstrapAnchors(workspace);
 			await patchFile(bootstrapPath, (source) =>
-				updatePluginHeaderCompatibility(source, compatibilityPolicy),
+				updatePluginHeaderCompatibility(source, compatibilityPolicy, {
+					onWarning: (warning) => {
+						compatibilityWarnings.push(warning);
+					},
+				}),
 			);
 			const packageScriptChanges = await ensureAiFeaturePackageScripts(workspace);
 			await ensureAiFeatureSyncProjectAnchors(workspace);
@@ -150,11 +155,14 @@ export async function scaffoldAiFeatureWorkspace({
 			});
 
 			return {
-				warnings: packageScriptChanges.addedProjectToolsDependency
-					? [
-							"Added `@wp-typia/project-tools` to devDependencies for `sync-ai`. If this workspace was already installed, rerun your package manager install command before the first `wp-typia sync ai`.",
-						]
-					: [],
+				warnings: [
+					...compatibilityWarnings,
+					...(packageScriptChanges.addedProjectToolsDependency
+						? [
+								"Added `@wp-typia/project-tools` to devDependencies for `sync-ai`. If this workspace was already installed, rerun your package manager install command before the first `wp-typia sync ai`.",
+							]
+						: []),
+				],
 			};
 		},
 	});

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-compatibility.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-compatibility.ts
@@ -12,7 +12,10 @@ import {
   type ResolvedAiFeatureCapabilityPlan,
   resolveAiFeatureCapabilityPlan,
 } from './ai-feature-capability.js';
-import { pickHigherVersionFloor } from './version-floor.js';
+import {
+  parseVersionFloorParts,
+  pickHigherVersionFloor,
+} from './version-floor.js';
 
 /**
  * WordPress plugin header version floors emitted by scaffold templates.
@@ -42,6 +45,17 @@ export interface ScaffoldCompatibilityConfig {
   requiredFeatureIds: string[];
   requiredFeatures: string[];
   runtimeGates: string[];
+}
+
+/**
+ * Optional hooks for surfacing user-authored compatibility header repairs.
+ */
+export interface UpdatePluginHeaderCompatibilityOptions {
+  /**
+   * Receives warnings when a malformed existing plugin header value is
+   * replaced by the resolved policy floor.
+   */
+  onWarning?: (warning: string) => void;
 }
 
 /**
@@ -90,6 +104,13 @@ function pickHigherScaffoldVersionFloor(
 function pickHigherHeaderVersionFloor(
   policyValue: string,
   currentValue: string,
+  {
+    headerName,
+    onWarning,
+  }: {
+    headerName: string;
+    onWarning?: (warning: string) => void;
+  },
 ): string {
   const normalizedCurrentValue = currentValue.trim();
   if (!normalizedCurrentValue) {
@@ -98,9 +119,42 @@ function pickHigherHeaderVersionFloor(
 
   try {
     return pickHigherScaffoldVersionFloor(policyValue, normalizedCurrentValue);
-  } catch {
+  } catch (error) {
+    const warning = [
+      `Invalid plugin header version floor for ${headerName}: "${normalizedCurrentValue}".`,
+      'Expected dotted numeric segments such as "6.7" or "8.1.2".',
+      `Replacing it with compatibility policy value "${policyValue}".`,
+    ].join(' ');
+
+    if (!onWarning) {
+      throw new Error(warning, { cause: error });
+    }
+
+    onWarning(warning);
     return policyValue;
   }
+}
+
+function assertPolicyVersionFloor(headerName: string, value: string): void {
+  try {
+    parseVersionFloorParts(value);
+  } catch (error) {
+    throw new Error(
+      [
+        `Invalid scaffold compatibility policy floor for ${headerName}: "${value}".`,
+        'Expected dotted numeric segments such as "6.7" or "8.1.2".',
+      ].join(' '),
+      { cause: error },
+    );
+  }
+}
+
+function assertPluginHeaderPolicyVersionFloors(
+  pluginHeader: ScaffoldPluginHeaderCompatibility,
+): void {
+  assertPolicyVersionFloor('Requires at least', pluginHeader.requiresAtLeast);
+  assertPolicyVersionFloor('Tested up to', pluginHeader.testedUpTo);
+  assertPolicyVersionFloor('Requires PHP', pluginHeader.requiresPhp);
 }
 
 function formatRuntimeGate(feature: ResolvedAiFeatureCapability): string[] {
@@ -205,6 +259,8 @@ function replacePluginHeaderVersionFloor(
   source: string,
   pattern: RegExp,
   policyValue: string,
+  headerName: string,
+  options: UpdatePluginHeaderCompatibilityOptions,
 ): string {
   return source.replace(
     pattern,
@@ -213,6 +269,10 @@ function replacePluginHeaderVersionFloor(
       return `${versionPrefix}${pickHigherHeaderVersionFloor(
         policyValue,
         currentValue,
+        {
+          headerName,
+          onWarning: options.onWarning,
+        },
       )}${lineEnding}`;
     },
   );
@@ -221,28 +281,38 @@ function replacePluginHeaderVersionFloor(
 /**
  * Patch a generated plugin bootstrap header without lowering custom floors.
  *
- * Preserves the original header line endings while replacing empty or invalid
- * version strings with the policy values.
+ * Preserves the original header line endings while replacing empty version
+ * strings with policy values. Malformed user-authored values are reported
+ * through `options.onWarning`; without a warning handler they throw instead of
+ * falling back silently.
  */
 export function updatePluginHeaderCompatibility(
   source: string,
   policy: ScaffoldCompatibilityPolicy,
+  options: UpdatePluginHeaderCompatibilityOptions = {},
 ): string {
   const { pluginHeader } = policy;
+  assertPluginHeaderPolicyVersionFloors(pluginHeader);
 
   const nextSource = replacePluginHeaderVersionFloor(
     source,
     /(\* Requires at least:[^\S\r\n]*)([^\r\n]*)(\r?)/u,
     pluginHeader.requiresAtLeast,
+    'Requires at least',
+    options,
   );
   const nextSourceWithTestedUpTo = replacePluginHeaderVersionFloor(
     nextSource,
     /(\* Tested up to:[^\S\r\n]*)([^\r\n]*)(\r?)/u,
     pluginHeader.testedUpTo,
+    'Tested up to',
+    options,
   );
   return replacePluginHeaderVersionFloor(
     nextSourceWithTestedUpTo,
     /(\* Requires PHP:[^\S\r\n]*)([^\r\n]*)(\r?)/u,
     pluginHeader.requiresPhp,
+    'Requires PHP',
+    options,
   );
 }

--- a/packages/wp-typia-project-tools/src/runtime/version-floor.ts
+++ b/packages/wp-typia-project-tools/src/runtime/version-floor.ts
@@ -55,10 +55,17 @@ export function pickHigherVersionFloor(
   current: string | undefined,
   candidate: string | undefined,
 ): string | undefined {
-  if (!candidate) {
+  if (current !== undefined) {
+    parseVersionFloorParts(current);
+  }
+  if (candidate !== undefined) {
+    parseVersionFloorParts(candidate);
+  }
+
+  if (candidate === undefined) {
     return current;
   }
-  if (!current) {
+  if (current === undefined) {
     return candidate;
   }
 

--- a/packages/wp-typia-project-tools/tests/wordpress-ai-spec.test.ts
+++ b/packages/wp-typia-project-tools/tests/wordpress-ai-spec.test.ts
@@ -503,7 +503,122 @@ describe('WordPress AI AbilitySpec foundation', () => {
     expect(nextSource).toContain(' */');
   });
 
+  test('surfaces invalid user-authored plugin header floors as warnings', () => {
+    const source = [
+      '<?php',
+      '/**',
+      ' * Plugin Name: Demo',
+      ' * Requires at least: 6.x',
+      ' * Tested up to:      6.9',
+      ' * Requires PHP:      8.x',
+      ' */',
+      '',
+    ].join('\n');
+    const warnings: string[] = [];
+    const nextSource = updatePluginHeaderCompatibility(
+      source,
+      resolveScaffoldCompatibilityPolicy(
+        REQUIRED_WORKSPACE_ABILITY_COMPATIBILITY,
+      ),
+      {
+        onWarning: (warning) => {
+          warnings.push(warning);
+        },
+      },
+    );
+
+    expect(nextSource).toContain(' * Requires at least: 7.0\n');
+    expect(nextSource).toContain(' * Tested up to:      7.0\n');
+    expect(nextSource).toContain(' * Requires PHP:      8.0\n');
+    expect(warnings).toEqual([
+      'Invalid plugin header version floor for Requires at least: "6.x". Expected dotted numeric segments such as "6.7" or "8.1.2". Replacing it with compatibility policy value "7.0".',
+      'Invalid plugin header version floor for Requires PHP: "8.x". Expected dotted numeric segments such as "6.7" or "8.1.2". Replacing it with compatibility policy value "8.0".',
+    ]);
+  });
+
+  test('rejects invalid user-authored plugin header floors without a warning handler', () => {
+    const source = [
+      '<?php',
+      '/**',
+      ' * Plugin Name: Demo',
+      ' * Requires at least: 6.x',
+      ' * Tested up to:      6.9',
+      ' * Requires PHP:      8.0',
+      ' */',
+      '',
+    ].join('\n');
+
+    expect(() =>
+      updatePluginHeaderCompatibility(
+        source,
+        resolveScaffoldCompatibilityPolicy(
+          REQUIRED_WORKSPACE_ABILITY_COMPATIBILITY,
+        ),
+      ),
+    ).toThrow(
+      /Invalid plugin header version floor for Requires at least: "6\.x"/,
+    );
+  });
+
+  test('rejects invalid scaffold compatibility baseline floors', () => {
+    expect(() =>
+      resolveScaffoldCompatibilityPolicy([], {
+        baseline: {
+          requiresAtLeast: '6.x',
+          requiresPhp: '8.0',
+          testedUpTo: '6.9',
+        },
+      }),
+    ).toThrow(/invalid version floor "6\.x"/);
+  });
+
   test('rejects invalid version floor segments instead of silently comparing them', () => {
+    expect(() =>
+      resolveAiFeatureCapabilityPlan(
+        [
+          {
+            featureId: 'invalid-feature',
+            mode: 'optional',
+          },
+        ],
+        {
+          'invalid-feature': {
+            description: 'Invalid optional floor',
+            id: 'invalid-feature',
+            label: 'Invalid optional floor',
+            minimumVersions: {
+              wordpress: '6.x',
+            },
+          },
+        },
+      ),
+    ).toThrow(
+      /parseVersionFloorParts received an invalid version floor "6\.x"/,
+    );
+
+    expect(() =>
+      resolveAiFeatureCapabilityPlan(
+        [
+          {
+            featureId: 'invalid-feature',
+            mode: 'required',
+          },
+        ],
+        {
+          'invalid-feature': {
+            description: 'Invalid floor',
+            id: 'invalid-feature',
+            label: 'Invalid floor',
+            minimumVersions: {
+              wordpress: '6.x',
+            },
+          },
+        },
+      ),
+    ).toThrow(
+      /parseVersionFloorParts received an invalid version floor "6\.x"/,
+    );
+
     expect(() =>
       resolveAiFeatureCapabilityPlan(
         [

--- a/packages/wp-typia-project-tools/tests/wordpress-ai-spec.test.ts
+++ b/packages/wp-typia-project-tools/tests/wordpress-ai-spec.test.ts
@@ -593,7 +593,7 @@ describe('WordPress AI AbilitySpec foundation', () => {
         },
       ),
     ).toThrow(
-      /parseVersionFloorParts received an invalid version floor "6\.x"/,
+      /Invalid wordpress minimum version floor for AI feature "invalid-feature": "6\.x"/,
     );
 
     expect(() =>
@@ -616,7 +616,7 @@ describe('WordPress AI AbilitySpec foundation', () => {
         },
       ),
     ).toThrow(
-      /parseVersionFloorParts received an invalid version floor "6\.x"/,
+      /Invalid wordpress minimum version floor for AI feature "invalid-feature": "6\.x"/,
     );
 
     expect(() =>
@@ -651,7 +651,7 @@ describe('WordPress AI AbilitySpec foundation', () => {
         },
       ),
     ).toThrow(
-      /parseVersionFloorParts received an invalid version floor "7\.x"/,
+      /Invalid wordpress minimum version floor for AI feature "invalid-feature": "7\.x"/,
     );
   });
 });

--- a/packages/wp-typia/src/add-kind-registry.ts
+++ b/packages/wp-typia/src/add-kind-registry.ts
@@ -520,8 +520,10 @@ export const ADD_KIND_REGISTRY = {
         getValues: (result) => ({
           abilitySlug: result.abilitySlug,
         }),
+        getWarnings: (result) => result.warnings,
         missingNameMessage:
           '`wp-typia add ability` requires <name>. Usage: wp-typia add ability <name>.',
+        warnLine: context.warnLine,
       });
     },
     sortOrder: 90,


### PR DESCRIPTION
Closes #742

## Summary
- validate selected scaffold compatibility version floors even when they are optional or the only candidate
- surface malformed existing plugin header floors as CLI warnings while replacing them with policy values
- document the dotted numeric floor format and add a Sampo changeset

## Tests
- bun test packages/wp-typia-project-tools/tests/wordpress-ai-spec.test.ts
- bun test packages/wp-typia-project-tools/tests/cli-add-workspace-ability.test.ts
- bun test packages/wp-typia/tests/completion-output.test.ts
- bun test packages/wp-typia/tests/cli-package.test.ts
- bun test packages/wp-typia-project-tools/tests/workspace-add.test.ts
- bun run typecheck
- bun run format:check
- bun run changesets:validate
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Invalid compatibility version floors now surface with CLI warnings instead of being silently processed
  * Malformed plugin header compatibility versions are now repaired with user warnings

* **Documentation**
  * Added validation rules for compatibility version floors (dotted numeric format required; wildcards and ranges disallowed)

* **Tests**
  * Added test coverage for warning emission and validation of compatibility version floors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->