### PR TITLE
[codex] docs(typia-llm): clarify mutable constraint merge

### DIFF
--- a/.sampo/changesets/743-typia-llm-mutating-merge-docs.md
+++ b/.sampo/changesets/743-typia-llm-mutating-merge-docs.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Clarify that typia.llm OpenAPI constraint restoration mutates its cloned target schema while preserving public artifact inputs.

--- a/packages/wp-typia-project-tools/src/runtime/typia-llm.ts
+++ b/packages/wp-typia-project-tools/src/runtime/typia-llm.ts
@@ -429,6 +429,13 @@ function collectOpenApiSeenReferences(
   return new Set([...seenReferences, reference]);
 }
 
+/**
+ * Copy constraint-oriented JSON Schema keywords from `source` into `target`.
+ *
+ * This helper intentionally mutates and returns `target` so nested OpenAPI
+ * constraint restoration can preserve the projected typia.llm schema shape.
+ * Callers that need immutable behavior should clone the target before calling.
+ */
 function mergeJsonSchemaConstraintProperties(
   document: OpenApiDocument,
   target: JsonSchemaObject,

--- a/packages/wp-typia-project-tools/tests/typia-llm.test.ts
+++ b/packages/wp-typia-project-tools/tests/typia-llm.test.ts
@@ -751,6 +751,50 @@ describe('typia.llm adapter emitter', () => {
     });
   });
 
+  test('restores OpenAPI constraints by mutating only the cloned target schema', () => {
+    const parameters = {
+      $defs: {},
+      additionalProperties: false,
+      properties: {
+        publicWriteToken: {
+          type: 'string',
+        },
+      },
+      required: ['publicWriteToken'],
+      type: 'object',
+    } satisfies ILlmSchema.IParameters;
+    const sourceArtifact = {
+      description: 'Increment the counter.',
+      name: 'incrementCounter',
+      parameters,
+      tags: ['Counter'],
+    };
+    const sourceParametersSnapshot = JSON.parse(
+      JSON.stringify(parameters),
+    ) as ILlmSchema.IParameters;
+
+    const constrainedArtifact = applyOpenApiConstraintsToTypiaLlmFunctionArtifact(
+      {
+        functionArtifact: sourceArtifact,
+        openApiDocument: COUNTER_OPENAPI,
+        operationId: 'incrementCounter',
+      },
+    );
+
+    expect(constrainedArtifact).not.toBe(sourceArtifact);
+    expect(constrainedArtifact.parameters).not.toBe(parameters);
+    expect(parameters as ILlmSchema.IParameters).toEqual(sourceParametersSnapshot);
+    expect(constrainedArtifact.parameters).toMatchObject({
+      properties: {
+        publicWriteToken: {
+          minLength: 16,
+          pattern: '^pt_[a-z0-9]+$',
+          type: 'string',
+        },
+      },
+    });
+  });
+
   test('rejects malformed typia.llm parameter artifacts before OpenAPI constraint projection', () => {
     expect(() =>
       applyOpenApiConstraintsToTypiaLlmFunctionArtifact({


### PR DESCRIPTION
## Summary

- document that OpenAPI constraint restoration intentionally mutates its target schema
- add a regression test proving public typia.llm artifacts are cloned before constraint mutation
- add a Sampo changeset for @wp-typia/project-tools

## Validation

- bun test packages/wp-typia-project-tools/tests/typia-llm.test.ts
- bun run typecheck
- bun run format:check
- bun run changesets:validate
- git diff --check

Closes #743