### PR TITLE
[codex] refactor(doctor): share bootstrap path resolution

### DIFF
--- a/.sampo/changesets/740-doctor-bootstrap-path-resolver.md
+++ b/.sampo/changesets/740-doctor-bootstrap-path-resolver.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Share workspace doctor bootstrap path resolution across scoped and unscoped package checks.

--- a/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace-bindings.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace-bindings.ts
@@ -6,6 +6,7 @@ import { parseScaffoldBlockMetadata } from "@wp-typia/block-runtime/blocks";
 import {
 	checkExistingFiles,
 	createDoctorCheck,
+	resolveWorkspaceBootstrapPath,
 	WORKSPACE_BINDING_EDITOR_ASSET,
 	WORKSPACE_BINDING_EDITOR_SCRIPT,
 	WORKSPACE_BINDING_SERVER_GLOB,
@@ -17,8 +18,7 @@ import type { WorkspaceInventory } from "./workspace-inventory.js";
 import type { WorkspaceProject } from "./workspace-project.js";
 
 function checkWorkspaceBindingBootstrap(projectDir: string, packageName: string): DoctorCheck {
-	const packageBaseName = packageName.split("/").pop() ?? packageName;
-	const bootstrapPath = path.join(projectDir, `${packageBaseName}.php`);
+	const bootstrapPath = resolveWorkspaceBootstrapPath(projectDir, packageName);
 	if (!fs.existsSync(bootstrapPath)) {
 		return createDoctorCheck(
 			"Binding bootstrap",

--- a/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace-blocks.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace-blocks.ts
@@ -6,6 +6,7 @@ import { parseScaffoldBlockMetadata } from "@wp-typia/block-runtime/blocks";
 import {
 	checkExistingFiles,
 	createDoctorCheck,
+	resolveWorkspaceBootstrapPath,
 	WORKSPACE_FULL_BLOCK_NAME_PATTERN,
 	WORKSPACE_GENERATED_BLOCK_ARTIFACTS,
 } from "./cli-doctor-workspace-shared.js";
@@ -515,8 +516,7 @@ function checkWorkspaceBlockIframeCompatibility(
 }
 
 function checkWorkspacePatternBootstrap(projectDir: string, packageName: string): DoctorCheck {
-	const packageBaseName = packageName.split("/").pop() ?? packageName;
-	const bootstrapPath = path.join(projectDir, `${packageBaseName}.php`);
+	const bootstrapPath = resolveWorkspaceBootstrapPath(projectDir, packageName);
 	if (!fs.existsSync(bootstrapPath)) {
 		return createDoctorCheck("Pattern bootstrap", "fail", `Missing ${path.basename(bootstrapPath)}`);
 	}

--- a/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace-features.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace-features.ts
@@ -10,6 +10,7 @@ import {
 import {
 	checkExistingFiles,
 	createDoctorCheck,
+	resolveWorkspaceBootstrapPath,
 	WORKSPACE_ABILITY_EDITOR_ASSET,
 	WORKSPACE_ABILITY_EDITOR_SCRIPT,
 	WORKSPACE_ABILITY_GLOB,
@@ -99,8 +100,7 @@ function checkWorkspaceRestResourceBootstrap(
 	packageName: string,
 	phpPrefix: string,
 ): DoctorCheck {
-	const packageBaseName = packageName.split("/").pop() ?? packageName;
-	const bootstrapPath = path.join(projectDir, `${packageBaseName}.php`);
+	const bootstrapPath = resolveWorkspaceBootstrapPath(projectDir, packageName);
 	if (!fs.existsSync(bootstrapPath)) {
 		return createDoctorCheck(
 			"REST resource bootstrap",
@@ -188,8 +188,7 @@ function checkWorkspaceAbilityBootstrap(
 	packageName: string,
 	phpPrefix: string,
 ): DoctorCheck {
-	const packageBaseName = packageName.split("/").pop() ?? packageName;
-	const bootstrapPath = path.join(projectDir, `${packageBaseName}.php`);
+	const bootstrapPath = resolveWorkspaceBootstrapPath(projectDir, packageName);
 	if (!fs.existsSync(bootstrapPath)) {
 		return createDoctorCheck(
 			"Ability bootstrap",
@@ -324,8 +323,7 @@ function checkWorkspaceAiFeatureBootstrap(
 	packageName: string,
 	phpPrefix: string,
 ): DoctorCheck {
-	const packageBaseName = packageName.split("/").pop() ?? packageName;
-	const bootstrapPath = path.join(projectDir, `${packageBaseName}.php`);
+	const bootstrapPath = resolveWorkspaceBootstrapPath(projectDir, packageName);
 	if (!fs.existsSync(bootstrapPath)) {
 		return createDoctorCheck(
 			"AI feature bootstrap",
@@ -389,8 +387,7 @@ function checkWorkspaceEditorPluginBootstrap(
 	packageName: string,
 	phpPrefix: string,
 ): DoctorCheck {
-	const packageBaseName = packageName.split("/").pop() ?? packageName;
-	const bootstrapPath = path.join(projectDir, `${packageBaseName}.php`);
+	const bootstrapPath = resolveWorkspaceBootstrapPath(projectDir, packageName);
 	if (!fs.existsSync(bootstrapPath)) {
 		return createDoctorCheck(
 			"Editor plugin bootstrap",
@@ -508,8 +505,7 @@ function checkWorkspaceAdminViewBootstrap(
 	packageName: string,
 	phpPrefix: string,
 ): DoctorCheck {
-	const packageBaseName = packageName.split("/").pop() ?? packageName;
-	const bootstrapPath = path.join(projectDir, `${packageBaseName}.php`);
+	const bootstrapPath = resolveWorkspaceBootstrapPath(projectDir, packageName);
 	if (!fs.existsSync(bootstrapPath)) {
 		return createDoctorCheck(
 			"Admin view bootstrap",

--- a/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace-shared.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace-shared.ts
@@ -87,6 +87,20 @@ export function getWorkspaceBootstrapRelativePath(packageName: string): string {
 }
 
 /**
+ * Resolve the expected workspace bootstrap file inside a project root.
+ *
+ * @param projectDir Absolute workspace root directory.
+ * @param packageName Package name used to derive the plugin bootstrap basename.
+ * @returns Absolute PHP bootstrap file path for the workspace root.
+ */
+export function resolveWorkspaceBootstrapPath(
+	projectDir: string,
+	packageName: string,
+): string {
+	return path.join(projectDir, getWorkspaceBootstrapRelativePath(packageName));
+}
+
+/**
  * Verify that every referenced relative file exists inside a workspace.
  *
  * @param projectDir Absolute workspace root directory.

--- a/packages/wp-typia-project-tools/tests/cli-doctor-boundaries.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-doctor-boundaries.test.ts
@@ -1,6 +1,8 @@
 import { expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { join, resolve } from "node:path";
+
+import { resolveWorkspaceBootstrapPath } from "../src/runtime/cli-doctor-workspace-shared.js";
 
 const sourceRoot = resolve(import.meta.dir, "..", "src", "runtime");
 
@@ -49,4 +51,15 @@ test("cli-doctor keeps environment and workspace checks in dedicated modules", (
 	expect(workspaceBindingsSource).toContain("export function getWorkspaceBindingDoctorChecks(");
 	expect(workspaceFeaturesSource).toContain("export function getWorkspaceFeatureDoctorChecks(");
 	expect(workspacePackageSource).toContain("export function getWorkspacePackageMetadataCheck(");
+});
+
+test("cli-doctor resolves workspace bootstrap paths for scoped and unscoped packages", () => {
+	const projectDir = resolve("/tmp", "wp-typia-doctor-demo");
+
+	expect(resolveWorkspaceBootstrapPath(projectDir, "@example/demo-plugin")).toBe(
+		join(projectDir, "demo-plugin.php"),
+	);
+	expect(resolveWorkspaceBootstrapPath(projectDir, "demo-plugin")).toBe(
+		join(projectDir, "demo-plugin.php"),
+	);
 });


### PR DESCRIPTION
## Summary

- add a shared workspace doctor bootstrap path resolver
- replace repeated scoped/unscoped package basename snippets in doctor bootstrap checks
- add resolver tests for scoped and unscoped package names
- add a Sampo changeset for @wp-typia/project-tools

## Validation

- bun test packages/wp-typia-project-tools/tests/cli-doctor-boundaries.test.ts packages/wp-typia-project-tools/tests/cli-doctor-workspace-bindings.test.ts packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
- bun test packages/wp-typia-project-tools/tests/workspace-add.test.ts packages/wp-typia-project-tools/tests/cli-add-workspace-ai.test.ts packages/wp-typia-project-tools/tests/cli-add-workspace-ability.test.ts
- bun run typecheck
- bun run format:check
- bun run changesets:validate
- git diff --check

Closes #740

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized bootstrap file path resolution in workspace doctor checks to ensure consistent behavior across scoped and unscoped packages.

* **Tests**
  * Added test coverage for bootstrap path resolution with both scoped and unscoped package names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->