### PR TITLE
[codex] refactor(runtime): reduce async scaffold sync fs calls

### DIFF
--- a/.sampo/changesets/744-async-scaffold-fs.md
+++ b/.sampo/changesets/744-async-scaffold-fs.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Reduce synchronous filesystem probes in async scaffold, add-block, and remote template normalization paths.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-block.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-block.ts
@@ -1,4 +1,3 @@
-import fs from "node:fs";
 import { promises as fsp } from "node:fs";
 import path from "node:path";
 
@@ -77,6 +76,7 @@ import {
 	normalizeOptionalCliString,
 	resolveLocalCliPathOption,
 } from "./cli-validation.js";
+import { pathExists } from "./fs-async.js";
 
 const COLLECTION_IMPORT_LINE = "import '../../collection';";
 // This is a lightweight preflight heuristic for the common install layouts:
@@ -152,17 +152,20 @@ async function renderWorkspacePersistenceServerModule(
 	await copyInterpolatedDirectory(templateDir, targetDir, variables);
 }
 
-function hasInstalledWorkspaceDependencies(projectDir: string): boolean {
-	return WORKSPACE_INSTALL_MARKERS.some((marker) =>
-		fs.existsSync(path.join(projectDir, marker)),
-	);
+async function hasInstalledWorkspaceDependencies(projectDir: string): Promise<boolean> {
+	for (const marker of WORKSPACE_INSTALL_MARKERS) {
+		if (await pathExists(path.join(projectDir, marker))) {
+			return true;
+		}
+	}
+	return false;
 }
 
-function assertWorkspaceDependenciesInstalled(workspace: {
+async function assertWorkspaceDependenciesInstalled(workspace: {
 	packageManager: PackageManagerId;
 	projectDir: string;
-}): void {
-	if (hasInstalledWorkspaceDependencies(workspace.projectDir)) {
+}): Promise<void> {
+	if (await hasInstalledWorkspaceDependencies(workspace.projectDir)) {
 		return;
 	}
 
@@ -299,13 +302,13 @@ function collectWorkspaceBlockPaths(
 	return [path.join(projectDir, "src", "blocks", variables.slugKebabCase)];
 }
 
-function assertBlockTargetsDoNotExist(
+async function assertBlockTargetsDoNotExist(
 	projectDir: string,
 	templateId: AddBlockTemplateId,
 	variables: ScaffoldTemplateVariables,
-): void {
+): Promise<void> {
 	for (const targetPath of collectWorkspaceBlockPaths(projectDir, templateId, variables)) {
-		if (fs.existsSync(targetPath)) {
+		if (await pathExists(targetPath)) {
 			throw new Error(
 				`A block already exists at ${path.relative(projectDir, targetPath)}. Choose a different name.`,
 			);
@@ -318,11 +321,11 @@ async function updateWorkspaceMigrationConfigIfPresent(
 	newBlocks: MigrationBlockConfig[],
 ): Promise<void> {
 	const configPath = path.join(projectDir, "src", "migrations", "config.ts");
-	if (!fs.existsSync(configPath)) {
+	const configSource = await readOptionalFile(configPath);
+	if (configSource === null) {
 		return;
 	}
 
-	const configSource = await fsp.readFile(configPath, "utf8");
 	const config = parseMigrationConfig(configSource);
 	const existingBlocks = Array.isArray(config.blocks) ? config.blocks : [];
 	const nextBlocks = [
@@ -562,7 +565,7 @@ export async function runAddBlockCommand({
 		parseCompoundInnerBlocksPreset(innerBlocksPreset);
 
 	const workspace = resolveWorkspaceProject(cwd);
-	assertWorkspaceDependenciesInstalled(workspace);
+	await assertWorkspaceDependenciesInstalled(workspace);
 	const normalizedExternalLayerId = normalizeOptionalCliString(externalLayerId);
 	const normalizedExternalLayerSource = resolveLocalCliPathOption({
 		cwd,
@@ -653,7 +656,11 @@ export async function runAddBlockCommand({
 			});
 			return scaffoldResult;
 		})();
-		assertBlockTargetsDoNotExist(workspace.projectDir, resolvedTemplateId, result.variables);
+		await assertBlockTargetsDoNotExist(
+			workspace.projectDir,
+			resolvedTemplateId,
+			result.variables,
+		);
 		const mutationSnapshot: WorkspaceMutationSnapshot = {
 			fileSources: await snapshotWorkspaceFiles([
 				blockConfigPath,

--- a/packages/wp-typia-project-tools/src/runtime/fs-async.ts
+++ b/packages/wp-typia-project-tools/src/runtime/fs-async.ts
@@ -1,0 +1,55 @@
+import { promises as fsp } from "node:fs";
+
+/**
+ * Return whether a filesystem path exists without blocking the event loop.
+ *
+ * @param filePath Absolute or relative path to check.
+ * @returns `true` when the path can be accessed, otherwise `false`.
+ */
+export async function pathExists(filePath: string): Promise<boolean> {
+	try {
+		await fsp.access(filePath);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Read a UTF-8 file when it exists and otherwise return `null`.
+ *
+ * @param filePath Absolute or relative file path to read.
+ * @returns The UTF-8 source, or `null` when the file is missing.
+ */
+export async function readOptionalUtf8File(filePath: string): Promise<string | null> {
+	try {
+		return await fsp.readFile(filePath, "utf8");
+	} catch (error) {
+		if (isFileNotFoundError(error)) {
+			return null;
+		}
+		throw error;
+	}
+}
+
+/**
+ * Extract a Node.js error code from an unknown thrown value.
+ *
+ * @param error Unknown error value.
+ * @returns The string error code, or an empty string when unavailable.
+ */
+export function getNodeErrorCode(error: unknown): string {
+	return typeof error === "object" && error !== null && "code" in error
+		? String((error as { code: unknown }).code)
+		: "";
+}
+
+/**
+ * Return whether an unknown error represents a missing filesystem path.
+ *
+ * @param error Unknown error value.
+ * @returns `true` when the error has Node.js code `ENOENT`.
+ */
+export function isFileNotFoundError(error: unknown): boolean {
+	return getNodeErrorCode(error) === "ENOENT";
+}

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-apply-utils.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-apply-utils.ts
@@ -1,4 +1,3 @@
-import fs from "node:fs";
 import { promises as fsp } from "node:fs";
 import path from "node:path";
 import { execSync } from "node:child_process";
@@ -38,6 +37,10 @@ import {
 	formatInstallCommand,
 	transformPackageManagerText,
 } from "./package-managers.js";
+import {
+	pathExists,
+	readOptionalUtf8File,
+} from "./fs-async.js";
 import { normalizePackageJson } from "./scaffold-package-manager-files.js";
 export {
 	applyWorkspaceMigrationCapability,
@@ -77,7 +80,7 @@ const LOCKFILES: Record<PackageManagerId, string[]> = {
 };
 
 export async function ensureDirectory(targetDir: string, allowExisting = false): Promise<void> {
-	if (!fs.existsSync(targetDir)) {
+	if (!(await pathExists(targetDir))) {
 		await fsp.mkdir(targetDir, { recursive: true });
 		return;
 	}
@@ -143,7 +146,7 @@ async function writeBuiltInCodeArtifacts(
 	}
 }
 
-function resolveScaffoldGeneratorNodeModulesPath(): string | null {
+async function resolveScaffoldGeneratorNodeModulesPath(): Promise<string | null> {
 	const projectToolsPackageRoot = path.resolve(__dirname, "..", "..");
 	const candidates = [
 		path.join(projectToolsPackageRoot, "node_modules"),
@@ -152,7 +155,7 @@ function resolveScaffoldGeneratorNodeModulesPath(): string | null {
 	];
 
 	for (const candidate of candidates) {
-		if (fs.existsSync(path.join(candidate, "typia", "package.json"))) {
+		if (await pathExists(path.join(candidate, "typia", "package.json"))) {
 			return candidate;
 		}
 	}
@@ -165,12 +168,12 @@ async function withEphemeralScaffoldNodeModules(
 	callback: () => Promise<void>,
 ): Promise<void> {
 	const targetNodeModulesPath = path.join(targetDir, "node_modules");
-	if (fs.existsSync(targetNodeModulesPath)) {
+	if (await pathExists(targetNodeModulesPath)) {
 		await callback();
 		return;
 	}
 
-	const sourceNodeModulesPath = resolveScaffoldGeneratorNodeModulesPath();
+	const sourceNodeModulesPath = await resolveScaffoldGeneratorNodeModulesPath();
 	if (!sourceNodeModulesPath) {
 		throw new Error(
 			"Unable to resolve a node_modules directory with typia for scaffold-time REST artifact generation.",
@@ -234,9 +237,7 @@ export async function normalizePackageManagerFiles(
 		return;
 	}
 
-	if (fs.existsSync(yarnRcPath)) {
-		await fsp.rm(yarnRcPath, { force: true });
-	}
+	await fsp.rm(yarnRcPath, { force: true });
 }
 
 export async function removeQueryLoopPlaceholderFiles(
@@ -265,10 +266,7 @@ export async function removeUnexpectedLockfiles(
 				return;
 			}
 
-			const filePath = path.join(targetDir, filename);
-			if (fs.existsSync(filePath)) {
-				await fsp.rm(filePath, { force: true });
-			}
+			await fsp.rm(path.join(targetDir, filename), { force: true });
 		}),
 	);
 }
@@ -426,7 +424,7 @@ export async function applyBuiltInScaffoldProjectFiles({
 		title: "Finalizing scaffold output",
 	});
 	const readmePath = path.join(projectDir, "README.md");
-	if (!fs.existsSync(readmePath)) {
+	if (!(await pathExists(readmePath))) {
 		await fsp.writeFile(
 			readmePath,
 			readmeContent ??
@@ -439,9 +437,7 @@ export async function applyBuiltInScaffoldProjectFiles({
 		);
 	}
 	const gitignorePath = path.join(projectDir, ".gitignore");
-	const existingGitignore = fs.existsSync(gitignorePath)
-		? await fsp.readFile(gitignorePath, "utf8")
-		: "";
+	const existingGitignore = await readOptionalUtf8File(gitignorePath) ?? "";
 	await fsp.writeFile(
 		gitignorePath,
 		mergeTextLines(gitignoreContent ?? buildGitignore(), existingGitignore),

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-apply-utils.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-apply-utils.ts
@@ -80,10 +80,7 @@ const LOCKFILES: Record<PackageManagerId, string[]> = {
 };
 
 export async function ensureDirectory(targetDir: string, allowExisting = false): Promise<void> {
-	if (!(await pathExists(targetDir))) {
-		await fsp.mkdir(targetDir, { recursive: true });
-		return;
-	}
+	await fsp.mkdir(targetDir, { recursive: true });
 
 	if (allowExisting) {
 		return;

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-bootstrap.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-bootstrap.ts
@@ -35,10 +35,7 @@ export async function ensureScaffoldDirectory(
 	targetDir: string,
 	allowExisting = false,
 ): Promise<void> {
-	if (!(await pathExists(targetDir))) {
-		await fsp.mkdir(targetDir, { recursive: true });
-		return;
-	}
+	await fsp.mkdir(targetDir, { recursive: true });
 
 	if (allowExisting) {
 		return;

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-bootstrap.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-bootstrap.ts
@@ -20,6 +20,7 @@ import {
 import type { BuiltInTemplateId } from "./template-registry.js";
 import { getScaffoldTemplateVariableGroups } from "./scaffold-template-variable-groups.js";
 import type { GeneratedPackageJson } from "./package-json-types.js";
+import { pathExists } from "./fs-async.js";
 
 const EPHEMERAL_NODE_MODULES_LINK_TYPE = process.platform === "win32" ? "junction" : "dir";
 
@@ -34,7 +35,7 @@ export async function ensureScaffoldDirectory(
 	targetDir: string,
 	allowExisting = false,
 ): Promise<void> {
-	if (!fs.existsSync(targetDir)) {
+	if (!(await pathExists(targetDir))) {
 		await fsp.mkdir(targetDir, { recursive: true });
 		return;
 	}
@@ -218,7 +219,7 @@ export async function applyWorkspaceMigrationCapability(
  *
  * @returns The first matching path, or `null` when no candidate contains `typia`.
  */
-function resolveScaffoldGeneratorNodeModulesPath(): string | null {
+async function resolveScaffoldGeneratorNodeModulesPath(): Promise<string | null> {
 	const candidates = [
 		path.join(PROJECT_TOOLS_PACKAGE_ROOT, "node_modules"),
 		path.resolve(PROJECT_TOOLS_PACKAGE_ROOT, "..", ".."),
@@ -226,7 +227,7 @@ function resolveScaffoldGeneratorNodeModulesPath(): string | null {
 	];
 
 	for (const candidate of candidates) {
-		if (fs.existsSync(path.join(candidate, "typia", "package.json"))) {
+		if (await pathExists(path.join(candidate, "typia", "package.json"))) {
 			return candidate;
 		}
 	}
@@ -252,12 +253,12 @@ async function withEphemeralScaffoldNodeModules(
 	callback: () => Promise<void>,
 ): Promise<void> {
 	const targetNodeModulesPath = path.join(targetDir, "node_modules");
-	if (fs.existsSync(targetNodeModulesPath)) {
+	if (await pathExists(targetNodeModulesPath)) {
 		await callback();
 		return;
 	}
 
-	const sourceNodeModulesPath = resolveScaffoldGeneratorNodeModulesPath();
+	const sourceNodeModulesPath = await resolveScaffoldGeneratorNodeModulesPath();
 	if (!sourceNodeModulesPath) {
 		throw new Error(
 			"Unable to resolve a node_modules directory with typia for scaffold-time REST artifact generation.",

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-package-manager-files.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-package-manager-files.ts
@@ -1,4 +1,3 @@
-import fs from "node:fs";
 import { promises as fsp } from "node:fs";
 import { execSync } from "node:child_process";
 import path from "node:path";
@@ -10,6 +9,7 @@ import {
 } from "./package-managers.js";
 import type { PackageManagerId } from "./package-managers.js";
 import type { GeneratedPackageJson } from "./package-json-types.js";
+import { readOptionalUtf8File } from "./fs-async.js";
 
 const LOCKFILES: Record<PackageManagerId, string[]> = {
 	bun: ["bun.lock", "bun.lockb"],
@@ -51,12 +51,13 @@ export async function normalizePackageJson(
 	packageManagerId: PackageManagerId,
 ): Promise<void> {
 	const packageJsonPath = path.join(targetDir, "package.json");
-	if (!fs.existsSync(packageJsonPath)) {
+	const packageJsonSource = await readOptionalUtf8File(packageJsonPath);
+	if (packageJsonSource === null) {
 		return;
 	}
 
 	const packageManager = getPackageManager(packageManagerId);
-	const packageJson = JSON.parse(await fsp.readFile(packageJsonPath, "utf8")) as GeneratedPackageJson;
+	const packageJson = JSON.parse(packageJsonSource) as GeneratedPackageJson;
 	if (packageManagerId === "npm") {
 		delete packageJson.packageManager;
 	} else {

--- a/packages/wp-typia-project-tools/src/runtime/template-source-external.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-external.ts
@@ -1,6 +1,7 @@
 /// <reference path="./external-template-modules.d.ts" />
 
 import fs from 'node:fs'
+import { promises as fsp } from 'node:fs'
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 
@@ -13,6 +14,7 @@ import { isPlainObject, type UnknownRecord } from './object-utils.js'
 import { toSegmentPascalCase } from './string-case.js'
 import { createManagedTempRoot } from './temp-roots.js'
 import { copyRawDirectory, copyRenderedDirectory } from './template-render.js'
+import { pathExists } from './fs-async.js'
 import type {
   ExternalTemplateConfig,
   SeedSource,
@@ -64,6 +66,25 @@ export function getExternalTemplateEntry(sourceDir: string): string | null {
   return null
 }
 
+/**
+ * Search a source directory for a supported external template entry asynchronously.
+ *
+ * @param sourceDir Directory that may contain an external template config entry.
+ * @returns The first matching entry path, or null when no supported entry exists.
+ */
+export async function findExternalTemplateEntry(
+  sourceDir: string,
+): Promise<string | null> {
+  for (const filename of EXTERNAL_TEMPLATE_ENTRY_CANDIDATES) {
+    const candidate = path.join(sourceDir, filename)
+    if (await pathExists(candidate)) {
+      return candidate
+    }
+  }
+
+  return null
+}
+
 async function loadExternalTemplateConfig<
   TView extends UnknownRecord = TemplateVariableContext,
 >(
@@ -72,7 +93,7 @@ async function loadExternalTemplateConfig<
   config: ExternalTemplateConfig<TView>
   warnings: string[]
 }> {
-  const entryPath = getExternalTemplateEntry(sourceDir)
+  const entryPath = await findExternalTemplateEntry(sourceDir)
   if (!entryPath) {
     throw new Error(`No external template config entry found in ${sourceDir}.`)
   }
@@ -81,7 +102,8 @@ async function loadExternalTemplateConfig<
     label: `External template config "${entryPath}"`,
     maxBytes: getExternalTemplateConfigMaxBytes(),
   })
-  const moduleUrl = `${pathToFileURL(entryPath).href}?mtime=${fs.statSync(entryPath).mtimeMs}`
+  const entryStats = await fsp.stat(entryPath)
+  const moduleUrl = `${pathToFileURL(entryPath).href}?mtime=${entryStats.mtimeMs}`
   const loadedModule = (await withExternalTemplateTimeout(
     `loading external template config "${entryPath}"`,
     () => import(moduleUrl),
@@ -324,10 +346,9 @@ export async function renderCreateBlockExternalTemplate(
       )
     }
 
+    const assetsDir = path.join(tempRoot, 'assets')
     return {
-      assetsDir: fs.existsSync(path.join(tempRoot, 'assets'))
-        ? path.join(tempRoot, 'assets')
-        : undefined,
+      assetsDir: (await pathExists(assetsDir)) ? assetsDir : undefined,
       blockDir,
       cleanup,
       formatHint,

--- a/packages/wp-typia-project-tools/src/runtime/template-source-normalization.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-normalization.ts
@@ -1,16 +1,18 @@
 /// <reference path="./external-template-modules.d.ts" />
 
-import fs from 'node:fs'
 import path from 'node:path'
 
 import { loadExternalTemplateLayerManifest } from './template-layers.js'
 import { getPackageVersions } from './package-versions.js'
-import { getExternalTemplateEntry } from './template-source-external.js'
-import { getTemplateProjectType } from './template-source-remote.js'
+import { findExternalTemplateEntry } from './template-source-external.js'
+import { getTemplateProjectTypeAsync } from './template-source-remote.js'
+import { pathExists } from './fs-async.js'
 export { renderCreateBlockExternalTemplate } from './template-source-external.js'
 export {
   getTemplateProjectType,
+  getTemplateProjectTypeAsync,
   getDefaultCategory,
+  getDefaultCategoryAsync,
   normalizeCreateBlockSubset,
   normalizeWpTypiaTemplateSeed,
 } from './template-source-remote.js'
@@ -54,7 +56,7 @@ export function getTemplateVariableContext(variables: {
 export async function detectTemplateSourceFormat(
   sourceDir: string,
 ): Promise<TemplateSourceFormat> {
-  if (fs.existsSync(path.join(sourceDir, 'package.json.mustache'))) {
+  if (await pathExists(path.join(sourceDir, 'package.json.mustache'))) {
     return 'wp-typia'
   }
 
@@ -64,33 +66,45 @@ export async function detectTemplateSourceFormat(
     )
   }
 
-  if (getExternalTemplateEntry(sourceDir)) {
+  if (await findExternalTemplateEntry(sourceDir)) {
     return 'create-block-external'
   }
 
-  if (getTemplateProjectType(sourceDir) !== null) {
+  if ((await getTemplateProjectTypeAsync(sourceDir)) !== null) {
     return 'wp-typia'
   }
 
-  const sourceRoot = fs.existsSync(path.join(sourceDir, 'src'))
+  const sourceRoot = await pathExists(path.join(sourceDir, 'src'))
     ? path.join(sourceDir, 'src')
     : sourceDir
   const blockJsonCandidates = [
     path.join(sourceDir, 'block.json'),
     path.join(sourceRoot, 'block.json'),
   ]
-  const hasBlockJson = blockJsonCandidates.some((candidate) =>
-    fs.existsSync(candidate),
-  )
-  const hasIndexFile = ['index.js', 'index.jsx', 'index.ts', 'index.tsx'].some(
-    (filename) => fs.existsSync(path.join(sourceRoot, filename)),
-  )
-  const hasEditFile = ['edit.js', 'edit.jsx', 'edit.ts', 'edit.tsx'].some(
-    (filename) => fs.existsSync(path.join(sourceRoot, filename)),
-  )
-  const hasSaveFile = ['save.js', 'save.jsx', 'save.ts', 'save.tsx'].some(
-    (filename) => fs.existsSync(path.join(sourceRoot, filename)),
-  )
+  const hasBlockJson = (
+    await Promise.all(blockJsonCandidates.map((candidate) => pathExists(candidate)))
+  ).some(Boolean)
+  const hasIndexFile = (
+    await Promise.all(
+      ['index.js', 'index.jsx', 'index.ts', 'index.tsx'].map((filename) =>
+        pathExists(path.join(sourceRoot, filename)),
+      ),
+    )
+  ).some(Boolean)
+  const hasEditFile = (
+    await Promise.all(
+      ['edit.js', 'edit.jsx', 'edit.ts', 'edit.tsx'].map((filename) =>
+        pathExists(path.join(sourceRoot, filename)),
+      ),
+    )
+  ).some(Boolean)
+  const hasSaveFile = (
+    await Promise.all(
+      ['save.js', 'save.jsx', 'save.ts', 'save.tsx'].map((filename) =>
+        pathExists(path.join(sourceRoot, filename)),
+      ),
+    )
+  ).some(Boolean)
 
   if (hasBlockJson && hasIndexFile && hasEditFile && hasSaveFile) {
     return 'create-block-subset'

--- a/packages/wp-typia-project-tools/src/runtime/template-source-remote.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-remote.ts
@@ -12,6 +12,7 @@ import {
 } from './template-builtins.js'
 import { copyRawDirectory } from './template-render.js'
 import { createManagedTempRoot } from './temp-roots.js'
+import { pathExists } from './fs-async.js'
 import type {
   ResolvedTemplateSource,
   SeedSource,
@@ -69,6 +70,25 @@ function readRemoteBlockJson(blockDir: string): Record<string, unknown> {
   throw new Error(`Unable to locate block.json in ${blockDir}`)
 }
 
+async function readRemoteBlockJsonAsync(
+  blockDir: string,
+): Promise<Record<string, unknown>> {
+  const sourceRoot = await getSeedSourceRoot(blockDir)
+  for (const candidate of [
+    path.join(blockDir, 'block.json'),
+    path.join(sourceRoot, 'block.json'),
+  ]) {
+    if (await pathExists(candidate)) {
+      return JSON.parse(await fsp.readFile(candidate, 'utf8')) as Record<
+        string,
+        unknown
+      >
+    }
+  }
+
+  throw new Error(`Unable to locate block.json in ${blockDir}`)
+}
+
 /**
  * Read a remote block source and return its default block category.
  *
@@ -78,6 +98,21 @@ function readRemoteBlockJson(blockDir: string): Record<string, unknown> {
 export function getDefaultCategory(sourceDir: string): string {
   try {
     const blockJson = readRemoteBlockJson(sourceDir)
+    return getDefaultCategoryFromBlockJson(blockJson)
+  } catch {
+    return 'widgets'
+  }
+}
+
+/**
+ * Read a remote block source and return its default block category asynchronously.
+ *
+ * @param sourceDir Block source directory that may contain a block.json file.
+ * @returns The declared block category, or "widgets" when detection fails.
+ */
+export async function getDefaultCategoryAsync(sourceDir: string): Promise<string> {
+  try {
+    const blockJson = await readRemoteBlockJsonAsync(sourceDir)
     return getDefaultCategoryFromBlockJson(blockJson)
   } catch {
     return 'widgets'
@@ -121,12 +156,76 @@ function readTemplatePackageJson(
   return null
 }
 
+async function readTemplatePackageJsonAsync(
+  sourceDir: string,
+): Promise<{
+  packageJson: { wpTypia?: { projectType?: unknown } }
+  sourcePath: string
+} | null> {
+  for (const candidate of [
+    path.join(sourceDir, 'package.json.mustache'),
+    path.join(sourceDir, 'package.json'),
+  ]) {
+    if (!(await pathExists(candidate))) {
+      continue
+    }
+
+    try {
+      assertExternalTemplateFileSize(candidate, {
+        label: `Template metadata file "${candidate}"`,
+        maxBytes: getExternalTemplatePackageJsonMaxBytes(),
+      })
+      return {
+        packageJson: JSON.parse(await fsp.readFile(candidate, 'utf8')) as {
+          wpTypia?: { projectType?: unknown }
+        },
+        sourcePath: candidate,
+      }
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Unknown parse failure'
+      throw new Error(
+        `Failed to parse template metadata file "${candidate}": ${message}`,
+      )
+    }
+  }
+
+  return null
+}
+
 /**
  * Read `wpTypia.projectType` from a rendered or source template package
  * manifest and return it when present.
  */
 export function getTemplateProjectType(sourceDir: string): string | null {
   const packageJsonEntry = readTemplatePackageJson(sourceDir)
+  if (!packageJsonEntry) {
+    return null
+  }
+
+  const projectType = packageJsonEntry.packageJson.wpTypia?.projectType
+  if (projectType === undefined) {
+    return null
+  }
+  if (typeof projectType !== 'string' || projectType.trim().length === 0) {
+    throw new Error(
+      `Template metadata file "${packageJsonEntry.sourcePath}" defines wpTypia.projectType, but it must be a non-empty string.`,
+    )
+  }
+
+  return projectType
+}
+
+/**
+ * Read `wpTypia.projectType` from template metadata asynchronously.
+ *
+ * @param sourceDir Template source directory to inspect.
+ * @returns The project type when present, otherwise `null`.
+ */
+export async function getTemplateProjectTypeAsync(
+  sourceDir: string,
+): Promise<string | null> {
+  const packageJsonEntry = await readTemplatePackageJsonAsync(sourceDir)
   if (!packageJsonEntry) {
     return null
   }
@@ -171,7 +270,7 @@ export async function normalizeWpTypiaTemplateSeed(
         )
       },
     })
-    if (seed.assetsDir && fs.existsSync(seed.assetsDir)) {
+    if (seed.assetsDir && (await pathExists(seed.assetsDir))) {
       await fsp.cp(seed.assetsDir, path.join(normalizedDir, 'assets'), {
         recursive: true,
         force: true,
@@ -371,18 +470,18 @@ async function patchRemotePackageJson(
   )
 }
 
-function getSeedSourceRoot(blockDir: string): string {
-  return fs.existsSync(path.join(blockDir, 'src'))
+async function getSeedSourceRoot(blockDir: string): Promise<string> {
+  return (await pathExists(path.join(blockDir, 'src')))
     ? path.join(blockDir, 'src')
     : blockDir
 }
 
-function findSeedRenderPhp(seed: SeedSource): string | null {
+async function findSeedRenderPhp(seed: SeedSource): Promise<string | null> {
   for (const candidate of [
     path.join(seed.blockDir, 'render.php'),
     path.join(seed.rootDir, 'render.php'),
   ]) {
-    if (fs.existsSync(candidate)) {
+    if (await pathExists(candidate)) {
       return candidate
     }
   }
@@ -442,12 +541,12 @@ export async function normalizeCreateBlockSubset(
   )
   try {
     const templateDir = path.join(tempRoot, 'template')
-    const blockJson = readRemoteBlockJson(seed.blockDir)
-    const sourceRoot = getSeedSourceRoot(seed.blockDir)
+    const blockJson = await readRemoteBlockJsonAsync(seed.blockDir)
+    const sourceRoot = await getSeedSourceRoot(seed.blockDir)
 
     await fsp.mkdir(templateDir, { recursive: true })
     for (const layerDir of getBuiltInTemplateLayerDirs('basic')) {
-      if (!fs.existsSync(layerDir)) {
+      if (!(await pathExists(layerDir))) {
         if (isOmittableBuiltInTemplateLayerDir('basic', layerDir)) {
           continue
         }
@@ -464,12 +563,12 @@ export async function normalizeCreateBlockSubset(
       force: true,
     })
 
-    const remoteRenderPath = findSeedRenderPhp(seed)
+    const remoteRenderPath = await findSeedRenderPhp(seed)
     if (remoteRenderPath) {
       await fsp.copyFile(remoteRenderPath, path.join(templateDir, 'render.php'))
     }
 
-    if (seed.assetsDir && fs.existsSync(seed.assetsDir)) {
+    if (seed.assetsDir && (await pathExists(seed.assetsDir))) {
       await fsp.cp(seed.assetsDir, path.join(templateDir, 'assets'), {
         recursive: true,
         force: true,
@@ -491,11 +590,19 @@ export async function normalizeCreateBlockSubset(
     const needsInteractivity =
       typeof blockJson.viewScriptModule === 'string' ||
       typeof blockJson.viewScript === 'string' ||
-      fs.existsSync(path.join(templateDir, 'src', 'view.js')) ||
-      fs.existsSync(path.join(templateDir, 'src', 'view.ts')) ||
-      fs.existsSync(path.join(templateDir, 'src', 'view.tsx')) ||
-      fs.existsSync(path.join(templateDir, 'src', 'interactivity.js')) ||
-      fs.existsSync(path.join(templateDir, 'src', 'interactivity.ts'))
+      (
+        await Promise.all(
+          [
+            'view.js',
+            'view.ts',
+            'view.tsx',
+            'interactivity.js',
+            'interactivity.ts',
+          ].map((filename) =>
+            pathExists(path.join(templateDir, 'src', filename)),
+          ),
+        )
+      ).some(Boolean)
 
     await patchRemotePackageJson(templateDir, needsInteractivity)
 

--- a/packages/wp-typia-project-tools/src/runtime/template-source-remote.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-remote.ts
@@ -594,6 +594,7 @@ export async function normalizeCreateBlockSubset(
         await Promise.all(
           [
             'view.js',
+            'view.jsx',
             'view.ts',
             'view.tsx',
             'interactivity.js',

--- a/packages/wp-typia-project-tools/src/runtime/template-source.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source.ts
@@ -121,30 +121,37 @@ export async function resolveTemplateSource(
         (await detectTemplateSourceFormat(normalizedSeed.blockDir))
       if (renderedFormat === 'wp-typia') {
         const normalized = await normalizeWpTypiaTemplateSeed(normalizedSeed)
-        const supportsMigrationUi =
-          (await getTemplateProjectTypeAsync(normalizedSeed.blockDir)) ===
-          'workspace'
-        return {
-          cleanup: async () => {
-            await normalized.cleanup?.()
-            await seed.cleanup?.()
-          },
-          defaultCategory: await getDefaultCategoryAsync(normalizedSeed.blockDir),
-          description:
-            'A wp-typia scaffold normalized from an official external template config',
-          features: [
-            'Remote source',
-            'official external template',
-            'wp-typia format',
-            ...(supportsMigrationUi ? ['workspace-capable scaffold'] : []),
-          ],
-          format,
-          id: 'remote:create-block-external',
-          isOfficialWorkspaceTemplate,
-          selectedVariant: normalizedSeed.selectedVariant ?? null,
-          supportsMigrationUi,
-          templateDir: normalized.blockDir,
-          warnings: normalizedSeed.warnings ?? [],
+        try {
+          const [projectType, defaultCategory] = await Promise.all([
+            getTemplateProjectTypeAsync(normalizedSeed.blockDir),
+            getDefaultCategoryAsync(normalizedSeed.blockDir),
+          ])
+          const supportsMigrationUi = projectType === 'workspace'
+          return {
+            cleanup: async () => {
+              await normalized.cleanup?.()
+              await seed.cleanup?.()
+            },
+            defaultCategory,
+            description:
+              'A wp-typia scaffold normalized from an official external template config',
+            features: [
+              'Remote source',
+              'official external template',
+              'wp-typia format',
+              ...(supportsMigrationUi ? ['workspace-capable scaffold'] : []),
+            ],
+            format,
+            id: 'remote:create-block-external',
+            isOfficialWorkspaceTemplate,
+            selectedVariant: normalizedSeed.selectedVariant ?? null,
+            supportsMigrationUi,
+            templateDir: normalized.blockDir,
+            warnings: normalizedSeed.warnings ?? [],
+          }
+        } catch (error) {
+          await normalized.cleanup?.()
+          throw error
         }
       }
 

--- a/packages/wp-typia-project-tools/src/runtime/template-source.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source.ts
@@ -12,8 +12,8 @@ import {
 } from './template-source-locators.js'
 import {
   detectTemplateSourceFormat,
-  getTemplateProjectType,
-  getDefaultCategory,
+  getTemplateProjectTypeAsync,
+  getDefaultCategoryAsync,
   getTemplateVariableContext,
   normalizeCreateBlockSubset,
   normalizeWpTypiaTemplateSeed,
@@ -86,10 +86,10 @@ export async function resolveTemplateSource(
       }
       normalizedSeed = await normalizeWpTypiaTemplateSeed(seed)
       const supportsMigrationUi =
-        getTemplateProjectType(seed.blockDir) === 'workspace'
+        (await getTemplateProjectTypeAsync(seed.blockDir)) === 'workspace'
       return {
         id: templateId,
-        defaultCategory: getDefaultCategory(seed.blockDir),
+        defaultCategory: await getDefaultCategoryAsync(seed.blockDir),
         description: 'A remote wp-typia template source',
         features: ['Remote source', 'wp-typia format'],
         format,
@@ -122,13 +122,14 @@ export async function resolveTemplateSource(
       if (renderedFormat === 'wp-typia') {
         const normalized = await normalizeWpTypiaTemplateSeed(normalizedSeed)
         const supportsMigrationUi =
-          getTemplateProjectType(normalizedSeed.blockDir) === 'workspace'
+          (await getTemplateProjectTypeAsync(normalizedSeed.blockDir)) ===
+          'workspace'
         return {
           cleanup: async () => {
             await normalized.cleanup?.()
             await seed.cleanup?.()
           },
-          defaultCategory: getDefaultCategory(normalizedSeed.blockDir),
+          defaultCategory: await getDefaultCategoryAsync(normalizedSeed.blockDir),
           description:
             'A wp-typia scaffold normalized from an official external template config',
           features: [


### PR DESCRIPTION
## Summary
- Add shared async filesystem helpers for non-blocking existence checks and optional UTF-8 reads.
- Convert low-risk sync filesystem probes in async scaffold, add-block, package-manager normalization, and remote template normalization paths to async `fsp`-based flows.
- Keep remaining sync probes only in sync compatibility APIs or synchronous template filter callbacks where changing the API would be broader than this refactor.

## Validation
- bun run lint:repo
- bun run typecheck
- bun run format:check
- bun run changesets:validate
- git diff --check
- bun test packages/wp-typia-project-tools/tests/template-source.test.ts
- bun run --filter @wp-typia/project-tools test:scaffold-core
- bun run --filter @wp-typia/project-tools test:workspace

Closes #744

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated filesystem operations throughout the scaffolding and template systems to improve application responsiveness.
  * Converted synchronous path and file checks to asynchronous implementations, enhancing performance during project initialization and block creation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->