### PR TITLE
[codex] perf(create): speed up npm scaffold installs

### DIFF
--- a/.sampo/changesets/745-npm-install-perf.md
+++ b/.sampo/changesets/745-npm-install-perf.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Use `npm install --no-audit` for first-run scaffold installs and document npm audit/peer-warning guidance for generated projects.

--- a/packages/wp-typia-project-tools/src/runtime/package-managers.ts
+++ b/packages/wp-typia-project-tools/src/runtime/package-managers.ts
@@ -23,7 +23,7 @@ const PACKAGE_MANAGER_DATA: PackageManagerDefinition[] = [
 		id: "npm",
 		label: "npm",
 		packageManagerField: "npm@11.6.1",
-		installCommand: "npm install",
+		installCommand: "npm install --no-audit",
 		frozenInstallCommand: "npm ci",
 	},
 	{

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-documents.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-documents.ts
@@ -54,9 +54,11 @@ function getPackageManagerInstallGuidance(packageManager: PackageManagerId): str
 		return '';
 	}
 
+	const installCommand = formatInstallCommand(packageManager);
+
 	return [
 		'',
-		'> npm note: the scaffold uses `npm install --no-audit` for the first install so npm does not spend the initial create flow in the audit resolver. Run `npm audit` separately when you want npm vulnerability output.',
+		`> npm note: the scaffold uses \`${installCommand}\` for the first install so npm does not spend the initial create flow in the audit resolver. Run \`npm audit\` separately when you want npm vulnerability output.`,
 		'> If npm prints React peer dependency noise from WordPress block-editor packages, validate with `npm run typecheck` and `npm run build` before changing WordPress package ranges.',
 	].join('\n');
 }

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-documents.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-documents.ts
@@ -49,6 +49,18 @@ function formatReadmeTemplateIdentity(templateId: string): string {
 	return [`- Template id: ${templateId}`, '- Type: custom or external scaffold'].join('\n');
 }
 
+function getPackageManagerInstallGuidance(packageManager: PackageManagerId): string {
+	if (packageManager !== 'npm') {
+		return '';
+	}
+
+	return [
+		'',
+		'> npm note: the scaffold uses `npm install --no-audit` for the first install so npm does not spend the initial create flow in the audit resolver. Run `npm audit` separately when you want npm vulnerability output.',
+		'> If npm prints React peer dependency noise from WordPress block-editor packages, validate with `npm run typecheck` and `npm run build` before changing WordPress package ranges.',
+	].join('\n');
+}
+
 /**
  * Builds the generated README markdown for one scaffolded project.
  *
@@ -150,6 +162,7 @@ ${formatReadmeTemplateIdentity(templateId)}
 ${formatInstallCommand(packageManager)}
 ${formatRunScript(packageManager, developmentScript)}
 \`\`\`
+${getPackageManagerInstallGuidance(packageManager)}
 
 ${getQuickStartWorkflowNote(packageManager, templateId, {
     compoundPersistenceEnabled,

--- a/packages/wp-typia-project-tools/tests/cli-entry.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-entry.test.ts
@@ -284,7 +284,7 @@ test("runScaffoldFlow defaults persistence scaffolds to custom-table and authent
   expect(pluginBootstrap).toContain("custom-table");
   expect(flow.nextSteps).toEqual([
     `cd ${projectInput}`,
-    "npm install",
+    "npm install --no-audit",
     "npm run dev",
   ]);
   expect(flow.optionalOnboarding.steps).toEqual(["npm run sync"]);
@@ -411,7 +411,7 @@ test("runScaffoldFlow keeps compound next steps minimal while surfacing optional
 
   expect(flow.nextSteps).toEqual([
     `cd ${projectInput}`,
-    "npm install",
+    "npm install --no-audit",
     "npm run dev",
   ]);
   expect(flow.optionalOnboarding.steps).toEqual(["npm run sync"]);
@@ -756,7 +756,7 @@ test("runScaffoldFlow carries query-loop post type overrides into the generated 
   expect(flow.result.variables.queryPostType).toBe("book");
   expect(flow.nextSteps).toEqual([
     `cd ${projectInput}`,
-    "npm install",
+    "npm install --no-audit",
     "npm run dev",
   ]);
   expect(flow.optionalOnboarding.steps).toEqual([]);

--- a/packages/wp-typia-project-tools/tests/cli-entry.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-entry.test.ts
@@ -1448,7 +1448,7 @@ test("node entry rejects add block before workspace dependencies are installed",
   );
 
   expect(errorMessage).toContain("Workspace dependencies have not been installed yet.");
-  expect(errorMessage).toContain("Run `npm install` from the workspace root");
+  expect(errorMessage).toContain("Run `npm install --no-audit` from the workspace root");
   expect(errorMessage).toContain("`wp-typia add block ...`");
 });
 

--- a/packages/wp-typia-project-tools/tests/scaffold-basic.test.ts
+++ b/packages/wp-typia-project-tools/tests/scaffold-basic.test.ts
@@ -291,7 +291,9 @@ describe('@wp-typia/project-tools scaffold core', () => {
       expect(fs.existsSync(path.join(targetDir, '.wp-env.test.json'))).toBe(
         false,
       );
-      expect(readme).toContain('npm install');
+      expect(readme).toContain('npm install --no-audit');
+      expect(readme).toContain('Run `npm audit` separately');
+      expect(readme).toContain('React peer dependency noise');
       expect(readme).toContain('npm run dev');
       expect(readme).toContain('npm run start');
       expect(readme).toContain('## Quick Start');

--- a/packages/wp-typia/tests/completion-output.test.ts
+++ b/packages/wp-typia/tests/completion-output.test.ts
@@ -53,7 +53,7 @@ describe('alternate-buffer completion output helpers', () => {
   test('create completion payload preserves reviewable next steps and optional onboarding', () => {
     const payload = buildCreateCompletionPayload(
       {
-        nextSteps: ['cd demo-block', 'npm install', 'npm run dev'],
+        nextSteps: ['cd demo-block', 'npm install --no-audit', 'npm run dev'],
         optionalOnboarding: {
           note: 'Run npm run sync before your first commit if you edited types.',
           shortNote:
@@ -80,7 +80,7 @@ describe('alternate-buffer completion output helpers', () => {
     ]);
     expect(payload.nextSteps).toEqual([
       'cd demo-block',
-      'npm install',
+      'npm install --no-audit',
       'npm run dev',
     ]);
     expect(payload.optionalTitle).toBe('Verify and sync (optional):');
@@ -99,7 +99,7 @@ describe('alternate-buffer completion output helpers', () => {
 
     printCompletionPayload(
       {
-        nextSteps: ['cd demo-block', 'npm install'],
+        nextSteps: ['cd demo-block', 'npm install --no-audit'],
         optionalLines: [
           `npx --yes wp-typia@${packageJson.version} doctor`,
           'npm run sync',
@@ -126,7 +126,7 @@ describe('alternate-buffer completion output helpers', () => {
       'Project directory: /tmp/demo-block',
       'Next steps:',
       '  cd demo-block',
-      '  npm install',
+      '  npm install --no-audit',
       '\nVerify and sync (optional):',
       `  npx --yes wp-typia@${packageJson.version} doctor`,
       '  npm run sync',

--- a/packages/wp-typia/tests/tui-lifecycle.test.ts
+++ b/packages/wp-typia/tests/tui-lifecycle.test.ts
@@ -191,7 +191,7 @@ describe("alternate-buffer TUI lifecycle", () => {
 
 	test("run helper can defer exit while completion state takes over", async () => {
 		const completion = {
-			nextSteps: ["cd demo", "npm install"],
+			nextSteps: ["cd demo", "npm install --no-audit"],
 			title: "✅ Created Demo Block",
 		};
 		let exited = 0;
@@ -363,7 +363,7 @@ describe("alternate-buffer TUI lifecycle", () => {
 		const rendered = renderStaticMarkupSilently(
 			createElement(FirstPartyCompletionViewport, {
 				completion: {
-					nextSteps: ["cd demo-block", "npm install", "npm run dev"],
+					nextSteps: ["cd demo-block", "npm install --no-audit", "npm run dev"],
 					optionalLines: ["npm run sync"],
 					optionalNote: "Review the generated metadata before first commit.",
 					optionalTitle: "Advanced sync (optional):",

--- a/tests/unit/package-managers.test.ts
+++ b/tests/unit/package-managers.test.ts
@@ -18,7 +18,7 @@ describe("package manager runtime helpers", () => {
 		expect(Object.keys(PACKAGE_MANAGERS)).toEqual(PACKAGE_MANAGER_IDS);
 		expect(getPackageManagerSelectOptions()).toEqual([
 			{ hint: "bun install", label: "Bun", value: "bun" },
-			{ hint: "npm install", label: "npm", value: "npm" },
+			{ hint: "npm install --no-audit", label: "npm", value: "npm" },
 			{ hint: "pnpm install", label: "pnpm", value: "pnpm" },
 			{ hint: "yarn install", label: "Yarn", value: "yarn" },
 		]);
@@ -38,7 +38,7 @@ describe("package manager runtime helpers", () => {
 				runWithArgs: "bun run sync-types --strict --report json",
 			},
 			npm: {
-				install: "npm install",
+				install: "npm install --no-audit",
 				run: "npm run sync-types",
 				runWithArgs: "npm run sync-types -- --strict --report json",
 			},
@@ -87,7 +87,7 @@ describe("package manager runtime helpers", () => {
 
 		expect(transformPackageManagerText(content, "npm")).toBe(
 			[
-				"npm install && npm run sync-types -- --strict || npm install --save-dev @types/node;",
+				"npm install --no-audit && npm run sync-types -- --strict || npm install --save-dev @types/node;",
 				"`npm run lint`, npm ci.",
 				"postbun run should stay untouched.",
 			].join(" "),


### PR DESCRIPTION
## Summary
- Use `npm install --no-audit` for npm scaffold first-run install/next-step guidance.
- Add generated README guidance telling npm users to run `npm audit` explicitly and to validate typecheck/build before changing WordPress ranges for React peer noise.
- Update CLI/TUI completion expectations and add a Sampo changeset.

## Investigation
- Captured representative `npm install --timing` from a fresh basic scaffold: 1914 packages, `real 116.72s`; npm audit dominated with `auditReport:init` around 49.5s and `reify:audit` around 49.9s.
- Re-ran the same scaffold with `npm install --timing --no-audit`: `real 75.64s`, saving about 41s in this environment.
- Peer warning source is `react-autosize-textarea@7.1.0` requiring React/React DOM <=16, reached through `@wordpress/block-editor@15.18.0` and also through `@types/wordpress__block-editor@11.5.17`. Because the generated project typecheck/build passes on the current WordPress ranges, this PR avoids package range churn and documents the expected npm guidance instead.
- Practical install comparison: Bun `20.32s`, pnpm `32.97s`, npm no-audit `75.64s`, npm default `116.72s`; Yarn was unavailable in the local environment.

## Validation
- bun test tests/unit/package-managers.test.ts packages/wp-typia-project-tools/tests/scaffold-basic.test.ts packages/wp-typia-project-tools/tests/cli-entry.test.ts packages/wp-typia/tests/completion-output.test.ts packages/wp-typia/tests/tui-lifecycle.test.ts
- bun run format:check
- bun run changesets:validate
- git diff --check
- bun run typecheck
- bun run lint:repo
- bun run --filter @wp-typia/project-tools build
- bun run --filter wp-typia build
- generated npm scaffold: npm run sync; npm run typecheck; npm run build

Closes #745

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated npm installation process to use `--no-audit` flag, providing faster setup times for newly scaffolded projects
  * Generated project README files now include helpful guidance about separately running `npm audit` and managing expected React peer dependency warnings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->