### PR TITLE
[codex] feat(config): validate wp-typia config schema

### DIFF
--- a/.sampo/changesets/733-config-schema-validation.md
+++ b/.sampo/changesets/733-config-schema-validation.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Validate loaded wp-typia config files with a strict runtime schema and report clear diagnostics for unknown keys or invalid value types.

--- a/packages/wp-typia/README.md
+++ b/packages/wp-typia/README.md
@@ -28,6 +28,13 @@ Extend an existing workspace with:
 `wp-typia create <project-dir>` when `<project-dir>` is the only positional
 argument.
 
+Configuration files:
+
+- `wp-typia` loads `~/.config/wp-typia/config.json`, `.wp-typiarc`, `.wp-typiarc.json`, then `package.json#wp-typia`; later sources override earlier sources
+- `--config <path>` is an explicit override loaded after the default sources, relative to the current working directory unless absolute
+- config files use a strict schema: unknown keys are errors rather than warnings or stripped values, so typos fail near the source config file
+- object values are deep-merged, while arrays such as `mcp.schemaSources` replace earlier arrays instead of concatenating
+
 Compatibility notes:
 
 - `@wp-typia/project-tools` is the canonical programmatic project orchestration package

--- a/packages/wp-typia/src/config.ts
+++ b/packages/wp-typia/src/config.ts
@@ -198,8 +198,7 @@ async function readJsonFile(filePath: string): Promise<unknown | undefined> {
 	}
 
 	try {
-		const parsed = JSON.parse(source);
-		return isRecord(parsed) ? parsed : null;
+		return JSON.parse(source);
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
 		throw createCliDiagnosticCodeError(

--- a/packages/wp-typia/src/config.ts
+++ b/packages/wp-typia/src/config.ts
@@ -137,7 +137,8 @@ function formatConfigValidationIssue(issue: ZodIssue): string {
 	const pathLabel = formatIssuePath(issue.path);
 	if (issue.code === "unrecognized_keys") {
 		const keys = issue.keys.map((key) => `"${String(key)}"`).join(", ");
-		return `${pathLabel}: unknown key ${keys}. Unknown keys are errors in wp-typia config.`;
+		const label = issue.keys.length === 1 ? "unknown key" : "unknown keys";
+		return `${pathLabel}: ${label} ${keys}. Unknown keys are errors in wp-typia config.`;
 	}
 
 	return `${pathLabel}: ${issue.message}`;

--- a/packages/wp-typia/src/config.ts
+++ b/packages/wp-typia/src/config.ts
@@ -7,6 +7,7 @@ import {
 	CLI_DIAGNOSTIC_CODES,
 	createCliDiagnosticCodeError,
 } from "@wp-typia/project-tools/cli-diagnostics";
+import { z, type ZodIssue } from "zod";
 
 export type WpTypiaSchemaSource = {
 	namespace: string;
@@ -58,6 +59,109 @@ export const WP_TYPIA_CONFIG_SOURCES = [
 ] as const;
 type JsonRecord = Record<string, unknown>;
 
+const wpTypiaSchemaSourceSchema = z
+	.object({
+		namespace: z.string(),
+		path: z.string(),
+	})
+	.strict();
+
+const createConfigSchema = z
+	.object({
+		"alternate-render-targets": z.string().optional(),
+		"inner-blocks-preset": z.string().optional(),
+		"data-storage": z.string().optional(),
+		"dry-run": z.boolean().optional(),
+		"external-layer-id": z.string().optional(),
+		"external-layer-source": z.string().optional(),
+		namespace: z.string().optional(),
+		"no-install": z.boolean().optional(),
+		"package-manager": z.string().optional(),
+		"persistence-policy": z.string().optional(),
+		"php-prefix": z.string().optional(),
+		"query-post-type": z.string().optional(),
+		template: z.string().optional(),
+		"text-domain": z.string().optional(),
+		variant: z.string().optional(),
+		"with-migration-ui": z.boolean().optional(),
+		"with-test-preset": z.boolean().optional(),
+		"with-wp-env": z.boolean().optional(),
+		yes: z.boolean().optional(),
+	})
+	.strict();
+
+const addBlockConfigSchema = z
+	.object({
+		"alternate-render-targets": z.string().optional(),
+		"data-storage": z.string().optional(),
+		"external-layer-id": z.string().optional(),
+		"external-layer-source": z.string().optional(),
+		"inner-blocks-preset": z.string().optional(),
+		"persistence-policy": z.string().optional(),
+		template: z.string().optional(),
+	})
+	.strict();
+
+const addConfigSchema = z
+	.object({
+		block: addBlockConfigSchema.optional(),
+	})
+	.strict();
+
+const mcpConfigSchema = z
+	.object({
+		schemaSources: z.array(wpTypiaSchemaSourceSchema).optional(),
+	})
+	.strict();
+
+const wpTypiaUserConfigSchema = z
+	.object({
+		add: addConfigSchema.optional(),
+		create: createConfigSchema.optional(),
+		mcp: mcpConfigSchema.optional(),
+	})
+	.strict();
+
+function formatIssuePath(issuePath: ZodIssue["path"]): string {
+	if (issuePath.length === 0) {
+		return "config";
+	}
+
+	return issuePath
+		.map((segment) => (typeof segment === "number" ? `[${segment}]` : `.${String(segment)}`))
+		.join("")
+		.replace(/^\./u, "");
+}
+
+function formatConfigValidationIssue(issue: ZodIssue): string {
+	const pathLabel = formatIssuePath(issue.path);
+	if (issue.code === "unrecognized_keys") {
+		const keys = issue.keys.map((key) => `"${String(key)}"`).join(", ");
+		return `${pathLabel}: unknown key ${keys}. Unknown keys are errors in wp-typia config.`;
+	}
+
+	return `${pathLabel}: ${issue.message}`;
+}
+
+export function validateWpTypiaUserConfig(
+	value: unknown,
+	source: string,
+): WpTypiaUserConfig {
+	const result = wpTypiaUserConfigSchema.safeParse(value);
+	if (result.success) {
+		return result.data;
+	}
+
+	const issueLines = result.error.issues.map(formatConfigValidationIssue);
+	throw createCliDiagnosticCodeError(
+		CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
+		[
+			`Invalid wp-typia config at ${source}.`,
+			...issueLines.map((line) => `- ${line}`),
+		].join("\n"),
+	);
+}
+
 function deepMerge<T extends JsonRecord>(base: T, incoming: JsonRecord): T {
 	const merged: JsonRecord = { ...base };
 
@@ -76,7 +180,7 @@ function deepMerge<T extends JsonRecord>(base: T, incoming: JsonRecord): T {
 	return merged as T;
 }
 
-async function readJsonFile(filePath: string): Promise<JsonRecord | null> {
+async function readJsonFile(filePath: string): Promise<unknown | undefined> {
 	let source: string;
 	try {
 		source = await fs.readFile(filePath, "utf8");
@@ -87,7 +191,7 @@ async function readJsonFile(filePath: string): Promise<JsonRecord | null> {
 			"code" in error &&
 			error.code === "ENOENT"
 		) {
-			return null;
+			return undefined;
 		}
 		throw error;
 	}
@@ -103,6 +207,11 @@ async function readJsonFile(filePath: string): Promise<JsonRecord | null> {
 			error instanceof Error ? { cause: error } : undefined,
 		);
 	}
+}
+
+async function readWpTypiaConfigFile(filePath: string): Promise<WpTypiaUserConfig | null> {
+	const parsed = await readJsonFile(filePath);
+	return parsed === undefined ? null : validateWpTypiaUserConfig(parsed, filePath);
 }
 
 function resolveConfigPath(cwd: string, source: string): string {
@@ -123,8 +232,8 @@ export async function loadWpTypiaUserConfigFromSource(
 	cwd: string,
 	source: string,
 ): Promise<WpTypiaUserConfig> {
-	const config = await readJsonFile(resolveConfigPath(cwd, source));
-	return (config ?? {}) as WpTypiaUserConfig;
+	const config = await readWpTypiaConfigFile(resolveConfigPath(cwd, source));
+	return config ?? {};
 }
 
 export async function loadWpTypiaUserConfig(cwd: string): Promise<WpTypiaUserConfig> {
@@ -132,15 +241,20 @@ export async function loadWpTypiaUserConfig(cwd: string): Promise<WpTypiaUserCon
 
 	for (const source of WP_TYPIA_CONFIG_SOURCES) {
 		const configPath = resolveConfigPath(cwd, source);
-		const config = await readJsonFile(configPath);
+		const config = await readWpTypiaConfigFile(configPath);
 		if (config) {
-			merged = deepMerge(merged, config);
+			merged = deepMerge(merged, config as JsonRecord);
 		}
 	}
 
-	const packageJson = await readJsonFile(path.join(cwd, "package.json"));
-	if (packageJson && isRecord(packageJson["wp-typia"])) {
-		merged = deepMerge(merged, packageJson["wp-typia"] as JsonRecord);
+	const packageJsonPath = path.join(cwd, "package.json");
+	const packageJson = await readJsonFile(packageJsonPath);
+	if (isRecord(packageJson) && "wp-typia" in packageJson) {
+		const packageConfig = validateWpTypiaUserConfig(
+			packageJson["wp-typia"],
+			`${packageJsonPath}#wp-typia`,
+		);
+		merged = deepMerge(merged, packageConfig as JsonRecord);
 	}
 
 	return merged as WpTypiaUserConfig;

--- a/packages/wp-typia/tests/config.test.ts
+++ b/packages/wp-typia/tests/config.test.ts
@@ -7,6 +7,7 @@ import {
   loadWpTypiaUserConfig,
   loadWpTypiaUserConfigFromSource,
   mergeWpTypiaUserConfig,
+  validateWpTypiaUserConfig,
   type WpTypiaUserConfig,
 } from '../src/config';
 import { extractWpTypiaConfigOverride } from '../src/config-override';
@@ -65,6 +66,41 @@ describe('wp-typia user config loading', () => {
     expect(merged.mcp?.schemaSources).not.toBe(incoming.mcp?.schemaSources);
   });
 
+  test('validates in-memory config objects with the strict unknown-key policy', () => {
+    expect(
+      validateWpTypiaUserConfig(
+        {
+          create: {
+            'dry-run': true,
+            template: 'basic',
+          },
+          mcp: {
+            schemaSources: [
+              {
+                namespace: 'demo',
+                path: './mcp-tools.json',
+              },
+            ],
+          },
+        },
+        'test config',
+      ),
+    ).toEqual({
+      create: {
+        'dry-run': true,
+        template: 'basic',
+      },
+      mcp: {
+        schemaSources: [
+          {
+            namespace: 'demo',
+            path: './mcp-tools.json',
+          },
+        ],
+      },
+    });
+  });
+
   test('loads explicit config sources relative to the requested working directory', async () => {
     const tempRoot = fs.mkdtempSync(
       path.join(os.tmpdir(), 'wp-typia-config-source-'),
@@ -86,6 +122,107 @@ describe('wp-typia user config loading', () => {
           template: 'compound',
         },
       });
+    } finally {
+      fs.rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('rejects unknown keys in explicit config override sources', async () => {
+    const tempRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'wp-typia-config-unknown-'),
+    );
+
+    try {
+      writeJson(path.join(tempRoot, 'override.json'), {
+        create: {
+          template: 'basic',
+          typo: 'unexpected',
+        },
+        custom: true,
+      });
+
+      let thrown: unknown;
+      try {
+        await loadWpTypiaUserConfigFromSource(tempRoot, './override.json');
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toBeInstanceOf(Error);
+      expect(thrown).toHaveProperty('code', 'invalid-argument');
+      expect(String((thrown as Error).message)).toContain(
+        'Invalid wp-typia config at',
+      );
+      expect(String((thrown as Error).message)).toContain(
+        'create: unknown key "typo"',
+      );
+      expect(String((thrown as Error).message)).toContain(
+        'config: unknown key "custom"',
+      );
+    } finally {
+      fs.rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('rejects invalid config value types with path-specific diagnostics', async () => {
+    const tempRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'wp-typia-config-invalid-type-'),
+    );
+
+    try {
+      writeJson(path.join(tempRoot, 'override.json'), {
+        create: {
+          'dry-run': 'yes',
+        },
+        mcp: {
+          schemaSources: [
+            {
+              namespace: 'demo',
+              path: false,
+            },
+          ],
+        },
+      });
+
+      let thrown: unknown;
+      try {
+        await loadWpTypiaUserConfigFromSource(tempRoot, './override.json');
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toBeInstanceOf(Error);
+      expect(thrown).toHaveProperty('code', 'invalid-argument');
+      expect(String((thrown as Error).message)).toContain('create.dry-run');
+      expect(String((thrown as Error).message)).toContain('expected boolean');
+      expect(String((thrown as Error).message)).toContain(
+        'mcp.schemaSources[0].path',
+      );
+      expect(String((thrown as Error).message)).toContain('expected string');
+    } finally {
+      fs.rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('rejects non-object config file roots instead of treating them as absent', async () => {
+    const tempRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'wp-typia-config-root-type-'),
+    );
+
+    try {
+      writeJson(path.join(tempRoot, 'override.json'), null);
+
+      let thrown: unknown;
+      try {
+        await loadWpTypiaUserConfigFromSource(tempRoot, './override.json');
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toBeInstanceOf(Error);
+      expect(thrown).toHaveProperty('code', 'invalid-argument');
+      expect(String((thrown as Error).message)).toContain('config');
+      expect(String((thrown as Error).message)).toContain('expected object');
     } finally {
       fs.rmSync(tempRoot, { force: true, recursive: true });
     }
@@ -161,6 +298,42 @@ describe('wp-typia user config loading', () => {
           ],
         },
       });
+    } finally {
+      fs.rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('validates package.json#wp-typia with the same config schema', async () => {
+    const tempRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'wp-typia-package-config-invalid-'),
+    );
+
+    try {
+      writeJson(path.join(tempRoot, 'package.json'), {
+        name: 'demo-config-project',
+        'wp-typia': {
+          mcp: {
+            schemaSources: 'not-an-array',
+          },
+        },
+      });
+
+      let thrown: unknown;
+      try {
+        await loadWpTypiaUserConfig(tempRoot);
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toBeInstanceOf(Error);
+      expect(thrown).toHaveProperty('code', 'invalid-argument');
+      expect(String((thrown as Error).message)).toContain(
+        'package.json#wp-typia',
+      );
+      expect(String((thrown as Error).message)).toContain(
+        'mcp.schemaSources',
+      );
+      expect(String((thrown as Error).message)).toContain('expected array');
     } finally {
       fs.rmSync(tempRoot, { force: true, recursive: true });
     }

--- a/packages/wp-typia/tests/config.test.ts
+++ b/packages/wp-typia/tests/config.test.ts
@@ -208,21 +208,45 @@ describe('wp-typia user config loading', () => {
     const tempRoot = fs.mkdtempSync(
       path.join(os.tmpdir(), 'wp-typia-config-root-type-'),
     );
+    const configPath = path.join(tempRoot, 'override.json');
 
     try {
-      writeJson(path.join(tempRoot, 'override.json'), null);
+      writeJson(configPath, null);
 
-      let thrown: unknown;
+      let nullRootError: unknown;
       try {
         await loadWpTypiaUserConfigFromSource(tempRoot, './override.json');
       } catch (error) {
-        thrown = error;
+        nullRootError = error;
       }
 
-      expect(thrown).toBeInstanceOf(Error);
-      expect(thrown).toHaveProperty('code', 'invalid-argument');
-      expect(String((thrown as Error).message)).toContain('config');
-      expect(String((thrown as Error).message)).toContain('expected object');
+      expect(nullRootError).toBeInstanceOf(Error);
+      expect(nullRootError).toHaveProperty('code', 'invalid-argument');
+      expect(String((nullRootError as Error).message)).toContain('config');
+      expect(String((nullRootError as Error).message)).toContain(
+        'expected object',
+      );
+      expect(String((nullRootError as Error).message)).toContain(
+        'received null',
+      );
+
+      writeJson(configPath, []);
+
+      let arrayRootError: unknown;
+      try {
+        await loadWpTypiaUserConfigFromSource(tempRoot, './override.json');
+      } catch (error) {
+        arrayRootError = error;
+      }
+
+      expect(arrayRootError).toBeInstanceOf(Error);
+      expect(arrayRootError).toHaveProperty('code', 'invalid-argument');
+      expect(String((arrayRootError as Error).message)).toContain(
+        'expected object',
+      );
+      expect(String((arrayRootError as Error).message)).toContain(
+        'received array',
+      );
     } finally {
       fs.rmSync(tempRoot, { force: true, recursive: true });
     }

--- a/packages/wp-typia/tests/node-cli-core.test.ts
+++ b/packages/wp-typia/tests/node-cli-core.test.ts
@@ -504,6 +504,54 @@ describe('Node fallback CLI core routing', () => {
     }
   });
 
+  test('reports config validation errors before dispatching create defaults', async () => {
+    const tempRoot = createTempRoot('wp-typia-node-config-invalid-');
+    writeJson(path.join(tempRoot, 'wp-typia.config.json'), {
+      create: {
+        'dry-run': 'yes',
+      },
+    });
+
+    try {
+      const result = await captureNodeCli(
+        [
+          'create',
+          'config-card',
+          '--config',
+          'wp-typia.config.json',
+          '--format',
+          'json',
+        ],
+        { cwd: tempRoot, entrypoint: true },
+      );
+      const parsed = JSON.parse(result.stderr) as {
+        error?: {
+          code?: string;
+          command?: string;
+          detailLines?: string[];
+          kind?: string;
+        };
+        ok?: boolean;
+      };
+
+      expect(result.error).toBeUndefined();
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).toBe('');
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error?.kind).toBe('command-execution');
+      expect(parsed.error?.command).toBe('create');
+      expect(parsed.error?.code).toBe('invalid-argument');
+      expect(parsed.error?.detailLines?.join('\n')).toContain(
+        'create.dry-run',
+      );
+      expect(parsed.error?.detailLines?.join('\n')).toContain(
+        'expected boolean',
+      );
+    } finally {
+      removeTempRoot(tempRoot);
+    }
+  });
+
   test('captures structured entrypoint errors on stderr', async () => {
     const result = await captureNodeCli(['create', '--format', 'json'], {
       entrypoint: true,


### PR DESCRIPTION
## Summary
- Add strict Zod validation for loaded wp-typia config files and `package.json#wp-typia` before they are cast to `WpTypiaUserConfig`.
- Treat unknown config keys as explicit errors and surface path-specific diagnostics for invalid value types, including `--config` override paths.
- Document config source precedence, strict unknown-key behavior, and array replacement merge semantics.

## Validation
- bun test packages/wp-typia/tests/config.test.ts packages/wp-typia/tests/node-cli-core.test.ts packages/wp-typia/tests/cli-package.test.ts
- bun run typecheck
- bun run format:check
- bun run changesets:validate
- git diff --check
- bun run lint:repo
- bun run --filter wp-typia build

Closes #733

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration files are now validated against a strict schema, catching unknown keys and invalid value types with clear error messages before execution.

* **Documentation**
  * Updated README with detailed configuration loading behavior, including default search order, override options, and merge semantics.

* **Tests**
  * Added comprehensive test coverage for configuration validation and error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->