### PR TITLE
[codex] fix(cli): support packaged routing metadata generation

### DIFF
--- a/.sampo/changesets/748-routing-metadata-packaged-project-tools.md
+++ b/.sampo/changesets/748-routing-metadata-packaged-project-tools.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Keep routing metadata generation working when wp-typia is installed with packaged project-tools files instead of monorepo source files.

--- a/packages/wp-typia/scripts/generate-routing-metadata.mjs
+++ b/packages/wp-typia/scripts/generate-routing-metadata.mjs
@@ -25,15 +25,68 @@ const commandRegistryModulePath = path.join(
   'command-registry.ts',
 );
 const addKindIdsModulePath = path.join(packageRoot, 'src', 'add-kind-ids.ts');
-const projectToolsAddKindIdsModulePath = path.join(
-  packageRoot,
-  '..',
-  'wp-typia-project-tools',
-  'src',
-  'runtime',
-  'cli-add-kind-ids.ts',
-);
+const projectToolsAddKindIdsModulePath =
+  process.env.WP_TYPIA_PROJECT_TOOLS_ADD_KIND_IDS_SOURCE ??
+  path.join(
+    packageRoot,
+    '..',
+    'wp-typia-project-tools',
+    'src',
+    'runtime',
+    'cli-add-kind-ids.ts',
+  );
 const checkOnly = process.argv.includes('--check');
+
+async function readOptionalUtf8(filePath) {
+  try {
+    return await fs.readFile(filePath, 'utf8');
+  } catch (error) {
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      error.code === 'ENOENT'
+    ) {
+      return null;
+    }
+
+    throw error;
+  }
+}
+
+function assertStringArray(value, label) {
+  if (
+    !Array.isArray(value) ||
+    !value.every((entry) => typeof entry === 'string')
+  ) {
+    throw new Error(`${label} must export ADD_KIND_IDS as a string array.`);
+  }
+}
+
+async function resolveProjectToolsAddKindIdsExternalModule() {
+  const source = await readOptionalUtf8(projectToolsAddKindIdsModulePath);
+  if (source !== null) {
+    return {
+      modulePath: projectToolsAddKindIdsModulePath,
+      source,
+      specifier: '@wp-typia/project-tools/cli-add-kind-ids',
+    };
+  }
+
+  const specifier = '@wp-typia/project-tools/cli-add-kind-ids';
+  const namespace = await import(specifier);
+  assertStringArray(namespace.ADD_KIND_IDS, specifier);
+
+  return {
+    modulePath: specifier,
+    source: `export const ADD_KIND_IDS = ${JSON.stringify(
+      namespace.ADD_KIND_IDS,
+      null,
+      2,
+    )} as const;\n`,
+    specifier,
+  };
+}
 
 async function importTranspiledTypeScriptModule(
   modulePath,
@@ -48,8 +101,10 @@ async function importTranspiledTypeScriptModule(
     import('typescript'),
     fs.readFile(modulePath, 'utf8'),
     ...siblingModules.map((siblingPath) => fs.readFile(siblingPath, 'utf8')),
-    ...externalModules.map(({ modulePath: externalModulePath }) =>
-      fs.readFile(externalModulePath, 'utf8'),
+    ...externalModules.map((externalModule) =>
+      externalModule.source === undefined
+        ? fs.readFile(externalModule.modulePath, 'utf8')
+        : externalModule.source,
     ),
   ]);
   const siblingSources = supportingSources.slice(0, siblingModules.length);
@@ -200,34 +255,28 @@ function failCheck(pathname) {
 
 const [
   { COMMAND_ROUTING_METADATA },
-  {
-    WP_TYPIA_BUN_REQUIRED_TOP_LEVEL_COMMAND_NAMES,
-    WP_TYPIA_INTERACTIVE_RUNTIME_TOP_LEVEL_COMMAND_NAMES,
-    WP_TYPIA_RESERVED_TOP_LEVEL_COMMAND_NAMES,
-  },
+  projectToolsAddKindIdsExternalModule,
 ] = await Promise.all([
   importTranspiledTypeScriptModule(commandOptionMetadataModulePath),
-  importTranspiledTypeScriptModule(
-    commandRegistryModulePath,
-    [addKindIdsModulePath],
-    [
-      {
-        modulePath: projectToolsAddKindIdsModulePath,
-        specifier: '@wp-typia/project-tools/cli-add-kind-ids',
-      },
-    ],
-  ),
+  resolveProjectToolsAddKindIdsExternalModule(),
 ]);
 
+const {
+  WP_TYPIA_BUN_REQUIRED_TOP_LEVEL_COMMAND_NAMES: bunRequiredCommandNames,
+  WP_TYPIA_INTERACTIVE_RUNTIME_TOP_LEVEL_COMMAND_NAMES:
+    interactiveRuntimeCommandNames,
+  WP_TYPIA_RESERVED_TOP_LEVEL_COMMAND_NAMES: reservedCommandNames,
+} = await importTranspiledTypeScriptModule(
+  commandRegistryModulePath,
+  [addKindIdsModulePath],
+  [projectToolsAddKindIdsExternalModule],
+);
+
 const renderedFiles = renderRoutingMetadataFiles({
-  fullRuntimeCommands: Array.from(
-    WP_TYPIA_BUN_REQUIRED_TOP_LEVEL_COMMAND_NAMES,
-  ),
-  interactiveRuntimeCommands: Array.from(
-    WP_TYPIA_INTERACTIVE_RUNTIME_TOP_LEVEL_COMMAND_NAMES,
-  ),
+  fullRuntimeCommands: Array.from(bunRequiredCommandNames),
+  interactiveRuntimeCommands: Array.from(interactiveRuntimeCommandNames),
   longValueOptions: COMMAND_ROUTING_METADATA.longValueOptions,
-  reservedCommands: Array.from(WP_TYPIA_RESERVED_TOP_LEVEL_COMMAND_NAMES),
+  reservedCommands: Array.from(reservedCommandNames),
   shortValueOptions: COMMAND_ROUTING_METADATA.shortValueOptions,
 });
 

--- a/packages/wp-typia/tests/bunli-prep.test.ts
+++ b/packages/wp-typia/tests/bunli-prep.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { CLI_DIAGNOSTIC_CODES } from '@wp-typia/project-tools/cli-diagnostics';
 
@@ -176,26 +177,48 @@ describe('wp-typia Bunli preparation', () => {
     expect(result.stderr).not.toContain('Routing metadata is out of date');
   });
 
-  test('validates routing metadata when project-tools source files are unavailable', () => {
-    const result = spawnSync(
-      'node',
-      ['scripts/generate-routing-metadata.mjs', '--check'],
-      {
-        cwd: packageRoot,
-        encoding: 'utf8',
-        env: {
-          ...process.env,
-          WP_TYPIA_PROJECT_TOOLS_ADD_KIND_IDS_SOURCE: path.join(
-            repoRoot,
-            '.cache',
-            'missing-cli-add-kind-ids.ts',
-          ),
-        },
-      },
+  test('validates routing metadata from a packaged copy without sibling source files', () => {
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'wp-typia-packaged-routing-'),
     );
+    const packagedRoot = path.join(tempDir, 'wp-typia');
 
-    expect(result.status).toBe(0);
-    expect(result.stderr).not.toContain('Routing metadata is out of date');
+    try {
+      for (const entry of ['bin', 'scripts', 'src', 'package.json']) {
+        fs.cpSync(path.join(packageRoot, entry), path.join(packagedRoot, entry), {
+          recursive: true,
+        });
+      }
+      fs.symlinkSync(
+        path.join(packageRoot, 'node_modules'),
+        path.join(packagedRoot, 'node_modules'),
+        'dir',
+      );
+
+      const result = spawnSync(
+        'node',
+        ['scripts/generate-routing-metadata.mjs', '--check'],
+        {
+          cwd: packagedRoot,
+          encoding: 'utf8',
+          env: {
+            ...process.env,
+            WP_TYPIA_PROJECT_TOOLS_ADD_KIND_IDS_SOURCE: path.join(
+              tempDir,
+              'wp-typia-project-tools',
+              'src',
+              'runtime',
+              'cli-add-kind-ids.ts',
+            ),
+          },
+        },
+      );
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).not.toContain('Routing metadata is out of date');
+    } finally {
+      fs.rmSync(tempDir, { force: true, recursive: true });
+    }
   });
 
   test('runtime rebuild fallback targets sibling linked packages directly', () => {

--- a/packages/wp-typia/tests/bunli-prep.test.ts
+++ b/packages/wp-typia/tests/bunli-prep.test.ts
@@ -176,6 +176,28 @@ describe('wp-typia Bunli preparation', () => {
     expect(result.stderr).not.toContain('Routing metadata is out of date');
   });
 
+  test('validates routing metadata when project-tools source files are unavailable', () => {
+    const result = spawnSync(
+      'node',
+      ['scripts/generate-routing-metadata.mjs', '--check'],
+      {
+        cwd: packageRoot,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          WP_TYPIA_PROJECT_TOOLS_ADD_KIND_IDS_SOURCE: path.join(
+            repoRoot,
+            '.cache',
+            'missing-cli-add-kind-ids.ts',
+          ),
+        },
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).not.toContain('Routing metadata is out of date');
+  });
+
   test('runtime rebuild fallback targets sibling linked packages directly', () => {
     const runtimeBuildScript = fs.readFileSync(
       path.join(packageRoot, 'scripts', 'build-bunli-runtime.ts'),


### PR DESCRIPTION
## Summary
- Keep routing metadata generation using the monorepo project-tools source when it exists.
- Fall back to importing `@wp-typia/project-tools/cli-add-kind-ids` from the installed package when source files are unavailable in packaged/file-dependency installs.
- Add coverage for the fallback path that matches the failing generated-project smoke environment.

## Main CI Failure Addressed
- Fixes main CI run 25303858197 failure in `Generated Project Smoke (smoke-reference-my-typia-block-bun)`, where `wp-typia/scripts/generate-routing-metadata.mjs` tried to read `wp-typia-project-tools/src/runtime/cli-add-kind-ids.ts` from an installed package that only ships `dist/`.

## Validation
- node scripts/generate-routing-metadata.mjs --check
- WP_TYPIA_PROJECT_TOOLS_ADD_KIND_IDS_SOURCE=/tmp/wp-typia-missing-cli-add-kind-ids.ts node scripts/generate-routing-metadata.mjs --check
- bun test packages/wp-typia/tests/bunli-prep.test.ts
- bun run changesets:validate
- bun run format:check
- bun run typecheck
- git diff --check
- bun run lint:repo
- bun run --filter wp-typia build
- node scripts/run-generated-project-smoke.mjs --runtime bun --package-manager bun --project-name smoke-reference-my-typia-block-bun --example-project my-typia-block

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed routing metadata generation to work correctly when wp-typia is installed using packaged project-tools instead of monorepo source files.

* **Tests**
  * Added test coverage for routing metadata generation with alternate external tool source configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->