### PR TITLE
[codex] fix(project-tools): align dataviews fallback range

### DIFF
--- a/.sampo/changesets/749-dataviews-fallback-range.md
+++ b/.sampo/changesets/749-dataviews-fallback-range.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Keep the managed @wp-typia/dataviews fallback range aligned with the released package version.

--- a/packages/wp-typia-project-tools/src/runtime/package-versions.ts
+++ b/packages/wp-typia-project-tools/src/runtime/package-versions.ts
@@ -47,7 +47,7 @@ export const DEFAULT_WORDPRESS_CORE_ABILITIES_VERSION = '^0.9.0';
 export const DEFAULT_WORDPRESS_CORE_DATA_VERSION = '^7.44.0';
 export const DEFAULT_WORDPRESS_DATA_VERSION = '^9.28.0';
 export const DEFAULT_WORDPRESS_DATAVIEWS_VERSION = '^14.1.0';
-export const DEFAULT_WP_TYPIA_DATAVIEWS_VERSION = '^0.1.0';
+export const DEFAULT_WP_TYPIA_DATAVIEWS_VERSION = '^0.1.1';
 
 let cachedPackageVersions: {
   cacheKey: string;


### PR DESCRIPTION
## Summary
- align the centralized @wp-typia/dataviews fallback range with the released 0.1.1 package
- add a patch changeset for @wp-typia/project-tools and wp-typia so the CLI dependency chain updates together
- restore the release-commit main CI failure in Project Tools scaffold/coverage tests

## Verification
- bun test packages/wp-typia-project-tools/tests/package-versions.test.ts
- bun run changesets:validate
- bun run format:check
- bun run typecheck
- bun run test:project-tools:scaffold-core
- bun run lint:repo
- git diff --check
- bun run test:coverage:project-tools

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the wp-typia dataviews package dependency to version 0.1.1 across the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->