### PR TITLE
[codex] refactor(wp-typia): single-source progress payload type

### DIFF
--- a/.sampo/changesets/769-single-source-progress-payload.md
+++ b/.sampo/changesets/769-single-source-progress-payload.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Single-source the create progress payload type across runtime bridge modules.

--- a/packages/wp-typia/src/runtime-bridge.ts
+++ b/packages/wp-typia/src/runtime-bridge.ts
@@ -23,6 +23,7 @@ import {
   buildCreateDryRunPayload,
   buildInitCompletionPayload,
   buildMigrationCompletionPayload,
+  type CreateProgressPayload,
   formatCreateProgressLine,
   printBlock,
   printCompletionPayload,
@@ -36,15 +37,11 @@ export {
   buildCreateDryRunPayload,
   buildInitCompletionPayload,
   buildMigrationCompletionPayload,
+  type CreateProgressPayload,
   formatCreateProgressLine,
   printCompletionPayload,
 } from './runtime-bridge-output';
 export { executeSyncCommand } from './runtime-bridge-sync';
-
-type CreateProgressPayload = {
-  detail: string;
-  title: string;
-};
 
 type CreateExecutionInput = {
   projectDir: string;

--- a/packages/wp-typia/tests/completion-output.test.ts
+++ b/packages/wp-typia/tests/completion-output.test.ts
@@ -7,6 +7,7 @@ import packageJson from '../package.json';
 import {
   buildCreateCompletionPayload,
   buildCreateDryRunPayload,
+  type CreateProgressPayload as BridgeCreateProgressPayload,
   formatCreateProgressLine,
   buildMigrationCompletionPayload,
   printCompletionPayload,
@@ -17,7 +18,25 @@ import {
   buildStructuredCompletionSuccessPayload,
   buildStructuredInitSuccessPayload,
   buildSyncDryRunPayload,
+  type CreateProgressPayload as OutputCreateProgressPayload,
 } from '../src/runtime-bridge-output';
+
+type ExpectTrue<TValue extends true> = TValue;
+type IsEqual<TLeft, TRight> =
+  (<TValue>() => TValue extends TLeft ? 1 : 2) extends <
+    TValue,
+  >() => TValue extends TRight ? 1 : 2
+    ? true
+    : false;
+type CreateProgressPayloadCompatibility = ExpectTrue<
+  IsEqual<BridgeCreateProgressPayload, OutputCreateProgressPayload>
+>;
+
+const runtimeBridgeOutputTypeCompatibilityChecks = {
+  createProgressPayload: true,
+} satisfies {
+  createProgressPayload: CreateProgressPayloadCompatibility;
+};
 
 const UNICODE_MARKER_OPTIONS = {
   env: {
@@ -50,6 +69,12 @@ afterAll(() => {
 });
 
 describe('alternate-buffer completion output helpers', () => {
+  test('keeps create progress payload type single-sourced across bridge exports', () => {
+    expect(runtimeBridgeOutputTypeCompatibilityChecks).toEqual({
+      createProgressPayload: true,
+    });
+  });
+
   test('create completion payload preserves reviewable next steps and optional onboarding', () => {
     const payload = buildCreateCompletionPayload(
       {


### PR DESCRIPTION
## Summary
- Reuse the canonical CreateProgressPayload type from runtime-bridge-output inside runtime-bridge
- Re-export the shared type from runtime-bridge for existing public import paths
- Add a compile-time compatibility assertion covering the bridge/output exports

Closes #769.

## Verification
- bun test packages/wp-typia/tests/completion-output.test.ts packages/wp-typia/tests/create-command.test.ts
- bun run changesets:validate
- bun run typecheck
- bun run format:check
- bun run lint:repo
- bun run --filter wp-typia test
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated progress payload type definition to ensure consistency across runtime bridge modules.

* **Tests**
  * Added type compatibility checks to verify type consistency across exports.

* **Chores**
  * Updated changeset metadata for patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->