### PR TITLE
[codex] refactor(wp-typia): derive config type from schema

### DIFF
--- a/.sampo/changesets/768-derived-config-type.md
+++ b/.sampo/changesets/768-derived-config-type.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Derive the public wp-typia user config types from the Zod validation schema.

--- a/packages/wp-typia/src/config.ts
+++ b/packages/wp-typia/src/config.ts
@@ -9,49 +9,6 @@ import {
 } from "@wp-typia/project-tools/cli-diagnostics";
 import { z, type ZodIssue } from "zod";
 
-export type WpTypiaSchemaSource = {
-	namespace: string;
-	path: string;
-};
-
-export type WpTypiaUserConfig = {
-	create?: {
-		"alternate-render-targets"?: string;
-		"inner-blocks-preset"?: string;
-		"data-storage"?: string;
-		"dry-run"?: boolean;
-		"external-layer-id"?: string;
-		"external-layer-source"?: string;
-		namespace?: string;
-		"no-install"?: boolean;
-		"package-manager"?: string;
-		"persistence-policy"?: string;
-		"php-prefix"?: string;
-		"query-post-type"?: string;
-		template?: string;
-		"text-domain"?: string;
-		variant?: string;
-		"with-migration-ui"?: boolean;
-		"with-test-preset"?: boolean;
-		"with-wp-env"?: boolean;
-		yes?: boolean;
-	};
-	add?: {
-		block?: {
-			"alternate-render-targets"?: string;
-			"data-storage"?: string;
-			"external-layer-id"?: string;
-			"external-layer-source"?: string;
-			"inner-blocks-preset"?: string;
-			"persistence-policy"?: string;
-			template?: string;
-		};
-	};
-	mcp?: {
-		schemaSources?: WpTypiaSchemaSource[];
-	};
-};
-
 export const WP_TYPIA_CONFIG_SOURCES = [
 	"~/.config/wp-typia/config.json",
 	".wp-typiarc",
@@ -114,13 +71,16 @@ const mcpConfigSchema = z
 	})
 	.strict();
 
-const wpTypiaUserConfigSchema = z
+export const wpTypiaUserConfigSchema = z
 	.object({
 		add: addConfigSchema.optional(),
 		create: createConfigSchema.optional(),
 		mcp: mcpConfigSchema.optional(),
 	})
 	.strict();
+
+export type WpTypiaSchemaSource = z.infer<typeof wpTypiaSchemaSourceSchema>;
+export type WpTypiaUserConfig = z.infer<typeof wpTypiaUserConfigSchema>;
 
 function formatIssuePath(issuePath: ZodIssue["path"]): string {
 	if (issuePath.length === 0) {

--- a/packages/wp-typia/tests/config.test.ts
+++ b/packages/wp-typia/tests/config.test.ts
@@ -2,15 +2,41 @@ import { describe, expect, test } from 'bun:test';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import type { z } from 'zod';
 
 import {
   loadWpTypiaUserConfig,
   loadWpTypiaUserConfigFromSource,
   mergeWpTypiaUserConfig,
   validateWpTypiaUserConfig,
+  type getMcpSchemaSources,
+  type WpTypiaSchemaSource,
   type WpTypiaUserConfig,
+  type wpTypiaUserConfigSchema,
 } from '../src/config';
 import { extractWpTypiaConfigOverride } from '../src/config-override';
+
+type ExpectTrue<TValue extends true> = TValue;
+type IsEqual<TLeft, TRight> =
+  (<TValue>() => TValue extends TLeft ? 1 : 2) extends <
+    TValue,
+  >() => TValue extends TRight ? 1 : 2
+    ? true
+    : false;
+type UserConfigSchemaCompatibility = ExpectTrue<
+  IsEqual<z.infer<typeof wpTypiaUserConfigSchema>, WpTypiaUserConfig>
+>;
+type SchemaSourceReturnCompatibility = ExpectTrue<
+  IsEqual<ReturnType<typeof getMcpSchemaSources>, WpTypiaSchemaSource[]>
+>;
+
+const configTypeCompatibilityChecks = {
+  schemaSources: true,
+  userConfig: true,
+} satisfies {
+  schemaSources: SchemaSourceReturnCompatibility;
+  userConfig: UserConfigSchemaCompatibility;
+};
 
 function writeJson(filePath: string, value: unknown): void {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
@@ -18,6 +44,13 @@ function writeJson(filePath: string, value: unknown): void {
 }
 
 describe('wp-typia user config loading', () => {
+  test('keeps exported config types derived from the Zod schema', () => {
+    expect(configTypeCompatibilityChecks).toEqual({
+      schemaSources: true,
+      userConfig: true,
+    });
+  });
+
   test('deep merges objects while replacing arrays from later config sources', () => {
     const base: WpTypiaUserConfig = {
       create: {


### PR DESCRIPTION
## Summary
- Derive WpTypiaUserConfig and WpTypiaSchemaSource from the Zod config schemas
- Export the canonical user config schema so compile-time tests can assert schema/type alignment
- Add a type-level config test that catches schema/type drift for the public config exports

Closes #768.

## Verification
- bun test packages/wp-typia/tests/config.test.ts
- bun run changesets:validate
- bun run typecheck
- bun run format:check
- bun run lint:repo
- bun run --filter wp-typia test
- git diff --check