### PR TITLE
[codex] chore(wp-typia): prune routing metadata temp dirs

### DIFF
--- a/.sampo/changesets/771-prune-routing-metadata-temp.md
+++ b/.sampo/changesets/771-prune-routing-metadata-temp.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Prune stale routing metadata generator temp directories before creating a new temp workspace.

--- a/packages/wp-typia/scripts/generate-routing-metadata.mjs
+++ b/packages/wp-typia/scripts/generate-routing-metadata.mjs
@@ -86,6 +86,8 @@ async function pruneStaleRoutingMetadataTempDirs() {
         fs.rm(path.join(routingMetadataTempParentDir, entry.name), {
           force: true,
           recursive: true,
+        }).catch(() => {
+          // Stale temp cleanup is best-effort and should not block generation.
         }),
       ),
   );
@@ -153,7 +155,6 @@ async function importTranspiledTypeScriptModule(
     },
     fileName: modulePath,
   });
-  await pruneStaleRoutingMetadataTempDirs();
   await fs.mkdir(routingMetadataTempParentDir, { recursive: true });
   const tempDir = await fs.mkdtemp(
     path.join(routingMetadataTempParentDir, routingMetadataTempDirPrefix),
@@ -289,6 +290,8 @@ function failCheck(pathname) {
   );
   process.exit(1);
 }
+
+await pruneStaleRoutingMetadataTempDirs();
 
 const [
   { COMMAND_ROUTING_METADATA },

--- a/packages/wp-typia/scripts/generate-routing-metadata.mjs
+++ b/packages/wp-typia/scripts/generate-routing-metadata.mjs
@@ -36,6 +36,8 @@ const projectToolsAddKindIdsModulePath =
     'cli-add-kind-ids.ts',
   );
 const checkOnly = process.argv.includes('--check');
+const routingMetadataTempDirPrefix = 'routing-metadata-';
+const routingMetadataTempParentDir = path.join(packageRoot, '.cache');
 
 async function readOptionalUtf8(filePath) {
   try {
@@ -52,6 +54,41 @@ async function readOptionalUtf8(filePath) {
 
     throw error;
   }
+}
+
+async function pruneStaleRoutingMetadataTempDirs() {
+  let entries;
+  try {
+    entries = await fs.readdir(routingMetadataTempParentDir, {
+      withFileTypes: true,
+    });
+  } catch (error) {
+    if (
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      error.code === 'ENOENT'
+    ) {
+      return;
+    }
+
+    throw error;
+  }
+
+  await Promise.all(
+    entries
+      .filter(
+        (entry) =>
+          entry.isDirectory() &&
+          entry.name.startsWith(routingMetadataTempDirPrefix),
+      )
+      .map((entry) =>
+        fs.rm(path.join(routingMetadataTempParentDir, entry.name), {
+          force: true,
+          recursive: true,
+        }),
+      ),
+  );
 }
 
 function assertStringArray(value, label) {
@@ -116,10 +153,10 @@ async function importTranspiledTypeScriptModule(
     },
     fileName: modulePath,
   });
-  const tempParentDir = path.join(packageRoot, '.cache');
-  await fs.mkdir(tempParentDir, { recursive: true });
+  await pruneStaleRoutingMetadataTempDirs();
+  await fs.mkdir(routingMetadataTempParentDir, { recursive: true });
   const tempDir = await fs.mkdtemp(
-    path.join(tempParentDir, 'routing-metadata-'),
+    path.join(routingMetadataTempParentDir, routingMetadataTempDirPrefix),
   );
   const tempFile = path.join(
     tempDir,

--- a/packages/wp-typia/tests/bunli-prep.test.ts
+++ b/packages/wp-typia/tests/bunli-prep.test.ts
@@ -177,6 +177,44 @@ describe('wp-typia Bunli preparation', () => {
     expect(result.stderr).not.toContain('Routing metadata is out of date');
   });
 
+  test('prunes stale routing metadata temp directories without touching other cache entries', () => {
+    const cacheDir = path.join(packageRoot, '.cache');
+    const staleRoutingTempDir = path.join(
+      cacheDir,
+      'routing-metadata-stale-test',
+    );
+    const unrelatedCacheDir = path.join(cacheDir, 'not-routing-metadata');
+
+    fs.mkdirSync(path.join(staleRoutingTempDir, 'nested'), {
+      recursive: true,
+    });
+    fs.writeFileSync(
+      path.join(staleRoutingTempDir, 'nested', 'leftover.js'),
+      '',
+      'utf8',
+    );
+    fs.mkdirSync(unrelatedCacheDir, { recursive: true });
+
+    try {
+      const result = spawnSync(
+        'node',
+        ['scripts/generate-routing-metadata.mjs', '--check'],
+        {
+          cwd: packageRoot,
+          encoding: 'utf8',
+        },
+      );
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).not.toContain('Routing metadata is out of date');
+      expect(fs.existsSync(staleRoutingTempDir)).toBe(false);
+      expect(fs.existsSync(unrelatedCacheDir)).toBe(true);
+    } finally {
+      fs.rmSync(staleRoutingTempDir, { force: true, recursive: true });
+      fs.rmSync(unrelatedCacheDir, { force: true, recursive: true });
+    }
+  });
+
   test('validates routing metadata from a packaged copy without sibling source files', () => {
     const tempDir = fs.mkdtempSync(
       path.join(os.tmpdir(), 'wp-typia-packaged-routing-'),


### PR DESCRIPTION
## Summary
- Prune stale .cache/routing-metadata-* directories before creating a new routing metadata temp workspace
- Keep cleanup scoped to routing metadata directories so unrelated cache entries are preserved
- Add a Bunli prep regression test that seeds a stale temp directory and verifies generator startup cleanup

Closes #771.

## Verification
- bun test packages/wp-typia/tests/bunli-prep.test.ts
- node packages/wp-typia/scripts/generate-routing-metadata.mjs --check
- bun run changesets:validate
- bun run format:check
- bun run typecheck
- bun run lint:repo
- bun run --filter wp-typia test
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented automatic pruning of stale temporary directories to improve disk space efficiency and prevent accumulation of unused cache artifacts.

* **Tests**
  * Added test validation ensuring stale cache directories are properly cleaned up while preserving unrelated cache entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->