### PR TITLE
[codex] fix(wp-typia): guide source checkout bootstrap

### DIFF
--- a/.sampo/changesets/774-source-checkout-bootstrap.md
+++ b/.sampo/changesets/774-source-checkout-bootstrap.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Improve source checkout bootstrap guidance when local project-tools build artifacts are missing.

--- a/packages/wp-typia/bin/wp-typia.js
+++ b/packages/wp-typia/bin/wp-typia.js
@@ -35,6 +35,24 @@ const buildScriptEntrypoint = path.join(
   'build-bunli-runtime.ts',
 );
 const sourceCliEntrypoint = path.join(packageRoot, 'src', 'cli.ts');
+const sourceCheckoutRoot = path.resolve(packageRoot, '..', '..');
+const sourceProjectToolsPackageRoot = path.resolve(
+  packageRoot,
+  '..',
+  'wp-typia-project-tools',
+);
+const sourceProjectToolsPackageManifest = path.join(
+  sourceProjectToolsPackageRoot,
+  'package.json',
+);
+const sourceProjectToolsRuntimeProbe = path.join(
+  sourceProjectToolsPackageRoot,
+  'dist',
+  'runtime',
+  'cli-diagnostics.js',
+);
+const sourceProjectToolsBuildCommand =
+  'bun run --filter @wp-typia/project-tools build';
 const standaloneGuidance =
   'Prefer not to install Bun? Use the standalone wp-typia binary from the GitHub release assets.';
 
@@ -67,12 +85,69 @@ function canAutobuildSourceCheckout() {
   );
 }
 
+function hasMissingSourceProjectToolsRuntime() {
+  return (
+    canAutobuildSourceCheckout() &&
+    fs.existsSync(path.join(sourceCheckoutRoot, 'package.json')) &&
+    fs.existsSync(sourceProjectToolsPackageManifest) &&
+    !fs.existsSync(sourceProjectToolsRuntimeProbe)
+  );
+}
+
+function ensureSourceProjectToolsRuntime() {
+  if (!hasMissingSourceProjectToolsRuntime()) {
+    return true;
+  }
+
+  const relativeProbe = path.relative(
+    sourceCheckoutRoot,
+    sourceProjectToolsRuntimeProbe,
+  );
+
+  console.error(
+    `wp-typia source checkout is missing @wp-typia/project-tools build artifacts (${relativeProbe}).`,
+  );
+  console.error(
+    `Running \`${sourceProjectToolsBuildCommand}\` from ${sourceCheckoutRoot} before rebuilding the CLI runtime...`,
+  );
+
+  const buildResult = spawnSync(
+    bunBinary,
+    ['run', '--filter', '@wp-typia/project-tools', 'build'],
+    {
+      cwd: sourceCheckoutRoot,
+      env: process.env,
+      stdio: 'inherit',
+    },
+  );
+
+  if (buildResult.status !== 0) {
+    console.error(
+      `Error: @wp-typia/project-tools build failed. Run \`${sourceProjectToolsBuildCommand}\` from the repository root, then rerun wp-typia.`,
+    );
+    process.exit(buildResult.status ?? 1);
+  }
+
+  if (fs.existsSync(sourceProjectToolsRuntimeProbe)) {
+    return true;
+  }
+
+  console.error(
+    `Error: @wp-typia/project-tools build completed but ${relativeProbe} is still missing. Run \`${sourceProjectToolsBuildCommand}\` from the repository root, then rerun wp-typia.`,
+  );
+  return false;
+}
+
 function ensureBuiltRuntime() {
   if (fs.existsSync(cliEntrypoint) && fs.existsSync(nodeCliEntrypoint)) {
     return true;
   }
 
   if (!canAutobuildSourceCheckout() || !isWorkingBunBinary()) {
+    return false;
+  }
+
+  if (!ensureSourceProjectToolsRuntime()) {
     return false;
   }
 

--- a/packages/wp-typia/bin/wp-typia.js
+++ b/packages/wp-typia/bin/wp-typia.js
@@ -107,6 +107,14 @@ function ensureSourceProjectToolsRuntime() {
   console.error(
     `wp-typia source checkout is missing @wp-typia/project-tools build artifacts (${relativeProbe}).`,
   );
+
+  if (!isWorkingBunBinary()) {
+    console.error(
+      `Error: wp-typia cannot rebuild @wp-typia/project-tools because no working Bun binary was found. Run \`${sourceProjectToolsBuildCommand}\` from the repository root after installing Bun, then rerun wp-typia.`,
+    );
+    process.exit(1);
+  }
+
   console.error(
     `Running \`${sourceProjectToolsBuildCommand}\` from ${sourceCheckoutRoot} before rebuilding the CLI runtime...`,
   );
@@ -139,15 +147,15 @@ function ensureSourceProjectToolsRuntime() {
 }
 
 function ensureBuiltRuntime() {
+  if (!ensureSourceProjectToolsRuntime()) {
+    return false;
+  }
+
   if (fs.existsSync(cliEntrypoint) && fs.existsSync(nodeCliEntrypoint)) {
     return true;
   }
 
   if (!canAutobuildSourceCheckout() || !isWorkingBunBinary()) {
-    return false;
-  }
-
-  if (!ensureSourceProjectToolsRuntime()) {
     return false;
   }
 

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -948,7 +948,7 @@ process.exit(0);
       expect(result.stderr).toContain(
         'source checkout is missing @wp-typia/project-tools build artifacts',
       );
-      expect(result.stderr).toContain(
+      expect(result.stderr.replace(/\\/g, '/')).toContain(
         'packages/wp-typia-project-tools/dist/runtime/cli-diagnostics.js',
       );
       expect(result.stderr).toContain(

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -829,6 +829,140 @@ describe('wp-typia package', () => {
     expect(result.stdout.trim()).toBe(`wp-typia ${packageManifest.version}`);
   });
 
+  test('guides source checkout bootstrap when project-tools dist is missing', () => {
+    const tempRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'wp-typia-source-bootstrap-'),
+    );
+    const sourcePackageRoot = path.join(tempRoot, 'packages', 'wp-typia');
+    const sourceProjectToolsRoot = path.join(
+      tempRoot,
+      'packages',
+      'wp-typia-project-tools',
+    );
+    const fakeBunPath = path.join(tempRoot, 'fake-bun.mjs');
+    const fakeBunLogPath = path.join(tempRoot, 'fake-bun.log');
+
+    try {
+      fs.writeFileSync(
+        path.join(tempRoot, 'package.json'),
+        `${JSON.stringify({
+          private: true,
+          workspaces: ['packages/*'],
+        })}\n`,
+        'utf8',
+      );
+      fs.mkdirSync(path.join(sourcePackageRoot, 'scripts'), {
+        recursive: true,
+      });
+      fs.mkdirSync(path.join(sourcePackageRoot, 'src'), { recursive: true });
+      fs.mkdirSync(sourceProjectToolsRoot, { recursive: true });
+      fs.cpSync(
+        path.join(packageRoot, 'bin'),
+        path.join(sourcePackageRoot, 'bin'),
+        { recursive: true },
+      );
+      fs.writeFileSync(
+        path.join(sourcePackageRoot, 'package.json'),
+        `${JSON.stringify(
+          {
+            name: 'wp-typia',
+            scripts: {
+              build: 'bun run generate && bun scripts/build-bunli-runtime.ts',
+            },
+            type: 'module',
+          },
+          null,
+          2,
+        )}\n`,
+        'utf8',
+      );
+      fs.writeFileSync(
+        path.join(sourcePackageRoot, 'scripts', 'build-bunli-runtime.ts'),
+        'export {};\n',
+        'utf8',
+      );
+      fs.writeFileSync(
+        path.join(sourcePackageRoot, 'src', 'cli.ts'),
+        'export {};\n',
+        'utf8',
+      );
+      fs.writeFileSync(
+        path.join(sourceProjectToolsRoot, 'package.json'),
+        `${JSON.stringify({
+          name: '@wp-typia/project-tools',
+          type: 'module',
+        })}\n`,
+        'utf8',
+      );
+      fs.writeFileSync(
+        fakeBunPath,
+        `#!/usr/bin/env node
+import fs from 'node:fs';
+
+const args = process.argv.slice(2);
+if (args.length === 1 && args[0] === '--version') {
+  console.log('1.3.11');
+  process.exit(0);
+}
+
+fs.appendFileSync(${JSON.stringify(fakeBunLogPath)}, \`\${JSON.stringify(args)}\\n\`);
+if (
+  args[0] === 'run' &&
+  args[1] === '--filter' &&
+  args[2] === '@wp-typia/project-tools' &&
+  args[3] === 'build'
+) {
+  console.error('simulated project-tools build failure');
+  process.exit(17);
+}
+
+process.exit(0);
+`,
+        'utf8',
+      );
+      fs.chmodSync(fakeBunPath, 0o755);
+
+      const result = runCapturedCommand(
+        process.execPath,
+        [path.join(sourcePackageRoot, 'bin', 'wp-typia.js'), '--version'],
+        {
+          env: {
+            ...withoutAIAgentEnv(),
+            BUN_BIN: fakeBunPath,
+            PATH: [
+              path.dirname(process.execPath),
+              process.env.PATH ?? '',
+            ].join(path.delimiter),
+          },
+        },
+      );
+      const fakeBunCalls = fs
+        .readFileSync(fakeBunLogPath, 'utf8')
+        .trim()
+        .split('\n')
+        .filter(Boolean)
+        .map((line) => JSON.parse(line) as string[]);
+
+      expect(result.status).toBe(17);
+      expect(result.stdout).toBe('');
+      expect(result.stderr).toContain(
+        'source checkout is missing @wp-typia/project-tools build artifacts',
+      );
+      expect(result.stderr).toContain(
+        'packages/wp-typia-project-tools/dist/runtime/cli-diagnostics.js',
+      );
+      expect(result.stderr).toContain(
+        'bun run --filter @wp-typia/project-tools build',
+      );
+      expect(result.stderr).toContain('repository root');
+      expect(fakeBunCalls).toEqual([
+        ['run', '--filter', '@wp-typia/project-tools', 'build'],
+      ]);
+    } finally {
+      fs.rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
   test('renders general and command help without requiring a local Bun binary', () => {
     const noCommandResult = runCapturedCommand(process.execPath, [entryPath], {
       env: withoutLocalBunEnv(),


### PR DESCRIPTION
## Summary
- detect source checkouts missing @wp-typia/project-tools dist artifacts before rebuilding the wp-typia runtime
- run the scoped project-tools build first and print the exact fallback command when it fails
- add a temp-checkout smoke test with a fake Bun binary for the missing-dist path

Closes #774

## Verification
- bun test packages/wp-typia/tests/cli-package.test.ts -t "guides source checkout bootstrap"
- bun test packages/wp-typia/tests/cli-package.test.ts
- bun run format:check
- bun run typecheck
- bun run lint:repo
- bun run changesets:validate
- bun run --filter wp-typia test
- node packages/wp-typia/bin/wp-typia.js --version
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CLI now auto-detects and rebuilds missing runtime components when needed, with enhanced error messaging to guide troubleshooting.

* **Tests**
  * Added test coverage for source checkout bootstrap scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->