### PR TITLE
[codex] refactor(project-tools): split init plan presentation helpers

### DIFF
--- a/.sampo/changesets/772-split-init-plan-presentation.md
+++ b/.sampo/changesets/772-split-init-plan-presentation.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Split retrofit init plan presentation helpers out of the main planning module.

--- a/packages/wp-typia-project-tools/src/runtime/cli-init-plan-presentation.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-init-plan-presentation.ts
@@ -1,0 +1,136 @@
+import {
+	formatAddDevDependenciesCommand,
+	formatPackageExecCommand,
+	formatRunScript,
+	type PackageManagerId,
+} from "./package-managers.js";
+import {
+	buildRequiredDevDependencyMapEntries,
+	getWpTypiaCliSpecifier,
+} from "./cli-init-package-json.js";
+import type {
+	InitCommandMode,
+	InitPlanLayoutKind,
+	InitPlanStatus,
+	RetrofitInitPlan,
+} from "./cli-init-types.js";
+
+export function buildInitPlanChangeSummary(
+	changes: Pick<
+		RetrofitInitPlan,
+		"generatedArtifacts" | "packageChanges" | "plannedFiles"
+	>,
+	options: {
+		includeGeneratedArtifacts: boolean;
+	},
+): string[] {
+	const lines: string[] = [];
+
+	for (const dependencyChange of changes.packageChanges.addDevDependencies) {
+		lines.push(
+			`devDependency ${dependencyChange.action} ${dependencyChange.name} -> ${dependencyChange.requiredValue}`,
+		);
+	}
+
+	if (changes.packageChanges.packageManagerField) {
+		lines.push(
+			`packageManager ${changes.packageChanges.packageManagerField.action} -> ${changes.packageChanges.packageManagerField.requiredValue}`,
+		);
+	}
+
+	for (const scriptChange of changes.packageChanges.scripts) {
+		lines.push(
+			`script ${scriptChange.action} ${scriptChange.name} -> ${scriptChange.requiredValue}`,
+		);
+	}
+
+	for (const filePlan of changes.plannedFiles) {
+		lines.push(`file ${filePlan.action} ${filePlan.path} (${filePlan.purpose})`);
+	}
+
+	if (options.includeGeneratedArtifacts) {
+		for (const artifactPath of changes.generatedArtifacts) {
+			lines.push(`generated artifact ${artifactPath}`);
+		}
+	}
+
+	return lines;
+}
+
+export function buildInitPlanNextSteps(options: {
+	commandMode: InitCommandMode;
+	dependencyChangeCount: number;
+	hasPlannedChanges: boolean;
+	layoutKind: InitPlanLayoutKind;
+	packageManager: PackageManagerId;
+}): string[] {
+	const cliSpecifier = getWpTypiaCliSpecifier();
+	const syncTypesRun = formatRunScript(options.packageManager, "sync-types");
+	const syncRun = formatRunScript(options.packageManager, "sync");
+	const doctorRun = formatPackageExecCommand(
+		options.packageManager,
+		cliSpecifier,
+		"doctor",
+	);
+	const migrationInitRun = formatPackageExecCommand(
+		options.packageManager,
+		cliSpecifier,
+		"migrate init --current-migration-version v1",
+	);
+	const dependencyInstallCommand = formatAddDevDependenciesCommand(
+		options.packageManager,
+		buildRequiredDevDependencyMapEntries(),
+	);
+
+	if (options.layoutKind === "unsupported") {
+		return [
+			"Align the project to one of the supported retrofit layouts listed below, then rerun `wp-typia init`.",
+			dependencyInstallCommand,
+			syncTypesRun,
+			doctorRun,
+		];
+	}
+
+	if (options.commandMode === "apply") {
+		return [
+			...(options.dependencyChangeCount > 0
+				? [
+						"Install or reinstall project dependencies so the retrofit sync scripts and metadata generators are available locally.",
+						dependencyInstallCommand,
+				  ]
+				: []),
+			syncRun,
+			doctorRun,
+			`Optional migration bootstrap: ${migrationInitRun}`,
+		];
+	}
+
+	return [
+		...(options.hasPlannedChanges
+			? [
+					"Re-run `wp-typia init --apply` to write the planned package.json changes and helper files automatically.",
+					...(options.dependencyChangeCount > 0 ? [dependencyInstallCommand] : []),
+			  ]
+			: []),
+		syncRun,
+		doctorRun,
+		`Optional migration bootstrap: ${migrationInitRun}`,
+	];
+}
+
+export function buildRetrofitPlanSummary(options: {
+	commandMode: InitCommandMode;
+	status: InitPlanStatus;
+}): string {
+	if (options.status === "already-initialized") {
+		return options.commandMode === "apply"
+			? "This project already exposes the minimum wp-typia retrofit surface. No files were changed."
+			: "This project already exposes the minimum wp-typia retrofit surface.";
+	}
+
+	if (options.commandMode === "apply") {
+		return "Applied the minimum wp-typia retrofit surface so package.json and helper scripts are ready for the next install and sync run.";
+	}
+
+	return "This command previews the minimum wp-typia adoption layer for the current project without rewriting it into a full scaffold.";
+}

--- a/packages/wp-typia-project-tools/src/runtime/cli-init-plan.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-init-plan.ts
@@ -6,23 +6,22 @@ import ts from "typescript";
 
 import { discoverMigrationInitLayout } from "./migration-project.js";
 import type { MigrationBlockConfig } from "./migration-types.js";
-import {
-	formatAddDevDependenciesCommand,
-	formatPackageExecCommand,
-	formatRunScript,
-	type PackageManagerId,
-} from "./package-managers.js";
+import { formatPackageExecCommand, formatRunScript, type PackageManagerId } from "./package-managers.js";
 import { toPascalCase } from "./string-case.js";
 import {
 	buildDependencyChanges,
 	buildPackageManagerFieldChange,
-	buildRequiredDevDependencyMapEntries,
 	buildScriptChanges,
 	getWpTypiaCliSpecifier,
 	hasExistingWpTypiaProjectSurface,
 	readProjectPackageJson,
 	resolveInitPackageManager,
 } from "./cli-init-package-json.js";
+import {
+	buildInitPlanChangeSummary,
+	buildInitPlanNextSteps,
+	buildRetrofitPlanSummary,
+} from "./cli-init-plan-presentation.js";
 import {
 	RETROFIT_APPLY_PREVIEW_NOTE,
 	SUPPORTED_RETROFIT_LAYOUT_NOTE,
@@ -264,128 +263,6 @@ function buildPlannedFiles(
 	];
 }
 
-function buildChangeSummary(
-	changes: Pick<
-		RetrofitInitPlan,
-		"generatedArtifacts" | "packageChanges" | "plannedFiles"
-	>,
-	options: {
-		includeGeneratedArtifacts: boolean;
-	},
-): string[] {
-	const lines: string[] = [];
-
-	for (const dependencyChange of changes.packageChanges.addDevDependencies) {
-		lines.push(
-			`devDependency ${dependencyChange.action} ${dependencyChange.name} -> ${dependencyChange.requiredValue}`,
-		);
-	}
-
-	if (changes.packageChanges.packageManagerField) {
-		lines.push(
-			`packageManager ${changes.packageChanges.packageManagerField.action} -> ${changes.packageChanges.packageManagerField.requiredValue}`,
-		);
-	}
-
-	for (const scriptChange of changes.packageChanges.scripts) {
-		lines.push(
-			`script ${scriptChange.action} ${scriptChange.name} -> ${scriptChange.requiredValue}`,
-		);
-	}
-
-	for (const filePlan of changes.plannedFiles) {
-		lines.push(`file ${filePlan.action} ${filePlan.path} (${filePlan.purpose})`);
-	}
-
-	if (options.includeGeneratedArtifacts) {
-		for (const artifactPath of changes.generatedArtifacts) {
-			lines.push(`generated artifact ${artifactPath}`);
-		}
-	}
-
-	return lines;
-}
-
-function buildNextSteps(options: {
-	commandMode: InitCommandMode;
-	dependencyChangeCount: number;
-	hasPlannedChanges: boolean;
-	layoutKind: InitPlanLayoutKind;
-	packageManager: PackageManagerId;
-}): string[] {
-	const cliSpecifier = getWpTypiaCliSpecifier();
-	const syncTypesRun = formatRunScript(options.packageManager, "sync-types");
-	const syncRun = formatRunScript(options.packageManager, "sync");
-	const doctorRun = formatPackageExecCommand(
-		options.packageManager,
-		cliSpecifier,
-		"doctor",
-	);
-	const migrationInitRun = formatPackageExecCommand(
-		options.packageManager,
-		cliSpecifier,
-		"migrate init --current-migration-version v1",
-	);
-	const dependencyInstallCommand = formatAddDevDependenciesCommand(
-		options.packageManager,
-		buildRequiredDevDependencyMapEntries(),
-	);
-
-	if (options.layoutKind === "unsupported") {
-		return [
-			"Align the project to one of the supported retrofit layouts listed below, then rerun `wp-typia init`.",
-			dependencyInstallCommand,
-			syncTypesRun,
-			doctorRun,
-		];
-	}
-
-	if (options.commandMode === "apply") {
-		return [
-			...(options.dependencyChangeCount > 0
-				? [
-						"Install or reinstall project dependencies so the retrofit sync scripts and metadata generators are available locally.",
-						dependencyInstallCommand,
-				  ]
-				: []),
-			syncRun,
-			doctorRun,
-			`Optional migration bootstrap: ${migrationInitRun}`,
-		];
-	}
-
-	const steps = [
-		...(options.hasPlannedChanges
-			? [
-					"Re-run `wp-typia init --apply` to write the planned package.json changes and helper files automatically.",
-					...(options.dependencyChangeCount > 0 ? [dependencyInstallCommand] : []),
-			  ]
-			: []),
-		syncRun,
-		doctorRun,
-		`Optional migration bootstrap: ${migrationInitRun}`,
-	];
-
-	return steps;
-}
-
-function buildRetrofitPlanSummary(options: {
-	commandMode: InitCommandMode;
-	status: InitPlanStatus;
-}): string {
-	if (options.status === "already-initialized") {
-		return options.commandMode === "apply"
-			? "This project already exposes the minimum wp-typia retrofit surface. No files were changed."
-			: "This project already exposes the minimum wp-typia retrofit surface.";
-	}
-
-	if (options.commandMode === "apply") {
-		return "Applied the minimum wp-typia retrofit surface so package.json and helper scripts are ready for the next install and sync run.";
-	}
-
-	return "This command previews the minimum wp-typia adoption layer for the current project without rewriting it into a full scaffold.";
-}
-
 export function createRetrofitPlan(options: {
 	commandMode: InitCommandMode;
 	detectedLayout: {
@@ -405,7 +282,7 @@ export function createRetrofitPlan(options: {
 	status: InitPlanStatus;
 }): RetrofitInitPlan {
 	const includeGeneratedArtifacts = options.commandMode === "preview-only";
-	const plannedChanges = buildChangeSummary(
+	const plannedChanges = buildInitPlanChangeSummary(
 		{
 			generatedArtifacts: options.generatedArtifacts,
 			packageChanges: options.packageChanges,
@@ -423,7 +300,7 @@ export function createRetrofitPlan(options: {
 		generatedArtifacts: options.generatedArtifacts,
 		nextSteps:
 			options.nextSteps ??
-			buildNextSteps({
+			buildInitPlanNextSteps({
 				commandMode: options.commandMode,
 				dependencyChangeCount: options.packageChanges.addDevDependencies.length,
 				hasPlannedChanges: plannedChanges.length > 0,

--- a/packages/wp-typia-project-tools/tests/init-command.test.ts
+++ b/packages/wp-typia-project-tools/tests/init-command.test.ts
@@ -5,6 +5,11 @@ import * as path from "node:path";
 import { applyInitPlan } from "../src/runtime/cli-init-apply.js";
 import { runInitCommand } from "../src/runtime/cli-init.js";
 import { getInitPlan } from "../src/runtime/cli-init-plan.js";
+import {
+	buildInitPlanChangeSummary,
+	buildInitPlanNextSteps,
+	buildRetrofitPlanSummary,
+} from "../src/runtime/cli-init-plan-presentation.js";
 import { getPackageVersions } from "../src/runtime/package-versions.js";
 import {
 	cleanupScaffoldTempRoot,
@@ -263,6 +268,81 @@ describe("wp-typia init", () => {
 				path.join(projectDir, "scripts", "sync-types-to-block-json.ts"),
 			),
 		).toBe(true);
+	});
+
+	test("plan presentation helpers keep summary, changes, and next steps stable", () => {
+		const changes = buildInitPlanChangeSummary(
+			{
+				generatedArtifacts: ["src/typia.manifest.json"],
+				packageChanges: {
+					addDevDependencies: [
+						{
+							action: "add",
+							name: "@wp-typia/block-runtime",
+							requiredValue: "1.2.3",
+						},
+					],
+					packageManagerField: {
+						action: "update",
+						currentValue: "bun@1.3.11",
+						requiredValue: "npm@11.6.1",
+					},
+					scripts: [
+						{
+							action: "add",
+							name: "sync",
+							requiredValue: "tsx scripts/sync-project.ts",
+						},
+					],
+				},
+				plannedFiles: [
+					{
+						action: "add",
+						path: "scripts/sync-project.ts",
+						purpose: "Provide one shared sync entrypoint.",
+					},
+				],
+			},
+			{
+				includeGeneratedArtifacts: true,
+			},
+		);
+		const nextSteps = buildInitPlanNextSteps({
+			commandMode: "preview-only",
+			dependencyChangeCount: 0,
+			hasPlannedChanges: false,
+			layoutKind: "single-block",
+			packageManager: "npm",
+		});
+
+		expect(changes).toEqual([
+			"devDependency add @wp-typia/block-runtime -> 1.2.3",
+			"packageManager update -> npm@11.6.1",
+			"script add sync -> tsx scripts/sync-project.ts",
+			"file add scripts/sync-project.ts (Provide one shared sync entrypoint.)",
+			"generated artifact src/typia.manifest.json",
+		]);
+		expect(nextSteps).toEqual([
+			"npm run sync",
+			`npx --yes wp-typia@${wpTypiaPackageManifest.version} doctor`,
+			`Optional migration bootstrap: npx --yes wp-typia@${wpTypiaPackageManifest.version} migrate init --current-migration-version v1`,
+		]);
+		expect(
+			buildRetrofitPlanSummary({
+				commandMode: "preview-only",
+				status: "preview",
+			}),
+		).toBe(
+			"This command previews the minimum wp-typia adoption layer for the current project without rewriting it into a full scaffold.",
+		);
+		expect(
+			buildRetrofitPlanSummary({
+				commandMode: "apply",
+				status: "already-initialized",
+			}),
+		).toBe(
+			"This project already exposes the minimum wp-typia retrofit surface. No files were changed.",
+		);
 	});
 
 	test("rolls back package.json changes when apply mode cannot finish writing helper files", async () => {


### PR DESCRIPTION
## Summary
- Split init retrofit plan presentation responsibilities into `cli-init-plan-presentation.ts`.
- Keep `cli-init-plan.ts` focused on plan assembly and layout/file planning while preserving existing plan summary/change/next-step strings.
- Add focused helper coverage plus a patch changeset for `@wp-typia/project-tools`.

Closes #772

## Verification
- bun test packages/wp-typia-project-tools/tests/init-command.test.ts
- bun run format:check
- bun run typecheck
- bun run lint:repo
- bun run changesets:validate
- bun test packages/wp-typia/tests/cli-package.test.ts -t "init"
- bun run test:project-tools:scaffold-core

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved initialization plan presentation with formatted summaries of changes and step-by-step instructions tailored to your project configuration.

* **Refactor**
  * Separated plan presentation logic into a dedicated module for better maintainability.

* **Tests**
  * Added test coverage for plan presentation formatting and next-step guidance generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->