### PR TITLE
[codex] docs(project-tools): clarify fixed acronym slug policy

### DIFF
--- a/apps/docs/src/content/docs/reference/cli.md
+++ b/apps/docs/src/content/docs/reference/cli.md
@@ -148,6 +148,27 @@ Common flags:
 The positional alias `wp-typia <project-dir>` remains available only for
 unambiguous create invocations with a single local project directory.
 
+### Generated slug casing and acronyms
+
+Generated block slugs, text domains, PHP prefixes, file names, and related
+identifiers are derived from the normalized kebab-case project or block name.
+The normalizer keeps a fixed built-in list of common WordPress/web acronyms
+together, including `API`, `CTA`, `HTML`, `HTTP`, `ID`, `JSON`, `REST`, `URL`,
+`UUID`, `WP`, and `XML`.
+
+That acronym list is intentionally not project-configurable. Domain-specific
+names such as `CRMLeadForm`, `SEOSettingsPanel`, or `SSOLoginBlock` still
+normalize as `crmlead-form`, `seosettings-panel`, and `ssologin-block` because
+`CRM`, `SEO`, and `SSO` are not part of the stable built-in set. Use explicit
+word separators instead, such as `CRM Lead Form`, when the generated slug must
+be `crm-lead-form`.
+
+Keeping the list fixed makes repeated scaffold/add commands reproducible across
+machines and config sources. A project-defined acronym dictionary could silently
+change generated paths, block names, package handles, REST routes, and migration
+fixture directories when config changes, so compatibility-sensitive projects
+should treat slug spelling as explicit input rather than ambient configuration.
+
 ### External template cache
 
 Remote template resolution keeps the existing timeout, size, and symlink guards.

--- a/packages/wp-typia-project-tools/src/runtime/string-case.ts
+++ b/packages/wp-typia-project-tools/src/runtime/string-case.ts
@@ -1,3 +1,5 @@
+// Keep this list fixed so generated slugs and file paths do not drift when
+// project config changes. Domain-specific acronyms should use separators.
 const COMMON_ACRONYM_PREFIXES = [
   'HTML',
   'HTTP',

--- a/packages/wp-typia-project-tools/tests/string-case.test.ts
+++ b/packages/wp-typia-project-tools/tests/string-case.test.ts
@@ -33,6 +33,16 @@ test("toKebabCase avoids inventing boundaries in acronym-lowercase words", () =>
 	expect(toKebabCase("AABBcc")).toBe("aabbcc");
 });
 
+test("toKebabCase keeps project-specific acronyms deterministic unless separated", () => {
+	expect(toKebabCase("CRMLeadForm")).toBe("crmlead-form");
+	expect(toKebabCase("SEOSettingsPanel")).toBe("seosettings-panel");
+	expect(toKebabCase("SSOLoginBlock")).toBe("ssologin-block");
+
+	expect(toKebabCase("CRM Lead Form")).toBe("crm-lead-form");
+	expect(toKebabCase("SEO Settings Panel")).toBe("seo-settings-panel");
+	expect(toKebabCase("SSO Login Block")).toBe("sso-login-block");
+});
+
 test("toKebabCase preserves common slug normalization behavior", () => {
 	expect(toKebabCase("Demo Card")).toBe("demo-card");
 	expect(toKebabCase("demo_card")).toBe("demo-card");


### PR DESCRIPTION
## Summary
- Document that generated slug acronym handling uses a fixed built-in list instead of project-defined dictionaries.
- Capture real domain-specific acronym examples where the built-in list remains intentionally insufficient.
- Add regression coverage for deterministic project-specific acronym behavior and explicit separator escape hatches.

Closes #773

## Verification
- bun test packages/wp-typia-project-tools/tests/string-case.test.ts
- bun run format:check
- bun run changesets:validate
- bun run typecheck
- bun run lint:repo
- bun run docs:build
- bun run --filter @wp-typia/project-tools test:quick

## Release notes
- No changeset: documentation and tests only; runtime slug behavior is unchanged.

## Migration / compatibility
- The documented decision keeps project-specific acronym dictionaries out of the config surface because changing them could rename generated slugs, paths, handles, REST routes, and migration fixture directories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide explaining how block slugs, text domains, PHP prefixes, and filenames are generated from kebab-case names, including handling of built-in acronyms and guidance for domain-specific acronyms.

* **Tests**
  * Added test cases verifying deterministic kebab-case conversion behavior with acronyms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->