### PR TITLE
[codex] refactor(project-tools): use async fs in add workspace helpers

### DIFF
--- a/.sampo/changesets/770-async-add-workspace-fs.md
+++ b/.sampo/changesets/770-async-add-workspace-fs.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Reduce synchronous filesystem probes in async add workspace and block JSON helpers.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-block-json.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-block-json.ts
@@ -1,10 +1,10 @@
-import fs from "node:fs";
 import path from "node:path";
 import { parseScaffoldBlockMetadata } from "@wp-typia/block-runtime/blocks";
 
 import type {
 	WorkspaceInventory,
 } from "./workspace-inventory.js";
+import { readOptionalUtf8File } from "./fs-async.js";
 
 /**
  * Resolve an existing workspace block inventory entry by slug.
@@ -35,15 +35,16 @@ export function resolveWorkspaceBlock(
  * @returns Parsed block metadata and the absolute `block.json` path.
  * @throws {Error} When the file is missing or cannot be parsed as scaffold metadata.
  */
-export function readWorkspaceBlockJson(
+export async function readWorkspaceBlockJson(
 	projectDir: string,
 	blockSlug: string,
-): {
+): Promise<{
 	blockJson: Record<string, unknown>;
 	blockJsonPath: string;
-} {
+}> {
 	const blockJsonPath = path.join(projectDir, "src", "blocks", blockSlug, "block.json");
-	if (!fs.existsSync(blockJsonPath)) {
+	const source = await readOptionalUtf8File(blockJsonPath);
+	if (source === null) {
 		throw new Error(
 			`Missing ${path.relative(projectDir, blockJsonPath)} for workspace block "${blockSlug}".`,
 		);
@@ -52,7 +53,7 @@ export function readWorkspaceBlockJson(
 	let blockJson: Record<string, unknown>;
 	try {
 		blockJson = parseScaffoldBlockMetadata<Record<string, unknown>>(
-			JSON.parse(fs.readFileSync(blockJsonPath, "utf8")),
+			JSON.parse(source),
 		);
 	} catch (error) {
 		throw new Error(

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace.ts
@@ -1,8 +1,8 @@
-import fs from "node:fs";
 import { promises as fsp } from "node:fs";
 import path from "node:path";
 
 import type { HookedBlockPositionId } from "./hooked-blocks.js";
+import { pathExists } from "./fs-async.js";
 import { resolveWorkspaceProject } from "./workspace-project.js";
 import { appendWorkspaceInventoryEntries, readWorkspaceInventory } from "./workspace-inventory.js";
 import { toKebabCase, toSnakeCase, toTitleCase } from "./string-case.js";
@@ -534,8 +534,7 @@ async function writeVariationRegistry(
 	const variationsIndexPath = path.join(variationsDir, "index.ts");
 	await fsp.mkdir(variationsDir, { recursive: true });
 
-	const existingVariationSlugs = fs
-		.readdirSync(variationsDir)
+	const existingVariationSlugs = (await fsp.readdir(variationsDir))
 		.filter((entry) => entry.endsWith(".ts") && entry !== "index.ts")
 		.map((entry) => entry.replace(/\.ts$/u, ""));
 	const nextVariationSlugs = Array.from(new Set([...existingVariationSlugs, variationSlug])).sort();
@@ -555,8 +554,7 @@ async function writeBlockStyleRegistry(
 	const stylesIndexPath = path.join(stylesDir, "index.ts");
 	await fsp.mkdir(stylesDir, { recursive: true });
 
-	const existingStyleSlugs = fs
-		.readdirSync(stylesDir)
+	const existingStyleSlugs = (await fsp.readdir(stylesDir))
 		.filter((entry) => entry.endsWith(".ts") && entry !== "index.ts")
 		.map((entry) => entry.replace(/\.ts$/u, ""));
 	const nextStyleSlugs = Array.from(new Set([...existingStyleSlugs, styleSlug])).sort();
@@ -572,8 +570,7 @@ async function writeBlockTransformRegistry(
 	const transformsIndexPath = path.join(transformsDir, "index.ts");
 	await fsp.mkdir(transformsDir, { recursive: true });
 
-	const existingTransformSlugs = fs
-		.readdirSync(transformsDir)
+	const existingTransformSlugs = (await fsp.readdir(transformsDir))
 		.filter((entry) => entry.endsWith(".ts") && entry !== "index.ts")
 		.map((entry) => entry.replace(/\.ts$/u, ""));
 	const nextTransformSlugs = Array.from(
@@ -707,7 +704,7 @@ export async function runAddVariationCommand({
 	const variationsDir = path.join(workspace.projectDir, "src", "blocks", blockSlug, "variations");
 	const variationFilePath = path.join(variationsDir, `${variationSlug}.ts`);
 	const variationsIndexPath = path.join(variationsDir, "index.ts");
-	const shouldRemoveVariationsDirOnRollback = !fs.existsSync(variationsDir);
+	const shouldRemoveVariationsDirOnRollback = !(await pathExists(variationsDir));
 	const mutationSnapshot: WorkspaceMutationSnapshot = {
 		fileSources: await snapshotWorkspaceFiles([
 			blockConfigPath,
@@ -787,7 +784,7 @@ export async function runAddBlockStyleCommand({
 	const stylesDir = path.join(workspace.projectDir, "src", "blocks", blockSlug, "styles");
 	const styleFilePath = path.join(stylesDir, `${styleSlug}.ts`);
 	const stylesIndexPath = path.join(stylesDir, "index.ts");
-	const shouldRemoveStylesDirOnRollback = !fs.existsSync(stylesDir);
+	const shouldRemoveStylesDirOnRollback = !(await pathExists(stylesDir));
 	const mutationSnapshot: WorkspaceMutationSnapshot = {
 		fileSources: await snapshotWorkspaceFiles([
 			blockConfigPath,
@@ -900,7 +897,7 @@ export async function runAddBlockTransformCommand({
 	);
 	const transformFilePath = path.join(transformsDir, `${transformSlug}.ts`);
 	const transformsIndexPath = path.join(transformsDir, "index.ts");
-	const shouldRemoveTransformsDirOnRollback = !fs.existsSync(transformsDir);
+	const shouldRemoveTransformsDirOnRollback = !(await pathExists(transformsDir));
 	const mutationSnapshot: WorkspaceMutationSnapshot = {
 		fileSources: await snapshotWorkspaceFiles([
 			blockConfigPath,
@@ -990,7 +987,10 @@ export async function runAddHookedBlockCommand({
 			"`wp-typia add hooked-block` cannot hook a block relative to its own block name.",
 		);
 	}
-	const { blockJson, blockJsonPath } = readWorkspaceBlockJson(workspace.projectDir, blockSlug);
+	const { blockJson, blockJsonPath } = await readWorkspaceBlockJson(
+		workspace.projectDir,
+		blockSlug,
+	);
 	const blockJsonRelativePath = path.relative(workspace.projectDir, blockJsonPath);
 	const blockHooks = getMutableBlockHooks(blockJson, blockJsonRelativePath);
 

--- a/packages/wp-typia-project-tools/tests/cli-add-shared.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-add-shared.test.ts
@@ -84,6 +84,14 @@ test('shared add runtime keeps compatibility exports around focused modules', ()
   expect(sharedSource).not.toContain('export function formatAddHelpText');
 });
 
+test('converted async add helpers do not use sync filesystem probes', () => {
+  for (const fileName of ['cli-add-workspace.ts', 'cli-add-block-json.ts']) {
+    expect(readRuntimeSource(fileName)).not.toMatch(
+      /\bfs\.(?:readdirSync|readFileSync|existsSync)\b/u,
+    );
+  }
+});
+
 test('focused add runtime modules own their helper categories', () => {
   const addKindIdsSource = readRuntimeSource('cli-add-kind-ids.ts');
   const typesSource = readRuntimeSource('cli-add-types.ts');
@@ -105,7 +113,7 @@ test('focused add runtime modules own their helper categories', () => {
   expect(validationSource).toContain('export function assertValidEditorPluginSlot');
   expect(filesystemSource).toContain('export async function snapshotWorkspaceFiles');
   expect(filesystemSource).toContain('export async function rollbackWorkspaceMutation');
-  expect(blockJsonSource).toContain('export function readWorkspaceBlockJson');
+  expect(blockJsonSource).toContain('export async function readWorkspaceBlockJson');
   expect(blockJsonSource).toContain('export function getMutableBlockHooks');
   expect(collisionSource).toContain('function assertAddKindScaffoldDoesNotExist');
   expect(collisionSource).toContain('export function assertScaffoldDoesNotExist');
@@ -347,7 +355,7 @@ test('shared optional file reader returns null for missing paths and reads exist
   await expect(readOptionalFile(filePath)).resolves.toBe('hello\n');
 });
 
-test('focused block-json helpers resolve workspace blocks and read metadata', () => {
+test('focused block-json helpers resolve workspace blocks and read metadata', async () => {
   const projectDir = path.join(tempRoot, 'block-json-read');
   const blockJsonPath = path.join(
     projectDir,
@@ -380,13 +388,15 @@ test('focused block-json helpers resolve workspace blocks and read metadata', ()
   );
 
   const { blockJson, blockJsonPath: resolvedBlockJsonPath } =
-    readWorkspaceBlockJson(projectDir, 'counter-card');
+    await readWorkspaceBlockJson(projectDir, 'counter-card');
   expect(resolvedBlockJsonPath).toBe(blockJsonPath);
   expect(blockJson).toMatchObject({
     name: 'demo/counter-card',
     title: 'Counter Card',
   });
-  expect(() => readWorkspaceBlockJson(projectDir, 'missing-card')).toThrow(
+  await expect(
+    readWorkspaceBlockJson(projectDir, 'missing-card'),
+  ).rejects.toThrow(
     'Missing src/blocks/missing-card/block.json for workspace block "missing-card".',
   );
 });


### PR DESCRIPTION
## Summary
- Convert add workspace registry reads from `fs.readdirSync` to `fsp.readdir`.
- Convert rollback directory probes from `fs.existsSync` to the shared async `pathExists` helper.
- Convert the focused block JSON helper from `existsSync`/`readFileSync` to `readOptionalUtf8File` and await it from hooked-block add.
- Add source-level regression coverage that the converted add-workspace/block-json helpers do not reintroduce sync fs probes.

Closes #770

## Sync FS inventory
- Converted: `packages/wp-typia-project-tools/src/runtime/cli-add-workspace.ts` (`readdirSync`, rollback `existsSync`).
- Converted: `packages/wp-typia-project-tools/src/runtime/cli-add-block-json.ts` (`existsSync`, `readFileSync`).
- Left for future focused PRs: broader doctor, migration, template discovery, and generated-script string paths where behavior is synchronous or outside this add-workspace slice.

## Verification
- bun test packages/wp-typia-project-tools/tests/cli-add-shared.test.ts
- bun test packages/wp-typia-project-tools/tests/workspace-add.test.ts -t "variation workflow|canonical CLI can add block styles and transforms|transform workflow rejects|canonical CLI can add hooked-block|dry-run hooked-block|hooked-block workflow"
- bun run changesets:validate
- bun run format:check
- bun run typecheck
- bun run lint:repo
- bun run --filter @wp-typia/project-tools test:quick

## Migration / compatibility
- Runtime behavior should stay unchanged. The changed paths remain covered by rollback and hooked-block/add-workspace tests.