### PR TITLE
[codex] fix(cli): code command contract validation errors

### DIFF
--- a/.sampo/changesets/785-command-contract-diagnostics.md
+++ b/.sampo/changesets/785-command-contract-diagnostics.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Tag positional alias command-contract validation failures with stable diagnostic codes.

--- a/packages/wp-typia/src/command-contract.ts
+++ b/packages/wp-typia/src/command-contract.ts
@@ -1,5 +1,9 @@
 import path from 'node:path';
 import {
+  CLI_DIAGNOSTIC_CODES,
+  createCliDiagnosticCodeError,
+} from '@wp-typia/project-tools/cli-diagnostics';
+import {
   collectPositionalIndexes,
   findFirstPositionalIndex,
 } from '../bin/argv-walker.js';
@@ -232,13 +236,15 @@ function assertPositionalAliasProjectDir(projectDir: string): void {
     path.normalize(projectDir).replace(/[\\/]+$/u, '') ||
     path.normalize(projectDir);
   if (normalizedProjectDir === '.' || normalizedProjectDir === '..') {
-    throw new Error(
+    throw createCliDiagnosticCodeError(
+      CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
       `The positional alias does not scaffold into \`${projectDir}\`. Use \`${WP_TYPIA_CANONICAL_CREATE_USAGE}\` with an explicit child directory instead.`,
     );
   }
 
   if (looksLikeStructuredProjectInput(projectDir)) {
-    throw new Error(
+    throw createCliDiagnosticCodeError(
+      CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
       `The positional alias only accepts unambiguous local project directories. Use \`${WP_TYPIA_CANONICAL_CREATE_USAGE}\` for \`${projectDir}\`.`,
     );
   }
@@ -260,7 +266,8 @@ export function normalizeWpTypiaArgv(argv: string[]): string[] {
   }
 
   if (firstPositional === 'migrations') {
-    throw new Error(
+    throw createCliDiagnosticCodeError(
+      CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
       '`wp-typia migrations` was removed in favor of `wp-typia migrate`. Use `wp-typia migrate <subcommand>` instead.',
     );
   }
@@ -279,7 +286,8 @@ export function normalizeWpTypiaArgv(argv: string[]): string[] {
           typeof value === 'string' && value.length > 0,
       );
 
-    throw new Error(
+    throw createCliDiagnosticCodeError(
+      CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
       `The positional alias only accepts a single project directory. Use \`${WP_TYPIA_CANONICAL_CREATE_USAGE}\` for scaffold invocations with additional positional arguments, or check the command spelling if you meant another top-level command. Extra positional arguments: ${extraPositionals.map((value) => `\`${value}\``).join(', ')}.`,
     );
   }

--- a/packages/wp-typia/tests/bunli-prep.test.ts
+++ b/packages/wp-typia/tests/bunli-prep.test.ts
@@ -48,6 +48,24 @@ describe('wp-typia Bunli preparation', () => {
     });
   }
 
+  function expectInvalidArgument(
+    callback: () => unknown,
+    message: RegExp,
+  ): void {
+    let caught: unknown;
+    try {
+      callback();
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect(caught).toMatchObject({
+      code: CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
+    });
+    expect((caught as Error).message).toMatch(message);
+  }
+
   test('checks in the Bunli prep tree while promoting a built CLI runtime', () => {
     expect(packageManifest.bin['wp-typia']).toBe('bin/wp-typia.js');
     expect(packageManifest.files).toContain('dist-bunli/');
@@ -340,6 +358,16 @@ describe('wp-typia Bunli preparation', () => {
     ).toContain('createCLI(');
   });
 
+  test('command contract validation failures stay diagnostic-coded', () => {
+    const commandContractSource = fs.readFileSync(
+      path.join(packageRoot, 'src', 'command-contract.ts'),
+      'utf8',
+    );
+
+    expect(commandContractSource).not.toMatch(/\bthrow new Error\b/u);
+    expect(commandContractSource).toContain('createCliDiagnosticCodeError');
+  });
+
   test('future Bunli command tree exposes every supported add kind', () => {
     const addCommand = WP_TYPIA_FUTURE_COMMAND_TREE.find(
       (command) => command.name === 'add',
@@ -409,13 +437,16 @@ describe('wp-typia Bunli preparation', () => {
     expect(normalizeWpTypiaArgv(['demo-block', '--template', 'basic'])).toEqual(
       ['create', 'demo-block', '--template', 'basic'],
     );
-    expect(() => normalizeWpTypiaArgv(['github:acme/template'])).toThrow(
+    expectInvalidArgument(
+      () => normalizeWpTypiaArgv(['github:acme/template']),
       /The positional alias only accepts unambiguous local project directories/,
     );
-    expect(() => normalizeWpTypiaArgv(['.'])).toThrow(
+    expectInvalidArgument(
+      () => normalizeWpTypiaArgv(['.']),
       /The positional alias does not scaffold into `\.`/,
     );
-    expect(() => normalizeWpTypiaArgv(['./'])).toThrow(
+    expectInvalidArgument(
+      () => normalizeWpTypiaArgv(['./']),
       /The positional alias does not scaffold into `\.\/`/,
     );
     expect(
@@ -449,8 +480,13 @@ describe('wp-typia Bunli preparation', () => {
     expect(
       normalizeWpTypiaArgv(['mcp', 'sync', '--output-dir', '.bunli/custom']),
     ).toEqual(['mcp', 'sync', '--output-dir', '.bunli/custom']);
-    expect(() => normalizeWpTypiaArgv(['temlates', 'list'])).toThrow(
+    expectInvalidArgument(
+      () => normalizeWpTypiaArgv(['temlates', 'list']),
       /only accepts a single project directory.*check the command spelling.*`list`/s,
+    );
+    expectInvalidArgument(
+      () => normalizeWpTypiaArgv(['migrations']),
+      /`wp-typia migrations` was removed/,
     );
   });
 });

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -2357,7 +2357,7 @@ process.exit(0);
     expect(parsed.error?.code).toBe('missing-argument');
   });
 
-  test('emits a machine-readable invalid-command error code for positional-alias typos after value options in Bun runtime JSON mode', () => {
+  test('emits a machine-readable invalid-argument error code for positional-alias typos after value options in Bun runtime JSON mode', () => {
     const result = runCapturedCommand(
       'bun',
       [
@@ -2383,7 +2383,7 @@ process.exit(0);
     expect(parsed.ok).toBe(false);
     expect(parsed.error?.kind).toBe('command-execution');
     expect(parsed.error?.command).toBe('temlates');
-    expect(parsed.error?.code).toBe('invalid-command');
+    expect(parsed.error?.code).toBe('invalid-argument');
   });
 
   test('loads MCP schema sources from an explicit --config override', () => {

--- a/packages/wp-typia/tests/node-cli-core.test.ts
+++ b/packages/wp-typia/tests/node-cli-core.test.ts
@@ -341,6 +341,32 @@ describe('Node fallback CLI core routing', () => {
     expect(parsed.error?.detailLines).toContain('`--id` requires a value.');
   });
 
+  test('emits structured positional alias diagnostics with stable codes', async () => {
+    const result = await captureNodeCli(['.', '--format', 'json'], {
+      entrypoint: true,
+    });
+    const parsed = JSON.parse(result.stderr) as {
+      error?: {
+        code?: string;
+        command?: string;
+        detailLines?: string[];
+        kind?: string;
+      };
+      ok?: boolean;
+    };
+
+    expect(result.error).toBeUndefined();
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe('');
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error?.kind).toBe('command-execution');
+    expect(parsed.error?.code).toBe('invalid-argument');
+    expect(parsed.error?.command).toBe('create');
+    expect(parsed.error?.detailLines?.join('\n')).toContain(
+      'The positional alias does not scaffold into `.`.',
+    );
+  });
+
   test('keeps pre-command unknown options on the top-level structured context', async () => {
     const result = await captureNodeCli(
       ['--unknown', 'alias-project', '--format', 'json'],


### PR DESCRIPTION
## Summary
- replace command-contract positional alias raw validation errors with explicit CLI diagnostic codes
- preserve existing alias guidance while reducing message-based diagnostic inference
- add direct and structured JSON regressions for alias validation failures

Fixes #785

## Verification
- bun test packages/wp-typia/tests/bunli-prep.test.ts packages/wp-typia/tests/node-cli-core.test.ts
- bun run changesets:validate
- bun run format:check
- git diff --check
- bun run typecheck
- bun run lint:repo
- bun test packages/wp-typia/tests/cli-package.test.ts -t "positional-alias typos"
- bun run --filter wp-typia test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Command validation errors for positional aliases now use stable diagnostic codes, improving error identification and debugging for scenarios like invalid scaffold directories or extra arguments.

* **Tests**
  * Enhanced test coverage for validation error diagnostics and structured error reporting across CLI entry points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->