### PR TITLE
[codex] fix(runtime): code runtime validation diagnostics

### DIFF
--- a/.sampo/changesets/786-runtime-diagnostics.md
+++ b/.sampo/changesets/786-runtime-diagnostics.md
@@ -1,0 +1,6 @@
+---
+npm/wp-typia: patch
+npm/@wp-typia/project-tools: patch
+---
+
+Tag scaffold identifier and MCP schema validation failures with stable CLI diagnostic codes.

--- a/packages/wp-typia-project-tools/src/runtime/cli-diagnostics.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-diagnostics.ts
@@ -324,6 +324,12 @@ export function createCliDiagnosticCodeError<TCode extends CliDiagnosticCode>(
 	return error;
 }
 
+/**
+ * Compatibility-only fallback for legacy or third-party errors that have not
+ * yet been tagged by their throw site. New user-facing failures should pass an
+ * explicit code through `createCliDiagnosticCodeError()` or
+ * `createCliCommandError({ code })` instead of relying on message matching.
+ */
 function inferCliDiagnosticCode(options: {
 	command: string;
 	detailLines: string[];

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-identifiers.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-identifiers.ts
@@ -1,4 +1,8 @@
 import {
+	CLI_DIAGNOSTIC_CODES,
+	createCliDiagnosticCodeError,
+} from "./cli-diagnostics.js";
+import {
 	toKebabCase,
 	toSnakeCase,
 } from "./string-case.js";
@@ -48,7 +52,10 @@ export function assertValidIdentifier(
 ): string {
 	const result = validate(value);
 	if (result !== true) {
-		throw new Error(typeof result === "string" ? `${label}: ${result}` : `${label} is invalid`);
+		throw createCliDiagnosticCodeError(
+			CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
+			typeof result === "string" ? `${label}: ${result}` : `${label} is invalid`,
+		);
 	}
 
 	return value;
@@ -81,10 +88,14 @@ export function resolveNonEmptyNormalizedBlockSlug(options: {
 	}
 
 	if (options.input.trim().length === 0) {
-		throw new Error(`${options.label} is required. Use \`${options.usage}\`.`);
+		throw createCliDiagnosticCodeError(
+			CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
+			`${options.label} is required. Use \`${options.usage}\`.`,
+		);
 	}
 
-	throw new Error(
+	throw createCliDiagnosticCodeError(
+		CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
 		`${options.label} "${options.input.trim()}" normalizes to an empty slug. Use letters or numbers so wp-typia can generate a block slug.`,
 	);
 }

--- a/packages/wp-typia-project-tools/tests/cli-entry.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-entry.test.ts
@@ -6,6 +6,7 @@ import { cleanupScaffoldTempRoot, createBlockExternalFixturePath, createBlockSub
 import { CLI_DIAGNOSTIC_CODE_METADATA, CLI_DIAGNOSTIC_CODES, createCliCommandError, createCliDiagnosticCodeError, getCliDiagnosticCodeMetadata, serializeCliDiagnosticError } from "../src/runtime/cli-diagnostics.js";
 import { formatHelpText, getDoctorChecks, getNextSteps, getOptionalOnboarding, runScaffoldFlow } from "../src/runtime/cli-core.js";
 import { assertValidEditorPluginSlot } from "../src/runtime/cli-add-shared.js";
+import { resolveNonEmptyNormalizedBlockSlug, resolveValidatedPhpPrefix } from "../src/runtime/scaffold-identifiers.js";
 import { collectScaffoldAnswers } from "../src/runtime/scaffold.js";
 import { getQuickStartWorkflowNote } from "../src/runtime/scaffold-onboarding.js";
 
@@ -129,6 +130,17 @@ describe("@wp-typia/project-tools scaffold CLI flow", () => {
     return parseStructuredCliFailure(output);
   }
 
+  function catchDiagnosticCodeError(callback: () => unknown): Error & { code?: string } {
+    try {
+      callback();
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      return error as Error & { code?: string };
+    }
+
+    throw new Error("Expected callback to throw.");
+  }
+
 test("CLI diagnostics do not classify unknown template variants as missing templates", () => {
   const diagnostic = serializeCliDiagnosticError(
     createCliCommandError({
@@ -153,6 +165,40 @@ test("CLI diagnostics preserve explicit throw-site codes without message inferen
 
   expect(diagnostic.code).toBe("missing-argument");
   expect(diagnostic.message).toContain("Opaque scaffold preflight failure.");
+});
+
+test("scaffold identifier validation failures carry explicit diagnostic codes", () => {
+  const invalidPrefix = catchDiagnosticCodeError(() =>
+    resolveValidatedPhpPrefix("123 invalid")
+  );
+  expect(invalidPrefix.code).toBe(CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT);
+  expect(invalidPrefix.message).toContain(
+    "PHP prefix: Use letters, numbers, and underscores only"
+  );
+
+  const missingSlug = catchDiagnosticCodeError(() =>
+    resolveNonEmptyNormalizedBlockSlug({
+      input: "   ",
+      label: "Block name",
+      usage: "wp-typia add block <name>",
+    })
+  );
+  expect(missingSlug.code).toBe(CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT);
+  expect(missingSlug.message).toBe(
+    "Block name is required. Use `wp-typia add block <name>`."
+  );
+
+  const emptyNormalizedSlug = catchDiagnosticCodeError(() =>
+    resolveNonEmptyNormalizedBlockSlug({
+      input: "!!!",
+      label: "Block name",
+      usage: "wp-typia add block <name>",
+    })
+  );
+  expect(emptyNormalizedSlug.code).toBe(CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT);
+  expect(emptyNormalizedSlug.message).toContain(
+    'Block name "!!!" normalizes to an empty slug.'
+  );
 });
 
 test("CLI diagnostic metadata covers every stable code", () => {

--- a/packages/wp-typia/src/mcp.ts
+++ b/packages/wp-typia/src/mcp.ts
@@ -9,6 +9,10 @@ import {
 	type MCPToolGroup,
 	type MCPTool,
 } from "@bunli/plugin-mcp";
+import {
+	CLI_DIAGNOSTIC_CODES,
+	createCliDiagnosticCodeError,
+} from "@wp-typia/project-tools/cli-diagnostics";
 
 import type { WpTypiaSchemaSource } from "./config";
 
@@ -33,13 +37,30 @@ function isToolGroup(value: unknown): value is MCPToolGroup {
 	);
 }
 
+function getErrorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+function getErrorCauseOptions(error: unknown): ErrorOptions | undefined {
+	return error instanceof Error ? { cause: error } : undefined;
+}
+
 async function readSchemaSource(
 	cwd: string,
 	source: WpTypiaSchemaSource,
 ): Promise<MCPToolGroup> {
 	const schemaPath = path.resolve(cwd, source.path);
 	const raw = await fs.readFile(schemaPath, "utf8");
-	const parsed = JSON.parse(raw);
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch (error) {
+		throw createCliDiagnosticCodeError(
+			CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
+			`Schema source "${source.path}" must contain valid JSON. ${getErrorMessage(error)}`,
+			getErrorCauseOptions(error),
+		);
+	}
 
 	if (isToolGroup(parsed)) {
 		return parsed;
@@ -52,7 +73,8 @@ async function readSchemaSource(
 		};
 	}
 
-	throw new Error(
+	throw createCliDiagnosticCodeError(
+		CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
 		`Schema source "${source.path}" must contain either one MCPToolGroup object or an array of MCP tools.`,
 	);
 }
@@ -79,7 +101,11 @@ export async function syncMcpSchemas(
 		tools: groups,
 	});
 	if (Result.isError(result)) {
-		throw result.error;
+		throw createCliDiagnosticCodeError(
+			CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
+			getErrorMessage(result.error),
+			getErrorCauseOptions(result.error),
+		);
 	}
 
 	const registry = groups.map((group) => ({
@@ -93,7 +119,11 @@ export async function syncMcpSchemas(
 			namespace: group.namespace,
 		});
 		if (Result.isError(convert)) {
-			throw convert.error;
+			throw createCliDiagnosticCodeError(
+				CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
+				getErrorMessage(convert.error),
+				getErrorCauseOptions(convert.error),
+			);
 		}
 	}
 

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -2247,6 +2247,78 @@ process.exit(0);
     expect(parsed.error?.code).toBe('configuration-missing');
   });
 
+  test('emits a machine-readable invalid-argument error code for malformed mcp schema sources', () => {
+    const tempRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'wp-typia-mcp-invalid-schema-'),
+    );
+    const schemaPath = path.join(tempRoot, 'mcp-tools.json');
+    const configPath = path.join(tempRoot, 'wp-typia.config.json');
+
+    try {
+      fs.writeFileSync(
+        schemaPath,
+        `${JSON.stringify(
+          {
+            namespace: 'demo',
+            tools: [{ description: 'Missing a tool name' }],
+          },
+          null,
+          2,
+        )}\n`,
+        'utf8',
+      );
+      fs.writeFileSync(
+        configPath,
+        `${JSON.stringify(
+          {
+            mcp: {
+              schemaSources: [
+                {
+                  namespace: 'demo',
+                  path: schemaPath,
+                },
+              ],
+            },
+          },
+          null,
+          2,
+        )}\n`,
+        'utf8',
+      );
+
+      const result = runCapturedCommand('node', [
+        entryPath,
+        '--config',
+        configPath,
+        'mcp',
+        'list',
+        '--format',
+        'json',
+      ]);
+      const parsed = JSON.parse(result.stderr.trim()) as {
+        error?: {
+          code?: string;
+          command?: string;
+          detailLines?: string[];
+          kind?: string;
+        };
+        ok?: boolean;
+      };
+
+      expect(result.status).toBe(1);
+      expect(result.stdout).toBe('');
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error?.kind).toBe('command-execution');
+      expect(parsed.error?.command).toBe('mcp');
+      expect(parsed.error?.code).toBe('invalid-argument');
+      expect(parsed.error?.detailLines?.join('\n')).toContain(
+        `Schema source "${schemaPath}" must contain either one MCPToolGroup object or an array of MCP tools.`,
+      );
+    } finally {
+      fs.rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
   test('emits a machine-readable missing-argument error code for create in Bun runtime JSON mode', () => {
     const result = runCapturedCommand(
       'bun',


### PR DESCRIPTION
## Summary
- tag scaffold identifier validation failures with explicit CLI diagnostic codes
- tag malformed MCP schema source failures with stable invalid-argument diagnostics
- document inferCliDiagnosticCode as compatibility-only fallback and add structured regression coverage

Fixes #786

## Verification
- bun run format:check
- git diff --check
- bun test packages/wp-typia-project-tools/tests/cli-entry.test.ts -t "diagnostic|scaffold identifier"
- bun test packages/wp-typia/tests/cli-package.test.ts -t "mcp"
- bun run changesets:validate
- bun run --filter @wp-typia/project-tools build
- bun run typecheck
- bun run lint:repo
- bun run --filter @wp-typia/project-tools test:scaffold-core
- bun run --filter wp-typia test