### PR TITLE
[codex] refactor(cli): split node fallback dispatchers

### DIFF
--- a/.sampo/changesets/787-node-fallback-dispatchers.md
+++ b/.sampo/changesets/787-node-fallback-dispatchers.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Split Node fallback add/create dispatchers and help rendering into focused modules.

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -10,16 +10,9 @@ import {
   ADD_OPTION_METADATA,
   buildCommandOptionParser,
   CREATE_OPTION_METADATA,
-  type CommandOptionMetadataMap,
-  DOCTOR_OPTION_METADATA,
   extractKnownOptionValuesFromArgv,
-  formatNodeFallbackOptionHelp,
-  INIT_OPTION_METADATA,
-  MIGRATE_OPTION_METADATA,
   parseCommandArgvWithMetadata,
   resolveCommandOptionValues,
-  SYNC_OPTION_METADATA,
-  TEMPLATES_OPTION_METADATA,
 } from './command-option-metadata';
 import { prefersStructuredCliArgv } from './cli-diagnostic-output';
 import {
@@ -31,10 +24,6 @@ import {
   listTemplates,
 } from '@wp-typia/project-tools/cli-templates';
 import {
-  formatAddKindList,
-  formatAddKindUsagePlaceholder,
-} from './add-kind-registry';
-import {
   getAddBlockDefaults,
   getCreateDefaults,
   loadWpTypiaUserConfig,
@@ -44,8 +33,6 @@ import {
 import { extractWpTypiaConfigOverride } from './config-override';
 import type { PrintLine } from './print-line';
 import {
-  executeAddCommand,
-  executeCreateCommand,
   executeDoctorCommand,
   executeInitCommand,
   executeMigrateCommand,
@@ -54,66 +41,35 @@ import {
 } from './runtime-bridge';
 import {
   buildStructuredInitSuccessPayload,
-  buildStructuredCompletionSuccessPayload,
   buildSyncDryRunPayload,
-  extractCompletionProjectDir,
   printCompletionPayload,
 } from './runtime-bridge-output';
 import { resolveSyncExecutionTarget } from './runtime-bridge-sync';
 import {
-  WP_TYPIA_CANONICAL_CREATE_USAGE,
-  WP_TYPIA_CANONICAL_MIGRATE_USAGE,
-  WP_TYPIA_FUTURE_COMMAND_TREE,
-  WP_TYPIA_NODE_FALLBACK_TOP_LEVEL_COMMAND_NAMES,
-  WP_TYPIA_POSITIONAL_ALIAS_USAGE,
   normalizeWpTypiaArgv,
   resolveCanonicalCommandContext,
 } from './command-contract';
-
-type GlobalFlags = {
-  format?: string;
-  id?: string;
-};
-type NodeFallbackTopLevelCommandName =
-  (typeof WP_TYPIA_NODE_FALLBACK_TOP_LEVEL_COMMAND_NAMES)[number];
-type NodeFallbackExecutableCommandName = Exclude<
-  NodeFallbackTopLevelCommandName,
-  'help' | 'version'
->;
-type NodeFallbackDispatchContext = {
-  cwd: string;
-  mergedFlags: Record<string, unknown>;
-  positionals: string[];
-};
-type NodeFallbackCommandHelpConfig = {
-  bodyLines?: string[];
-  heading: string;
-  optionMetadata: CommandOptionMetadataMap;
-};
+import { dispatchNodeFallbackAdd } from './node-fallback/dispatchers/add';
+import { dispatchNodeFallbackCreate } from './node-fallback/dispatchers/create';
+import {
+  NODE_FALLBACK_HELP_RENDERERS,
+  STANDALONE_GUIDANCE_LINE,
+  renderGeneralHelp,
+} from './node-fallback/help';
+import type {
+  NodeFallbackCommandDispatcher,
+  NodeFallbackDispatchContext,
+  NodeFallbackExecutableCommandName,
+  NodeFallbackGlobalFlags,
+} from './node-fallback/types';
 
 const NODE_FALLBACK_OPTION_PARSER = buildCommandOptionParser(
   ALL_COMMAND_OPTION_METADATA,
 );
 const NODE_FALLBACK_BOOLEAN_OPTION_NAMES = ['help', 'version'] as const;
-const STANDALONE_GUIDANCE_LINE =
-  'Prefer not to install Bun? Use the standalone wp-typia binary from the GitHub release assets.';
-
-const NODE_FALLBACK_RUNTIME_SUMMARY_LINES = [
-  'Runtime: Node fallback',
-  'Human-readable fallback for common non-interactive create/init/add/migrate flows, doctor, sync, templates, --help, and --version when Bun is unavailable.',
-  `Install Bun 1.3.11+ or use \`bunx wp-typia ...\` for the full Bunli/OpenTUI runtime and Bun-only command surfaces such as \`skills\`, \`completions\`, and \`mcp\`. ${STANDALONE_GUIDANCE_LINE}`,
-  'Output markers: WP_TYPIA_ASCII=1 forces ASCII markers, WP_TYPIA_ASCII=0 opts back into Unicode markers, and non-empty NO_COLOR requests ASCII markers when WP_TYPIA_ASCII is unset.',
-];
-
 const printLine: PrintLine = (line) => {
   console.log(line);
 };
-
-function printBlock(lines: string[]) {
-  for (const line of lines) {
-    printLine(line);
-  }
-}
 
 export function hasFlagBeforeTerminator(argv: string[], flag: string): boolean {
   for (const arg of argv) {
@@ -130,7 +86,7 @@ export function hasFlagBeforeTerminator(argv: string[], flag: string): boolean {
 
 export function parseGlobalFlags(argv: string[]): {
   argv: string[];
-  flags: GlobalFlags;
+  flags: NodeFallbackGlobalFlags;
 } {
   const { argv: nextArgv, flags } = extractKnownOptionValuesFromArgv(argv, {
     optionNames: ['format', 'id'],
@@ -192,87 +148,6 @@ function parseArgv(argv: string[]) {
   });
 }
 
-function renderGeneralHelp() {
-  printBlock([
-    `wp-typia ${packageJson.version}`,
-    '',
-    'Canonical CLI package for wp-typia scaffolding and project workflows.',
-    '',
-    ...NODE_FALLBACK_RUNTIME_SUMMARY_LINES,
-    '',
-    'Commands:',
-    ...WP_TYPIA_FUTURE_COMMAND_TREE.map(
-      (command) => `- ${command.name}: ${command.description}`,
-    ),
-    '',
-    'Canonical usage:',
-    `- ${WP_TYPIA_CANONICAL_CREATE_USAGE}`,
-    '- wp-typia init [project-dir]',
-    `- ${WP_TYPIA_CANONICAL_MIGRATE_USAGE}`,
-    `- ${WP_TYPIA_POSITIONAL_ALIAS_USAGE}`,
-  ]);
-}
-
-/**
- * Render one Node fallback command help screen from shared command metadata.
- */
-function renderNodeFallbackCommandHelp(config: NodeFallbackCommandHelpConfig) {
-  printBlock([
-    config.heading,
-    '',
-    ...NODE_FALLBACK_RUNTIME_SUMMARY_LINES,
-    '',
-    ...(config.bodyLines ? [...config.bodyLines, ''] : []),
-    'Supported flags:',
-    ...formatNodeFallbackOptionHelp(config.optionMetadata),
-  ]);
-}
-
-const NODE_FALLBACK_COMMAND_HELP_CONFIG = {
-  add: {
-    bodyLines: [`Supported kinds: ${formatAddKindList()}`],
-    heading: 'Usage: wp-typia add <kind> <name>',
-    optionMetadata: ADD_OPTION_METADATA,
-  },
-  create: {
-    heading: `Usage: ${WP_TYPIA_CANONICAL_CREATE_USAGE}`,
-    optionMetadata: CREATE_OPTION_METADATA,
-  },
-  doctor: {
-    bodyLines: [
-      'Runs read-only environment readiness checks. Official wp-typia workspace roots also get inventory, source-tree drift, iframe/API v3 compatibility, and shared convention checks.',
-    ],
-    heading: 'Usage: wp-typia doctor [--format json]',
-    optionMetadata: DOCTOR_OPTION_METADATA,
-  },
-  init: {
-    bodyLines: [
-      'Preview-by-default retrofit planner for existing WordPress block or plugin projects. Re-run with --apply to write package.json updates and helper scripts.',
-    ],
-    heading: 'Usage: wp-typia init [project-dir]',
-    optionMetadata: INIT_OPTION_METADATA,
-  },
-  migrate: {
-    heading: `Usage: ${WP_TYPIA_CANONICAL_MIGRATE_USAGE}`,
-    optionMetadata: MIGRATE_OPTION_METADATA,
-  },
-  sync: {
-    heading: 'Usage: wp-typia sync [ai]',
-    optionMetadata: SYNC_OPTION_METADATA,
-  },
-  templates: {
-    heading: 'wp-typia templates <list|inspect>',
-    optionMetadata: TEMPLATES_OPTION_METADATA,
-  },
-} satisfies Record<NodeFallbackExecutableCommandName, NodeFallbackCommandHelpConfig>;
-
-const NODE_FALLBACK_HELP_RENDERERS = Object.fromEntries(
-  Object.entries(NODE_FALLBACK_COMMAND_HELP_CONFIG).map(([command, config]) => [
-    command,
-    () => renderNodeFallbackCommandHelp(config),
-  ]),
-) as Record<NodeFallbackExecutableCommandName, () => void>;
-
 function renderVersion(
   options: {
     format?: string;
@@ -299,7 +174,10 @@ function renderVersion(
   printLine(`wp-typia ${packageJson.version}`);
 }
 
-function renderTemplatesJson(flags: GlobalFlags, subcommand: string) {
+function renderTemplatesJson(
+  flags: NodeFallbackGlobalFlags,
+  subcommand: string,
+) {
   if (subcommand === 'list') {
     printLine(
       JSON.stringify(
@@ -384,110 +262,8 @@ async function renderDoctorJson(): Promise<void> {
 }
 
 const NODE_FALLBACK_COMMAND_DISPATCHERS = {
-  add: async ({
-    cwd,
-    mergedFlags,
-    positionals,
-  }: NodeFallbackDispatchContext) => {
-    if (!positionals[1]) {
-      const { formatAddHelpText } =
-        await import('@wp-typia/project-tools/cli-add');
-      printLine(formatAddHelpText());
-      throw createCliCommandError({
-        code: CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
-        command: 'add',
-        detailLines: [
-          `\`wp-typia add\` requires <kind>. Usage: wp-typia add ${formatAddKindUsagePlaceholder()} ...`,
-        ],
-      });
-    }
-    if (mergedFlags.format === 'json') {
-      let completion;
-      try {
-        completion = await executeAddCommand({
-          cwd,
-          emitOutput: false,
-          flags: mergedFlags,
-          interactive: false,
-          kind: positionals[1],
-          name: positionals[2],
-        });
-      } catch (error) {
-        throw createCliCommandError({
-          command: 'add',
-          error,
-        });
-      }
-      printLine(
-        JSON.stringify(
-          buildStructuredCompletionSuccessPayload('add', completion, {
-            dryRun: Boolean(mergedFlags['dry-run']),
-            kind: positionals[1],
-            name: positionals[2],
-            projectDir: extractCompletionProjectDir(completion) ?? cwd,
-          }),
-          null,
-          2,
-        ),
-      );
-      return;
-    }
-    await executeAddCommand({
-      cwd,
-      flags: mergedFlags,
-      interactive: undefined,
-      kind: positionals[1],
-      name: positionals[2],
-    });
-  },
-  create: async ({
-    cwd,
-    mergedFlags,
-    positionals,
-  }: NodeFallbackDispatchContext) => {
-    const projectDir = positionals[1];
-    if (!projectDir) {
-      throw createCliCommandError({
-        code: CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
-        command: 'create',
-        detailLines: [
-          '`wp-typia create` requires <project-dir>.',
-          '`--dry-run` still needs a logical project directory name because wp-typia derives slugs, package names, and planned file paths from it.',
-        ],
-      });
-    }
-    let completion;
-    try {
-      completion = await executeCreateCommand({
-        cwd,
-        emitOutput: mergedFlags.format !== 'json',
-        flags: mergedFlags,
-        interactive: mergedFlags.format === 'json' ? false : undefined,
-        projectDir,
-      });
-    } catch (error) {
-      throw createCliCommandError({
-        command: 'create',
-        error,
-      });
-    }
-    if (mergedFlags.format === 'json') {
-      printLine(
-        JSON.stringify(
-          buildStructuredCompletionSuccessPayload('create', completion, {
-            dryRun: Boolean(mergedFlags['dry-run']),
-            projectDir: extractCompletionProjectDir(completion) ?? projectDir,
-            template:
-              typeof mergedFlags.template === 'string'
-                ? mergedFlags.template
-                : undefined,
-          }),
-          null,
-          2,
-        ),
-      );
-    }
-  },
+  add: dispatchNodeFallbackAdd,
+  create: dispatchNodeFallbackCreate,
   doctor: async ({ cwd, mergedFlags }: NodeFallbackDispatchContext) => {
     if (mergedFlags.format === 'json') {
       await renderDoctorJson();
@@ -614,7 +390,7 @@ const NODE_FALLBACK_COMMAND_DISPATCHERS = {
   },
 } satisfies Record<
   NodeFallbackExecutableCommandName,
-  (context: NodeFallbackDispatchContext) => Promise<void>
+  NodeFallbackCommandDispatcher
 >;
 
 export async function runNodeCli(argv = process.argv.slice(2)): Promise<void> {
@@ -639,7 +415,7 @@ export async function runNodeCli(argv = process.argv.slice(2)): Promise<void> {
     hasFlagBeforeTerminator(cliArgv, '--version') || command === 'version';
 
   if (cliArgv.length === 0) {
-    renderGeneralHelp();
+    renderGeneralHelp(printLine);
     process.exitCode = 1;
     return;
   }
@@ -651,18 +427,18 @@ export async function runNodeCli(argv = process.argv.slice(2)): Promise<void> {
           helpTarget as NodeFallbackExecutableCommandName
         ];
       if (helpRenderer) {
-        helpRenderer();
+        helpRenderer(printLine);
         return;
       }
       if (helpTarget === 'help' || helpTarget === 'version') {
-        renderGeneralHelp();
+        renderGeneralHelp(printLine);
         return;
       }
     } else {
-      renderGeneralHelp();
+      renderGeneralHelp(printLine);
       return;
     }
-    renderGeneralHelp();
+    renderGeneralHelp(printLine);
     return;
   }
 
@@ -694,6 +470,7 @@ export async function runNodeCli(argv = process.argv.slice(2)): Promise<void> {
       cwd: process.cwd(),
       mergedFlags,
       positionals,
+      printLine,
     });
     return;
   }

--- a/packages/wp-typia/src/node-fallback/dispatchers/add.ts
+++ b/packages/wp-typia/src/node-fallback/dispatchers/add.ts
@@ -1,0 +1,73 @@
+import {
+  CLI_DIAGNOSTIC_CODES,
+  createCliCommandError,
+} from '@wp-typia/project-tools/cli-diagnostics';
+import { formatAddKindUsagePlaceholder } from '../../add-kind-registry';
+import { executeAddCommand } from '../../runtime-bridge';
+import {
+  buildStructuredCompletionSuccessPayload,
+  extractCompletionProjectDir,
+} from '../../runtime-bridge-output';
+import type { NodeFallbackDispatchContext } from '../types';
+
+export async function dispatchNodeFallbackAdd({
+  cwd,
+  mergedFlags,
+  positionals,
+  printLine,
+}: NodeFallbackDispatchContext): Promise<void> {
+  if (!positionals[1]) {
+    const { formatAddHelpText } =
+      await import('@wp-typia/project-tools/cli-add');
+    printLine(formatAddHelpText());
+    throw createCliCommandError({
+      code: CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
+      command: 'add',
+      detailLines: [
+        `\`wp-typia add\` requires <kind>. Usage: wp-typia add ${formatAddKindUsagePlaceholder()} ...`,
+      ],
+    });
+  }
+
+  // Add-specific normalization stays here: map positionals to kind/name and
+  // switch JSON mode to structured completion output.
+  if (mergedFlags.format === 'json') {
+    let completion;
+    try {
+      completion = await executeAddCommand({
+        cwd,
+        emitOutput: false,
+        flags: mergedFlags,
+        interactive: false,
+        kind: positionals[1],
+        name: positionals[2],
+      });
+    } catch (error) {
+      throw createCliCommandError({
+        command: 'add',
+        error,
+      });
+    }
+    printLine(
+      JSON.stringify(
+        buildStructuredCompletionSuccessPayload('add', completion, {
+          dryRun: Boolean(mergedFlags['dry-run']),
+          kind: positionals[1],
+          name: positionals[2],
+          projectDir: extractCompletionProjectDir(completion) ?? cwd,
+        }),
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  await executeAddCommand({
+    cwd,
+    flags: mergedFlags,
+    interactive: undefined,
+    kind: positionals[1],
+    name: positionals[2],
+  });
+}

--- a/packages/wp-typia/src/node-fallback/dispatchers/add.ts
+++ b/packages/wp-typia/src/node-fallback/dispatchers/add.ts
@@ -17,9 +17,11 @@ export async function dispatchNodeFallbackAdd({
   printLine,
 }: NodeFallbackDispatchContext): Promise<void> {
   if (!positionals[1]) {
-    const { formatAddHelpText } =
-      await import('@wp-typia/project-tools/cli-add');
-    printLine(formatAddHelpText());
+    if (mergedFlags.format !== 'json') {
+      const { formatAddHelpText } =
+        await import('@wp-typia/project-tools/cli-add');
+      printLine(formatAddHelpText());
+    }
     throw createCliCommandError({
       code: CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
       command: 'add',

--- a/packages/wp-typia/src/node-fallback/dispatchers/create.ts
+++ b/packages/wp-typia/src/node-fallback/dispatchers/create.ts
@@ -1,0 +1,64 @@
+import {
+  CLI_DIAGNOSTIC_CODES,
+  createCliCommandError,
+} from '@wp-typia/project-tools/cli-diagnostics';
+import { executeCreateCommand } from '../../runtime-bridge';
+import {
+  buildStructuredCompletionSuccessPayload,
+  extractCompletionProjectDir,
+} from '../../runtime-bridge-output';
+import type { NodeFallbackDispatchContext } from '../types';
+
+export async function dispatchNodeFallbackCreate({
+  cwd,
+  mergedFlags,
+  positionals,
+  printLine,
+}: NodeFallbackDispatchContext): Promise<void> {
+  const projectDir = positionals[1];
+  if (!projectDir) {
+    throw createCliCommandError({
+      code: CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
+      command: 'create',
+      detailLines: [
+        '`wp-typia create` requires <project-dir>.',
+        '`--dry-run` still needs a logical project directory name because wp-typia derives slugs, package names, and planned file paths from it.',
+      ],
+    });
+  }
+
+  // Create-specific normalization stays here: JSON mode suppresses human output
+  // and forces non-interactive execution after shared flag parsing/defaults.
+  let completion;
+  try {
+    completion = await executeCreateCommand({
+      cwd,
+      emitOutput: mergedFlags.format !== 'json',
+      flags: mergedFlags,
+      interactive: mergedFlags.format === 'json' ? false : undefined,
+      projectDir,
+    });
+  } catch (error) {
+    throw createCliCommandError({
+      command: 'create',
+      error,
+    });
+  }
+
+  if (mergedFlags.format === 'json') {
+    printLine(
+      JSON.stringify(
+        buildStructuredCompletionSuccessPayload('create', completion, {
+          dryRun: Boolean(mergedFlags['dry-run']),
+          projectDir: extractCompletionProjectDir(completion) ?? projectDir,
+          template:
+            typeof mergedFlags.template === 'string'
+              ? mergedFlags.template
+              : undefined,
+        }),
+        null,
+        2,
+      ),
+    );
+  }
+}

--- a/packages/wp-typia/src/node-fallback/help.ts
+++ b/packages/wp-typia/src/node-fallback/help.ts
@@ -1,0 +1,124 @@
+import packageJson from '../../package.json';
+import { formatAddKindList } from '../add-kind-registry';
+import {
+  ADD_OPTION_METADATA,
+  CREATE_OPTION_METADATA,
+  DOCTOR_OPTION_METADATA,
+  formatNodeFallbackOptionHelp,
+  INIT_OPTION_METADATA,
+  MIGRATE_OPTION_METADATA,
+  SYNC_OPTION_METADATA,
+  TEMPLATES_OPTION_METADATA,
+  type CommandOptionMetadataMap,
+} from '../command-option-metadata';
+import {
+  WP_TYPIA_CANONICAL_CREATE_USAGE,
+  WP_TYPIA_CANONICAL_MIGRATE_USAGE,
+  WP_TYPIA_FUTURE_COMMAND_TREE,
+  WP_TYPIA_POSITIONAL_ALIAS_USAGE,
+} from '../command-contract';
+import type { PrintLine } from '../print-line';
+import type { NodeFallbackExecutableCommandName } from './types';
+
+export const STANDALONE_GUIDANCE_LINE =
+  'Prefer not to install Bun? Use the standalone wp-typia binary from the GitHub release assets.';
+
+export const NODE_FALLBACK_RUNTIME_SUMMARY_LINES = [
+  'Runtime: Node fallback',
+  'Human-readable fallback for common non-interactive create/init/add/migrate flows, doctor, sync, templates, --help, and --version when Bun is unavailable.',
+  `Install Bun 1.3.11+ or use \`bunx wp-typia ...\` for the full Bunli/OpenTUI runtime and Bun-only command surfaces such as \`skills\`, \`completions\`, and \`mcp\`. ${STANDALONE_GUIDANCE_LINE}`,
+  'Output markers: WP_TYPIA_ASCII=1 forces ASCII markers, WP_TYPIA_ASCII=0 opts back into Unicode markers, and non-empty NO_COLOR requests ASCII markers when WP_TYPIA_ASCII is unset.',
+];
+
+export type NodeFallbackCommandHelpConfig = {
+  bodyLines?: string[];
+  heading: string;
+  optionMetadata: CommandOptionMetadataMap;
+};
+
+export function printBlock(printLine: PrintLine, lines: string[]) {
+  for (const line of lines) {
+    printLine(line);
+  }
+}
+
+export function renderGeneralHelp(printLine: PrintLine) {
+  printBlock(printLine, [
+    `wp-typia ${packageJson.version}`,
+    '',
+    'Canonical CLI package for wp-typia scaffolding and project workflows.',
+    '',
+    ...NODE_FALLBACK_RUNTIME_SUMMARY_LINES,
+    '',
+    'Commands:',
+    ...WP_TYPIA_FUTURE_COMMAND_TREE.map(
+      (command) => `- ${command.name}: ${command.description}`,
+    ),
+    '',
+    'Canonical usage:',
+    `- ${WP_TYPIA_CANONICAL_CREATE_USAGE}`,
+    '- wp-typia init [project-dir]',
+    `- ${WP_TYPIA_CANONICAL_MIGRATE_USAGE}`,
+    `- ${WP_TYPIA_POSITIONAL_ALIAS_USAGE}`,
+  ]);
+}
+
+export function renderNodeFallbackCommandHelp(
+  printLine: PrintLine,
+  config: NodeFallbackCommandHelpConfig,
+) {
+  printBlock(printLine, [
+    config.heading,
+    '',
+    ...NODE_FALLBACK_RUNTIME_SUMMARY_LINES,
+    '',
+    ...(config.bodyLines ? [...config.bodyLines, ''] : []),
+    'Supported flags:',
+    ...formatNodeFallbackOptionHelp(config.optionMetadata),
+  ]);
+}
+
+const NODE_FALLBACK_COMMAND_HELP_CONFIG = {
+  add: {
+    bodyLines: [`Supported kinds: ${formatAddKindList()}`],
+    heading: 'Usage: wp-typia add <kind> <name>',
+    optionMetadata: ADD_OPTION_METADATA,
+  },
+  create: {
+    heading: `Usage: ${WP_TYPIA_CANONICAL_CREATE_USAGE}`,
+    optionMetadata: CREATE_OPTION_METADATA,
+  },
+  doctor: {
+    bodyLines: [
+      'Runs read-only environment readiness checks. Official wp-typia workspace roots also get inventory, source-tree drift, iframe/API v3 compatibility, and shared convention checks.',
+    ],
+    heading: 'Usage: wp-typia doctor [--format json]',
+    optionMetadata: DOCTOR_OPTION_METADATA,
+  },
+  init: {
+    bodyLines: [
+      'Preview-by-default retrofit planner for existing WordPress block or plugin projects. Re-run with --apply to write package.json updates and helper scripts.',
+    ],
+    heading: 'Usage: wp-typia init [project-dir]',
+    optionMetadata: INIT_OPTION_METADATA,
+  },
+  migrate: {
+    heading: `Usage: ${WP_TYPIA_CANONICAL_MIGRATE_USAGE}`,
+    optionMetadata: MIGRATE_OPTION_METADATA,
+  },
+  sync: {
+    heading: 'Usage: wp-typia sync [ai]',
+    optionMetadata: SYNC_OPTION_METADATA,
+  },
+  templates: {
+    heading: 'wp-typia templates <list|inspect>',
+    optionMetadata: TEMPLATES_OPTION_METADATA,
+  },
+} satisfies Record<NodeFallbackExecutableCommandName, NodeFallbackCommandHelpConfig>;
+
+export const NODE_FALLBACK_HELP_RENDERERS = Object.fromEntries(
+  Object.entries(NODE_FALLBACK_COMMAND_HELP_CONFIG).map(([command, config]) => [
+    command,
+    (printLine: PrintLine) => renderNodeFallbackCommandHelp(printLine, config),
+  ]),
+) as Record<NodeFallbackExecutableCommandName, (printLine: PrintLine) => void>;

--- a/packages/wp-typia/src/node-fallback/types.ts
+++ b/packages/wp-typia/src/node-fallback/types.ts
@@ -1,0 +1,26 @@
+import type { WP_TYPIA_NODE_FALLBACK_TOP_LEVEL_COMMAND_NAMES } from '../command-contract';
+import type { PrintLine } from '../print-line';
+
+export type NodeFallbackGlobalFlags = {
+  format?: string;
+  id?: string;
+};
+
+export type NodeFallbackTopLevelCommandName =
+  (typeof WP_TYPIA_NODE_FALLBACK_TOP_LEVEL_COMMAND_NAMES)[number];
+
+export type NodeFallbackExecutableCommandName = Exclude<
+  NodeFallbackTopLevelCommandName,
+  'help' | 'version'
+>;
+
+export type NodeFallbackDispatchContext = {
+  cwd: string;
+  mergedFlags: Record<string, unknown>;
+  positionals: string[];
+  printLine: PrintLine;
+};
+
+export type NodeFallbackCommandDispatcher = (
+  context: NodeFallbackDispatchContext,
+) => Promise<void>;

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -81,6 +81,10 @@ const nodeCliSource = fs.readFileSync(
   path.join(packageRoot, 'src', 'node-cli.ts'),
   'utf8',
 );
+const nodeFallbackHelpSource = fs.readFileSync(
+  path.join(packageRoot, 'src', 'node-fallback', 'help.ts'),
+  'utf8',
+);
 const cliSource = fs.readFileSync(
   path.join(packageRoot, 'src', 'cli.ts'),
   'utf8',
@@ -1131,26 +1135,29 @@ process.exit(0);
       'buildCommandOptions(TEMPLATES_OPTION_METADATA)',
     );
     expect(nodeCliSource).toMatch(/from ['"]\.\/command-option-metadata['"]/);
-    expect(nodeCliSource).toContain('renderNodeFallbackCommandHelp(config)');
-    expect(nodeCliSource).toContain(
+    expect(nodeCliSource).toContain("from './node-fallback/help'");
+    expect(nodeFallbackHelpSource).toContain(
+      'renderNodeFallbackCommandHelp(printLine, config)',
+    );
+    expect(nodeFallbackHelpSource).toContain(
       'optionMetadata: CREATE_OPTION_METADATA',
     );
-    expect(nodeCliSource).toContain(
+    expect(nodeFallbackHelpSource).toContain(
       'optionMetadata: INIT_OPTION_METADATA',
     );
-    expect(nodeCliSource).toContain(
+    expect(nodeFallbackHelpSource).toContain(
       'optionMetadata: ADD_OPTION_METADATA',
     );
-    expect(nodeCliSource).toContain(
+    expect(nodeFallbackHelpSource).toContain(
       'optionMetadata: SYNC_OPTION_METADATA',
     );
-    expect(nodeCliSource).toContain(
+    expect(nodeFallbackHelpSource).toContain(
       'optionMetadata: DOCTOR_OPTION_METADATA',
     );
-    expect(nodeCliSource).toContain(
+    expect(nodeFallbackHelpSource).toContain(
       'optionMetadata: MIGRATE_OPTION_METADATA',
     );
-    expect(nodeCliSource).toContain(
+    expect(nodeFallbackHelpSource).toContain(
       'optionMetadata: TEMPLATES_OPTION_METADATA',
     );
   });

--- a/packages/wp-typia/tests/node-cli-core.test.ts
+++ b/packages/wp-typia/tests/node-cli-core.test.ts
@@ -148,6 +148,46 @@ describe('Node fallback CLI core routing', () => {
     expect(result.stdout).not.toContain('Usage: wp-typia create <project-dir>');
   });
 
+  test('keeps Node fallback dispatcher and help modules focused', () => {
+    const packageRoot = path.resolve(import.meta.dir, '..');
+    const nodeCliSource = fs.readFileSync(
+      path.join(packageRoot, 'src', 'node-cli.ts'),
+      'utf8',
+    );
+    const addDispatcherSource = fs.readFileSync(
+      path.join(packageRoot, 'src', 'node-fallback', 'dispatchers', 'add.ts'),
+      'utf8',
+    );
+    const createDispatcherSource = fs.readFileSync(
+      path.join(
+        packageRoot,
+        'src',
+        'node-fallback',
+        'dispatchers',
+        'create.ts',
+      ),
+      'utf8',
+    );
+    const helpSource = fs.readFileSync(
+      path.join(packageRoot, 'src', 'node-fallback', 'help.ts'),
+      'utf8',
+    );
+
+    expect(nodeCliSource).toContain(
+      "from './node-fallback/dispatchers/add'",
+    );
+    expect(nodeCliSource).toContain(
+      "from './node-fallback/dispatchers/create'",
+    );
+    expect(nodeCliSource).toContain("from './node-fallback/help'");
+    expect(nodeCliSource).not.toContain('formatAddHelpText');
+    expect(addDispatcherSource).toContain('Add-specific normalization stays here');
+    expect(createDispatcherSource).toContain(
+      'Create-specific normalization stays here',
+    );
+    expect(helpSource).toContain('export function printBlock');
+  });
+
   test('prints human and structured version output from the fallback runtime', async () => {
     const human = await captureNodeCli(['--version']);
     const text = await captureNodeCli(['version', '--format', 'text']);

--- a/packages/wp-typia/tests/node-cli-core.test.ts
+++ b/packages/wp-typia/tests/node-cli-core.test.ts
@@ -181,9 +181,11 @@ describe('Node fallback CLI core routing', () => {
     );
     expect(nodeCliSource).toContain("from './node-fallback/help'");
     expect(nodeCliSource).not.toContain('formatAddHelpText');
-    expect(addDispatcherSource).toContain('Add-specific normalization stays here');
+    expect(addDispatcherSource).toContain(
+      'export async function dispatchNodeFallbackAdd',
+    );
     expect(createDispatcherSource).toContain(
-      'Create-specific normalization stays here',
+      'export async function dispatchNodeFallbackCreate',
     );
     expect(helpSource).toContain('export function printBlock');
   });
@@ -272,6 +274,24 @@ describe('Node fallback CLI core routing', () => {
       code: 'missing-argument',
       command: 'add',
     });
+  });
+
+  test('keeps missing add kinds machine-readable in structured mode', async () => {
+    const result = await captureNodeCli(['add', '--format', 'json'], {
+      entrypoint: true,
+    });
+    const parsed = JSON.parse(result.stderr) as {
+      error?: { code?: string; command?: string; kind?: string };
+      ok?: boolean;
+    };
+
+    expect(result.error).toBeUndefined();
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe('');
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error?.kind).toBe('command-execution');
+    expect(parsed.error?.command).toBe('add');
+    expect(parsed.error?.code).toBe('missing-argument');
   });
 
   test('dispatches init structured previews from the Node fallback runtime', async () => {


### PR DESCRIPTION
## Summary
- Split Node fallback add/create dispatchers into focused modules under `src/node-fallback/dispatchers`.
- Moved shared Node fallback help rendering and runtime guidance into `src/node-fallback/help.ts`.
- Added regression coverage for dispatcher/help boundaries and updated metadata source tests for the new module layout.

Fixes #787

## Verification
- `bun test packages/wp-typia/tests/node-cli-core.test.ts`
- `bun test packages/wp-typia/tests/cli-package.test.ts -t "derives Bunli and Node fallback option metadata from the same source"`
- `bun run format:check`
- `bun run changesets:validate`
- `bun run typecheck`
- `bun run lint:repo`
- `bun run --filter wp-typia test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized CLI command structure by splitting dispatchers into focused modules.
  * Enhanced help system rendering for Node fallback environments.
  * Optimized command option parsing logic.

* **Tests**
  * Added module isolation tests to verify code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->