### PR TITLE
[codex] fix(php): handle interpolation scanner blocks

### DIFF
--- a/.sampo/changesets/788-php-interpolation-scanner.md
+++ b/.sampo/changesets/788-php-interpolation-scanner.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Keep double-quoted PHP interpolation blocks in string scan mode.

--- a/packages/wp-typia-project-tools/src/runtime/php-utils.ts
+++ b/packages/wp-typia-project-tools/src/runtime/php-utils.ts
@@ -16,6 +16,7 @@ type PhpFunctionScanMode =
 	| "block-comment"
 	| "code"
 	| "double-quoted"
+	| "double-quoted-interpolation"
 	| "heredoc"
 	| "line-comment"
 	| "single-quoted";
@@ -27,6 +28,8 @@ type PhpHeredocStart = {
 
 type PhpScannerState = {
 	heredocDelimiter: string;
+	interpolationDepth: number;
+	interpolationQuote: string;
 	mode: PhpFunctionScanMode;
 };
 
@@ -229,6 +232,8 @@ function matchesPhpFunctionCallAt(
 function createPhpScannerState(): PhpScannerState {
 	return {
 		heredocDelimiter: "",
+		interpolationDepth: 0,
+		interpolationQuote: "",
 		mode: "code",
 	};
 }
@@ -264,9 +269,50 @@ function advancePhpScanner(
 		if (character === "\\") {
 			return { ambiguous: false, inCode: false, index: index + 2 };
 		}
+		if (
+			state.mode === "double-quoted" &&
+			character === "{" &&
+			source[index + 1] === "$"
+		) {
+			state.mode = "double-quoted-interpolation";
+			state.interpolationDepth = 1;
+			state.interpolationQuote = "";
+			return { ambiguous: false, inCode: false, index: index + 2 };
+		}
 		if (character === quote) {
 			state.mode = "code";
 		}
+		return { ambiguous: false, inCode: false, index: index + 1 };
+	}
+
+	if (state.mode === "double-quoted-interpolation") {
+		if (state.interpolationQuote) {
+			if (character === "\\") {
+				return { ambiguous: false, inCode: false, index: index + 2 };
+			}
+			if (character === state.interpolationQuote) {
+				state.interpolationQuote = "";
+			}
+			return { ambiguous: false, inCode: false, index: index + 1 };
+		}
+
+		if (character === "'" || character === '"') {
+			state.interpolationQuote = character;
+			return { ambiguous: false, inCode: false, index: index + 1 };
+		}
+		if (character === "{") {
+			state.interpolationDepth += 1;
+			return { ambiguous: false, inCode: false, index: index + 1 };
+		}
+		if (character === "}") {
+			state.interpolationDepth -= 1;
+			if (state.interpolationDepth <= 0) {
+				state.interpolationDepth = 0;
+				state.mode = "double-quoted";
+			}
+			return { ambiguous: false, inCode: false, index: index + 1 };
+		}
+
 		return { ambiguous: false, inCode: false, index: index + 1 };
 	}
 

--- a/packages/wp-typia-project-tools/src/runtime/php-utils.ts
+++ b/packages/wp-typia-project-tools/src/runtime/php-utils.ts
@@ -28,6 +28,7 @@ type PhpHeredocStart = {
 
 type PhpScannerState = {
 	heredocDelimiter: string;
+	interpolationComment: "" | "block" | "line";
 	interpolationDepth: number;
 	interpolationQuote: string;
 	mode: PhpFunctionScanMode;
@@ -232,6 +233,7 @@ function matchesPhpFunctionCallAt(
 function createPhpScannerState(): PhpScannerState {
 	return {
 		heredocDelimiter: "",
+		interpolationComment: "",
 		interpolationDepth: 0,
 		interpolationQuote: "",
 		mode: "code",
@@ -275,6 +277,7 @@ function advancePhpScanner(
 			source[index + 1] === "$"
 		) {
 			state.mode = "double-quoted-interpolation";
+			state.interpolationComment = "";
 			state.interpolationDepth = 1;
 			state.interpolationQuote = "";
 			return { ambiguous: false, inCode: false, index: index + 2 };
@@ -296,6 +299,32 @@ function advancePhpScanner(
 			return { ambiguous: false, inCode: false, index: index + 1 };
 		}
 
+		if (state.interpolationComment === "line") {
+			if (character === "\r" || character === "\n") {
+				state.interpolationComment = "";
+			}
+			return { ambiguous: false, inCode: false, index: index + 1 };
+		}
+		if (state.interpolationComment === "block") {
+			if (character === "*" && source[index + 1] === "/") {
+				state.interpolationComment = "";
+				return { ambiguous: false, inCode: false, index: index + 2 };
+			}
+			return { ambiguous: false, inCode: false, index: index + 1 };
+		}
+
+		if (character === "/" && source[index + 1] === "/") {
+			state.interpolationComment = "line";
+			return { ambiguous: false, inCode: false, index: index + 2 };
+		}
+		if (character === "#" && source[index + 1] !== "[") {
+			state.interpolationComment = "line";
+			return { ambiguous: false, inCode: false, index: index + 1 };
+		}
+		if (character === "/" && source[index + 1] === "*") {
+			state.interpolationComment = "block";
+			return { ambiguous: false, inCode: false, index: index + 2 };
+		}
 		if (character === "'" || character === '"') {
 			state.interpolationQuote = character;
 			return { ambiguous: false, inCode: false, index: index + 1 };
@@ -307,6 +336,7 @@ function advancePhpScanner(
 		if (character === "}") {
 			state.interpolationDepth -= 1;
 			if (state.interpolationDepth <= 0) {
+				state.interpolationComment = "";
 				state.interpolationDepth = 0;
 				state.mode = "double-quoted";
 			}

--- a/packages/wp-typia-project-tools/tests/php-utils.test.ts
+++ b/packages/wp-typia-project-tools/tests/php-utils.test.ts
@@ -83,6 +83,37 @@ function keep_me() {
 	expect(range?.source).not.toContain("function keep_me()");
 });
 
+test("PHP scanner keeps double-quoted interpolation blocks in string mode", () => {
+	const source = `<?php
+function wp_typia_demo() {
+\t$name = 'Reader';
+\t$message = "Hello {$name}";
+\t$value = "Value: {$object->property}";
+\t$quoted = "Quoted: {$object->labels["wp_enqueue_script_module("]}";
+\t$brace = "Brace: {$object->labels["}"]}";
+\treturn array( $message, $value, $quoted, $brace );
+}
+
+function keep_me() {
+\twp_enqueue_script_module( 'real-call', 'url', array(), null );
+}
+`;
+
+	const range = findPhpFunctionRange(source, "wp_typia_demo");
+
+	expect(range).not.toBeNull();
+	expect(range?.source).toContain('$message = "Hello {$name}";');
+	expect(range?.source).toContain('$value = "Value: {$object->property}";');
+	expect(range?.source).toContain(
+		'$quoted = "Quoted: {$object->labels["wp_enqueue_script_module("]}";',
+	);
+	expect(range?.source).toContain('$brace = "Brace: {$object->labels["}"]}";');
+	expect(range?.source).not.toContain("function keep_me()");
+	expect(hasPhpFunctionCall(range?.source ?? "", "wp_enqueue_script_module")).toBe(
+		false,
+	);
+});
+
 test("findPhpFunctionRange ignores braces inside heredoc and nowdoc content", () => {
 	const source = `<?php
 function wp_typia_demo() {

--- a/packages/wp-typia-project-tools/tests/php-utils.test.ts
+++ b/packages/wp-typia-project-tools/tests/php-utils.test.ts
@@ -91,7 +91,8 @@ function wp_typia_demo() {
 \t$value = "Value: {$object->property}";
 \t$quoted = "Quoted: {$object->labels["wp_enqueue_script_module("]}";
 \t$brace = "Brace: {$object->labels["}"]}";
-\treturn array( $message, $value, $quoted, $brace );
+\t$commented = "Comment: {$object/* " } wp_enqueue_script_module( */->property}";
+\treturn array( $message, $value, $quoted, $brace, $commented );
 }
 
 function keep_me() {
@@ -108,6 +109,9 @@ function keep_me() {
 		'$quoted = "Quoted: {$object->labels["wp_enqueue_script_module("]}";',
 	);
 	expect(range?.source).toContain('$brace = "Brace: {$object->labels["}"]}";');
+	expect(range?.source).toContain(
+		'$commented = "Comment: {$object/* " } wp_enqueue_script_module( */->property}";',
+	);
 	expect(range?.source).not.toContain("function keep_me()");
 	expect(hasPhpFunctionCall(range?.source ?? "", "wp_enqueue_script_module")).toBe(
 		false,


### PR DESCRIPTION
## Summary
- Teach the shared PHP scanner to keep `{$...}` blocks inside double-quoted strings in string scan mode.
- Track interpolation depth and quoted strings inside interpolation so inner quotes/braces are not treated as executable PHP.
- Add regression coverage for `"Hello {$name}"`, `"Value: {$object->property}"`, function-like text, and interpolation braces inside PHP functions.

Fixes #788

## Verification
- `bun test packages/wp-typia-project-tools/tests/php-utils.test.ts`
- `bun run format:check`
- `bun run changesets:validate`
- `bun run typecheck`
- `bun run lint:repo`
- `bun run --filter @wp-typia/project-tools test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced PHP string scanning to properly handle interpolation blocks within double-quoted strings, enabling accurate detection of PHP function calls in interpolated content.

* **Tests**
  * Added test coverage for double-quoted PHP string interpolation scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->