### PR TITLE
[codex] refactor(cache): split template source cache policy

### DIFF
--- a/.sampo/changesets/789-template-source-cache-policy.md
+++ b/.sampo/changesets/789-template-source-cache-policy.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Split external template cache policy helpers into a focused runtime module.

--- a/packages/wp-typia-project-tools/src/runtime/template-source-cache-policy.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-cache-policy.ts
@@ -1,0 +1,189 @@
+import os from 'node:os'
+import path from 'node:path'
+
+/**
+ * Environment variable that disables external template cache reads and writes.
+ *
+ * Set to `0`, `false`, `no`, or `off` to bypass the cache.
+ */
+export const EXTERNAL_TEMPLATE_CACHE_ENV = 'WP_TYPIA_EXTERNAL_TEMPLATE_CACHE'
+
+/**
+ * Environment variable that overrides the external template cache root.
+ */
+export const EXTERNAL_TEMPLATE_CACHE_DIR_ENV =
+  'WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR'
+
+/**
+ * Environment variable that enables TTL-based external template cache pruning.
+ *
+ * Unset, empty, zero, negative, and non-numeric values keep pruning disabled.
+ */
+export const EXTERNAL_TEMPLATE_CACHE_TTL_DAYS_ENV =
+  'WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_TTL_DAYS'
+
+/**
+ * Environment variable that overrides how often TTL pruning may scan the cache.
+ *
+ * Unset values use the default interval. Zero, negative, and non-numeric values
+ * disable scan throttling.
+ */
+export const EXTERNAL_TEMPLATE_CACHE_PRUNE_INTERVAL_MS_ENV =
+  'WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_PRUNE_INTERVAL_MS'
+
+/**
+ * Milliseconds in one TTL day.
+ */
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000
+
+/**
+ * Default minimum interval between full external template cache prune scans.
+ */
+const DEFAULT_CACHE_PRUNE_INTERVAL_MS = 60 * 60 * 1000
+
+/**
+ * Normalized environment values that disable the cache.
+ */
+const DISABLED_CACHE_VALUES = new Set(['0', 'false', 'no', 'off'])
+
+/**
+ * Checks whether remote external template source caching is enabled.
+ *
+ * Caching is enabled by default. Set `WP_TYPIA_EXTERNAL_TEMPLATE_CACHE` to
+ * `0`, `false`, `no`, or `off` to force uncached resolution.
+ *
+ * @param env Environment object to inspect, defaulting to `process.env`.
+ * @returns Whether external template source cache reads and writes are enabled.
+ */
+export function isExternalTemplateCacheEnabled(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  const rawValue = env[EXTERNAL_TEMPLATE_CACHE_ENV]
+  if (rawValue === undefined) {
+    return true
+  }
+
+  return !DISABLED_CACHE_VALUES.has(rawValue.trim().toLowerCase())
+}
+
+/**
+ * Resolves the external template source cache root directory.
+ *
+ * `WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR` overrides the location. Without an
+ * override, wp-typia uses a per-user `wp-typia-template-source-cache-*`
+ * directory inside the operating system temp directory.
+ *
+ * @param env Environment object to inspect, defaulting to `process.env`.
+ * @returns Absolute cache root directory path.
+ */
+export function getExternalTemplateCacheRoot(
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const configuredCacheDir = env[EXTERNAL_TEMPLATE_CACHE_DIR_ENV]?.trim()
+  if (configuredCacheDir) {
+    return path.resolve(configuredCacheDir)
+  }
+
+  return path.join(
+    os.tmpdir(),
+    `wp-typia-template-source-cache-${getCurrentUserCacheSegment()}`,
+  )
+}
+
+function parseExternalTemplateCacheTtlDays(value: unknown): number | null {
+  if (typeof value !== 'string' && typeof value !== 'number') {
+    return null
+  }
+
+  const ttlDays = typeof value === 'number' ? value : Number(value.trim())
+  if (!Number.isFinite(ttlDays) || ttlDays <= 0) {
+    return null
+  }
+
+  return ttlDays
+}
+
+export function resolveExternalTemplateCacheTtlMs(
+  options: {
+    env?: NodeJS.ProcessEnv
+    ttlDays?: number
+  } = {},
+): number | null {
+  const env = options.env ?? process.env
+  const ttlDays =
+    options.ttlDays === undefined
+      ? parseExternalTemplateCacheTtlDays(
+          env[EXTERNAL_TEMPLATE_CACHE_TTL_DAYS_ENV],
+        )
+      : parseExternalTemplateCacheTtlDays(options.ttlDays)
+  if (ttlDays === null) {
+    return null
+  }
+
+  const ttlMs = ttlDays * MILLISECONDS_PER_DAY
+  return Number.isFinite(ttlMs) ? ttlMs : null
+}
+
+function parseExternalTemplateCachePruneIntervalMs(
+  value: unknown,
+): number | null {
+  if (typeof value !== 'string' && typeof value !== 'number') {
+    return null
+  }
+
+  const intervalMs =
+    typeof value === 'number' ? value : Number(value.trim())
+  if (!Number.isFinite(intervalMs) || intervalMs <= 0) {
+    return null
+  }
+
+  return intervalMs
+}
+
+export function resolveExternalTemplateCachePruneIntervalMs(
+  options: {
+    env?: NodeJS.ProcessEnv
+    pruneIntervalMs?: number
+  } = {},
+): number | null {
+  if (options.pruneIntervalMs !== undefined) {
+    return parseExternalTemplateCachePruneIntervalMs(options.pruneIntervalMs)
+  }
+
+  const env = options.env ?? process.env
+  const envValue = env[EXTERNAL_TEMPLATE_CACHE_PRUNE_INTERVAL_MS_ENV]
+  if (envValue === undefined) {
+    return DEFAULT_CACHE_PRUNE_INTERVAL_MS
+  }
+
+  return parseExternalTemplateCachePruneIntervalMs(envValue)
+}
+
+export function getExternalTemplateCacheNowMs(
+  now: Date | number | undefined,
+): number {
+  const nowMs =
+    now instanceof Date
+      ? now.getTime()
+      : typeof now === 'number'
+        ? now
+        : Date.now()
+
+  return Number.isFinite(nowMs) ? nowMs : Date.now()
+}
+
+function getCurrentUserCacheSegment(): string {
+  if (typeof process.getuid === 'function') {
+    return String(process.getuid())
+  }
+
+  try {
+    const safeUsername = os
+      .userInfo()
+      .username.trim()
+      .replace(/[^A-Za-z0-9._-]+/gu, '-')
+    return safeUsername.length > 0 ? safeUsername : 'user'
+  } catch {
+    return 'user'
+  }
+}

--- a/packages/wp-typia-project-tools/src/runtime/template-source-cache.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-cache.ts
@@ -1,38 +1,22 @@
 import { createHash } from 'node:crypto'
 import fs from 'node:fs'
 import { promises as fsp } from 'node:fs'
-import os from 'node:os'
 import path from 'node:path'
-
-/**
- * Environment variable that disables external template cache reads and writes.
- *
- * Set to `0`, `false`, `no`, or `off` to bypass the cache.
- */
-export const EXTERNAL_TEMPLATE_CACHE_ENV = 'WP_TYPIA_EXTERNAL_TEMPLATE_CACHE'
-
-/**
- * Environment variable that overrides the external template cache root.
- */
-export const EXTERNAL_TEMPLATE_CACHE_DIR_ENV =
-  'WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR'
-
-/**
- * Environment variable that enables TTL-based external template cache pruning.
- *
- * Unset, empty, zero, negative, and non-numeric values keep pruning disabled.
- */
-export const EXTERNAL_TEMPLATE_CACHE_TTL_DAYS_ENV =
-  'WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_TTL_DAYS'
-
-/**
- * Environment variable that overrides how often TTL pruning may scan the cache.
- *
- * Unset values use the default interval. Zero, negative, and non-numeric values
- * disable scan throttling.
- */
-export const EXTERNAL_TEMPLATE_CACHE_PRUNE_INTERVAL_MS_ENV =
-  'WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_PRUNE_INTERVAL_MS'
+import {
+  getExternalTemplateCacheNowMs,
+  getExternalTemplateCacheRoot,
+  isExternalTemplateCacheEnabled,
+  resolveExternalTemplateCachePruneIntervalMs,
+  resolveExternalTemplateCacheTtlMs,
+} from './template-source-cache-policy.js'
+export {
+  EXTERNAL_TEMPLATE_CACHE_DIR_ENV,
+  EXTERNAL_TEMPLATE_CACHE_ENV,
+  EXTERNAL_TEMPLATE_CACHE_PRUNE_INTERVAL_MS_ENV,
+  EXTERNAL_TEMPLATE_CACHE_TTL_DAYS_ENV,
+  getExternalTemplateCacheRoot,
+  isExternalTemplateCacheEnabled,
+} from './template-source-cache-policy.js'
 
 /**
  * Marker file written after a cache entry is fully populated.
@@ -45,16 +29,6 @@ const CACHE_MARKER_FILE = 'wp-typia-template-cache.json'
 const CACHE_PRUNE_MARKER_FILE = 'wp-typia-template-cache-prune.json'
 
 /**
- * Milliseconds in one TTL day.
- */
-const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000
-
-/**
- * Default minimum interval between full external template cache prune scans.
- */
-const DEFAULT_CACHE_PRUNE_INTERVAL_MS = 60 * 60 * 1000
-
-/**
  * Private directory mode used for cache roots and entries on POSIX platforms.
  */
 const PRIVATE_CACHE_DIRECTORY_MODE = 0o700
@@ -63,11 +37,6 @@ const PRIVATE_CACHE_DIRECTORY_MODE = 0o700
  * Marker value used when URL-like metadata cannot be safely normalized.
  */
 const REDACTED_CACHE_METADATA_VALUE = '[redacted]'
-
-/**
- * Normalized environment values that disable the cache.
- */
-const DISABLED_CACHE_VALUES = new Set(['0', 'false', 'no', 'off'])
 
 /**
  * Filesystem errors that mean another writer published the same cache entry.
@@ -224,116 +193,6 @@ export interface ExternalTemplateCachePruneResult {
 }
 
 /**
- * Checks whether remote external template source caching is enabled.
- *
- * Caching is enabled by default. Set `WP_TYPIA_EXTERNAL_TEMPLATE_CACHE` to
- * `0`, `false`, `no`, or `off` to force uncached resolution.
- *
- * @param env Environment object to inspect, defaulting to `process.env`.
- * @returns Whether external template source cache reads and writes are enabled.
- */
-export function isExternalTemplateCacheEnabled(
-  env: NodeJS.ProcessEnv = process.env,
-): boolean {
-  const rawValue = env[EXTERNAL_TEMPLATE_CACHE_ENV]
-  if (rawValue === undefined) {
-    return true
-  }
-
-  return !DISABLED_CACHE_VALUES.has(rawValue.trim().toLowerCase())
-}
-
-/**
- * Resolves the external template source cache root directory.
- *
- * `WP_TYPIA_EXTERNAL_TEMPLATE_CACHE_DIR` overrides the location. Without an
- * override, wp-typia uses a per-user `wp-typia-template-source-cache-*`
- * directory inside the operating system temp directory.
- *
- * @param env Environment object to inspect, defaulting to `process.env`.
- * @returns Absolute cache root directory path.
- */
-export function getExternalTemplateCacheRoot(
-  env: NodeJS.ProcessEnv = process.env,
-): string {
-  const configuredCacheDir = env[EXTERNAL_TEMPLATE_CACHE_DIR_ENV]?.trim()
-  if (configuredCacheDir) {
-    return path.resolve(configuredCacheDir)
-  }
-
-  return path.join(
-    os.tmpdir(),
-    `wp-typia-template-source-cache-${getCurrentUserCacheSegment()}`,
-  )
-}
-
-function parseExternalTemplateCacheTtlDays(value: unknown): number | null {
-  if (typeof value !== 'string' && typeof value !== 'number') {
-    return null
-  }
-
-  const ttlDays = typeof value === 'number' ? value : Number(value.trim())
-  if (!Number.isFinite(ttlDays) || ttlDays <= 0) {
-    return null
-  }
-
-  return ttlDays
-}
-
-function resolveExternalTemplateCacheTtlMs(
-  options: Pick<ExternalTemplateCachePruneOptions, 'env' | 'ttlDays'> = {},
-): number | null {
-  const env = options.env ?? process.env
-  const ttlDays =
-    options.ttlDays === undefined
-      ? parseExternalTemplateCacheTtlDays(
-          env[EXTERNAL_TEMPLATE_CACHE_TTL_DAYS_ENV],
-        )
-      : parseExternalTemplateCacheTtlDays(options.ttlDays)
-  if (ttlDays === null) {
-    return null
-  }
-
-  const ttlMs = ttlDays * MILLISECONDS_PER_DAY
-  return Number.isFinite(ttlMs) ? ttlMs : null
-}
-
-function parseExternalTemplateCachePruneIntervalMs(
-  value: unknown,
-): number | null {
-  if (typeof value !== 'string' && typeof value !== 'number') {
-    return null
-  }
-
-  const intervalMs =
-    typeof value === 'number' ? value : Number(value.trim())
-  if (!Number.isFinite(intervalMs) || intervalMs <= 0) {
-    return null
-  }
-
-  return intervalMs
-}
-
-function resolveExternalTemplateCachePruneIntervalMs(
-  options: Pick<
-    ExternalTemplateCachePruneOptions,
-    'env' | 'pruneIntervalMs'
-  > = {},
-): number | null {
-  if (options.pruneIntervalMs !== undefined) {
-    return parseExternalTemplateCachePruneIntervalMs(options.pruneIntervalMs)
-  }
-
-  const env = options.env ?? process.env
-  const envValue = env[EXTERNAL_TEMPLATE_CACHE_PRUNE_INTERVAL_MS_ENV]
-  if (envValue === undefined) {
-    return DEFAULT_CACHE_PRUNE_INTERVAL_MS
-  }
-
-  return parseExternalTemplateCachePruneIntervalMs(envValue)
-}
-
-/**
  * Creates a deterministic cache key from source identity and integrity parts.
  *
  * @param keyParts Ordered values that identify one cached template source.
@@ -376,22 +235,6 @@ async function removeTemporaryCacheEntry(entryDir: string): Promise<void> {
     await fsp.rm(entryDir, { force: true, recursive: true })
   } catch {
     // Cache cleanup is best-effort; the caller can still continue uncached.
-  }
-}
-
-function getCurrentUserCacheSegment(): string {
-  if (typeof process.getuid === 'function') {
-    return String(process.getuid())
-  }
-
-  try {
-    const safeUsername = os
-      .userInfo()
-      .username.trim()
-      .replace(/[^A-Za-z0-9._-]+/gu, '-')
-    return safeUsername.length > 0 ? safeUsername : 'user'
-  } catch {
-    return 'user'
   }
 }
 
@@ -603,17 +446,6 @@ function cacheMetadataMatches(
   expected: ExternalTemplateCacheMetadata,
 ): boolean {
   return Object.entries(expected).every(([key, value]) => actual[key] === value)
-}
-
-function getExternalTemplateCacheNowMs(now: Date | number | undefined): number {
-  const nowMs =
-    now instanceof Date
-      ? now.getTime()
-      : typeof now === 'number'
-        ? now
-        : Date.now()
-
-  return Number.isFinite(nowMs) ? nowMs : Date.now()
 }
 
 function isCacheEntryFreshForTtl(

--- a/packages/wp-typia-project-tools/tests/template-source-cache-boundaries.test.ts
+++ b/packages/wp-typia-project-tools/tests/template-source-cache-boundaries.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from 'bun:test'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const runtimeRoot = path.join(import.meta.dir, '..', 'src', 'runtime')
+
+test('template source cache delegates environment policy to a focused module', () => {
+  const cacheSource = fs.readFileSync(
+    path.join(runtimeRoot, 'template-source-cache.ts'),
+    'utf8',
+  )
+  const policySource = fs.readFileSync(
+    path.join(runtimeRoot, 'template-source-cache-policy.ts'),
+    'utf8',
+  )
+
+  expect(cacheSource).toContain("from './template-source-cache-policy.js'")
+  expect(cacheSource).toContain(
+    'EXTERNAL_TEMPLATE_CACHE_PRUNE_INTERVAL_MS_ENV',
+  )
+  expect(cacheSource).not.toContain(
+    "const DISABLED_CACHE_VALUES = new Set(['0', 'false', 'no', 'off'])",
+  )
+  expect(cacheSource).not.toMatch(
+    /export\s+function\s+isExternalTemplateCacheEnabled\s*\(/,
+  )
+  expect(policySource).toContain(
+    "export const EXTERNAL_TEMPLATE_CACHE_ENV = 'WP_TYPIA_EXTERNAL_TEMPLATE_CACHE'",
+  )
+  expect(policySource).toMatch(
+    /export\s+function\s+isExternalTemplateCacheEnabled\s*\(/,
+  )
+  expect(policySource).toMatch(
+    /export\s+function\s+resolveExternalTemplateCacheTtlMs\s*\(/,
+  )
+})


### PR DESCRIPTION
Fixes #789.

## Summary

- split external template cache environment/root/TTL policy into `template-source-cache-policy.ts`
- keep the existing `template-source-cache.ts` public exports available through re-exports
- add a boundary test so the cache module continues delegating policy helpers to the focused module

## Validation

- `bun test packages/wp-typia-project-tools/tests/template-source-cache-boundaries.test.ts packages/wp-typia-project-tools/tests/template-source.test.ts`
- `bun run format:check`
- `bun run changesets:validate`
- `bun run typecheck`
- `bun run lint:repo`
- `bun run --filter @wp-typia/project-tools test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized external template cache policy configuration into a dedicated runtime module with re-exported public API maintaining backward compatibility.

* **Tests**
  * Added test coverage validating cache policy module separation and API delegation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->