### PR TITLE
[codex] refactor(runtime): read workspace inventory async

### DIFF
--- a/.sampo/changesets/790-async-workspace-inventory.md
+++ b/.sampo/changesets/790-async-workspace-inventory.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Read workspace inventory asynchronously in add workflow hot paths.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ability-scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ability-scaffold.ts
@@ -1,4 +1,3 @@
-import fs from "node:fs";
 import { promises as fsp } from "node:fs";
 import path from "node:path";
 
@@ -7,8 +6,9 @@ import semver from "semver";
 
 import {
 	appendWorkspaceInventoryEntries,
-	readWorkspaceInventory,
+	readWorkspaceInventoryAsync,
 } from "./workspace-inventory.js";
+import { pathExists, readOptionalUtf8File } from "./fs-async.js";
 import {
 	buildAbilityClientSource,
 	buildAbilityConfigEntry,
@@ -74,19 +74,25 @@ function resolveManagedDependencyVersion(
 		: requiredVersion;
 }
 
-function resolveAbilityRegistryPath(projectDir: string): string {
+async function resolveAbilityRegistryPath(projectDir: string): Promise<string> {
 	const abilitiesDir = path.join(projectDir, "src", "abilities");
-	return [path.join(abilitiesDir, "index.ts"), path.join(abilitiesDir, "index.js")].find(
-		(candidatePath) => fs.existsSync(candidatePath),
-	) ?? path.join(abilitiesDir, "index.ts");
+	for (const candidatePath of [
+		path.join(abilitiesDir, "index.ts"),
+		path.join(abilitiesDir, "index.js"),
+	]) {
+		if (await pathExists(candidatePath)) {
+			return candidatePath;
+		}
+	}
+	return path.join(abilitiesDir, "index.ts");
 }
 
-function readAbilityRegistrySlugs(registryPath: string): string[] {
-	if (!fs.existsSync(registryPath)) {
+async function readAbilityRegistrySlugs(registryPath: string): Promise<string[]> {
+	const source = await readOptionalUtf8File(registryPath);
+	if (source === null) {
 		return [];
 	}
 
-	const source = fs.readFileSync(registryPath, "utf8");
 	return Array.from(
 		source.matchAll(/^\s*export\s+\*\s+from\s+['"]\.\/([^/'"]+)\/client['"];?\s*$/gmu),
 	).map((match) => match[1]);
@@ -97,20 +103,18 @@ async function writeAbilityRegistry(
 	abilitySlug: string,
 ): Promise<void> {
 	const abilitiesDir = path.join(projectDir, "src", "abilities");
-	const registryPath = resolveAbilityRegistryPath(projectDir);
+	const registryPath = await resolveAbilityRegistryPath(projectDir);
 	await fsp.mkdir(abilitiesDir, { recursive: true });
 
-	const existingAbilitySlugs = readWorkspaceInventory(projectDir).abilities.map(
-		(entry) => entry.slug,
-	);
-	const existingRegistrySlugs = readAbilityRegistrySlugs(registryPath);
+	const existingAbilitySlugs = (
+		await readWorkspaceInventoryAsync(projectDir)
+	).abilities.map((entry) => entry.slug);
+	const existingRegistrySlugs = await readAbilityRegistrySlugs(registryPath);
 	const nextAbilitySlugs = Array.from(
 		new Set([...existingAbilitySlugs, ...existingRegistrySlugs, abilitySlug]),
 	).sort();
 	const generatedSection = buildAbilityRegistrySource(nextAbilitySlugs);
-	const existingSource = fs.existsSync(registryPath)
-		? fs.readFileSync(registryPath, "utf8")
-		: "";
+	const existingSource = (await readOptionalUtf8File(registryPath)) ?? "";
 	const generatedSectionPattern = new RegExp(
 		`${escapeRegex(ABILITY_REGISTRY_START_MARKER)}[\\s\\S]*?${escapeRegex(ABILITY_REGISTRY_END_MARKER)}\\n?`,
 		"u",
@@ -500,7 +504,7 @@ export async function scaffoldAbilityWorkspace({
 		"sync-project.ts",
 	);
 	const webpackConfigPath = path.join(workspace.projectDir, "webpack.config.js");
-	const abilitiesIndexPath = resolveAbilityRegistryPath(workspace.projectDir);
+	const abilitiesIndexPath = await resolveAbilityRegistryPath(workspace.projectDir);
 	const abilityDir = path.join(workspace.projectDir, "src", "abilities", abilitySlug);
 	const configFilePath = path.join(abilityDir, "ability.config.json");
 	const typesFilePath = path.join(abilityDir, "types.ts");

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ability-scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ability-scaffold.ts
@@ -94,7 +94,9 @@ async function readAbilityRegistrySlugs(registryPath: string): Promise<string[]>
 	}
 
 	return Array.from(
-		source.matchAll(/^\s*export\s+\*\s+from\s+['"]\.\/([^/'"]+)\/client['"];?\s*$/gmu),
+		source.matchAll(
+			/^\s*export\s+\*\s+from\s+['"]\.\/([^/'"]+)\/client(?:\.[cm]?[jt]sx?)?['"];?\s*$/gmu,
+		),
 	).map((match) => match[1]);
 }
 

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ability.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ability.ts
@@ -5,7 +5,7 @@ import {
 	type RunAddAbilityCommandOptions,
 } from "./cli-add-shared.js";
 import { scaffoldAbilityWorkspace } from "./cli-add-workspace-ability-scaffold.js";
-import { readWorkspaceInventory } from "./workspace-inventory.js";
+import { readWorkspaceInventoryAsync } from "./workspace-inventory.js";
 import { resolveWorkspaceProject } from "./workspace-project.js";
 import {
 	REQUIRED_WORKSPACE_ABILITY_COMPATIBILITY,
@@ -33,7 +33,7 @@ export async function runAddAbilityCommand({
 		"wp-typia add ability <name>",
 	);
 
-	const inventory = readWorkspaceInventory(workspace.projectDir);
+	const inventory = await readWorkspaceInventoryAsync(workspace.projectDir);
 	assertAbilityDoesNotExist(workspace.projectDir, abilitySlug, inventory);
 
 	const compatibilityPolicy = resolveScaffoldCompatibilityPolicy(

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-admin-view-scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-admin-view-scaffold.ts
@@ -1,11 +1,11 @@
-import fs from 'node:fs';
 import { promises as fsp } from 'node:fs';
 import path from 'node:path';
 
 import type { WorkspaceProject } from './workspace-project.js';
+import { pathExists, readOptionalUtf8File } from './fs-async.js';
 import {
   appendWorkspaceInventoryEntries,
-  readWorkspaceInventory,
+  readWorkspaceInventoryAsync,
 } from './workspace-inventory.js';
 import {
   buildAdminViewConfigEntry,
@@ -266,23 +266,25 @@ async function ensureAdminViewWebpackAnchors(
   });
 }
 
-function resolveAdminViewRegistryPath(projectDir: string): string {
+async function resolveAdminViewRegistryPath(projectDir: string): Promise<string> {
   const adminViewsDir = path.join(projectDir, 'src', 'admin-views');
-  return (
-    [
-      path.join(adminViewsDir, 'index.ts'),
-      path.join(adminViewsDir, 'index.js'),
-    ].find((candidatePath) => fs.existsSync(candidatePath)) ??
-    path.join(adminViewsDir, 'index.ts')
-  );
+  for (const candidatePath of [
+    path.join(adminViewsDir, 'index.ts'),
+    path.join(adminViewsDir, 'index.js'),
+  ]) {
+    if (await pathExists(candidatePath)) {
+      return candidatePath;
+    }
+  }
+  return path.join(adminViewsDir, 'index.ts');
 }
 
-function readAdminViewRegistrySlugs(registryPath: string): string[] {
-  if (!fs.existsSync(registryPath)) {
+async function readAdminViewRegistrySlugs(registryPath: string): Promise<string[]> {
+  const source = await readOptionalUtf8File(registryPath);
+  if (source === null) {
     return [];
   }
 
-  const source = fs.readFileSync(registryPath, 'utf8');
   return Array.from(
     source.matchAll(
       /^\s*import\s+['"]\.\/([^/'"]+)(?:\/index(?:\.[cm]?[jt]sx?)?)?['"];?\s*$/gmu,
@@ -295,13 +297,13 @@ async function writeAdminViewRegistry(
   adminViewSlug: string,
 ): Promise<void> {
   const adminViewsDir = path.join(projectDir, 'src', 'admin-views');
-  const registryPath = resolveAdminViewRegistryPath(projectDir);
+  const registryPath = await resolveAdminViewRegistryPath(projectDir);
   await fsp.mkdir(adminViewsDir, { recursive: true });
 
-  const existingAdminViewSlugs = readWorkspaceInventory(
-    projectDir,
+  const existingAdminViewSlugs = (
+    await readWorkspaceInventoryAsync(projectDir)
   ).adminViews.map((entry) => entry.slug);
-  const existingRegistrySlugs = readAdminViewRegistrySlugs(registryPath);
+  const existingRegistrySlugs = await readAdminViewRegistrySlugs(registryPath);
   const nextAdminViewSlugs = Array.from(
     new Set([
       ...existingAdminViewSlugs,
@@ -346,7 +348,7 @@ export async function scaffoldAdminViewWorkspace(options: {
     workspace.projectDir,
     'webpack.config.js',
   );
-  const adminViewsIndexPath = resolveAdminViewRegistryPath(
+  const adminViewsIndexPath = await resolveAdminViewRegistryPath(
     workspace.projectDir,
   );
   const adminViewDir = path.join(

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-admin-view.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-admin-view.ts
@@ -12,7 +12,7 @@ import {
 } from './cli-add-workspace-admin-view-source.js';
 import { scaffoldAdminViewWorkspace } from './cli-add-workspace-admin-view-scaffold.js';
 import { formatAdminViewSourceLocator } from './cli-add-workspace-admin-view-types.js';
-import { readWorkspaceInventory } from './workspace-inventory.js';
+import { readWorkspaceInventoryAsync } from './workspace-inventory.js';
 import { resolveWorkspaceProject } from './workspace-project.js';
 
 const ADD_ADMIN_VIEW_USAGE =
@@ -39,7 +39,7 @@ export async function runAddAdminViewCommand({
     ADD_ADMIN_VIEW_USAGE,
   );
   const parsedSource = parseAdminViewSource(source);
-  const inventory = readWorkspaceInventory(workspace.projectDir);
+  const inventory = await readWorkspaceInventoryAsync(workspace.projectDir);
   const restResource = resolveRestResourceSource(
     inventory.restResources,
     parsedSource,

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai.ts
@@ -6,7 +6,7 @@ import {
 	type RunAddAiFeatureCommandOptions,
 } from "./cli-add-shared.js";
 import { scaffoldAiFeatureWorkspace } from "./cli-add-workspace-ai-scaffold.js";
-import { readWorkspaceInventory } from "./workspace-inventory.js";
+import { readWorkspaceInventoryAsync } from "./workspace-inventory.js";
 import { resolveWorkspaceProject } from "./workspace-project.js";
 import {
 	OPTIONAL_WORDPRESS_AI_CLIENT_COMPATIBILITY,
@@ -44,7 +44,7 @@ export async function runAddAiFeatureCommand({
 		OPTIONAL_WORDPRESS_AI_CLIENT_COMPATIBILITY,
 	);
 
-	const inventory = readWorkspaceInventory(workspace.projectDir);
+	const inventory = await readWorkspaceInventoryAsync(workspace.projectDir);
 	assertAiFeatureDoesNotExist(workspace.projectDir, aiFeatureSlug, inventory);
 
 	const scaffoldResult = await scaffoldAiFeatureWorkspace({

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-assets.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-assets.ts
@@ -1,4 +1,3 @@
-import fs from "node:fs";
 import { promises as fsp } from "node:fs";
 import path from "node:path";
 
@@ -12,8 +11,8 @@ import {
 	type WorkspaceProject,
 } from "./workspace-project.js";
 import {
-	readWorkspaceInventory,
 	appendWorkspaceInventoryEntries,
+	readWorkspaceInventoryAsync,
 	type WorkspaceInventory,
 } from "./workspace-inventory.js";
 import { toPascalCase, toTitleCase } from "./string-case.js";
@@ -45,6 +44,7 @@ import {
 	appendPhpSnippetBeforeClosingTag,
 	insertPhpSnippetBeforeWorkspaceAnchors,
 } from "./cli-add-workspace-mutation.js";
+import { pathExists, readOptionalUtf8File } from "./fs-async.js";
 import { normalizeOptionalCliString } from "./cli-validation.js";
 
 const PATTERN_BOOTSTRAP_CATEGORY = "register_block_pattern_category";
@@ -960,11 +960,17 @@ async function ensureEditorPluginWebpackAnchors(workspace: WorkspaceProject): Pr
 	});
 }
 
-function resolveBindingSourceRegistryPath(projectDir: string): string {
+async function resolveBindingSourceRegistryPath(projectDir: string): Promise<string> {
 	const bindingsDir = path.join(projectDir, "src", "bindings");
-	return [path.join(bindingsDir, "index.ts"), path.join(bindingsDir, "index.js")].find(
-		(candidatePath) => fs.existsSync(candidatePath),
-	) ?? path.join(bindingsDir, "index.ts");
+	for (const candidatePath of [
+		path.join(bindingsDir, "index.ts"),
+		path.join(bindingsDir, "index.js"),
+	]) {
+		if (await pathExists(candidatePath)) {
+			return candidatePath;
+		}
+	}
+	return path.join(bindingsDir, "index.ts");
 }
 
 async function writeBindingSourceRegistry(
@@ -972,11 +978,10 @@ async function writeBindingSourceRegistry(
 	bindingSourceSlug: string,
 ): Promise<void> {
 	const bindingsDir = path.join(projectDir, "src", "bindings");
-	const bindingsIndexPath = resolveBindingSourceRegistryPath(projectDir);
+	const bindingsIndexPath = await resolveBindingSourceRegistryPath(projectDir);
 	await fsp.mkdir(bindingsDir, { recursive: true });
 
-	const existingBindingSourceSlugs = fs
-		.readdirSync(bindingsDir, { withFileTypes: true })
+	const existingBindingSourceSlugs = (await fsp.readdir(bindingsDir, { withFileTypes: true }))
 		.filter((entry) => entry.isDirectory())
 		.map((entry) => entry.name);
 	const nextBindingSourceSlugs = Array.from(
@@ -989,20 +994,25 @@ async function writeBindingSourceRegistry(
 	);
 }
 
-function resolveEditorPluginRegistryPath(projectDir: string): string {
+async function resolveEditorPluginRegistryPath(projectDir: string): Promise<string> {
 	const editorPluginsDir = path.join(projectDir, "src", "editor-plugins");
-	return [
+	for (const candidatePath of [
 		path.join(editorPluginsDir, "index.ts"),
 		path.join(editorPluginsDir, "index.js"),
-	].find((candidatePath) => fs.existsSync(candidatePath)) ?? path.join(editorPluginsDir, "index.ts");
+	]) {
+		if (await pathExists(candidatePath)) {
+			return candidatePath;
+		}
+	}
+	return path.join(editorPluginsDir, "index.ts");
 }
 
-function readEditorPluginRegistrySlugs(registryPath: string): string[] {
-	if (!fs.existsSync(registryPath)) {
+async function readEditorPluginRegistrySlugs(registryPath: string): Promise<string[]> {
+	const source = await readOptionalUtf8File(registryPath);
+	if (source === null) {
 		return [];
 	}
 
-	const source = fs.readFileSync(registryPath, "utf8");
 	return Array.from(
 		source.matchAll(
 			/^\s*import\s+['"]\.\/([^/'"]+)(?:\/index(?:\.[cm]?[jt]sx?)?)?['"];?\s*$/gmu,
@@ -1015,13 +1025,13 @@ async function writeEditorPluginRegistry(
 	editorPluginSlug: string,
 ): Promise<void> {
 	const editorPluginsDir = path.join(projectDir, "src", "editor-plugins");
-	const registryPath = resolveEditorPluginRegistryPath(projectDir);
+	const registryPath = await resolveEditorPluginRegistryPath(projectDir);
 	await fsp.mkdir(editorPluginsDir, { recursive: true });
 
-	const existingEditorPluginSlugs = readWorkspaceInventory(projectDir).editorPlugins.map((entry) =>
-		entry.slug,
-	);
-	const existingRegistrySlugs = readEditorPluginRegistrySlugs(registryPath);
+	const existingEditorPluginSlugs = (
+		await readWorkspaceInventoryAsync(projectDir)
+	).editorPlugins.map((entry) => entry.slug);
+	const existingRegistrySlugs = await readEditorPluginRegistrySlugs(registryPath);
 	const nextEditorPluginSlugs = Array.from(
 		new Set([...existingEditorPluginSlugs, ...existingRegistrySlugs, editorPluginSlug]),
 	).sort();
@@ -1064,13 +1074,15 @@ export async function runAddEditorPluginCommand({
 	);
 	const resolvedSlot = assertValidEditorPluginSlot(slot);
 
-	const inventory = readWorkspaceInventory(workspace.projectDir);
+	const inventory = await readWorkspaceInventoryAsync(workspace.projectDir);
 	assertEditorPluginDoesNotExist(workspace.projectDir, editorPluginSlug, inventory);
 
 	const blockConfigPath = path.join(workspace.projectDir, "scripts", "block-config.ts");
 	const bootstrapPath = getWorkspaceBootstrapPath(workspace);
 	const buildScriptPath = path.join(workspace.projectDir, "scripts", "build-workspace.mjs");
-	const editorPluginsIndexPath = resolveEditorPluginRegistryPath(workspace.projectDir);
+	const editorPluginsIndexPath = await resolveEditorPluginRegistryPath(
+		workspace.projectDir,
+	);
 	const webpackConfigPath = path.join(workspace.projectDir, "webpack.config.js");
 	const editorPluginDir = path.join(
 		workspace.projectDir,
@@ -1176,7 +1188,7 @@ export async function runAddPatternCommand({
 		"wp-typia add pattern <name>",
 	);
 
-	const inventory = readWorkspaceInventory(workspace.projectDir);
+	const inventory = await readWorkspaceInventoryAsync(workspace.projectDir);
 	assertPatternDoesNotExist(workspace.projectDir, patternSlug, inventory);
 
 	const blockConfigPath = path.join(workspace.projectDir, "scripts", "block-config.ts");
@@ -1252,7 +1264,7 @@ export async function runAddBindingSourceCommand({
 		"wp-typia add binding-source <name> [--block <block-slug|namespace/block-slug> --attribute <attribute>]",
 	);
 
-	const inventory = readWorkspaceInventory(workspace.projectDir);
+	const inventory = await readWorkspaceInventoryAsync(workspace.projectDir);
 	assertBindingSourceDoesNotExist(workspace.projectDir, bindingSourceSlug, inventory);
 	const target = resolveBindingTarget(
 		{
@@ -1265,7 +1277,7 @@ export async function runAddBindingSourceCommand({
 
 	const blockConfigPath = path.join(workspace.projectDir, "scripts", "block-config.ts");
 	const bootstrapPath = getWorkspaceBootstrapPath(workspace);
-	const bindingsIndexPath = resolveBindingSourceRegistryPath(workspace.projectDir);
+	const bindingsIndexPath = await resolveBindingSourceRegistryPath(workspace.projectDir);
 	const bindingSourceDir = path.join(workspace.projectDir, "src", "bindings", bindingSourceSlug);
 	const serverFilePath = path.join(bindingSourceDir, "server.php");
 	const editorFilePath = path.join(bindingSourceDir, "editor.ts");

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest.ts
@@ -31,7 +31,7 @@ import { syncRestResourceArtifacts } from "./rest-resource-artifacts.js";
 import { toPascalCase, toTitleCase } from "./string-case.js";
 import {
 	appendWorkspaceInventoryEntries,
-	readWorkspaceInventory,
+	readWorkspaceInventoryAsync,
 } from "./workspace-inventory.js";
 import { resolveWorkspaceProject } from "./workspace-project.js";
 
@@ -501,7 +501,7 @@ export async function runAddRestResourceCommand({
 		namespace,
 	);
 
-	const inventory = readWorkspaceInventory(workspace.projectDir);
+	const inventory = await readWorkspaceInventoryAsync(workspace.projectDir);
 	assertRestResourceDoesNotExist(workspace.projectDir, restResourceSlug, inventory);
 
 	const blockConfigPath = path.join(workspace.projectDir, "scripts", "block-config.ts");

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace.ts
@@ -4,7 +4,10 @@ import path from "node:path";
 import type { HookedBlockPositionId } from "./hooked-blocks.js";
 import { pathExists } from "./fs-async.js";
 import { resolveWorkspaceProject } from "./workspace-project.js";
-import { appendWorkspaceInventoryEntries, readWorkspaceInventory } from "./workspace-inventory.js";
+import {
+	appendWorkspaceInventoryEntries,
+	readWorkspaceInventoryAsync,
+} from "./workspace-inventory.js";
 import { toKebabCase, toSnakeCase, toTitleCase } from "./string-case.js";
 import {
 	assertBlockStyleDoesNotExist,
@@ -695,7 +698,7 @@ export async function runAddVariationCommand({
 		"wp-typia add variation <name> --block <block-slug>",
 	);
 
-	const inventory = readWorkspaceInventory(workspace.projectDir);
+	const inventory = await readWorkspaceInventoryAsync(workspace.projectDir);
 	resolveWorkspaceBlock(inventory, blockSlug);
 	assertVariationDoesNotExist(workspace.projectDir, blockSlug, variationSlug, inventory);
 
@@ -775,7 +778,7 @@ export async function runAddBlockStyleCommand({
 		"wp-typia add style <name> --block <block-slug>",
 	);
 
-	const inventory = readWorkspaceInventory(workspace.projectDir);
+	const inventory = await readWorkspaceInventoryAsync(workspace.projectDir);
 	resolveWorkspaceBlock(inventory, blockSlug);
 	assertBlockStyleDoesNotExist(workspace.projectDir, blockSlug, styleSlug, inventory);
 
@@ -871,7 +874,7 @@ export async function runAddBlockTransformCommand({
 		"--to",
 	);
 
-	const inventory = readWorkspaceInventory(workspace.projectDir);
+	const inventory = await readWorkspaceInventoryAsync(workspace.projectDir);
 	resolveWorkspaceBlock(inventory, target.blockSlug);
 	assertBlockTransformDoesNotExist(
 		workspace.projectDir,
@@ -976,7 +979,7 @@ export async function runAddHookedBlockCommand({
 }> {
 	const workspace = resolveWorkspaceProject(cwd);
 	const blockSlug = normalizeBlockSlug(blockName);
-	const inventory = readWorkspaceInventory(workspace.projectDir);
+	const inventory = await readWorkspaceInventoryAsync(workspace.projectDir);
 	resolveWorkspaceBlock(inventory, blockSlug);
 
 	const resolvedAnchorBlockName = assertValidHookAnchor(anchorBlockName);

--- a/packages/wp-typia-project-tools/src/runtime/workspace-inventory.ts
+++ b/packages/wp-typia-project-tools/src/runtime/workspace-inventory.ts
@@ -1,4 +1,4 @@
-import fs from "node:fs";
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import { readFile, writeFile } from "node:fs/promises";
 
@@ -1079,7 +1079,11 @@ export function parseWorkspaceInventorySource(source: string): Omit<WorkspaceInv
 }
 
 /**
- * Read and parse the canonical workspace inventory file.
+ * Synchronously read and parse the canonical workspace inventory file.
+ *
+ * This compatibility helper is intentionally sync-only for callers that expose
+ * synchronous APIs. Prefer `readWorkspaceInventoryAsync()` from async command
+ * paths so workspace reads do not block the event loop.
  *
  * @param projectDir Workspace root directory.
  * @returns Parsed `WorkspaceInventory` including the resolved `blockConfigPath`.
@@ -1089,7 +1093,41 @@ export function readWorkspaceInventory(projectDir: string): WorkspaceInventory {
 	const blockConfigPath = path.join(projectDir, "scripts", "block-config.ts");
 	let source: string;
 	try {
-		source = fs.readFileSync(blockConfigPath, "utf8");
+		source = readFileSync(blockConfigPath, "utf8");
+	} catch (error) {
+		if (
+			typeof error === "object" &&
+			error !== null &&
+			"code" in error &&
+			error.code === "ENOENT"
+		) {
+			throw new Error(
+				`Workspace inventory file is missing at ${blockConfigPath}. Expected scripts/block-config.ts to exist.`,
+			);
+		}
+		throw error;
+	}
+
+	return {
+		blockConfigPath,
+		...parseWorkspaceInventorySource(source),
+	};
+}
+
+/**
+ * Asynchronously read and parse the canonical workspace inventory file.
+ *
+ * @param projectDir Workspace root directory.
+ * @returns Parsed `WorkspaceInventory` including the resolved `blockConfigPath`.
+ * @throws {Error} When `scripts/block-config.ts` is missing or invalid.
+ */
+export async function readWorkspaceInventoryAsync(
+	projectDir: string,
+): Promise<WorkspaceInventory> {
+	const blockConfigPath = path.join(projectDir, "scripts", "block-config.ts");
+	let source: string;
+	try {
+		source = await readFile(blockConfigPath, "utf8");
 	} catch (error) {
 		if (
 			typeof error === "object" &&

--- a/packages/wp-typia-project-tools/tests/cli-add-workspace-ability.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-add-workspace-ability.test.ts
@@ -413,6 +413,47 @@ function demo_space_enqueue_workflow_abilities() {
 		expect(webpackSource.match(/'abilities\/index'/g)?.length).toBe(1);
 	}, 20_000);
 
+	test("ability add keeps extension-suffixed registry entries when rewriting the generated section", async () => {
+		const targetDir = path.join(
+			tempRoot,
+			"demo-workspace-add-ability-extension-registry",
+		);
+		const workspaceSlug = "demo-workspace-add-ability-extension-registry";
+
+		await scaffoldAbilityWorkspace(
+			targetDir,
+			workspaceSlug,
+			"Demo Workspace Add Ability Extension Registry",
+			"Demo workspace add ability extension registry",
+		);
+		seedLegacyAbilityWorkspace(targetDir, workspaceSlug);
+
+		const abilitiesDir = path.join(targetDir, "src", "abilities");
+		fs.mkdirSync(abilitiesDir, { recursive: true });
+		const abilitiesIndexPath = path.join(abilitiesDir, "index.js");
+		fs.writeFileSync(
+			abilitiesIndexPath,
+			`// wp-typia add ability entries start
+export * from './legacy-workflow/client.js';
+// wp-typia add ability entries end
+`,
+			"utf8",
+		);
+
+		runCli("node", [entryPath, "add", "ability", "review-workflow"], {
+			cwd: targetDir,
+		});
+
+		const abilitiesIndexSource = fs.readFileSync(abilitiesIndexPath, "utf8");
+
+		expect(abilitiesIndexSource).toContain(
+			"export * from './legacy-workflow/client';",
+		);
+		expect(abilitiesIndexSource).toContain(
+			"export * from './review-workflow/client';",
+		);
+	}, 20_000);
+
 	test("ability duplicate failures preserve generated workspace files", async () => {
 		const targetDir = path.join(tempRoot, "demo-workspace-add-ability-rollback");
 		const workspaceSlug = "demo-workspace-add-ability-rollback";

--- a/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
@@ -4,7 +4,12 @@ import * as path from "node:path";
 import { cleanupScaffoldTempRoot, createScaffoldTempRoot, entryPath, getCommandErrorMessage, linkWorkspaceNodeModules, parseJsonObjectFromOutput, runCli, scaffoldOfficialWorkspace, stripPhpFunction, workspaceTemplatePackageManifest } from "./helpers/scaffold-test-harness.js";
 import { scaffoldProject } from "../src/runtime/index.js";
 import { getDoctorChecks } from "../src/runtime/cli-core.js";
-import { parseWorkspaceInventorySource, updateWorkspaceInventorySource } from "../src/runtime/workspace-inventory.js";
+import {
+  parseWorkspaceInventorySource,
+  readWorkspaceInventory,
+  readWorkspaceInventoryAsync,
+  updateWorkspaceInventorySource,
+} from "../src/runtime/workspace-inventory.js";
 
 describe("@wp-typia/project-tools workspace doctor", () => {
   const tempRoot = createScaffoldTempRoot("wp-typia-workspace-doctor-");
@@ -740,6 +745,27 @@ export const REST_RESOURCES = [
 ];
 `)
   ).toThrow("REST_RESOURCES[0].methods includes unsupported values: publish.");
+});
+
+test("async workspace inventory reader matches the sync compatibility reader", async () => {
+  const projectDir = path.join(tempRoot, "workspace-inventory-async-reader");
+  const scriptsDir = path.join(projectDir, "scripts");
+  fs.mkdirSync(scriptsDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(scriptsDir, "block-config.ts"),
+    `export const BLOCKS = [
+\t{
+\t\tslug: "counter-card",
+\t\ttypesFile: "src/blocks/counter-card/types.ts",
+\t},
+];
+`,
+    "utf8"
+  );
+
+  await expect(readWorkspaceInventoryAsync(projectDir)).resolves.toEqual(
+    readWorkspaceInventory(projectDir)
+  );
 });
 
 test("workspace inventory repair avoids duplicating existing section constants", () => {


### PR DESCRIPTION
## Summary
- Add async workspace inventory reading and mark the existing sync reader as a compatibility path for synchronous callers.
- Move async `wp-typia add` hot paths to `readWorkspaceInventoryAsync()` and async registry/file probes for ability, admin-view, binding-source, editor-plugin, pattern, REST, AI, variation, style, transform, and hooked-block flows.
- Add regression coverage comparing the async inventory reader with the sync compatibility reader, plus a Sampo changeset.

## Notes
- `runtime-bridge-sync.ts` does not exist in the current tree, so there was no project-context bridge file read to convert.
- Remaining `fs.existsSync` hits in touched add files are generated template source strings or sync-only compatibility/doctor paths.

## Validation
- bun test packages/wp-typia-project-tools/tests/workspace-doctor.test.ts packages/wp-typia-project-tools/tests/workspace-add.test.ts packages/wp-typia-project-tools/tests/cli-add-workspace-ability.test.ts packages/wp-typia-project-tools/tests/cli-add-workspace-ai.test.ts packages/wp-typia-project-tools/tests/cli-add-workspace-admin-view.test.ts
- bun run --filter @wp-typia/project-tools test
- bun run format:check
- bun run changesets:validate
- bun run typecheck
- bun run lint:repo
- git diff --check

Fixes #790


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Converted workspace inventory and registry operations to asynchronous processing for improved responsiveness during CLI operations.
  * Transitioned file system interactions to non-blocking operations across workspace management tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->