### PR TITLE
[codex] refactor(runtime): consolidate shared helpers

### DIFF
--- a/.sampo/changesets/791-consolidate-runtime-helpers.md
+++ b/.sampo/changesets/791-consolidate-runtime-helpers.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Consolidate runtime filesystem, property-name, and block target helpers.

--- a/packages/wp-typia-project-tools/src/runtime/block-targets.ts
+++ b/packages/wp-typia-project-tools/src/runtime/block-targets.ts
@@ -1,0 +1,103 @@
+import { normalizeBlockSlug } from "./scaffold-identifiers.js";
+
+const FULL_BLOCK_NAME_PATTERN = /^[a-z0-9-]+\/[a-z0-9-]+$/u;
+
+export interface WorkspaceBlockTargetName {
+	blockName: string;
+	blockSlug: string;
+}
+
+export interface WorkspaceBlockTargetDiagnostics {
+	empty: () => string;
+	emptySegment: (input: string) => string;
+	invalidFormat: (input: string) => string;
+	namespaceMismatch: (input: string, actualNamespace: string, expectedNamespace: string) => string;
+}
+
+/**
+ * Validate a full `namespace/block-slug` block name.
+ *
+ * @param blockName Candidate block name.
+ * @param flagName CLI flag name used in diagnostics.
+ * @returns The trimmed full block name.
+ * @throws {Error} When the block name is empty or not a full block name.
+ */
+export function assertFullBlockName(blockName: string, flagName: string): string {
+	const trimmed = blockName.trim();
+	if (!trimmed) {
+		throw new Error(`\`${flagName}\` requires a block name.`);
+	}
+	if (!FULL_BLOCK_NAME_PATTERN.test(trimmed)) {
+		throw new Error(`\`${flagName}\` must use <namespace/block-slug> format.`);
+	}
+
+	return trimmed;
+}
+
+/**
+ * Resolve a workspace block target from either `block-slug` or
+ * `namespace/block-slug` input while preserving caller-owned diagnostics.
+ *
+ * @param blockName Candidate block target.
+ * @param namespace Expected workspace namespace.
+ * @param diagnostics Error message builders for the caller's UX context.
+ * @returns The normalized workspace block target.
+ * @throws {Error} When the target is empty, malformed, or references another namespace.
+ */
+export function resolveWorkspaceBlockTargetName(
+	blockName: string,
+	namespace: string,
+	diagnostics: WorkspaceBlockTargetDiagnostics,
+): WorkspaceBlockTargetName {
+	const trimmed = blockName.trim();
+	if (!trimmed) {
+		throw new Error(diagnostics.empty());
+	}
+
+	const blockNameSegments = trimmed.split("/");
+	if (blockNameSegments.length > 2) {
+		throw new Error(diagnostics.invalidFormat(trimmed));
+	}
+	if (blockNameSegments.some((segment) => segment.trim() === "")) {
+		throw new Error(diagnostics.emptySegment(trimmed));
+	}
+
+	const [maybeNamespace, maybeSlug] =
+		blockNameSegments.length === 2
+			? blockNameSegments
+			: [undefined, blockNameSegments[0]];
+	if (maybeNamespace && maybeNamespace !== namespace) {
+		throw new Error(diagnostics.namespaceMismatch(trimmed, maybeNamespace, namespace));
+	}
+
+	const blockSlug = normalizeBlockSlug(maybeSlug ?? "");
+	return {
+		blockName: `${namespace}/${blockSlug}`,
+		blockSlug,
+	};
+}
+
+/**
+ * Resolve the standard `--to` style workspace block target used by add flows.
+ *
+ * @param blockName Candidate block target.
+ * @param namespace Expected workspace namespace.
+ * @param flagName CLI flag name used in diagnostics.
+ * @returns The normalized workspace block target.
+ * @throws {Error} When the target is empty, malformed, or references another namespace.
+ */
+export function resolveWorkspaceTargetBlockName(
+	blockName: string,
+	namespace: string,
+	flagName: string,
+): WorkspaceBlockTargetName {
+	return resolveWorkspaceBlockTargetName(blockName, namespace, {
+		empty: () => `\`${flagName}\` requires <block-slug|namespace/block-slug>.`,
+		emptySegment: () =>
+			`\`${flagName}\` must use <block-slug|namespace/block-slug> format.`,
+		invalidFormat: () =>
+			`\`${flagName}\` must use <block-slug|namespace/block-slug> format.`,
+		namespaceMismatch: (_input, actualNamespace, expectedNamespace) =>
+			`\`${flagName}\` references namespace "${actualNamespace}". Expected "${expectedNamespace}".`,
+	});
+}

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-assets.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-assets.ts
@@ -44,8 +44,10 @@ import {
 	appendPhpSnippetBeforeClosingTag,
 	insertPhpSnippetBeforeWorkspaceAnchors,
 } from "./cli-add-workspace-mutation.js";
+import { resolveWorkspaceBlockTargetName } from "./block-targets.js";
 import { pathExists, readOptionalUtf8File } from "./fs-async.js";
 import { normalizeOptionalCliString } from "./cli-validation.js";
+import { getPropertyNameText } from "./ts-property-names.js";
 
 const PATTERN_BOOTSTRAP_CATEGORY = "register_block_pattern_category";
 const BINDING_SOURCE_SERVER_GLOB = "/src/bindings/*/server.php";
@@ -100,42 +102,6 @@ function assertValidBindingAttributeName(attributeName: string): string {
 	}
 
 	return trimmed;
-}
-
-function resolveBindingTargetBlockSlug(
-	blockName: string,
-	namespace: string,
-): string {
-	const trimmed = blockName.trim();
-	if (!trimmed) {
-		throw new Error(
-			"`wp-typia add binding-source` requires --block <block-slug|namespace/block-slug> to include a value when --attribute is provided.",
-		);
-	}
-
-	const blockNameSegments = trimmed.split("/");
-	if (blockNameSegments.length > 2) {
-		throw new Error(
-			`Binding target block "${trimmed}" must use <block-slug> or <namespace/block-slug> format.`,
-		);
-	}
-	if (blockNameSegments.some((segment) => segment.trim() === "")) {
-		throw new Error(
-			`Binding target block "${trimmed}" must use <block-slug> or <namespace/block-slug> format without empty path segments.`,
-		);
-	}
-
-	const [maybeNamespace, maybeSlug] =
-		blockNameSegments.length === 2
-			? blockNameSegments
-			: [undefined, blockNameSegments[0]];
-	if (maybeNamespace && maybeNamespace !== namespace) {
-		throw new Error(
-			`Binding target block "${trimmed}" uses namespace "${maybeNamespace}". Expected "${namespace}".`,
-		);
-	}
-
-	return normalizeBlockSlug(maybeSlug ?? "");
 }
 
 function buildEditorPluginConfigEntry(
@@ -338,9 +304,20 @@ function resolveBindingTarget(
 		);
 	}
 
+	const targetBlock = resolveWorkspaceBlockTargetName(blockName ?? "", namespace, {
+		empty: () =>
+			"`wp-typia add binding-source` requires --block <block-slug|namespace/block-slug> to include a value when --attribute is provided.",
+		emptySegment: (input) =>
+			`Binding target block "${input}" must use <block-slug> or <namespace/block-slug> format without empty path segments.`,
+		invalidFormat: (input) =>
+			`Binding target block "${input}" must use <block-slug> or <namespace/block-slug> format.`,
+		namespaceMismatch: (input, actualNamespace, expectedNamespace) =>
+			`Binding target block "${input}" uses namespace "${actualNamespace}". Expected "${expectedNamespace}".`,
+	});
+
 	return {
 		attributeName: assertValidBindingAttributeName(attributeName ?? ""),
-		blockSlug: resolveBindingTargetBlockSlug(blockName ?? "", namespace),
+		blockSlug: targetBlock.blockSlug,
 	};
 }
 
@@ -382,14 +359,6 @@ function getInterfaceDeclaration(
 	visit(sourceFile);
 
 	return declaration ? { declaration, sourceFile } : undefined;
-}
-
-function getPropertyNameText(name: ts.PropertyName): string | undefined {
-	if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) {
-		return name.text;
-	}
-
-	return undefined;
 }
 
 function interfaceHasAttributeMember(

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace.ts
@@ -3,6 +3,10 @@ import path from "node:path";
 
 import type { HookedBlockPositionId } from "./hooked-blocks.js";
 import { pathExists } from "./fs-async.js";
+import {
+	assertFullBlockName,
+	resolveWorkspaceTargetBlockName,
+} from "./block-targets.js";
 import { resolveWorkspaceProject } from "./workspace-project.js";
 import {
 	appendWorkspaceInventoryEntries,
@@ -57,7 +61,6 @@ const BLOCK_TRANSFORMS_CALL_PATTERN =
 	/applyWorkspaceBlockTransforms\s*\(\s*registration\s*\.\s*settings\s*\)\s*;?/u;
 const SCAFFOLD_REGISTRATION_SETTINGS_CALL_PATTERN =
 	/registerScaffoldBlockType\s*\(\s*registration\s*\.\s*name\s*,\s*registration\s*\.\s*settings\s*\)\s*;?/u;
-const FULL_BLOCK_NAME_PATTERN = /^[a-z0-9-]+\/[a-z0-9-]+$/u;
 
 function isIdentifierBoundary(source: string, index: number): boolean {
 	if (index < 0 || index >= source.length) {
@@ -584,53 +587,6 @@ async function writeBlockTransformRegistry(
 		buildBlockTransformIndexSource(nextTransformSlugs),
 		"utf8",
 	);
-}
-
-function assertFullBlockName(blockName: string, flagName: string): string {
-	const trimmed = blockName.trim();
-	if (!trimmed) {
-		throw new Error(`\`${flagName}\` requires a block name.`);
-	}
-	if (!FULL_BLOCK_NAME_PATTERN.test(trimmed)) {
-		throw new Error(`\`${flagName}\` must use <namespace/block-slug> format.`);
-	}
-
-	return trimmed;
-}
-
-function resolveWorkspaceTargetBlockName(
-	blockName: string,
-	namespace: string,
-	flagName: string,
-): { blockName: string; blockSlug: string } {
-	const trimmed = blockName.trim();
-	if (!trimmed) {
-		throw new Error(`\`${flagName}\` requires <block-slug|namespace/block-slug>.`);
-	}
-
-	const blockNameSegments = trimmed.split("/");
-	if (
-		blockNameSegments.length > 2 ||
-		blockNameSegments.some((segment) => segment.trim() === "")
-	) {
-		throw new Error(`\`${flagName}\` must use <block-slug|namespace/block-slug> format.`);
-	}
-
-	const [maybeNamespace, maybeSlug] =
-		blockNameSegments.length === 2
-			? blockNameSegments
-			: [undefined, blockNameSegments[0]];
-	if (maybeNamespace && maybeNamespace !== namespace) {
-		throw new Error(
-			`\`${flagName}\` references namespace "${maybeNamespace}". Expected "${namespace}".`,
-		);
-	}
-
-	const blockSlug = normalizeBlockSlug(maybeSlug ?? "");
-	return {
-		blockName: `${namespace}/${blockSlug}`,
-		blockSlug,
-	};
 }
 
 /**

--- a/packages/wp-typia-project-tools/src/runtime/template-source-cache.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-cache.ts
@@ -1,7 +1,8 @@
 import { createHash } from 'node:crypto'
-import fs from 'node:fs'
+import type { Dirent } from 'node:fs'
 import { promises as fsp } from 'node:fs'
 import path from 'node:path'
+import { getNodeErrorCode, pathExists } from './fs-async.js'
 import {
   getExternalTemplateCacheNowMs,
   getExternalTemplateCacheRoot,
@@ -206,15 +207,6 @@ export function createExternalTemplateCacheKey(
     .digest('hex')
 }
 
-async function pathExists(filePath: string): Promise<boolean> {
-  try {
-    await fsp.access(filePath, fs.constants.F_OK)
-    return true
-  } catch {
-    return false
-  }
-}
-
 async function isDirectoryPath(directory: string): Promise<boolean> {
   try {
     const stats = await fsp.lstat(directory)
@@ -222,12 +214,6 @@ async function isDirectoryPath(directory: string): Promise<boolean> {
   } catch {
     return false
   }
-}
-
-function getNodeErrorCode(error: unknown): string {
-  return typeof error === 'object' && error !== null && 'code' in error
-    ? String((error as { code: unknown }).code)
-    : ''
 }
 
 async function removeTemporaryCacheEntry(entryDir: string): Promise<void> {
@@ -679,7 +665,7 @@ export async function pruneExternalTemplateCache(
     return result
   }
 
-  let namespaceEntries: fs.Dirent[]
+  let namespaceEntries: Dirent[]
   try {
     namespaceEntries = await fsp.readdir(cacheRoot, { withFileTypes: true })
   } catch {
@@ -701,7 +687,7 @@ export async function pruneExternalTemplateCache(
       continue
     }
 
-    let cacheEntries: fs.Dirent[]
+    let cacheEntries: Dirent[]
     try {
       cacheEntries = await fsp.readdir(namespaceDir, { withFileTypes: true })
     } catch {
@@ -792,7 +778,7 @@ export async function findReusableExternalTemplateSourceCache(
   const nowMs = getExternalTemplateCacheNowMs(undefined)
   await pruneExternalTemplateCache()
 
-  let entries: fs.Dirent[]
+  let entries: Dirent[]
   try {
     entries = await fsp.readdir(namespaceDir, { withFileTypes: true })
   } catch {

--- a/packages/wp-typia-project-tools/src/runtime/ts-property-names.ts
+++ b/packages/wp-typia-project-tools/src/runtime/ts-property-names.ts
@@ -1,0 +1,18 @@
+import ts from "typescript";
+
+/**
+ * Extract the literal text for TypeScript property names this runtime supports.
+ *
+ * Computed property names are intentionally not resolved because their runtime
+ * values are not statically knowable from the syntax node alone.
+ *
+ * @param name TypeScript property name node.
+ * @returns Identifier, string-literal, or numeric-literal text; otherwise `null`.
+ */
+export function getPropertyNameText(name: ts.PropertyName): string | null {
+	if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) {
+		return name.text;
+	}
+
+	return null;
+}

--- a/packages/wp-typia-project-tools/src/runtime/workspace-inventory.ts
+++ b/packages/wp-typia-project-tools/src/runtime/workspace-inventory.ts
@@ -6,6 +6,7 @@ import ts from "typescript";
 
 import { REST_RESOURCE_METHOD_IDS } from "./cli-add-shared.js";
 import { escapeRegex } from "./php-utils.js";
+import { getPropertyNameText } from "./ts-property-names.js";
 
 export interface WorkspaceBlockInventoryEntry {
 	apiTypesFile?: string;
@@ -803,14 +804,6 @@ const INVENTORY_SECTIONS: readonly InventorySectionDescriptor[] = [
 		},
 	},
 ];
-
-function getPropertyNameText(name: ts.PropertyName): string | null {
-	if (ts.isIdentifier(name) || ts.isStringLiteral(name)) {
-		return name.text;
-	}
-
-	return null;
-}
 
 function findExportedArrayLiteral(
 	sourceFile: ts.SourceFile,

--- a/packages/wp-typia-project-tools/tests/runtime-helper-consolidation.test.ts
+++ b/packages/wp-typia-project-tools/tests/runtime-helper-consolidation.test.ts
@@ -1,0 +1,132 @@
+import { afterAll, expect, test } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import ts from 'typescript';
+
+import {
+  assertFullBlockName,
+  resolveWorkspaceBlockTargetName,
+  resolveWorkspaceTargetBlockName,
+} from '../src/runtime/block-targets.js';
+import { getNodeErrorCode, pathExists } from '../src/runtime/fs-async.js';
+import { getPropertyNameText } from '../src/runtime/ts-property-names.js';
+
+const runtimeRoot = path.join(import.meta.dir, '..', 'src', 'runtime');
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wp-typia-runtime-helpers-'));
+
+afterAll(() => {
+  fs.rmSync(tempRoot, { force: true, recursive: true });
+});
+
+function readRuntimeSource(fileName: string): string {
+  return fs.readFileSync(path.join(runtimeRoot, fileName), 'utf8');
+}
+
+test('runtime helper modules own filesystem and TypeScript property-name helpers', () => {
+  expect(readRuntimeSource('template-source-cache.ts')).not.toContain(
+    'async function pathExists',
+  );
+  expect(readRuntimeSource('template-source-cache.ts')).not.toContain(
+    'function getNodeErrorCode',
+  );
+  expect(readRuntimeSource('workspace-inventory.ts')).not.toContain(
+    'function getPropertyNameText',
+  );
+  expect(readRuntimeSource('cli-add-workspace-assets.ts')).not.toContain(
+    'function getPropertyNameText',
+  );
+  expect(readRuntimeSource('cli-add-workspace.ts')).not.toContain(
+    'function assertFullBlockName',
+  );
+  expect(readRuntimeSource('cli-add-workspace.ts')).not.toContain(
+    'function resolveWorkspaceTargetBlockName',
+  );
+  expect(readRuntimeSource('cli-add-workspace-assets.ts')).not.toContain(
+    'function resolveBindingTargetBlockSlug',
+  );
+});
+
+test('shared async filesystem helpers expose path existence and node error codes', async () => {
+  const existingPath = path.join(tempRoot, 'existing.txt');
+  fs.writeFileSync(existingPath, 'ok', 'utf8');
+
+  await expect(pathExists(existingPath)).resolves.toBe(true);
+  await expect(pathExists(path.join(tempRoot, 'missing.txt'))).resolves.toBe(false);
+  expect(getNodeErrorCode(Object.assign(new Error('denied'), { code: 'EACCES' }))).toBe(
+    'EACCES',
+  );
+  expect(getNodeErrorCode(new Error('plain'))).toBe('');
+});
+
+test('shared TypeScript property-name helper aligns literal property support', () => {
+  const sourceFile = ts.createSourceFile(
+    'fixture.ts',
+    `const value = {
+  plain: true,
+  'quoted-name': true,
+  7: true,
+  [dynamicName]: true,
+};`,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const statement = sourceFile.statements[0];
+  const declaration = ts.isVariableStatement(statement)
+    ? statement.declarationList.declarations[0]
+    : undefined;
+  const initializer = declaration?.initializer;
+  if (
+    !statement ||
+    !ts.isVariableStatement(statement) ||
+    !initializer ||
+    !ts.isObjectLiteralExpression(initializer)
+  ) {
+    throw new Error('Test fixture did not parse as an object literal.');
+  }
+  const objectLiteral = initializer;
+
+  expect(
+    objectLiteral.properties.map((property) =>
+      ts.isPropertyAssignment(property) ? getPropertyNameText(property.name) : null,
+    ),
+  ).toEqual(['plain', 'quoted-name', '7', null]);
+});
+
+test('shared block target helpers preserve workspace target diagnostics', () => {
+  expect(assertFullBlockName(' demo-space/counter-card ', '--from')).toBe(
+    'demo-space/counter-card',
+  );
+  expect(() => assertFullBlockName('', '--from')).toThrow(
+    '`--from` requires a block name.',
+  );
+  expect(() => assertFullBlockName('counter-card', '--from')).toThrow(
+    '`--from` must use <namespace/block-slug> format.',
+  );
+  expect(resolveWorkspaceTargetBlockName('counter-card', 'demo-space', '--to')).toEqual({
+    blockName: 'demo-space/counter-card',
+    blockSlug: 'counter-card',
+  });
+  expect(
+    resolveWorkspaceTargetBlockName('demo-space/counter-card', 'demo-space', '--to'),
+  ).toEqual({
+    blockName: 'demo-space/counter-card',
+    blockSlug: 'counter-card',
+  });
+  expect(() =>
+    resolveWorkspaceTargetBlockName('other-space/counter-card', 'demo-space', '--to'),
+  ).toThrow('`--to` references namespace "other-space". Expected "demo-space".');
+});
+
+test('shared block target resolver lets callers keep custom diagnostics', () => {
+  expect(() =>
+    resolveWorkspaceBlockTargetName('/counter-card', 'demo-space', {
+      empty: () => 'empty',
+      emptySegment: (input) => `empty segment: ${input}`,
+      invalidFormat: (input) => `invalid: ${input}`,
+      namespaceMismatch: (input, actual, expected) =>
+        `namespace mismatch: ${input} ${actual} ${expected}`,
+    }),
+  ).toThrow('empty segment: /counter-card');
+});

--- a/scripts/lib/typescript-runtime-policy.mjs
+++ b/scripts/lib/typescript-runtime-policy.mjs
@@ -31,6 +31,7 @@ export const TYPESCRIPT_RUNTIME_PACKAGE_POLICIES = [
 		requiredTypeScriptImportFiles: [
 			"src/runtime/cli-add-workspace-assets.ts",
 			"src/runtime/cli-init-plan.ts",
+			"src/runtime/ts-property-names.ts",
 			"src/runtime/workspace-inventory.ts",
 		],
 		runtimeSourceRoots: ["src/runtime"],


### PR DESCRIPTION
## Summary

- consolidate shared runtime block target parsing in `block-targets.ts` while preserving CLI diagnostics
- centralize TypeScript property-name text extraction in `ts-property-names.ts`
- reuse `fs-async` `pathExists` and `getNodeErrorCode` from template source caching
- keep the sync `template-render.ts` path existence helper intentionally separate for the sync render API

## Validation

- `bun test packages/wp-typia-project-tools/tests/runtime-helper-consolidation.test.ts packages/wp-typia-project-tools/tests/cli-add-shared.test.ts packages/wp-typia-project-tools/tests/workspace-add.test.ts packages/wp-typia-project-tools/tests/template-source.test.ts`
- `bun run --filter @wp-typia/project-tools test`
- `bun run typecheck`
- `bun run format:check`
- `bun run changesets:validate`
- `bun run lint:repo`
- `git diff --check`

Fixes #791


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated runtime utilities for filesystem operations, property name handling, and workspace block targeting into shared modules for improved code organization.

* **Tests**
  * Added comprehensive test coverage for runtime helper consolidation and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->