### PR TITLE
[codex] fix(create): validate template ids before scaffolding

### DIFF
--- a/.sampo/changesets/792-create-template-boundary-validation.md
+++ b/.sampo/changesets/792-create-template-boundary-validation.md
@@ -1,0 +1,6 @@
+---
+npm/wp-typia: patch
+npm/@wp-typia/project-tools: patch
+---
+
+Validate explicit create template ids before entering the full scaffold flow.

--- a/packages/wp-typia-project-tools/package.json
+++ b/packages/wp-typia-project-tools/package.json
@@ -47,6 +47,11 @@
       "import": "./dist/runtime/cli-scaffold.js",
       "default": "./dist/runtime/cli-scaffold.js"
     },
+    "./create-template-validation": {
+      "types": "./dist/runtime/create-template-validation.d.ts",
+      "import": "./dist/runtime/create-template-validation.js",
+      "default": "./dist/runtime/create-template-validation.js"
+    },
     "./ai-artifacts": {
       "types": "./dist/runtime/ai-artifacts.d.ts",
       "import": "./dist/runtime/ai-artifacts.js",

--- a/packages/wp-typia-project-tools/src/runtime/create-template-validation.ts
+++ b/packages/wp-typia-project-tools/src/runtime/create-template-validation.ts
@@ -31,7 +31,7 @@ const USER_FACING_TEMPLATE_IDS = [
 	OFFICIAL_WORKSPACE_TEMPLATE_ALIAS,
 ] as const;
 
-export function normalizeCreateTemplateSelection(templateId: string): string {
+function normalizeCreateTemplateSelection(templateId: string): string {
 	return templateId === OFFICIAL_WORKSPACE_TEMPLATE_ALIAS
 		? OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE
 		: templateId;
@@ -48,14 +48,17 @@ function looksLikeExplicitNonNpmExternalTemplateLocator(
 		path.isAbsolute(templateId) ||
 		looksLikeWindowsAbsoluteTemplatePath(templateId) ||
 		templateId.startsWith("./") ||
+		templateId.startsWith(".\\") ||
 		templateId.startsWith("../") ||
+		templateId.startsWith("..\\") ||
 		templateId.startsWith("@") ||
 		templateId.startsWith("github:") ||
-		templateId.includes("/")
+		templateId.includes("/") ||
+		templateId.includes("\\")
 	);
 }
 
-export function looksLikeExplicitCreateExternalTemplateLocator(
+function looksLikeExplicitCreateExternalTemplateLocator(
 	templateId: string,
 ): boolean {
 	return (

--- a/packages/wp-typia-project-tools/src/runtime/create-template-validation.ts
+++ b/packages/wp-typia-project-tools/src/runtime/create-template-validation.ts
@@ -1,0 +1,176 @@
+import path from "node:path";
+
+import {
+	CLI_DIAGNOSTIC_CODES,
+	createCliDiagnosticCodeError,
+} from "./cli-diagnostics.js";
+import {
+	OFFICIAL_WORKSPACE_TEMPLATE_ALIAS,
+	OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE,
+	TEMPLATE_IDS,
+	getTemplateById,
+	isBuiltInTemplateId,
+} from "./template-registry.js";
+import {
+	getRemovedBuiltInTemplateMessage,
+	isRemovedBuiltInTemplateId,
+} from "./template-defaults.js";
+import { parseNpmTemplateLocator } from "./template-source-locators.js";
+
+export const CREATE_TEMPLATE_SELECTION_HINT = `--template <${[
+	...TEMPLATE_IDS,
+	OFFICIAL_WORKSPACE_TEMPLATE_ALIAS,
+].join("|")}|./path|github:owner/repo/path[#ref]|npm-package>`;
+
+const TEMPLATE_SUGGESTION_IDS = [
+	...TEMPLATE_IDS,
+	OFFICIAL_WORKSPACE_TEMPLATE_ALIAS,
+] as const;
+const USER_FACING_TEMPLATE_IDS = [
+	...TEMPLATE_IDS,
+	OFFICIAL_WORKSPACE_TEMPLATE_ALIAS,
+] as const;
+
+export function normalizeCreateTemplateSelection(templateId: string): string {
+	return templateId === OFFICIAL_WORKSPACE_TEMPLATE_ALIAS
+		? OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE
+		: templateId;
+}
+
+function looksLikeWindowsAbsoluteTemplatePath(templateId: string): boolean {
+	return /^[a-z]:[\\/]/iu.test(templateId) || /^\\\\[^\\]+\\[^\\]+/u.test(templateId);
+}
+
+function looksLikeExplicitNonNpmExternalTemplateLocator(
+	templateId: string,
+): boolean {
+	return (
+		path.isAbsolute(templateId) ||
+		looksLikeWindowsAbsoluteTemplatePath(templateId) ||
+		templateId.startsWith("./") ||
+		templateId.startsWith("../") ||
+		templateId.startsWith("@") ||
+		templateId.startsWith("github:") ||
+		templateId.includes("/")
+	);
+}
+
+export function looksLikeExplicitCreateExternalTemplateLocator(
+	templateId: string,
+): boolean {
+	return (
+		looksLikeExplicitNonNpmExternalTemplateLocator(templateId) ||
+		parseNpmTemplateLocator(templateId) !== null
+	);
+}
+
+function getEditDistance(left: string, right: string): number {
+	const previous = Array.from({ length: right.length + 1 }, (_, index) => index);
+	const current = new Array<number>(right.length + 1);
+
+	for (let leftIndex = 0; leftIndex < left.length; leftIndex += 1) {
+		current[0] = leftIndex + 1;
+
+		for (let rightIndex = 0; rightIndex < right.length; rightIndex += 1) {
+			const substitutionCost = left[leftIndex] === right[rightIndex] ? 0 : 1;
+			current[rightIndex + 1] = Math.min(
+				current[rightIndex] + 1,
+				previous[rightIndex + 1] + 1,
+				previous[rightIndex] + substitutionCost,
+			);
+		}
+
+		for (let index = 0; index < current.length; index += 1) {
+			previous[index] = current[index] as number;
+		}
+	}
+
+	return previous[right.length] as number;
+}
+
+function findMistypedBuiltInTemplateSuggestion(templateId: string): string | null {
+	const normalizedTemplateId = templateId.trim().toLowerCase();
+	if (
+		normalizedTemplateId.length === 0 ||
+		looksLikeExplicitNonNpmExternalTemplateLocator(normalizedTemplateId)
+	) {
+		return null;
+	}
+
+	let bestCandidate: { distance: number; id: string } | null = null;
+
+	for (const candidateId of TEMPLATE_SUGGESTION_IDS) {
+		const distance = getEditDistance(normalizedTemplateId, candidateId);
+		if (bestCandidate === null || distance < bestCandidate.distance) {
+			bestCandidate = {
+				distance,
+				id: candidateId,
+			};
+		}
+	}
+
+	return bestCandidate && bestCandidate.distance <= 2
+		? bestCandidate.id
+		: null;
+}
+
+function getMistypedBuiltInTemplateMessage(templateId: string): string | null {
+	const suggestion = findMistypedBuiltInTemplateSuggestion(templateId);
+	if (!suggestion) {
+		return null;
+	}
+
+	const suggestionDescription =
+		suggestion === OFFICIAL_WORKSPACE_TEMPLATE_ALIAS
+			? "official workspace scaffold"
+			: "built-in scaffold";
+
+	return `Unknown template "${templateId}". Did you mean "${suggestion}"? Use \`--template ${suggestion}\` for the ${suggestionDescription}, or pass a local path, \`github:owner/repo/path[#ref]\`, or an npm package spec for an external template.`;
+}
+
+function getUnknownTemplateMessage(templateId: string): string {
+	return [
+		`Unknown template "${templateId}". Expected one of: ${USER_FACING_TEMPLATE_IDS.join(", ")}.`,
+		"Run `wp-typia templates list` to inspect available templates.",
+		"Pass an explicit external template locator such as `./path`, `github:owner/repo/path[#ref]`, or `@scope/template` for custom templates.",
+	].join(" ");
+}
+
+/**
+ * Validate an explicitly supplied create template id before entering the full
+ * scaffold flow.
+ *
+ * Built-in template ids and the workspace alias resolve immediately, common
+ * built-in typos keep suggestion diagnostics, and explicit external template
+ * locators remain deferred to the external template resolver.
+ */
+export function validateExplicitCreateTemplateId(templateId: string): string {
+	const normalizedTemplateId = normalizeCreateTemplateSelection(templateId);
+	if (isRemovedBuiltInTemplateId(templateId)) {
+		throw createCliDiagnosticCodeError(
+			CLI_DIAGNOSTIC_CODES.UNKNOWN_TEMPLATE,
+			getRemovedBuiltInTemplateMessage(templateId),
+		);
+	}
+	if (normalizedTemplateId === OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE) {
+		return normalizedTemplateId;
+	}
+	if (isBuiltInTemplateId(normalizedTemplateId)) {
+		return getTemplateById(normalizedTemplateId).id;
+	}
+	const mistypedBuiltInTemplateMessage =
+		getMistypedBuiltInTemplateMessage(templateId);
+	if (mistypedBuiltInTemplateMessage) {
+		throw createCliDiagnosticCodeError(
+			CLI_DIAGNOSTIC_CODES.UNKNOWN_TEMPLATE,
+			mistypedBuiltInTemplateMessage,
+		);
+	}
+	if (!looksLikeExplicitCreateExternalTemplateLocator(normalizedTemplateId)) {
+		throw createCliDiagnosticCodeError(
+			CLI_DIAGNOSTIC_CODES.UNKNOWN_TEMPLATE,
+			getUnknownTemplateMessage(templateId),
+		);
+	}
+	return normalizedTemplateId;
+}

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-answer-resolution.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-answer-resolution.ts
@@ -1,6 +1,4 @@
 import { execSync } from 'node:child_process';
-import path from 'node:path';
-
 import {
   PACKAGE_MANAGER_IDS,
   getPackageManager,
@@ -17,16 +15,13 @@ import {
   createCliDiagnosticCodeError,
 } from './cli-diagnostics.js';
 import {
-  OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE,
-  TEMPLATE_IDS,
   getTemplateById,
   isBuiltInTemplateId,
 } from './template-registry.js';
 import {
-  getRemovedBuiltInTemplateMessage,
-  isRemovedBuiltInTemplateId,
-} from './template-defaults.js';
-import { parseNpmTemplateLocator } from './template-source-locators.js';
+  CREATE_TEMPLATE_SELECTION_HINT,
+  validateExplicitCreateTemplateId,
+} from './create-template-validation.js';
 import {
   toSnakeCase,
   toTitleCase,
@@ -38,18 +33,8 @@ import type {
   ScaffoldAnswers,
 } from './scaffold.js';
 
-const WORKSPACE_TEMPLATE_ALIAS = 'workspace';
-const TEMPLATE_SELECTION_HINT = `--template <${[
-  ...TEMPLATE_IDS,
-  WORKSPACE_TEMPLATE_ALIAS,
-].join('|')}|./path|github:owner/repo/path[#ref]|npm-package>`;
-const TEMPLATE_SUGGESTION_IDS = [...TEMPLATE_IDS, WORKSPACE_TEMPLATE_ALIAS] as const;
 const QUERY_POST_TYPE_RULE =
   'Use lowercase, 1-20 chars, and only a-z, 0-9, "_" or "-".';
-const USER_FACING_TEMPLATE_IDS = [
-  ...TEMPLATE_IDS,
-  WORKSPACE_TEMPLATE_ALIAS,
-] as const;
 
 /**
  * Detect the current author name from local Git config.
@@ -128,110 +113,6 @@ function normalizeQueryPostType(value: string | undefined): string | undefined {
   return value.trim().toLowerCase();
 }
 
-function normalizeTemplateSelection(templateId: string): string {
-  return templateId === WORKSPACE_TEMPLATE_ALIAS
-    ? OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE
-    : templateId;
-}
-
-function looksLikeWindowsAbsoluteTemplatePath(templateId: string): boolean {
-  return /^[a-z]:[\\/]/iu.test(templateId) || /^\\\\[^\\]+\\[^\\]+/u.test(templateId);
-}
-
-function looksLikeExplicitNonNpmExternalTemplateLocator(templateId: string): boolean {
-  return (
-    path.isAbsolute(templateId) ||
-    looksLikeWindowsAbsoluteTemplatePath(templateId) ||
-    templateId.startsWith('./') ||
-    templateId.startsWith('../') ||
-    templateId.startsWith('@') ||
-    templateId.startsWith('github:') ||
-    templateId.includes('/')
-  );
-}
-
-function looksLikeExplicitExternalTemplateLocator(templateId: string): boolean {
-  return (
-    looksLikeExplicitNonNpmExternalTemplateLocator(templateId) ||
-    parseNpmTemplateLocator(templateId) !== null
-  );
-}
-
-function getEditDistance(left: string, right: string): number {
-  const previous = Array.from({ length: right.length + 1 }, (_, index) => index);
-  const current = new Array<number>(right.length + 1);
-
-  for (let leftIndex = 0; leftIndex < left.length; leftIndex += 1) {
-    current[0] = leftIndex + 1;
-
-    for (let rightIndex = 0; rightIndex < right.length; rightIndex += 1) {
-      const substitutionCost = left[leftIndex] === right[rightIndex] ? 0 : 1;
-      current[rightIndex + 1] = Math.min(
-        current[rightIndex] + 1,
-        previous[rightIndex + 1] + 1,
-        previous[rightIndex] + substitutionCost,
-      );
-    }
-
-    for (let index = 0; index < current.length; index += 1) {
-      previous[index] = current[index] as number;
-    }
-  }
-
-  return previous[right.length] as number;
-}
-
-function findMistypedBuiltInTemplateSuggestion(templateId: string): string | null {
-  const normalizedTemplateId = templateId.trim().toLowerCase();
-  if (
-    normalizedTemplateId.length === 0 ||
-    looksLikeExplicitNonNpmExternalTemplateLocator(normalizedTemplateId)
-  ) {
-    return null;
-  }
-
-  let bestCandidate: { distance: number; id: string } | null = null;
-
-  for (const candidateId of TEMPLATE_SUGGESTION_IDS) {
-    const distance = getEditDistance(normalizedTemplateId, candidateId);
-    if (
-      bestCandidate === null ||
-      distance < bestCandidate.distance
-    ) {
-      bestCandidate = {
-        distance,
-        id: candidateId,
-      };
-    }
-  }
-
-  return bestCandidate && bestCandidate.distance <= 2
-    ? bestCandidate.id
-    : null;
-}
-
-function getMistypedBuiltInTemplateMessage(templateId: string): string | null {
-  const suggestion = findMistypedBuiltInTemplateSuggestion(templateId);
-  if (!suggestion) {
-    return null;
-  }
-
-  const suggestionDescription =
-    suggestion === WORKSPACE_TEMPLATE_ALIAS
-      ? 'official workspace scaffold'
-      : 'built-in scaffold';
-
-  return `Unknown template "${templateId}". Did you mean "${suggestion}"? Use \`--template ${suggestion}\` for the ${suggestionDescription}, or pass a local path, \`github:owner/repo/path[#ref]\`, or an npm package spec for an external template.`;
-}
-
-function getUnknownTemplateMessage(templateId: string): string {
-  return [
-    `Unknown template "${templateId}". Expected one of: ${USER_FACING_TEMPLATE_IDS.join(', ')}.`,
-    'Run `wp-typia templates list` to inspect available templates.',
-    'Pass an explicit external template locator such as `./path`, `github:owner/repo/path[#ref]`, or `@scope/template` for custom templates.',
-  ].join(' ');
-}
-
 /**
  * Resolve the scaffold template id from flags, defaults, and interactive selection.
  *
@@ -245,33 +126,7 @@ export async function resolveTemplateId({
   selectTemplate,
 }: ResolveTemplateOptions): Promise<string> {
   if (templateId) {
-    const normalizedTemplateId = normalizeTemplateSelection(templateId);
-    if (isRemovedBuiltInTemplateId(templateId)) {
-      throw createCliDiagnosticCodeError(
-        CLI_DIAGNOSTIC_CODES.UNKNOWN_TEMPLATE,
-        getRemovedBuiltInTemplateMessage(templateId),
-      );
-    }
-    if (normalizedTemplateId === OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE) {
-      return normalizedTemplateId;
-    }
-    if (isBuiltInTemplateId(normalizedTemplateId)) {
-      return getTemplateById(normalizedTemplateId).id;
-    }
-    const mistypedBuiltInTemplateMessage = getMistypedBuiltInTemplateMessage(templateId);
-    if (mistypedBuiltInTemplateMessage) {
-      throw createCliDiagnosticCodeError(
-        CLI_DIAGNOSTIC_CODES.UNKNOWN_TEMPLATE,
-        mistypedBuiltInTemplateMessage,
-      );
-    }
-    if (!looksLikeExplicitExternalTemplateLocator(normalizedTemplateId)) {
-      throw createCliDiagnosticCodeError(
-        CLI_DIAGNOSTIC_CODES.UNKNOWN_TEMPLATE,
-        getUnknownTemplateMessage(templateId),
-      );
-    }
-    return normalizedTemplateId;
+    return validateExplicitCreateTemplateId(templateId);
   }
 
   if (yes) {
@@ -281,11 +136,11 @@ export async function resolveTemplateId({
   if (!isInteractive || !selectTemplate) {
     throw createCliDiagnosticCodeError(
       CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
-      `Template is required in non-interactive mode. Use ${TEMPLATE_SELECTION_HINT}.`,
+      `Template is required in non-interactive mode. Use ${CREATE_TEMPLATE_SELECTION_HINT}.`,
     );
   }
 
-  return normalizeTemplateSelection(await selectTemplate());
+  return validateExplicitCreateTemplateId(await selectTemplate());
 }
 
 /**

--- a/packages/wp-typia-project-tools/tests/create-template-validation.test.ts
+++ b/packages/wp-typia-project-tools/tests/create-template-validation.test.ts
@@ -41,7 +41,10 @@ describe("create template boundary validation", () => {
 	test("keeps explicit external template locators for downstream resolution", () => {
 		const externalTemplateIds = [
 			"./templates/custom",
+			String.raw`.\templates\custom`,
 			"../templates/custom",
+			String.raw`..\templates\custom`,
+			String.raw`templates\custom`,
 			"/tmp/wp-typia-template",
 			String.raw`C:\templates\wp-typia-template`,
 			"github:owner/repo/templates/basic#main",

--- a/packages/wp-typia-project-tools/tests/create-template-validation.test.ts
+++ b/packages/wp-typia-project-tools/tests/create-template-validation.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+	CLI_DIAGNOSTIC_CODES,
+	type CliDiagnosticCodeError,
+} from "../src/runtime/cli-diagnostics.js";
+import {
+	CREATE_TEMPLATE_SELECTION_HINT,
+	validateExplicitCreateTemplateId,
+} from "../src/runtime/create-template-validation.js";
+import {
+	OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE,
+	TEMPLATE_IDS,
+} from "../src/runtime/template-registry.js";
+
+function catchTemplateValidationError(templateId: string): CliDiagnosticCodeError {
+	try {
+		validateExplicitCreateTemplateId(templateId);
+	} catch (error) {
+		expect(error).toBeInstanceOf(Error);
+		return error as CliDiagnosticCodeError;
+	}
+
+	throw new Error("Expected template validation to throw.");
+}
+
+describe("create template boundary validation", () => {
+	test("normalizes supported built-in and workspace template ids", () => {
+		for (const templateId of TEMPLATE_IDS) {
+			expect(validateExplicitCreateTemplateId(templateId)).toBe(templateId);
+		}
+
+		expect(validateExplicitCreateTemplateId("workspace")).toBe(
+			OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE,
+		);
+		expect(
+			validateExplicitCreateTemplateId(OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE),
+		).toBe(OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE);
+	});
+
+	test("keeps explicit external template locators for downstream resolution", () => {
+		const externalTemplateIds = [
+			"./templates/custom",
+			"../templates/custom",
+			"/tmp/wp-typia-template",
+			String.raw`C:\templates\wp-typia-template`,
+			"github:owner/repo/templates/basic#main",
+			"@scope/create-wp-typia-template",
+			"@scope/create-wp-typia-template@^1.2.0",
+			"my-create-template",
+			"my-create-template@latest",
+		];
+
+		for (const templateId of externalTemplateIds) {
+			expect(validateExplicitCreateTemplateId(templateId)).toBe(templateId);
+		}
+	});
+
+	test("rejects mistyped built-in template ids with existing suggestions", () => {
+		const error = catchTemplateValidationError("basicc");
+
+		expect(error.code).toBe(CLI_DIAGNOSTIC_CODES.UNKNOWN_TEMPLATE);
+		expect(error.message).toContain('Unknown template "basicc". Did you mean "basic"?');
+		expect(error.message).toContain("`--template basic`");
+	});
+
+	test("rejects non-locator template text with valid alternatives", () => {
+		const error = catchTemplateValidationError("bad template");
+
+		expect(error.code).toBe(CLI_DIAGNOSTIC_CODES.UNKNOWN_TEMPLATE);
+		expect(error.message).toContain(
+			'Unknown template "bad template". Expected one of: basic, interactivity, persistence, compound, query-loop, workspace.',
+		);
+		expect(error.message).toContain(
+			"Pass an explicit external template locator such as `./path`",
+		);
+		expect(CREATE_TEMPLATE_SELECTION_HINT).toContain("github:owner/repo/path[#ref]");
+	});
+});

--- a/packages/wp-typia/src/runtime-bridge.ts
+++ b/packages/wp-typia/src/runtime-bridge.ts
@@ -101,6 +101,8 @@ const loadCliScaffoldRuntime = () =>
   import('@wp-typia/project-tools/cli-scaffold');
 const loadCliTemplatesRuntime = () =>
   import('@wp-typia/project-tools/cli-templates');
+const loadCreateTemplateValidationRuntime = () =>
+  import('@wp-typia/project-tools/create-template-validation');
 const loadWorkspaceProjectRuntime = () =>
   import('@wp-typia/project-tools/workspace-project');
 const loadMigrationsRuntime = () =>
@@ -282,26 +284,36 @@ export async function executeCreateCommand({
   prompt,
   warnLine = console.warn as PrintLine,
 }: CreateExecutionInput): Promise<AlternateBufferCompletionPayload> {
-  const [
-    { createReadlinePrompt },
-    { runScaffoldFlow },
-    { getTemplateSelectOptions },
-  ] = await Promise.all([
-    loadCliPromptRuntime(),
-    loadCliScaffoldRuntime(),
-    loadCliTemplatesRuntime(),
-  ]);
-  const shouldPrompt =
-    interactive ?? (!Boolean(flags.yes) && isInteractiveTerminal());
-  const activePrompt = shouldPrompt
-    ? (prompt ?? createReadlinePrompt())
-    : undefined;
-  const shouldPromptForExternalLayerSelection =
-    Boolean(activePrompt) && activePrompt !== prompt;
-  const effectiveYes =
-    Boolean(flags.yes) || (Boolean(flags['dry-run']) && !Boolean(activePrompt));
+  let activePrompt: ReadlinePrompt | undefined;
 
   try {
+    const requestedTemplateId = readOptionalLooseStringFlag(flags, 'template');
+    const resolvedTemplateId = requestedTemplateId
+      ? (
+          await loadCreateTemplateValidationRuntime()
+        ).validateExplicitCreateTemplateId(requestedTemplateId)
+      : undefined;
+    const [
+      { createReadlinePrompt },
+      { runScaffoldFlow },
+      { getTemplateSelectOptions },
+    ] = await Promise.all([
+      loadCliPromptRuntime(),
+      loadCliScaffoldRuntime(),
+      loadCliTemplatesRuntime(),
+    ]);
+    const shouldPrompt =
+      interactive ?? (!Boolean(flags.yes) && isInteractiveTerminal());
+    activePrompt = shouldPrompt
+      ? (prompt ?? createReadlinePrompt())
+      : undefined;
+    const scaffoldPrompt = activePrompt;
+    const shouldPromptForExternalLayerSelection =
+      Boolean(scaffoldPrompt) && scaffoldPrompt !== prompt;
+    const effectiveYes =
+      Boolean(flags.yes) ||
+      (Boolean(flags['dry-run']) && !Boolean(scaffoldPrompt));
+
     const flow = await runScaffoldFlow({
       alternateRenderTargets: readOptionalLooseStringFlag(
         flags,
@@ -319,7 +331,7 @@ export async function executeCreateCommand({
         flags,
         'inner-blocks-preset',
       ),
-      isInteractive: Boolean(activePrompt),
+      isInteractive: Boolean(scaffoldPrompt),
       namespace: readOptionalLooseStringFlag(flags, 'namespace'),
       noInstall: Boolean(flags['no-install']),
       packageManager: readOptionalLooseStringFlag(flags, 'package-manager'),
@@ -339,77 +351,77 @@ export async function executeCreateCommand({
           printLine(formatCreateProgressLine(payload));
         }
       },
-      promptText: activePrompt
+      promptText: scaffoldPrompt
         ? (message, defaultValue, validate) =>
-            activePrompt.text(message, defaultValue, validate)
+            scaffoldPrompt.text(message, defaultValue, validate)
         : undefined,
       queryPostType: readOptionalLooseStringFlag(flags, 'query-post-type'),
-      selectDataStorage: activePrompt
+      selectDataStorage: scaffoldPrompt
         ? () =>
-            activePrompt.select(
+            scaffoldPrompt.select(
               'Select a data storage mode',
               [...DATA_STORAGE_PROMPT_OPTIONS],
               1,
             )
         : undefined,
       selectExternalLayerId:
-        shouldPromptForExternalLayerSelection && activePrompt
+        shouldPromptForExternalLayerSelection && scaffoldPrompt
           ? (options) =>
-              activePrompt.select(
+              scaffoldPrompt.select(
                 'Select an external layer',
                 toExternalLayerPromptOptions(options),
                 1,
               )
           : undefined,
-      selectPackageManager: activePrompt
+      selectPackageManager: scaffoldPrompt
         ? () =>
-            activePrompt.select(
+            scaffoldPrompt.select(
               'Select a package manager',
               [...PACKAGE_MANAGER_PROMPT_OPTIONS],
               1,
             )
         : undefined,
-      selectPersistencePolicy: activePrompt
+      selectPersistencePolicy: scaffoldPrompt
         ? () =>
-            activePrompt.select(
+            scaffoldPrompt.select(
               'Select a persistence policy',
               [...PERSISTENCE_POLICY_PROMPT_OPTIONS],
               1,
             )
         : undefined,
-      selectTemplate: activePrompt
+      selectTemplate: scaffoldPrompt
         ? () =>
-            activePrompt.select(
+            scaffoldPrompt.select(
               'Select a template',
               getTemplateSelectOptions(),
               1,
             )
         : undefined,
-      selectWithMigrationUi: activePrompt
+      selectWithMigrationUi: scaffoldPrompt
         ? async () =>
-            (await activePrompt.select(
+            (await scaffoldPrompt.select(
               'Enable migration UI support?',
               [...BOOLEAN_PROMPT_OPTIONS],
               2,
             )) === 'yes'
         : undefined,
-      selectWithTestPreset: activePrompt
+      selectWithTestPreset: scaffoldPrompt
         ? async () =>
-            (await activePrompt.select(
+            (await scaffoldPrompt.select(
               'Include the Playwright test preset?',
               [...BOOLEAN_PROMPT_OPTIONS],
               2,
             )) === 'yes'
         : undefined,
-      selectWithWpEnv: activePrompt
+      selectWithWpEnv: scaffoldPrompt
         ? async () =>
-            (await activePrompt.select(
+            (await scaffoldPrompt.select(
               'Include a local wp-env preset?',
               [...BOOLEAN_PROMPT_OPTIONS],
               2,
             )) === 'yes'
         : undefined,
-      templateId: readOptionalLooseStringFlag(flags, 'template'),
+      templateId: resolvedTemplateId,
       textDomain: readOptionalLooseStringFlag(flags, 'text-domain'),
       variant: readOptionalLooseStringFlag(flags, 'variant'),
       withMigrationUi: flags['with-migration-ui'] as boolean | undefined,

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -1164,17 +1164,26 @@ process.exit(0);
 
   test('packs a built dist-bunli runtime for the published CLI entrypoint', () => {
     const rootSegment = path.basename(os.homedir());
-    const packResult = runCapturedCommand(
-      'npm',
-      ['pack', '--json', '--pack-destination', packageRoot],
-      {
-        cwd: packageRoot,
-        env: {
-          ...process.env,
-          WP_TYPIA_SKIP_POSTPACK_RESTORE: '',
-        },
-      },
+    const packDestination = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'wp-typia-pack-'),
     );
+    const packResult = (() => {
+      try {
+        return runCapturedCommand(
+          'npm',
+          ['pack', '--json', '--pack-destination', packDestination],
+          {
+            cwd: packageRoot,
+            env: {
+              ...process.env,
+              WP_TYPIA_SKIP_POSTPACK_RESTORE: '',
+            },
+          },
+        );
+      } finally {
+        fs.rmSync(packDestination, { force: true, recursive: true });
+      }
+    })();
 
     expect(packResult.status).toBe(0);
     const parsed = parseJsonArrayFromOutput<
@@ -1245,9 +1254,6 @@ process.exit(0);
       ),
     ).toBe(true);
 
-    if (tarball?.filename) {
-      fs.rmSync(path.join(packageRoot, tarball.filename), { force: true });
-    }
   }, 30000);
 
   test('rejects sync outside a generated project root with explicit guidance', () => {

--- a/packages/wp-typia/tests/create-command.test.ts
+++ b/packages/wp-typia/tests/create-command.test.ts
@@ -22,7 +22,35 @@ describe("wp-typia create command bridge", () => {
 		fs.rmSync(tempRoot, { force: true, recursive: true });
 	});
 
-test("keeps ambiguous external layers fail-fast when a synthetic prompt is supplied", async () => {
+	test("rejects mistyped template ids before scaffold progress starts", async () => {
+		const progress: string[] = [];
+		const targetDir = path.join(tempRoot, "demo-early-template-validation");
+
+		const error = await executeCreateCommand({
+			cwd: tempRoot,
+			emitOutput: false,
+			flags: {
+				"no-install": true,
+				"package-manager": "npm",
+				template: "basicc",
+				yes: true,
+			},
+			interactive: false,
+			onProgress: ({ detail, title }) => {
+				progress.push(`${title}: ${detail}`);
+			},
+			projectDir: "demo-early-template-validation",
+		}).catch((error) => error);
+
+		expect(error).toBeInstanceOf(Error);
+		expect((error as Error).message).toContain(
+			'Unknown template "basicc". Did you mean "basic"?',
+		);
+		expect(progress).toEqual([]);
+		expect(fs.existsSync(targetDir)).toBe(false);
+	});
+
+	test("keeps ambiguous external layers fail-fast when a synthetic prompt is supplied", async () => {
 		const defaultPrompt = {
 			close() {},
 			select<T extends string>(


### PR DESCRIPTION
## Summary

- add a lightweight `create-template-validation` runtime subpath for create template id checks
- validate explicit `wp-typia create --template` values in the CLI bridge before loading the full scaffold flow
- keep external template locators and npm specs deferred to the existing external resolver
- add regression coverage for typo suggestions, invalid non-locator ids, workspace alias normalization, external bypass, and early bridge failure

## Validation

- `bun run format:check`
- `git diff --check`
- `bun run typecheck`
- `bun run lint:repo`
- `bun run changesets:validate`
- `bun run manifest-policy:validate`
- `bun test packages/wp-typia/tests/cli-package.test.ts`
- `bun test packages/wp-typia-project-tools/tests/create-template-validation.test.ts packages/wp-typia/tests/create-command.test.ts packages/wp-typia-project-tools/tests/cli-entry.test.ts`
- `bun run --filter @wp-typia/project-tools build`
- `bun run --filter wp-typia build`

Fixes #792


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Template IDs are now validated early in the create process, before starting the scaffold flow.
  * Added intelligent suggestions for correcting mistyped template IDs to help users select valid templates.

* **Bug Fixes**
  * Prevents unnecessary scaffold progress when invalid template IDs are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->