### PR TITLE
[codex] refactor(scaffold): use typed boolean variable groups

### DIFF
--- a/.sampo/changesets/793-typed-scaffold-booleans.md
+++ b/.sampo/changesets/793-typed-scaffold-booleans.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Use typed scaffold variable groups for boolean scaffold decisions and assert generated identifier safety at built-in template render boundaries.

--- a/packages/wp-typia-project-tools/src/runtime/built-in-block-artifact-types.ts
+++ b/packages/wp-typia-project-tools/src/runtime/built-in-block-artifact-types.ts
@@ -1,6 +1,7 @@
 import type {
 	ScaffoldTemplateVariables,
 } from "./scaffold.js";
+import { isCompoundPersistenceEnabled } from "./scaffold-template-variable-groups.js";
 
 interface AttributeDescription {
 	lines: string[];
@@ -293,7 +294,7 @@ export function buildCompoundTypesSource(
 	variables: ScaffoldTemplateVariables,
 	attributes: readonly EmittedAttributeDefinition[],
 ): string {
-	const persistenceEnabled = variables.compoundPersistenceEnabled === "true";
+	const persistenceEnabled = isCompoundPersistenceEnabled(variables);
 
 	return emitTypesModule({
 		preambleLines: persistenceEnabled

--- a/packages/wp-typia-project-tools/src/runtime/built-in-block-attribute-specs.ts
+++ b/packages/wp-typia-project-tools/src/runtime/built-in-block-attribute-specs.ts
@@ -1,4 +1,5 @@
 import type { ScaffoldTemplateVariables } from "./scaffold.js";
+import { isCompoundPersistenceEnabled } from "./scaffold-template-variable-groups.js";
 import {
 	DEFAULT_COMPOUND_CHILD_BODY_PLACEHOLDER,
 	buildAttributesFromSpecs,
@@ -385,7 +386,7 @@ export function buildCompoundParentAttributes(
 	variables: ScaffoldTemplateVariables,
 ): EmittedAttributeDefinition[] {
 	return buildAttributesFromSpecs(
-		variables.compoundPersistenceEnabled === "true"
+		isCompoundPersistenceEnabled(variables)
 			? [
 				...COMPOUND_PARENT_BASE_ATTRIBUTE_SPECS,
 				...COMPOUND_PARENT_PERSISTENCE_ATTRIBUTE_SPECS,

--- a/packages/wp-typia-project-tools/src/runtime/built-in-block-code-artifacts.ts
+++ b/packages/wp-typia-project-tools/src/runtime/built-in-block-code-artifacts.ts
@@ -42,6 +42,7 @@ import {
 	SHARED_HOOKS_TEMPLATE,
 } from "./built-in-block-code-templates.js";
 import { getScaffoldTemplateVariableGroups } from "./scaffold-template-variable-groups.js";
+import { assertScaffoldTemplateCodeIdentifiers } from "./scaffold-template-assertions.js";
 import { renderMustacheTemplateString } from "./template-render.js";
 
 /**
@@ -72,6 +73,7 @@ function renderCodeTemplate(
 	template: string,
 	variables: ScaffoldTemplateVariables,
 ): string {
+	assertScaffoldTemplateCodeIdentifiers(variables);
 	const rendered = renderMustacheTemplateString(template, variables);
 	return rendered.endsWith("\n") ? rendered : `${rendered}\n`;
 }

--- a/packages/wp-typia-project-tools/src/runtime/built-in-block-non-ts-family-artifacts.ts
+++ b/packages/wp-typia-project-tools/src/runtime/built-in-block-non-ts-family-artifacts.ts
@@ -5,6 +5,10 @@ import {
 	renderArtifact,
 	toPhpSingleQuotedString,
 } from "./built-in-block-non-ts-render-utils.js";
+import {
+	getScaffoldAlternateRenderTargets,
+	isCompoundPersistenceEnabled,
+} from "./scaffold-template-variable-groups.js";
 
 const BASIC_STYLE_TEMPLATE = `/**
  * {{title}} Block Styles
@@ -855,7 +859,8 @@ export function buildInteractivityArtifacts(
 export function buildPersistenceArtifacts(
 	variables: ScaffoldTemplateVariables,
 ): BuiltInCodeArtifact[] {
-	if (variables.hasAlternateRenderTargets !== "true") {
+	const alternateRenderTargets = getScaffoldAlternateRenderTargets(variables);
+	if (!alternateRenderTargets.enabled) {
 		return [
 			renderArtifact("src/style.scss", PERSISTENCE_STYLE_TEMPLATE, variables),
 			renderArtifact("src/render.php", PERSISTENCE_RENDER_TEMPLATE, variables),
@@ -872,17 +877,17 @@ export function buildPersistenceArtifacts(
 		buildAlternateRenderEntryArtifact("src/render.php", "web", variables),
 	];
 
-	if (variables.hasAlternateEmailRenderTarget === "true") {
+	if (alternateRenderTargets.hasEmail) {
 		artifacts.push(
 			buildAlternateRenderEntryArtifact("src/render-email.php", "email", variables),
 		);
 	}
-	if (variables.hasAlternateMjmlRenderTarget === "true") {
+	if (alternateRenderTargets.hasMjml) {
 		artifacts.push(
 			buildAlternateRenderEntryArtifact("src/render-mjml.php", "mjml", variables),
 		);
 	}
-	if (variables.hasAlternatePlainTextRenderTarget === "true") {
+	if (alternateRenderTargets.hasPlainText) {
 		artifacts.push(
 			buildAlternateRenderEntryArtifact(
 				"src/render-text.php",
@@ -904,6 +909,7 @@ export function buildPersistenceArtifacts(
 export function buildCompoundArtifacts(
 	variables: ScaffoldTemplateVariables,
 ): BuiltInCodeArtifact[] {
+	const alternateRenderTargets = getScaffoldAlternateRenderTargets(variables);
 	const artifacts = [
 		renderArtifact(
 			`src/blocks/${variables.slugKebabCase}/style.scss`,
@@ -912,12 +918,12 @@ export function buildCompoundArtifacts(
 		),
 	];
 
-	if (variables.compoundPersistenceEnabled === "true") {
+	if (isCompoundPersistenceEnabled(variables)) {
 		const renderView = {
 			...variables,
 			titlePhpLiteral: toPhpSingleQuotedString(variables.title),
 		};
-		if (variables.hasAlternateRenderTargets === "true") {
+		if (alternateRenderTargets.enabled) {
 			artifacts.push(
 				renderArtifact(
 					`src/blocks/${variables.slugKebabCase}/render-targets.php`,
@@ -930,7 +936,7 @@ export function buildCompoundArtifacts(
 					variables,
 				),
 			);
-			if (variables.hasAlternateEmailRenderTarget === "true") {
+			if (alternateRenderTargets.hasEmail) {
 				artifacts.push(
 					buildAlternateRenderEntryArtifact(
 						`src/blocks/${variables.slugKebabCase}/render-email.php`,
@@ -939,7 +945,7 @@ export function buildCompoundArtifacts(
 					),
 				);
 			}
-			if (variables.hasAlternateMjmlRenderTarget === "true") {
+			if (alternateRenderTargets.hasMjml) {
 				artifacts.push(
 					buildAlternateRenderEntryArtifact(
 						`src/blocks/${variables.slugKebabCase}/render-mjml.php`,
@@ -948,7 +954,7 @@ export function buildCompoundArtifacts(
 					),
 				);
 			}
-			if (variables.hasAlternatePlainTextRenderTarget === "true") {
+			if (alternateRenderTargets.hasPlainText) {
 				artifacts.push(
 					buildAlternateRenderEntryArtifact(
 						`src/blocks/${variables.slugKebabCase}/render-text.php`,

--- a/packages/wp-typia-project-tools/src/runtime/built-in-block-non-ts-render-utils.ts
+++ b/packages/wp-typia-project-tools/src/runtime/built-in-block-non-ts-render-utils.ts
@@ -1,5 +1,6 @@
 import type { BuiltInCodeArtifact } from "./built-in-block-code-artifacts.js";
 import type { ScaffoldTemplateVariables } from "./scaffold.js";
+import { assertScaffoldTemplateCodeIdentifiers } from "./scaffold-template-assertions.js";
 import { renderMustacheTemplateString } from "./template-render.js";
 
 /**
@@ -15,6 +16,7 @@ export function renderArtifact(
 	template: string,
 	view: Record<string, unknown>,
 ): BuiltInCodeArtifact {
+	assertScaffoldTemplateCodeIdentifiers(view);
 	const source = renderMustacheTemplateString(template, view);
 	return {
 		relativePath,

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-block-config.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-block-config.ts
@@ -5,6 +5,7 @@ import {
 } from "./template-registry.js";
 import type { MigrationBlockConfig } from "./migration-types.js";
 import type { ScaffoldTemplateVariables } from "./scaffold.js";
+import { isCompoundPersistenceEnabled } from "./scaffold-template-variable-groups.js";
 import {
 	type AddBlockTemplateId,
 	quoteTsString,
@@ -127,7 +128,7 @@ export function buildConfigEntries(
 		return [buildPersistenceBlockConfigEntry(variables)];
 	}
 
-	if (variables.compoundPersistenceEnabled === "true") {
+	if (isCompoundPersistenceEnabled(variables)) {
 		return [
 			buildPersistenceBlockConfigEntry(variables),
 			buildCompoundChildConfigEntry(variables),

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-block.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-block.ts
@@ -67,6 +67,7 @@ import {
 	type PackageManagerId,
 } from "./package-managers.js";
 import { parseCompoundInnerBlocksPreset } from "./compound-inner-blocks.js";
+import { isCompoundPersistenceEnabled } from "./scaffold-template-variable-groups.js";
 import {
 	resolveOptionalInteractiveExternalLayerId,
 } from "./external-layer-selection.js";
@@ -196,7 +197,7 @@ async function copyScaffoldedBlockSlice(
 			path.join(tempProjectDir, "src", "blocks", `${variables.slugKebabCase}-item`),
 			path.join(projectDir, "src", "blocks", `${variables.slugKebabCase}-item`),
 		);
-		if (variables.compoundPersistenceEnabled === "true") {
+		if (isCompoundPersistenceEnabled(variables)) {
 			await renderWorkspacePersistenceServerModule(projectDir, variables);
 		}
 		return;
@@ -399,7 +400,7 @@ async function syncWorkspaceAddedBlockArtifacts(
 
 	if (
 		templateId === "persistence" ||
-		(templateId === "compound" && variables.compoundPersistenceEnabled === "true")
+		(templateId === "compound" && isCompoundPersistenceEnabled(variables))
 	) {
 		await syncWorkspacePersistenceArtifacts(projectDir, variables);
 	}
@@ -704,7 +705,7 @@ export async function runAddBlockCommand({
 				buildConfigEntries(resolvedTemplateId, result.variables),
 				resolvedTemplateId === "persistence" ||
 					(resolvedTemplateId === "compound" &&
-						result.variables.compoundPersistenceEnabled === "true"),
+						isCompoundPersistenceEnabled(result.variables)),
 			);
 			await syncWorkspaceAddedBlockArtifacts(
 				workspace.projectDir,

--- a/packages/wp-typia-project-tools/src/runtime/cli-scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-scaffold.ts
@@ -14,6 +14,7 @@ import {
 } from "./scaffold.js";
 import { parseAlternateRenderTargets } from "./alternate-render-targets.js";
 import { parseCompoundInnerBlocksPreset } from "./compound-inner-blocks.js";
+import { isCompoundPersistenceEnabled } from "./scaffold-template-variable-groups.js";
 import {
 	formatInstallCommand,
 	formatRunScript,
@@ -806,8 +807,9 @@ export async function runScaffoldFlow({
 				availableScripts,
 				packageManager: resolvedPackageManager,
 				templateId: resolvedTemplateId,
-				compoundPersistenceEnabled:
-					resolvedResult.result.variables.compoundPersistenceEnabled === "true",
+				compoundPersistenceEnabled: isCompoundPersistenceEnabled(
+					resolvedResult.result.variables,
+				),
 			}),
 			plan: resolvedResult.plan,
 			projectDir,

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-apply-utils.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-apply-utils.ts
@@ -54,6 +54,7 @@ import type {
 	ScaffoldProgressEvent,
 	ScaffoldTemplateVariables,
 } from "./scaffold.js";
+import { isCompoundPersistenceEnabled } from "./scaffold-template-variable-groups.js";
 export { buildGitignore, buildReadme, mergeTextLines } from "./scaffold-documents.js";
 
 export interface InstallDependenciesOptions {
@@ -197,7 +198,7 @@ export async function seedBuiltInPersistenceArtifacts(
 ): Promise<void> {
 	const needsPersistenceArtifacts =
 		templateId === "persistence" ||
-		(templateId === "compound" && variables.compoundPersistenceEnabled === "true");
+		(templateId === "compound" && isCompoundPersistenceEnabled(variables));
 
 	if (!needsPersistenceArtifacts) {
 		return;
@@ -442,7 +443,7 @@ export async function applyBuiltInScaffoldProjectFiles({
 	);
 	await normalizePackageJson(projectDir, packageManager);
 	await applyGeneratedProjectDxPackageJson({
-		compoundPersistenceEnabled: variables.compoundPersistenceEnabled === "true",
+		compoundPersistenceEnabled: isCompoundPersistenceEnabled(variables),
 		packageManager,
 		projectDir,
 		templateId,

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-template-assertions.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-template-assertions.ts
@@ -1,0 +1,50 @@
+const BLOCK_SLUG_PATTERN = /^[a-z][a-z0-9-]*$/u;
+const PHP_IDENTIFIER_PATTERN = /^[a-z_][a-z0-9_]*$/u;
+const PHP_CONSTANT_IDENTIFIER_PATTERN = /^[A-Z_][A-Z0-9_]*$/u;
+const JAVASCRIPT_IDENTIFIER_PATTERN = /^[A-Za-z_$][\w$]*$/u;
+const QUERY_POST_TYPE_PATTERN = /^[a-z][a-z0-9_-]{0,19}$/u;
+
+function assertOptionalStringPattern(
+	view: Record<string, unknown>,
+	key: string,
+	pattern: RegExp,
+	description: string,
+): void {
+	const value = view[key];
+	if (typeof value === "undefined") {
+		return;
+	}
+
+	if (typeof value !== "string" || !pattern.test(value)) {
+		throw new Error(
+			`Unsafe scaffold template variable "${key}" for ${description}: ${JSON.stringify(value)}.`,
+		);
+	}
+}
+
+/**
+ * Revalidates target-language identifiers at the built-in template builder
+ * boundary so generated PHP and TypeScript never rely only on upstream CLI
+ * normalization.
+ */
+export function assertScaffoldTemplateCodeIdentifiers(
+	view: Record<string, unknown>,
+): void {
+	assertOptionalStringPattern(view, "namespace", BLOCK_SLUG_PATTERN, "block namespace");
+	assertOptionalStringPattern(view, "slug", BLOCK_SLUG_PATTERN, "block slug");
+	assertOptionalStringPattern(view, "slugKebabCase", BLOCK_SLUG_PATTERN, "block slug");
+	assertOptionalStringPattern(view, "textDomain", BLOCK_SLUG_PATTERN, "text domain");
+	assertOptionalStringPattern(view, "textdomain", BLOCK_SLUG_PATTERN, "text domain");
+	assertOptionalStringPattern(view, "queryPostType", QUERY_POST_TYPE_PATTERN, "query post type");
+	assertOptionalStringPattern(view, "phpPrefix", PHP_IDENTIFIER_PATTERN, "PHP identifier");
+	assertOptionalStringPattern(view, "slugSnakeCase", PHP_IDENTIFIER_PATTERN, "PHP identifier");
+	assertOptionalStringPattern(
+		view,
+		"phpPrefixUpper",
+		PHP_CONSTANT_IDENTIFIER_PATTERN,
+		"PHP constant identifier",
+	);
+	assertOptionalStringPattern(view, "pascalCase", JAVASCRIPT_IDENTIFIER_PATTERN, "JavaScript identifier");
+	assertOptionalStringPattern(view, "slugCamelCase", JAVASCRIPT_IDENTIFIER_PATTERN, "JavaScript identifier");
+	assertOptionalStringPattern(view, "titleCase", JAVASCRIPT_IDENTIFIER_PATTERN, "JavaScript identifier");
+}

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-template-assertions.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-template-assertions.ts
@@ -2,7 +2,7 @@ const BLOCK_SLUG_PATTERN = /^[a-z][a-z0-9-]*$/u;
 const PHP_IDENTIFIER_PATTERN = /^[a-z_][a-z0-9_]*$/u;
 const PHP_CONSTANT_IDENTIFIER_PATTERN = /^[A-Z_][A-Z0-9_]*$/u;
 const JAVASCRIPT_IDENTIFIER_PATTERN = /^[A-Za-z_$][\w$]*$/u;
-const QUERY_POST_TYPE_PATTERN = /^[a-z][a-z0-9_-]{0,19}$/u;
+const QUERY_POST_TYPE_PATTERN = /^[a-z0-9_-]{1,20}$/u;
 
 function assertOptionalStringPattern(
 	view: Record<string, unknown>,

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-template-variable-groups.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-template-variable-groups.ts
@@ -230,3 +230,16 @@ export function getScaffoldTemplateVariableGroups(
 ): ScaffoldTemplateVariableGroups {
 	return variables[SCAFFOLD_TEMPLATE_VARIABLE_GROUPS];
 }
+
+export function isCompoundPersistenceEnabled(
+	variables: ScaffoldTemplateVariableGroupsCarrier,
+): boolean {
+	const compound = getScaffoldTemplateVariableGroups(variables).compound;
+	return compound.enabled && compound.persistenceEnabled;
+}
+
+export function getScaffoldAlternateRenderTargets(
+	variables: ScaffoldTemplateVariableGroupsCarrier,
+): ScaffoldAlternateRenderTargetVariableGroup {
+	return getScaffoldTemplateVariableGroups(variables).alternateRenderTargets;
+}

--- a/packages/wp-typia-project-tools/tests/built-in-block-artifacts.test.ts
+++ b/packages/wp-typia-project-tools/tests/built-in-block-artifacts.test.ts
@@ -981,6 +981,25 @@ describe('built-in block artifacts', () => {
     ).toThrow('Unsafe scaffold template variable "phpPrefix" for PHP identifier');
   });
 
+  test('built-in query-loop builders accept CLI-valid post type identifiers', () => {
+    const answers = buildAnswers('query-loop');
+    answers.queryPostType = '3d-model';
+    const spec = createBuiltInBlockSpec({
+      answers,
+      templateId: 'query-loop',
+    });
+    const variables = buildTemplateVariablesFromBlockSpec(spec);
+    const codeArtifacts = buildBuiltInCodeArtifacts({
+      templateId: 'query-loop',
+      variables,
+    });
+
+    expect(
+      codeArtifacts.find((artifact) => artifact.relativePath === 'src/index.ts')
+        ?.source,
+    ).toContain('postType: "3d-model"');
+  });
+
   test('compound persistence render emitter quotes heading fallbacks safely', () => {
     const answers = buildAnswers('compound');
     answers.title = `John's "Compound"`;

--- a/packages/wp-typia-project-tools/tests/built-in-block-artifacts.test.ts
+++ b/packages/wp-typia-project-tools/tests/built-in-block-artifacts.test.ts
@@ -966,6 +966,21 @@ describe('built-in block artifacts', () => {
     },
   );
 
+  test('built-in code artifact builders assert target-language identifiers locally', () => {
+    const { variables } = buildArtifacts('basic');
+    const unsafeVariables = {
+      ...variables,
+      phpPrefix: '123-bad-prefix',
+    } as typeof variables;
+
+    expect(() =>
+      buildBuiltInCodeArtifacts({
+        templateId: 'basic',
+        variables: unsafeVariables,
+      }),
+    ).toThrow('Unsafe scaffold template variable "phpPrefix" for PHP identifier');
+  });
+
   test('compound persistence render emitter quotes heading fallbacks safely', () => {
     const answers = buildAnswers('compound');
     answers.title = `John's "Compound"`;

--- a/packages/wp-typia-project-tools/tests/scaffold-template-variable-groups.test.ts
+++ b/packages/wp-typia-project-tools/tests/scaffold-template-variable-groups.test.ts
@@ -5,6 +5,10 @@ import {
 	getTemplateVariables,
 } from "../src/runtime/index.js";
 import {
+	getScaffoldAlternateRenderTargets,
+	isCompoundPersistenceEnabled,
+} from "../src/runtime/scaffold-template-variable-groups.js";
+import {
 	buildTemplateVariablesFromBlockSpec,
 	createBuiltInBlockSpec,
 } from "../src/runtime/block-generator-service-spec.js";
@@ -63,12 +67,18 @@ describe("scaffold template variable groups", () => {
 			throw new Error("Expected compound group to be enabled");
 		}
 		expect(groups.compound.persistenceEnabled).toBe(true);
+		expect(isCompoundPersistenceEnabled(variables)).toBe(true);
 		expect(groups.compound.innerBlocks.preset).toBe("horizontal");
-			expect(groups.alternateRenderTargets.enabled).toBe(true);
-			expect(groups.alternateRenderTargets.targets).toEqual(["email", "mjml"]);
-			expect(groups.alternateRenderTargets.hasEmail).toBe(true);
-			expect(groups.alternateRenderTargets.hasMjml).toBe(true);
-			expect(groups.alternateRenderTargets.hasPlainText).toBe(false);
+		expect(variables.compoundPersistenceEnabled).toBe("true");
+		expect(typeof groups.compound.persistenceEnabled).toBe("boolean");
+		expect(groups.alternateRenderTargets.enabled).toBe(true);
+		expect(groups.alternateRenderTargets.targets).toEqual(["email", "mjml"]);
+		expect(groups.alternateRenderTargets.hasEmail).toBe(true);
+		expect(groups.alternateRenderTargets.hasMjml).toBe(true);
+		expect(groups.alternateRenderTargets.hasPlainText).toBe(false);
+		expect(getScaffoldAlternateRenderTargets(variables).hasEmail).toBe(true);
+		expect(variables.hasAlternateEmailRenderTarget).toBe("true");
+		expect(typeof groups.alternateRenderTargets.hasEmail).toBe("boolean");
 		expect(groups.persistence.enabled).toBe(true);
 		if (!groups.persistence.enabled) {
 			throw new Error("Expected persistence group to be enabled");


### PR DESCRIPTION
## Summary

- route scaffold boolean decisions through typed variable-group helpers instead of string comparisons against `"true"`
- keep flat string variables available for the final template rendering boundary so generated output stays stable
- add local built-in template assertions for PHP identifiers, slugs, query post types, and JavaScript identifiers before rendering code artifacts
- add regression tests for typed boolean groups and local identifier assertions

## Validation

- `bun run format:check`
- `git diff --check`
- `bun run typecheck`
- `bun test packages/wp-typia-project-tools/tests/scaffold-template-variable-groups.test.ts packages/wp-typia-project-tools/tests/built-in-block-artifacts.test.ts packages/wp-typia-project-tools/tests/cli-entry.test.ts`
- `bun run lint:repo`
- `bun run changesets:validate`
- `bun run manifest-policy:validate`
- `bun run --filter @wp-typia/project-tools build`
- `bun run --filter @wp-typia/project-tools test:scaffold-core`

Fixes #793


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added runtime validation to ensure generated identifiers conform to safety requirements at template rendering boundaries.

* **Refactor**
  * Centralized scaffold persistence decision logic through dedicated helper functions across the project tools.
  * Improved flexibility for alternate render target handling using data-driven configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->