### PR TITLE
[codex] hardening(cache): use crypto temp cache suffixes

### DIFF
--- a/.sampo/changesets/794-cache-temp-randomness.md
+++ b/.sampo/changesets/794-cache-temp-randomness.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Use crypto-backed randomness for external template cache staging directory names.

--- a/packages/wp-typia-project-tools/src/runtime/template-source-cache.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-cache.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto'
+import { createHash, randomUUID } from 'node:crypto'
 import type { Dirent } from 'node:fs'
 import { promises as fsp } from 'node:fs'
 import path from 'node:path'
@@ -69,6 +69,12 @@ const SAFE_CACHE_NAMESPACE_SEGMENT = /^[A-Za-z0-9_.-]+$/u
  * Cache entries are deterministic SHA-256 digest directory names.
  */
 const SAFE_CACHE_ENTRY_SEGMENT = /^[a-f0-9]{64}$/u
+
+function createTemporaryCacheEntryDirName(cacheKey: string): string {
+  // Crypto randomness keeps concurrent cache populators from colliding on the
+  // staging directory before the final atomic rename publishes the cache entry.
+  return `.tmp-${cacheKey}-${process.pid}-${Date.now()}-${randomUUID()}`
+}
 
 /**
  * Serializable metadata recorded in the cache marker for diagnostics.
@@ -878,9 +884,7 @@ export async function resolveExternalTemplateSourceCache(
 
   const temporaryEntryDir = path.join(
     namespaceDir,
-    `.tmp-${cacheKey}-${process.pid}-${Date.now()}-${Math.random()
-      .toString(16)
-      .slice(2)}`,
+    createTemporaryCacheEntryDirName(cacheKey),
   )
   const temporarySourceDir = path.join(temporaryEntryDir, 'source')
   let populateFailed = false

--- a/packages/wp-typia-project-tools/tests/template-source-cache-boundaries.test.ts
+++ b/packages/wp-typia-project-tools/tests/template-source-cache-boundaries.test.ts
@@ -43,6 +43,6 @@ test('template source cache uses crypto randomness for temporary cache entries',
 
   expect(cacheSource).toContain("import { createHash, randomUUID } from 'node:crypto'")
   expect(cacheSource).toContain('createTemporaryCacheEntryDirName')
-  expect(cacheSource).toContain('Crypto randomness keeps concurrent cache populators')
+  expect(cacheSource).toContain('randomUUID()')
   expect(cacheSource).not.toContain('Math.random()')
 })

--- a/packages/wp-typia-project-tools/tests/template-source-cache-boundaries.test.ts
+++ b/packages/wp-typia-project-tools/tests/template-source-cache-boundaries.test.ts
@@ -34,3 +34,15 @@ test('template source cache delegates environment policy to a focused module', (
     /export\s+function\s+resolveExternalTemplateCacheTtlMs\s*\(/,
   )
 })
+
+test('template source cache uses crypto randomness for temporary cache entries', () => {
+  const cacheSource = fs.readFileSync(
+    path.join(runtimeRoot, 'template-source-cache.ts'),
+    'utf8',
+  )
+
+  expect(cacheSource).toContain("import { createHash, randomUUID } from 'node:crypto'")
+  expect(cacheSource).toContain('createTemporaryCacheEntryDirName')
+  expect(cacheSource).toContain('Crypto randomness keeps concurrent cache populators')
+  expect(cacheSource).not.toContain('Math.random()')
+})


### PR DESCRIPTION
## Summary

- replace the external template cache temporary directory suffix with `randomUUID()`-backed crypto randomness
- keep the existing atomic rename publish path and temporary entry cleanup behavior intact
- add a boundary regression test and Sampo changeset for the cache hardening change

## Validation

- `bun run format:check`
- `bun test packages/wp-typia-project-tools/tests/template-source-cache-boundaries.test.ts packages/wp-typia-project-tools/tests/template-source.test.ts`
- `bun run typecheck`
- `bun run lint:repo`
- `bun run changesets:validate`
- `bun run manifest-policy:validate`
- `bun run --filter @wp-typia/project-tools build`
- `bun run --filter @wp-typia/project-tools test:scaffold-core`
- `git diff --check`

Fixes #794


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved security of temporary cache staging directories by adopting cryptographically-secure randomization for deterministic directory naming.

* **Tests**
  * Added comprehensive test coverage to validate secure randomness implementation in cache directory naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->