### PR TITLE
[codex] enhancement(string-case): split selected acronym slug suffixes

### DIFF
--- a/.sampo/changesets/795-string-case-acronym-boundaries.md
+++ b/.sampo/changesets/795-string-case-acronym-boundaries.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Improve WordPress acronym slug normalization for selected lowercase slug suffixes.

--- a/packages/wp-typia-project-tools/src/runtime/string-case.ts
+++ b/packages/wp-typia-project-tools/src/runtime/string-case.ts
@@ -6,7 +6,9 @@ const COMMON_ACRONYM_PREFIXES = [
   'JSON',
   'REST',
   'UUID',
+  'AJAX',
   'API',
+  'CPT',
   'CSS',
   'CTA',
   'DOM',
@@ -21,12 +23,22 @@ const COMMON_ACRONYM_PREFIXES = [
   'WP',
 ] as const;
 
+// Keep lowercase suffix splitting narrow so naturalized words such as
+// `RESTful` remain stable while WordPress slug terms like `URLslug` read well.
+const COMMON_ACRONYM_LOWERCASE_SUFFIXES = ['slug'] as const;
+
 function capitalizeSegment(segment: string): string {
   return segment.charAt(0).toUpperCase() + segment.slice(1);
 }
 
 function findCommonAcronymPrefix(segment: string): string | undefined {
   return COMMON_ACRONYM_PREFIXES.find((prefix) => segment.startsWith(prefix));
+}
+
+function isCommonAcronymLowercaseSuffix(suffix: string): boolean {
+  return COMMON_ACRONYM_LOWERCASE_SUFFIXES.includes(
+    suffix as (typeof COMMON_ACRONYM_LOWERCASE_SUFFIXES)[number],
+  );
 }
 
 function splitKnownAcronymSegment(segment: string): string {
@@ -40,6 +52,9 @@ function splitKnownAcronymSegment(segment: string): string {
     }
     const suffix = remaining.slice(prefix.length);
     if (/^[A-Z][a-z]/.test(suffix)) {
+      return [...prefixes, prefix, suffix].join('-');
+    }
+    if (/^[a-z]+$/.test(suffix) && isCommonAcronymLowercaseSuffix(suffix)) {
       return [...prefixes, prefix, suffix].join('-');
     }
 
@@ -61,10 +76,8 @@ function splitAcronymBoundary(value: string): string {
 /**
  * Normalize arbitrary text into a kebab-case identifier.
  * Common acronym runs stay grouped, with a boundary before the next
- * capitalized word.
- * Ambiguous acronym+lowercase inputs like `URLslug` intentionally stay as one
- * word because there is no PascalCase boundary marker before the lowercase
- * suffix.
+ * capitalized word or before a narrow allow-list of lowercase WordPress slug
+ * terms. Naturalized words such as `RESTful` intentionally stay as one word.
  *
  * @param input Raw text that may contain spaces, punctuation, or camelCase.
  * @returns A lowercase kebab-case string with collapsed separators.

--- a/packages/wp-typia-project-tools/tests/string-case.test.ts
+++ b/packages/wp-typia-project-tools/tests/string-case.test.ts
@@ -18,6 +18,8 @@ test("toKebabCase keeps acronym runs together", () => {
 	expect(toKebabCase("HeroCTABlock")).toBe("hero-cta-block");
 	expect(toKebabCase("JSONAPIResponse")).toBe("json-api-response");
 	expect(toKebabCase("XMLHTTPParser")).toBe("xml-http-parser");
+	expect(toKebabCase("AJAXHandler")).toBe("ajax-handler");
+	expect(toKebabCase("CPTArchive")).toBe("cpt-archive");
 
 	const repeatedIds = `${"ID".repeat(256)}Ab`;
 	expect(toKebabCase(repeatedIds)).toBe(
@@ -25,8 +27,15 @@ test("toKebabCase keeps acronym runs together", () => {
 	);
 });
 
-test("toKebabCase avoids inventing boundaries in acronym-lowercase words", () => {
-	expect(toKebabCase("URLslug")).toBe("urlslug");
+test("toKebabCase splits selected acronym-lowercase slug terms", () => {
+	expect(toKebabCase("URLslug")).toBe("url-slug");
+	expect(toKebabCase("AJAXslug")).toBe("ajax-slug");
+	expect(toKebabCase("CPTslug")).toBe("cpt-slug");
+	expect(toKebabCase("AJAXURLslug")).toBe("ajax-url-slug");
+});
+
+test("toKebabCase keeps naturalized acronym-lowercase words stable", () => {
+	expect(toKebabCase("RESTful")).toBe("restful");
 	expect(toKebabCase("HTTPserver")).toBe("httpserver");
 	expect(toKebabCase("XMLparser")).toBe("xmlparser");
 	expect(toKebabCase("GUIDe")).toBe("guide");


### PR DESCRIPTION
## Summary

- split selected known-acronym + lowercase `slug` inputs such as `URLslug`, `AJAXslug`, and `CPTslug`
- add WordPress-specific `AJAX` and `CPT` acronym handling for capitalized boundaries
- document and test that naturalized forms such as `RESTful` stay collapsed to avoid broad slug drift

## Validation

- `bun test packages/wp-typia-project-tools/tests/string-case.test.ts`
- `bun run format:check`
- `bun run typecheck`
- `bun run lint:repo`
- `bun run changesets:validate`
- `bun run manifest-policy:validate`
- `bun run --filter @wp-typia/project-tools build`
- `bun run --filter @wp-typia/project-tools test:scaffold-core`
- `git diff --check`

Fixes #795


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced WordPress acronym slug normalization to better handle lowercase slug suffixes and improve acronym boundary detection in compound terms.

* **Tests**
  * Added comprehensive test coverage validating improved acronym and slug boundary behavior across various WordPress-specific scenarios and combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->