### PR TITLE
[codex] refactor(package-versions): read manifests through file handles

### DIFF
--- a/.sampo/changesets/796-package-manifest-fd-read.md
+++ b/.sampo/changesets/796-package-manifest-fd-read.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Read package manifest cache metadata and contents through one file descriptor.

--- a/packages/wp-typia-project-tools/src/runtime/package-versions.ts
+++ b/packages/wp-typia-project-tools/src/runtime/package-versions.ts
@@ -101,12 +101,28 @@ function createContentFingerprint(source: string): string {
   return (hash >>> 0).toString(16);
 }
 
+function readPackageManifestFile(packageJsonPath: string): {
+  source: string;
+  stats: fs.Stats;
+} {
+  const fileDescriptor = fs.openSync(packageJsonPath, 'r');
+  try {
+    // Keep cache metadata and manifest contents tied to one opened file, so a
+    // concurrent path replacement cannot mix stats from one manifest with
+    // contents from another. The content fingerprint remains the final guard.
+    const stats = fs.fstatSync(fileDescriptor);
+    const source = fs.readFileSync(fileDescriptor, 'utf8');
+    return { source, stats };
+  } finally {
+    fs.closeSync(fileDescriptor);
+  }
+}
+
 function resolvePackageManifestLocation(
   packageJsonPath: string,
 ): PackageManifestLocation {
   try {
-    const stats = fs.statSync(packageJsonPath);
-    const source = fs.readFileSync(packageJsonPath, 'utf8');
+    const { source, stats } = readPackageManifestFile(packageJsonPath);
     return {
       cacheKey: `file:${packageJsonPath}:${stats.ino}:${stats.mtimeMs}:${stats.ctimeMs}:${stats.size}:${createContentFingerprint(source)}`,
       packageJsonPath,

--- a/packages/wp-typia-project-tools/tests/package-versions.test.ts
+++ b/packages/wp-typia-project-tools/tests/package-versions.test.ts
@@ -127,6 +127,26 @@ describe('package version cache invalidation', () => {
     expect(result.stderr).toBe('');
   });
 
+  test('reads package manifest metadata and contents through one file descriptor', () => {
+    const packageVersionsSource = fs.readFileSync(
+      path.join(import.meta.dir, '..', 'src', 'runtime', 'package-versions.ts'),
+      'utf8',
+    );
+
+    expect(packageVersionsSource).toContain(
+      "const fileDescriptor = fs.openSync(packageJsonPath, 'r')",
+    );
+    expect(packageVersionsSource).toContain('fs.fstatSync(fileDescriptor)');
+    expect(packageVersionsSource).toContain(
+      "fs.readFileSync(fileDescriptor, 'utf8')",
+    );
+    expect(packageVersionsSource).toContain('fs.closeSync(fileDescriptor)');
+    expect(packageVersionsSource).not.toContain('fs.statSync(packageJsonPath)');
+    expect(packageVersionsSource).not.toContain(
+      "fs.readFileSync(packageJsonPath, 'utf8')",
+    );
+  });
+
   test('centralizes managed workspace dependency fallback ranges', async () => {
     const packageVersionsModuleUrl = pathToFileURL(
       path.join(import.meta.dir, '..', 'src', 'runtime', 'package-versions.ts'),


### PR DESCRIPTION
## Summary

- read package manifest stats and source through one opened file descriptor
- preserve the existing manifest content fingerprint in package version cache keys
- add a package-versions regression test covering the file-descriptor read path

## Validation

- `bun test packages/wp-typia-project-tools/tests/package-versions.test.ts`
- `bun run format:check`
- `bun run typecheck`
- `bun run lint:repo`
- `bun run changesets:validate`
- `bun run manifest-policy:validate`
- `bun run --filter @wp-typia/project-tools build`
- `bun run --filter @wp-typia/project-tools test:scaffold-core`
- `git diff --check`

Fixes #796
