### PR TITLE
[codex] dx(cli): share printBlock helper signature

### DIFF
--- a/.sampo/changesets/810-align-print-block-signature.md
+++ b/.sampo/changesets/810-align-print-block-signature.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Share the CLI printBlock helper between runtime bridge and Node fallback help output.

--- a/packages/wp-typia/src/node-fallback/help.ts
+++ b/packages/wp-typia/src/node-fallback/help.ts
@@ -18,6 +18,7 @@ import {
   WP_TYPIA_POSITIONAL_ALIAS_USAGE,
 } from '../command-contract';
 import type { PrintLine } from '../print-line';
+import { printBlock } from '../print-block';
 import type { NodeFallbackExecutableCommandName } from './types';
 
 export const STANDALONE_GUIDANCE_LINE =
@@ -35,12 +36,6 @@ export type NodeFallbackCommandHelpConfig = {
   heading: string;
   optionMetadata: CommandOptionMetadataMap;
 };
-
-export function printBlock(printLine: PrintLine, lines: string[]) {
-  for (const line of lines) {
-    printLine(line);
-  }
-}
 
 export function renderGeneralHelp(printLine: PrintLine) {
   printBlock(printLine, [

--- a/packages/wp-typia/src/print-block.ts
+++ b/packages/wp-typia/src/print-block.ts
@@ -1,0 +1,14 @@
+import type { PrintLine } from './print-line';
+
+/**
+ * Prints a block of text lines using a shared line printer.
+ *
+ * @param printLine Line printer to use.
+ * @param lines Lines to print in order.
+ * @returns Nothing.
+ */
+export function printBlock(printLine: PrintLine, lines: string[]): void {
+  for (const line of lines) {
+    printLine(line);
+  }
+}

--- a/packages/wp-typia/src/runtime-bridge-output.ts
+++ b/packages/wp-typia/src/runtime-bridge-output.ts
@@ -643,22 +643,10 @@ export function buildSyncDryRunPayload(
 }
 
 /**
- * Prints a block of text lines using a shared line printer.
- *
- * @param lines Lines to print in order.
- * @param printLine Line printer to use.
- * @returns Nothing.
- */
-export function printBlock(lines: string[], printLine: PrintLine): void {
-  for (const line of lines) {
-    printLine(line);
-  }
-}
-
-/**
  * Converts external layer options into prompt-compatible select items.
  *
  * @param options External layer options returned by the block generator.
  * @returns Prompt select options with labels and hints.
  */
+export { printBlock } from './print-block';
 export { toExternalLayerPromptOptions } from './external-layer-prompt-options';

--- a/packages/wp-typia/src/runtime-bridge-output.ts
+++ b/packages/wp-typia/src/runtime-bridge-output.ts
@@ -642,11 +642,11 @@ export function buildSyncDryRunPayload(
   };
 }
 
+export { printBlock } from './print-block';
 /**
  * Converts external layer options into prompt-compatible select items.
  *
  * @param options External layer options returned by the block generator.
  * @returns Prompt select options with labels and hints.
  */
-export { printBlock } from './print-block';
 export { toExternalLayerPromptOptions } from './external-layer-prompt-options';

--- a/packages/wp-typia/src/runtime-bridge.ts
+++ b/packages/wp-typia/src/runtime-bridge.ts
@@ -547,8 +547,8 @@ export async function executeTemplatesCommand(
   if (subcommand === 'list') {
     for (const template of listTemplates()) {
       printBlock(
-        [formatTemplateSummary(template), formatTemplateFeatures(template)],
         printLine,
+        [formatTemplateSummary(template), formatTemplateFeatures(template)],
       );
     }
     return;
@@ -568,7 +568,7 @@ export async function executeTemplatesCommand(
         `Unknown template "${flags.id}".`,
       );
     }
-    printBlock([formatTemplateDetails(template)], printLine);
+    printBlock(printLine, [formatTemplateDetails(template)]);
     return;
   }
 

--- a/packages/wp-typia/tests/node-cli-core.test.ts
+++ b/packages/wp-typia/tests/node-cli-core.test.ts
@@ -172,6 +172,10 @@ describe('Node fallback CLI core routing', () => {
       path.join(packageRoot, 'src', 'node-fallback', 'help.ts'),
       'utf8',
     );
+    const printBlockSource = fs.readFileSync(
+      path.join(packageRoot, 'src', 'print-block.ts'),
+      'utf8',
+    );
 
     expect(nodeCliSource).toContain(
       "from './node-fallback/dispatchers/add'",
@@ -187,7 +191,14 @@ describe('Node fallback CLI core routing', () => {
     expect(createDispatcherSource).toContain(
       'export async function dispatchNodeFallbackCreate',
     );
-    expect(helpSource).toContain('export function printBlock');
+    expect(helpSource).toContain("import { printBlock } from '../print-block'");
+    expect(helpSource).not.toContain('export function printBlock');
+    expect(printBlockSource).toContain(
+      'export function printBlock(printLine: PrintLine, lines: string[])',
+    );
+    expect(printBlockSource).not.toContain(
+      'export function printBlock(lines: string[], printLine: PrintLine)',
+    );
   });
 
   test('prints human and structured version output from the fallback runtime', async () => {


### PR DESCRIPTION
## Summary

- move `printBlock` into a tiny shared CLI output helper with the `printLine, lines` signature
- update runtime bridge template output and Node fallback help rendering to use that shared helper
- add a focused source-boundary assertion so the duplicate fallback helper does not return

## Validation

- `bun test packages/wp-typia/tests/node-cli-core.test.ts packages/wp-typia/tests/completion-output.test.ts`
- `bun run format:check`
- `bun run typecheck`
- `bun run lint:repo`
- `bun run changesets:validate`
- `bun run manifest-policy:validate`
- `bun run --filter wp-typia build`
- `bun run --filter wp-typia test`
- `git diff --check`

Fixes #810


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated a shared utility function into a dedicated module to reduce code duplication and improve maintainability.
  * Standardized function parameter ordering across related components for consistency.
  * Updated tests to verify the new code structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->