### PR TITLE
dx(cli): centralize missing argument messages

### DIFF
--- a/.sampo/changesets/811-centralize-cli-missing-argument-messages.md
+++ b/.sampo/changesets/811-centralize-cli-missing-argument-messages.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Centralize shared CLI missing-argument messages across Bunli and Node fallback paths.

--- a/packages/wp-typia/src/cli-error-messages.ts
+++ b/packages/wp-typia/src/cli-error-messages.ts
@@ -1,0 +1,18 @@
+import { formatAddKindUsagePlaceholder } from './add-kind-registry';
+
+const MISSING_CREATE_PROJECT_DIR_DETAIL_LINES = [
+  '`wp-typia create` requires <project-dir>.',
+  '`--dry-run` still needs a logical project directory name because wp-typia derives slugs, package names, and planned file paths from it.',
+];
+
+export function formatMissingAddKindDetailLine(): string {
+  return `\`wp-typia add\` requires <kind>. Usage: wp-typia add ${formatAddKindUsagePlaceholder()} ...`;
+}
+
+export function buildMissingAddKindDetailLines(): string[] {
+  return [formatMissingAddKindDetailLine()];
+}
+
+export function buildMissingCreateProjectDirDetailLines(): string[] {
+  return [...MISSING_CREATE_PROJECT_DIR_DETAIL_LINES];
+}

--- a/packages/wp-typia/src/commands/create.ts
+++ b/packages/wp-typia/src/commands/create.ts
@@ -12,6 +12,7 @@ import {
 	emitCliDiagnosticFailure,
 	prefersStructuredCliOutput,
 } from "../cli-diagnostic-output";
+import { buildMissingCreateProjectDirDetailLines } from "../cli-error-messages";
 import { getCreateDefaults } from "../config";
 import { resolveBundledModuleHref } from "../render-loader";
 import { executeCreateCommand } from "../runtime-bridge";
@@ -47,10 +48,7 @@ export const createCommand = defineCommand({
 			emitCliDiagnosticFailure(args, {
 				code: CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
 				command: "create",
-				detailLines: [
-					"`wp-typia create` requires <project-dir>.",
-					"`--dry-run` still needs a logical project directory name because wp-typia derives slugs, package names, and planned file paths from it.",
-				],
+				detailLines: buildMissingCreateProjectDirDetailLines(),
 			});
 			return;
 		}

--- a/packages/wp-typia/src/node-fallback/dispatchers/add.ts
+++ b/packages/wp-typia/src/node-fallback/dispatchers/add.ts
@@ -2,7 +2,7 @@ import {
   CLI_DIAGNOSTIC_CODES,
   createCliCommandError,
 } from '@wp-typia/project-tools/cli-diagnostics';
-import { formatAddKindUsagePlaceholder } from '../../add-kind-registry';
+import { buildMissingAddKindDetailLines } from '../../cli-error-messages';
 import { executeAddCommand } from '../../runtime-bridge';
 import {
   buildStructuredCompletionSuccessPayload,
@@ -25,9 +25,7 @@ export async function dispatchNodeFallbackAdd({
     throw createCliCommandError({
       code: CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
       command: 'add',
-      detailLines: [
-        `\`wp-typia add\` requires <kind>. Usage: wp-typia add ${formatAddKindUsagePlaceholder()} ...`,
-      ],
+      detailLines: buildMissingAddKindDetailLines(),
     });
   }
 

--- a/packages/wp-typia/src/node-fallback/dispatchers/create.ts
+++ b/packages/wp-typia/src/node-fallback/dispatchers/create.ts
@@ -7,6 +7,7 @@ import {
   buildStructuredCompletionSuccessPayload,
   extractCompletionProjectDir,
 } from '../../runtime-bridge-output';
+import { buildMissingCreateProjectDirDetailLines } from '../../cli-error-messages';
 import type { NodeFallbackDispatchContext } from '../types';
 
 export async function dispatchNodeFallbackCreate({
@@ -20,10 +21,7 @@ export async function dispatchNodeFallbackCreate({
     throw createCliCommandError({
       code: CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
       command: 'create',
-      detailLines: [
-        '`wp-typia create` requires <project-dir>.',
-        '`--dry-run` still needs a logical project directory name because wp-typia derives slugs, package names, and planned file paths from it.',
-      ],
+      detailLines: buildMissingCreateProjectDirDetailLines(),
     });
   }
 

--- a/packages/wp-typia/src/runtime-bridge.ts
+++ b/packages/wp-typia/src/runtime-bridge.ts
@@ -9,11 +9,11 @@ import {
   type AddKindExecutionContext,
   type AddKindId,
   formatAddKindList,
-  formatAddKindUsagePlaceholder,
   getAddKindExecutionPlan,
   isAddKindId,
   supportsAddKindDryRun,
 } from './add-kind-registry';
+import { formatMissingAddKindDetailLine } from './cli-error-messages';
 import { simulateWorkspaceAddDryRun } from './runtime-bridge-add-dry-run';
 import type { AlternateBufferCompletionPayload } from './ui/alternate-buffer-lifecycle';
 import {
@@ -476,7 +476,7 @@ export async function executeAddCommand({
       }
       throw createCliDiagnosticCodeError(
         CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
-        `\`wp-typia add\` requires <kind>. Usage: wp-typia add ${formatAddKindUsagePlaceholder()} ...`,
+        formatMissingAddKindDetailLine(),
       );
     }
     if (!isAddKindId(kind)) {

--- a/packages/wp-typia/tests/node-cli-core.test.ts
+++ b/packages/wp-typia/tests/node-cli-core.test.ts
@@ -5,6 +5,10 @@ import path from 'node:path';
 import { afterEach, describe, expect, test } from 'bun:test';
 
 import packageJson from '../package.json';
+import {
+  buildMissingAddKindDetailLines,
+  buildMissingCreateProjectDirDetailLines,
+} from '../src/cli-error-messages';
 import { runNodeCli, runNodeCliEntrypoint } from '../src/node-cli';
 
 async function captureNodeCli(
@@ -168,8 +172,20 @@ describe('Node fallback CLI core routing', () => {
       ),
       'utf8',
     );
+    const createCommandSource = fs.readFileSync(
+      path.join(packageRoot, 'src', 'commands', 'create.ts'),
+      'utf8',
+    );
+    const runtimeBridgeSource = fs.readFileSync(
+      path.join(packageRoot, 'src', 'runtime-bridge.ts'),
+      'utf8',
+    );
     const helpSource = fs.readFileSync(
       path.join(packageRoot, 'src', 'node-fallback', 'help.ts'),
+      'utf8',
+    );
+    const cliErrorMessagesSource = fs.readFileSync(
+      path.join(packageRoot, 'src', 'cli-error-messages.ts'),
       'utf8',
     );
     const printBlockSource = fs.readFileSync(
@@ -188,8 +204,23 @@ describe('Node fallback CLI core routing', () => {
     expect(addDispatcherSource).toContain(
       'export async function dispatchNodeFallbackAdd',
     );
+    expect(addDispatcherSource).toContain('buildMissingAddKindDetailLines');
+    expect(addDispatcherSource).not.toContain('formatAddKindUsagePlaceholder');
     expect(createDispatcherSource).toContain(
       'export async function dispatchNodeFallbackCreate',
+    );
+    expect(createDispatcherSource).toContain(
+      'buildMissingCreateProjectDirDetailLines',
+    );
+    expect(createCommandSource).toContain(
+      'buildMissingCreateProjectDirDetailLines',
+    );
+    expect(runtimeBridgeSource).toContain('formatMissingAddKindDetailLine');
+    expect(cliErrorMessagesSource).toContain(
+      'export function formatMissingAddKindDetailLine',
+    );
+    expect(cliErrorMessagesSource).toContain(
+      'export function buildMissingCreateProjectDirDetailLines',
     );
     expect(helpSource).toContain("import { printBlock } from '../print-block'");
     expect(helpSource).not.toContain('export function printBlock');
@@ -292,7 +323,12 @@ describe('Node fallback CLI core routing', () => {
       entrypoint: true,
     });
     const parsed = JSON.parse(result.stderr) as {
-      error?: { code?: string; command?: string; kind?: string };
+      error?: {
+        code?: string;
+        command?: string;
+        detailLines?: string[];
+        kind?: string;
+      };
       ok?: boolean;
     };
 
@@ -303,6 +339,7 @@ describe('Node fallback CLI core routing', () => {
     expect(parsed.error?.kind).toBe('command-execution');
     expect(parsed.error?.command).toBe('add');
     expect(parsed.error?.code).toBe('missing-argument');
+    expect(parsed.error?.detailLines).toEqual(buildMissingAddKindDetailLines());
   });
 
   test('dispatches init structured previews from the Node fallback runtime', async () => {
@@ -654,7 +691,12 @@ describe('Node fallback CLI core routing', () => {
       entrypoint: true,
     });
     const parsed = JSON.parse(result.stderr) as {
-      error?: { code?: string; command?: string; kind?: string };
+      error?: {
+        code?: string;
+        command?: string;
+        detailLines?: string[];
+        kind?: string;
+      };
       ok?: boolean;
     };
 
@@ -665,6 +707,9 @@ describe('Node fallback CLI core routing', () => {
     expect(parsed.error?.kind).toBe('command-execution');
     expect(parsed.error?.command).toBe('create');
     expect(parsed.error?.code).toBe('missing-argument');
+    expect(parsed.error?.detailLines).toEqual(
+      buildMissingCreateProjectDirDetailLines(),
+    );
   });
 
   test('keeps Bun-only top-level commands on the unsupported-command diagnostic path', async () => {


### PR DESCRIPTION
## Summary
- add shared CLI missing-argument message builders for create project-dir and add kind failures
- route Bunli/runtime bridge and Node fallback dispatchers through the shared builders
- strengthen Node fallback structured diagnostics tests for missing add kind and create project-dir

Fixes #811.

## Validation
- bun test packages/wp-typia/tests/node-cli-core.test.ts
- bun test packages/wp-typia/tests/node-cli-core.test.ts packages/wp-typia/tests/cli-package.test.ts
- bun run typecheck
- bun run lint:repo
- bun run format:check
- bun run changesets:validate && git diff --check
- bun run manifest-policy:validate
- bun run --filter wp-typia build
- bun run --filter wp-typia test