### PR TITLE
refactor(template-source): use async fs probes

### DIFF
--- a/.sampo/changesets/814-async-template-source-probes.md
+++ b/.sampo/changesets/814-async-template-source-probes.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Remove synchronous filesystem probes from async template-source and scaffold paths.

--- a/packages/wp-typia-project-tools/src/runtime/cli-scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-scaffold.ts
@@ -1,4 +1,3 @@
-import fs from "node:fs";
 import { promises as fsp } from "node:fs";
 import path from "node:path";
 
@@ -33,6 +32,7 @@ import {
 	getOptionalOnboardingSteps,
 } from "./scaffold-onboarding.js";
 import { formatNonEmptyTargetDirectoryError } from "./scaffold-bootstrap.js";
+import { pathExists } from "./fs-async.js";
 import {
 	OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE,
 	isBuiltInTemplateId,
@@ -141,7 +141,7 @@ async function assertDryRunTargetDirectoryReady(
 	projectDir: string,
 	allowExistingDir: boolean,
 ): Promise<void> {
-	if (!fs.existsSync(projectDir) || allowExistingDir) {
+	if (!(await pathExists(projectDir)) || allowExistingDir) {
 		return;
 	}
 
@@ -783,7 +783,7 @@ export async function runScaffoldFlow({
 		if (!dryRun) {
 			try {
 				const parsedPackageJson = JSON.parse(
-					fs.readFileSync(path.join(projectDir, "package.json"), "utf8"),
+					await fsp.readFile(path.join(projectDir, "package.json"), "utf8"),
 				) as {
 					scripts?: unknown;
 				};

--- a/packages/wp-typia-project-tools/src/runtime/scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold.ts
@@ -1,4 +1,3 @@
-import fs from "node:fs";
 import { promises as fsp } from "node:fs";
 import path from "node:path";
 
@@ -46,6 +45,7 @@ import type {
 import {
 	assertExternalLayerCompositionOptions,
 } from "./cli-validation.js";
+import { pathExists } from "./fs-async.js";
 
 /**
  * User-facing scaffold answers before template rendering.
@@ -442,7 +442,7 @@ export async function scaffoldProject({
 		title: "Finalizing scaffold output",
 	});
 	const readmePath = path.join(projectDir, "README.md");
-	if (!fs.existsSync(readmePath)) {
+	if (!(await pathExists(readmePath))) {
 		await fsp.writeFile(
 			readmePath,
 			buildReadme(resolvedTemplateId, variables, resolvedPackageManager, {
@@ -455,7 +455,7 @@ export async function scaffoldProject({
 		);
 	}
 	const gitignorePath = path.join(projectDir, ".gitignore");
-	const existingGitignore = fs.existsSync(gitignorePath)
+	const existingGitignore = (await pathExists(gitignorePath))
 		? await fsp.readFile(gitignorePath, "utf8")
 		: "";
 	await fsp.writeFile(

--- a/packages/wp-typia-project-tools/src/runtime/template-builtins.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-builtins.ts
@@ -1,7 +1,7 @@
-import fs from "node:fs";
 import path from "node:path";
 import { promises as fsp } from "node:fs";
 
+import { pathExists } from "./fs-async.js";
 import { createManagedTempRoot } from "./temp-roots.js";
 import {
 	getTemplateById,
@@ -225,21 +225,24 @@ export function isOmittableBuiltInTemplateLayerDir(
 	);
 }
 
-function resolveMaterializedTemplateLayerDirs(
+async function resolveMaterializedTemplateLayerDirs(
 	templateId: BuiltInTemplateId,
 	layerDirs: readonly string[],
-): string[] {
-	return layerDirs.flatMap((layerDir) => {
-		if (fs.existsSync(layerDir)) {
-			return [layerDir];
+): Promise<string[]> {
+	const materializedLayerDirs: string[] = [];
+	for (const layerDir of layerDirs) {
+		if (await pathExists(layerDir)) {
+			materializedLayerDirs.push(layerDir);
+			continue;
 		}
 
 		if (isOmittableBuiltInTemplateLayerDir(templateId, layerDir)) {
-			return [];
+			continue;
 		}
 
 		throw new Error(`Built-in template layer is missing: ${layerDir}`);
-	});
+	}
+	return materializedLayerDirs;
 }
 
 async function materializeBuiltInTemplateSource(
@@ -247,7 +250,7 @@ async function materializeBuiltInTemplateSource(
 	layerDirs: readonly string[],
 ): Promise<MaterializedBuiltInTemplateSource> {
 	const template = getTemplateById(templateId);
-	const materializedLayerDirs = resolveMaterializedTemplateLayerDirs(
+	const materializedLayerDirs = await resolveMaterializedTemplateLayerDirs(
 		templateId,
 		layerDirs,
 	);

--- a/packages/wp-typia-project-tools/src/runtime/template-layers.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-layers.ts
@@ -1,7 +1,7 @@
-import fs from "node:fs";
 import path from "node:path";
 import { promises as fsp } from "node:fs";
 
+import { pathExists } from "./fs-async.js";
 import { isPlainObject } from "./object-utils.js";
 import {
 	getBuiltInSharedTemplateLayerDir,
@@ -119,7 +119,7 @@ export async function loadExternalTemplateLayerManifest(
 	sourceRoot: string,
 ): Promise<ExternalTemplateLayerManifest | null> {
 	const manifestPath = path.join(sourceRoot, TEMPLATE_LAYER_MANIFEST_FILENAME);
-	if (!fs.existsSync(manifestPath)) {
+	if (!(await pathExists(manifestPath))) {
 		return null;
 	}
 

--- a/packages/wp-typia-project-tools/src/runtime/template-source-external.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-external.ts
@@ -52,6 +52,9 @@ function resolveSourceSubpath(sourceDir: string, relativePath: string): string {
 /**
  * Search a source directory for the first supported external template entry.
  *
+ * @deprecated Use `findExternalTemplateEntry()` from async template-source
+ * paths. This synchronous helper remains only for compatibility callers.
+ *
  * @param sourceDir Directory that may contain an external template config entry.
  * @returns The first matching entry path, or null when no supported entry exists.
  */
@@ -322,7 +325,7 @@ export async function renderCreateBlockExternalTemplate(
     )
     const blockTemplateDir = resolveSourceSubpath(sourceDir, templatePath)
     await copyRenderedDirectory(blockTemplateDir, blockDir, view, {
-      filter: (sourcePath, _destinationPath, entry) => {
+      filter: async (sourcePath, _destinationPath, entry) => {
         const mustacheVariantPath = path.join(
           path.dirname(sourcePath),
           `${entry.name}.mustache`,
@@ -330,7 +333,7 @@ export async function renderCreateBlockExternalTemplate(
         return !(
           entry.isFile() &&
           (entry.name === 'package.json' || entry.name === 'README.md') &&
-          fs.existsSync(mustacheVariantPath)
+          (await pathExists(mustacheVariantPath))
         )
       },
     })

--- a/packages/wp-typia-project-tools/src/runtime/template-source-remote.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-remote.ts
@@ -92,6 +92,9 @@ async function readRemoteBlockJsonAsync(
 /**
  * Read a remote block source and return its default block category.
  *
+ * @deprecated Use `getDefaultCategoryAsync()` from async template-source paths.
+ * This synchronous helper remains only for compatibility callers.
+ *
  * @param sourceDir Block source directory that may contain a block.json file.
  * @returns The declared block category, or "widgets" when detection fails.
  */
@@ -196,6 +199,9 @@ async function readTemplatePackageJsonAsync(
 /**
  * Read `wpTypia.projectType` from a rendered or source template package
  * manifest and return it when present.
+ *
+ * @deprecated Use `getTemplateProjectTypeAsync()` from async template-source
+ * paths. This synchronous helper remains only for compatibility callers.
  */
 export function getTemplateProjectType(sourceDir: string): string | null {
   const packageJsonEntry = readTemplatePackageJson(sourceDir)
@@ -258,7 +264,7 @@ export async function normalizeWpTypiaTemplateSeed(
   const normalizedDir = path.join(tempRoot, 'template')
   try {
     await copyRawDirectory(seed.blockDir, normalizedDir, {
-      filter: (sourcePath, _targetPath, entry) => {
+      filter: async (sourcePath, _targetPath, entry) => {
         const mustacheVariantPath = path.join(
           path.dirname(sourcePath),
           `${entry.name}.mustache`,
@@ -266,7 +272,7 @@ export async function normalizeWpTypiaTemplateSeed(
         return !(
           entry.isFile() &&
           (entry.name === 'package.json' || entry.name === 'README.md') &&
-          fs.existsSync(mustacheVariantPath)
+          (await pathExists(mustacheVariantPath))
         )
       },
     })

--- a/packages/wp-typia-project-tools/src/runtime/template-source-seeds.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-seeds.ts
@@ -25,6 +25,7 @@ import {
   CLI_DIAGNOSTIC_CODES,
   createCliDiagnosticCodeError,
 } from './cli-diagnostics.js'
+import { pathExists } from './fs-async.js'
 import {
   OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE,
   OFFICIAL_WORKSPACE_TEMPLATE_ALIAS,
@@ -300,7 +301,9 @@ async function fetchNpmTemplateSource(
  * Resolve a locally installed npm template package from the caller workspace.
  *
  * Bare package ids are preferred here so monorepo and offline workflows can
- * use an already-installed template without forcing a registry fetch.
+ * use an already-installed template without forcing a registry fetch. This
+ * path intentionally keeps Node's synchronous `require.resolve` semantics
+ * because the module resolver itself has no async equivalent.
  */
 function resolveInstalledNpmTemplateSource(
   locator: NpmTemplateLocator,
@@ -380,6 +383,12 @@ function resolveInstalledNpmTemplateSource(
   }
 }
 
+/**
+ * Synchronously identify the bundled workspace template seed.
+ *
+ * This remains sync-only for compatibility callers. Async template resolution
+ * paths should use `isOfficialWorkspaceTemplateSeedAsync()`.
+ */
 export function isOfficialWorkspaceTemplateSeed(seed: SeedSource): boolean {
   const packageJsonPath = path.join(seed.rootDir, 'package.json')
   if (!fs.existsSync(packageJsonPath)) {
@@ -389,6 +398,27 @@ export function isOfficialWorkspaceTemplateSeed(seed: SeedSource): boolean {
   try {
     const packageJson = JSON.parse(
       fs.readFileSync(packageJsonPath, 'utf8'),
+    ) as { name?: string }
+    return packageJson.name === OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Asynchronously identify the bundled workspace template seed.
+ */
+export async function isOfficialWorkspaceTemplateSeedAsync(
+  seed: SeedSource,
+): Promise<boolean> {
+  const packageJsonPath = path.join(seed.rootDir, 'package.json')
+  if (!(await pathExists(packageJsonPath))) {
+    return false
+  }
+
+  try {
+    const packageJson = JSON.parse(
+      await fsp.readFile(packageJsonPath, 'utf8'),
     ) as { name?: string }
     return packageJson.name === OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE
   } catch {
@@ -452,16 +482,16 @@ function getGitHubTemplateRepositoryUrl(locator: GitHubTemplateLocator): string 
   return `https://github.com/${locator.owner}/${locator.repo}.git`
 }
 
-function resolveGitHubTemplateDirectory(
+async function resolveGitHubTemplateDirectory(
   checkoutDir: string,
   locator: GitHubTemplateLocator,
-): string {
+): Promise<string> {
   const sourceDir = path.resolve(checkoutDir, locator.sourcePath)
   const relativeSourceDir = path.relative(checkoutDir, sourceDir)
   if (relativeSourceDir.startsWith('..') || path.isAbsolute(relativeSourceDir)) {
     throw new Error('GitHub template path must stay within the cloned repository.')
   }
-  if (!fs.existsSync(sourceDir)) {
+  if (!(await pathExists(sourceDir))) {
     throw new Error(`GitHub template path does not exist: ${locator.sourcePath}`)
   }
   return sourceDir
@@ -675,7 +705,7 @@ async function reuseGitHubTemplateCacheByMetadata(
     return null
   }
 
-  const sourceDir = resolveGitHubTemplateDirectory(
+  const sourceDir = await resolveGitHubTemplateDirectory(
     cachedSource.sourceDir,
     locator,
   )
@@ -729,7 +759,7 @@ async function resolveGitHubTemplateSource(
         },
         async (checkoutDir) => {
           cloneGitHubTemplateSource(locator, checkoutDir)
-          const sourceDir = resolveGitHubTemplateDirectory(checkoutDir, locator)
+          const sourceDir = await resolveGitHubTemplateDirectory(checkoutDir, locator)
           await assertNoSymlinks(sourceDir)
           pinGitHubTemplateCacheRevision(
             locator,
@@ -739,7 +769,7 @@ async function resolveGitHubTemplateSource(
         },
       )
       if (cachedSource) {
-        const sourceDir = resolveGitHubTemplateDirectory(
+        const sourceDir = await resolveGitHubTemplateDirectory(
           cachedSource.sourceDir,
           locator,
         )
@@ -764,7 +794,7 @@ async function resolveGitHubTemplateSource(
 
   try {
     cloneGitHubTemplateSource(locator, checkoutDir)
-    const sourceDir = resolveGitHubTemplateDirectory(checkoutDir, locator)
+    const sourceDir = await resolveGitHubTemplateDirectory(checkoutDir, locator)
     await assertNoSymlinks(sourceDir)
 
     return {
@@ -792,7 +822,7 @@ export async function resolveTemplateSeed(
 ): Promise<SeedSource> {
   if (locator.kind === 'path') {
     const sourceDir = path.resolve(cwd, locator.templatePath)
-    if (!fs.existsSync(sourceDir)) {
+    if (!(await pathExists(sourceDir))) {
       throw new Error(`Template path does not exist: ${sourceDir}`)
     }
     await assertNoSymlinks(sourceDir)

--- a/packages/wp-typia-project-tools/src/runtime/template-source-seeds.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-seeds.ts
@@ -407,6 +407,9 @@ export function isOfficialWorkspaceTemplateSeed(seed: SeedSource): boolean {
 
 /**
  * Asynchronously identify the bundled workspace template seed.
+ *
+ * @param seed Seed source to inspect.
+ * @returns Whether the seed resolves to the official workspace template package.
  */
 export async function isOfficialWorkspaceTemplateSeedAsync(
   seed: SeedSource,

--- a/packages/wp-typia-project-tools/src/runtime/template-source.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source.ts
@@ -20,7 +20,7 @@ import {
   renderCreateBlockExternalTemplate,
 } from './template-source-normalization.js'
 import {
-  isOfficialWorkspaceTemplateSeed,
+  isOfficialWorkspaceTemplateSeedAsync,
   resolveTemplateSeed,
 } from './template-source-seeds.js'
 import {
@@ -73,7 +73,7 @@ export async function resolveTemplateSource(
   const seed = await resolveTemplateSeed(locator, cwd)
   const isOfficialWorkspaceTemplate =
     templateId === OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE ||
-    isOfficialWorkspaceTemplateSeed(seed)
+    (await isOfficialWorkspaceTemplateSeedAsync(seed))
   let normalizedSeed: SeedSource | null = null
 
   try {

--- a/packages/wp-typia-project-tools/tests/template-source.test.ts
+++ b/packages/wp-typia-project-tools/tests/template-source.test.ts
@@ -1922,6 +1922,23 @@ test("template-source-normalization stays as a facade over external and remote h
   );
 });
 
+test("template source copy filters use async filesystem probes", () => {
+  const runtimeDir = path.join(packageRoot, "src", "runtime");
+  const templateSourceExternal = fs.readFileSync(
+    path.join(runtimeDir, "template-source-external.ts"),
+    "utf8"
+  );
+  const templateSourceRemote = fs.readFileSync(
+    path.join(runtimeDir, "template-source-remote.ts"),
+    "utf8"
+  );
+
+  for (const source of [templateSourceExternal, templateSourceRemote]) {
+    expect(source).toContain("await pathExists(mustacheVariantPath)");
+    expect(source).not.toContain("fs.existsSync(mustacheVariantPath)");
+  }
+});
+
 test("official workspace template scaffolds through the local npm template resolver", async () => {
   const targetDir = path.join(tempRoot, "demo-workspace-template");
 


### PR DESCRIPTION
## Summary
- replace remaining synchronous filesystem probes in async scaffold/template-source paths with `pathExists`
- add async official workspace seed detection for async template resolution
- document remaining sync helpers as compatibility-only and add focused coverage for async copy filters

## Validation
- `git diff --check`
- `bun test packages/wp-typia-project-tools/tests/template-source.test.ts`
- previously in this branch: `bun run typecheck`, `bun run format:check`, `bun run lint:repo`, `bun run changesets:validate`, `bun run manifest-policy:validate`, `bun run --filter @wp-typia/project-tools build`

Fixes #814

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of project scaffolding and template resolution flows by updating filesystem operations.

* **Deprecations**
  * `getDefaultCategory()` and `getTemplateProjectType()` functions marked as deprecated; migrate to alternative APIs.

* **Tests**
  * Added test coverage for async filesystem operations in template handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->