### PR TITLE
dx(cli): tag remaining errors with diagnostic codes

### DIFF
--- a/.sampo/changesets/815-cli-diagnostic-coded-errors.md
+++ b/.sampo/changesets/815-cli-diagnostic-coded-errors.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Tag remaining CLI-layer artifact, sync execution, and standalone target failures with stable diagnostic codes.

--- a/packages/wp-typia/src/render-loader.ts
+++ b/packages/wp-typia/src/render-loader.ts
@@ -1,6 +1,11 @@
 import fs from "node:fs";
 import { fileURLToPath } from "node:url";
 
+import {
+	CLI_DIAGNOSTIC_CODES,
+	createCliDiagnosticCodeError,
+} from "@wp-typia/project-tools/cli-diagnostics";
+
 export function resolveBundledModuleHref(
 	baseUrl: string,
 	candidates: string[],
@@ -19,7 +24,8 @@ export function resolveBundledModuleHref(
 		fileURLToPath(new URL(candidate, baseUrl)),
 	);
 	const label = options.moduleLabel ?? "bundled wp-typia runtime module";
-	throw new Error(
+	throw createCliDiagnosticCodeError(
+		CLI_DIAGNOSTIC_CODES.MISSING_BUILD_ARTIFACT,
 		[
 			`Missing bundled build artifacts for ${label}.`,
 			"None of the expected files were found:",

--- a/packages/wp-typia/src/runtime-bridge-sync.ts
+++ b/packages/wp-typia/src/runtime-bridge-sync.ts
@@ -338,9 +338,13 @@ function runProjectScript(
       : undefined;
 
   if (result.error || result.status !== 0) {
-    throw new Error(`\`${plannedCommand.displayCommand}\` failed.`, {
-      cause: result.error ?? (stderr ? new Error(stderr.trim()) : undefined),
-    });
+    throw createCliDiagnosticCodeError(
+      CLI_DIAGNOSTIC_CODES.COMMAND_EXECUTION,
+      `\`${plannedCommand.displayCommand}\` failed.`,
+      {
+        cause: result.error ?? (stderr ? new Error(stderr.trim()) : undefined),
+      },
+    );
   }
 
   return {

--- a/packages/wp-typia/src/standalone-distribution.ts
+++ b/packages/wp-typia/src/standalone-distribution.ts
@@ -1,3 +1,8 @@
+import {
+	CLI_DIAGNOSTIC_CODES,
+	createCliDiagnosticCodeError,
+} from "@wp-typia/project-tools/cli-diagnostics";
+
 export const STANDALONE_TARGETS = [
 	"darwin-arm64",
 	"darwin-x64",
@@ -46,7 +51,8 @@ export function detectNativeStandaloneTarget(
 		return "windows-x64";
 	}
 
-	throw new Error(
+	throw createCliDiagnosticCodeError(
+		CLI_DIAGNOSTIC_CODES.UNSUPPORTED_COMMAND,
 		`Unsupported native standalone target for ${platform}/${arch}. Supported standalone targets: ${STANDALONE_TARGETS.join(", ")}`,
 	);
 }
@@ -87,7 +93,8 @@ export function parseStandaloneTargets(
 		}
 
 		if (!isStandaloneTarget(candidate)) {
-			throw new Error(
+			throw createCliDiagnosticCodeError(
+				CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
 				`Unsupported standalone target "${candidate}". Expected one of: native, all, ${STANDALONE_TARGETS.join(", ")}`,
 			);
 		}
@@ -98,7 +105,8 @@ export function parseStandaloneTargets(
 	}
 
 	if (resolvedTargets.length === 0) {
-		throw new Error(
+		throw createCliDiagnosticCodeError(
+			CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
 			"At least one standalone target is required. Use `native`, `all`, or a comma-separated list of supported targets.",
 		);
 	}

--- a/packages/wp-typia/tests/node-cli-core.test.ts
+++ b/packages/wp-typia/tests/node-cli-core.test.ts
@@ -712,6 +712,54 @@ describe('Node fallback CLI core routing', () => {
     );
   });
 
+  test('emits structured sync execution diagnostics with stable codes', async () => {
+    const tempRoot = createTempRoot('wp-typia-node-sync-failure-');
+
+    try {
+      fs.mkdirSync(path.join(tempRoot, 'scripts'), { recursive: true });
+      fs.mkdirSync(path.join(tempRoot, 'node_modules'), { recursive: true });
+      writeJson(path.join(tempRoot, 'package.json'), {
+        name: 'demo-sync-failure',
+        packageManager: 'npm@10.9.0',
+        scripts: {
+          sync: 'node scripts/fail.mjs',
+        },
+      });
+      fs.writeFileSync(
+        path.join(tempRoot, 'scripts', 'fail.mjs'),
+        ['console.error("sync failed intentionally");', 'process.exit(42);'].join(
+          '\n',
+        ),
+        'utf8',
+      );
+
+      const result = await captureNodeCli(['sync', '--format', 'json'], {
+        cwd: tempRoot,
+        entrypoint: true,
+      });
+      const parsed = JSON.parse(result.stderr) as {
+        error?: {
+          code?: string;
+          command?: string;
+          detailLines?: string[];
+          kind?: string;
+        };
+        ok?: boolean;
+      };
+
+      expect(result.error).toBeUndefined();
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).toBe('');
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error?.kind).toBe('command-execution');
+      expect(parsed.error?.code).toBe('command-execution');
+      expect(parsed.error?.command).toBe('sync');
+      expect(parsed.error?.detailLines).toContain('`npm run sync` failed.');
+    } finally {
+      removeTempRoot(tempRoot);
+    }
+  });
+
   test('keeps Bun-only top-level commands on the unsupported-command diagnostic path', async () => {
     const result = await captureNodeCli(['skills', 'list']);
 

--- a/packages/wp-typia/tests/render-loader.test.ts
+++ b/packages/wp-typia/tests/render-loader.test.ts
@@ -46,6 +46,9 @@ test("resolveBundledModuleHref reports missing bundled artifacts directly", () =
 	}
 
 	expect(error).toBeInstanceOf(Error);
+	expect((error as { code?: string } | undefined)?.code).toBe(
+		"missing-build-artifact",
+	);
 	expect(error?.message).toMatch(/Missing bundled build artifacts for the add-flow UI/);
 	expect(error?.message).toMatch(/bun run --filter wp-typia build/);
 });

--- a/packages/wp-typia/tests/runtime-bridge-sync.test.ts
+++ b/packages/wp-typia/tests/runtime-bridge-sync.test.ts
@@ -199,6 +199,34 @@ test('sync can capture executed script output for structured callers', async () 
   expect(result.executedCommands?.[0]?.stdout).toContain('ran:sync\n');
 });
 
+test('sync execution failures carry a stable command-execution code', async () => {
+  const projectDir = writeSyncFixture({
+    name: 'demo-sync-failure-code',
+    scripts: {
+      sync: 'node scripts/fail.mjs',
+    },
+    withInstallMarker: true,
+  });
+  const scriptsDir = path.join(projectDir, 'scripts');
+  fs.mkdirSync(scriptsDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(scriptsDir, 'fail.mjs'),
+    ['console.error("sync failed intentionally");', 'process.exit(42);'].join(
+      '\n',
+    ),
+    'utf8',
+  );
+
+  const error = await executeSyncCommand({
+    captureOutput: true,
+    cwd: projectDir,
+  }).catch((thrown) => thrown);
+
+  expect(error).toBeInstanceOf(Error);
+  expect((error as { code?: string }).code).toBe('command-execution');
+  expect((error as Error).message).toContain('npm run sync');
+});
+
 test('legacy split sync plans include sync-ai after sync-rest when the project opts in', async () => {
   const projectDir = writeSyncFixture({
     name: 'demo-sync-with-ai',

--- a/packages/wp-typia/tests/standalone-distribution.test.ts
+++ b/packages/wp-typia/tests/standalone-distribution.test.ts
@@ -7,6 +7,7 @@ import {
 	detectNativeStandaloneTarget,
 	getStandaloneArchiveFilename,
 	getStandaloneBinaryFilename,
+	parseStandaloneTargets,
 	STANDALONE_CHECKSUMS_FILENAME,
 	STANDALONE_MANIFEST_FILENAME,
 	STANDALONE_TARGETS,
@@ -125,6 +126,24 @@ describe("wp-typia standalone distribution", () => {
 				"windows-x64",
 			),
 		).toBe(`wp-typia-${packageManifest.version}-windows-x64.zip`);
+	});
+
+	test("classifies unsupported standalone targets as invalid arguments", () => {
+		expect(() => parseStandaloneTargets("linux-riscv64")).toThrow(
+			/Unsupported standalone target/,
+		);
+
+		let error: Error | undefined;
+		try {
+			parseStandaloneTargets("linux-riscv64");
+		} catch (caught) {
+			error = caught as Error;
+		}
+
+		expect(error).toBeInstanceOf(Error);
+		expect((error as { code?: string } | undefined)?.code).toBe(
+			"invalid-argument",
+		);
 	});
 
 	test("declares standalone build scripts and release asset workflow", () => {


### PR DESCRIPTION
## Summary
- tag missing bundled render artifacts with `missing-build-artifact`
- tag generated sync script failures with `command-execution` instead of raw errors
- classify standalone target parsing/detection failures with stable diagnostic codes
- add regression coverage for structured JSON sync diagnostics and direct code-bearing errors

## Validation
- `bun test packages/wp-typia/tests/render-loader.test.ts packages/wp-typia/tests/runtime-bridge-sync.test.ts packages/wp-typia/tests/standalone-distribution.test.ts packages/wp-typia/tests/node-cli-core.test.ts`
- `bun run format:check`
- `bun run typecheck`
- `bun run changesets:validate`
- `bun run manifest-policy:validate`
- `bun run --filter wp-typia build`
- `bun run lint:repo`
- `git diff --check`

Fixes #815

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced structured diagnostic error codes for improved error reporting and debugging. CLI operations now provide standardized, categorized error messages for missing build artifacts, command execution failures, and invalid target configurations.

* **Tests**
  * Added comprehensive error handling test coverage for diagnostic code validation across CLI operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->