### PR TITLE
fix(create): guard completion package manager

### DIFF
--- a/.sampo/changesets/816-create-package-manager-guard.md
+++ b/.sampo/changesets/816-create-package-manager-guard.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Guard create completion package-manager formatting before building next-step commands.

--- a/packages/wp-typia/src/runtime-bridge-output.ts
+++ b/packages/wp-typia/src/runtime-bridge-output.ts
@@ -1,9 +1,15 @@
 import packageJson from '../package.json';
 import {
+  PACKAGE_MANAGER_IDS,
   formatPackageExecCommand,
   inferPackageManagerId,
+  parsePackageManagerField,
   type PackageManagerId,
 } from '@wp-typia/project-tools/package-managers';
+import {
+  CLI_DIAGNOSTIC_CODES,
+  createCliDiagnosticCodeError,
+} from '@wp-typia/project-tools/cli-diagnostics';
 import {
   buildAddKindCompletionDetails,
   type AddKindId,
@@ -177,6 +183,20 @@ function extractPlannedFiles(
 
 const PROJECT_DIRECTORY_SUMMARY_PREFIX = 'Project directory: ';
 
+function resolveCreateCompletionPackageManager(
+  packageManager: string,
+): PackageManagerId {
+  const parsedPackageManager = parsePackageManagerField(packageManager);
+  if (parsedPackageManager) {
+    return parsedPackageManager;
+  }
+
+  throw createCliDiagnosticCodeError(
+    CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
+    `Unsupported package manager "${packageManager}" in create completion payload. Expected one of: ${PACKAGE_MANAGER_IDS.join(', ')}.`,
+  );
+}
+
 /**
  * Reads the normalized workspace path from a completion summary when present.
  *
@@ -320,9 +340,12 @@ export function buildCreateCompletionPayload(
   },
   markerOptions?: OutputMarkerOptions,
 ): AlternateBufferCompletionPayload {
+  const packageManager = resolveCreateCompletionPackageManager(
+    flow.packageManager,
+  );
   const verificationSteps = [
     formatPackageExecCommand(
-      flow.packageManager as 'bun' | 'npm' | 'pnpm' | 'yarn',
+      packageManager,
       `wp-typia@${packageJson.version}`,
       'doctor',
     ),

--- a/packages/wp-typia/tests/completion-output.test.ts
+++ b/packages/wp-typia/tests/completion-output.test.ts
@@ -118,6 +118,67 @@ describe('alternate-buffer completion output helpers', () => {
     );
   });
 
+  test('create completion payload keeps package-manager doctor commands stable', () => {
+    const expectedDoctorCommands = {
+      bun: `bunx wp-typia@${packageJson.version} doctor`,
+      npm: `npx --yes wp-typia@${packageJson.version} doctor`,
+      pnpm: `pnpm dlx wp-typia@${packageJson.version} doctor`,
+      yarn: `yarn dlx wp-typia@${packageJson.version} doctor`,
+    } as const;
+
+    for (const [packageManager, expectedDoctorCommand] of Object.entries(
+      expectedDoctorCommands,
+    )) {
+      const payload = buildCreateCompletionPayload({
+        nextSteps: ['cd demo-block'],
+        optionalOnboarding: {
+          note: 'Run sync when needed.',
+          steps: [],
+        },
+        packageManager,
+        projectDir: '/tmp/demo-block',
+        result: {
+          variables: {
+            title: 'Demo Block',
+          },
+          warnings: [],
+        },
+      });
+
+      expect(payload.optionalLines?.[0]).toBe(expectedDoctorCommand);
+    }
+  });
+
+  test('create completion payload rejects unknown package managers clearly', () => {
+    let error: Error | undefined;
+    try {
+      buildCreateCompletionPayload({
+        nextSteps: ['cd demo-block'],
+        optionalOnboarding: {
+          note: 'Run sync when needed.',
+          steps: [],
+        },
+        packageManager: 'deno',
+        projectDir: '/tmp/demo-block',
+        result: {
+          variables: {
+            title: 'Demo Block',
+          },
+          warnings: [],
+        },
+      });
+    } catch (caught) {
+      error = caught as Error;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as { code?: string } | undefined)?.code).toBe(
+      'invalid-argument',
+    );
+    expect(error?.message).toContain('Unsupported package manager "deno"');
+    expect(error?.message).toContain('Expected one of: bun, npm, pnpm, yarn');
+  });
+
   test('completion printer keeps warning and next-step ordering stable', () => {
     const printed: string[] = [];
     const warned: string[] = [];


### PR DESCRIPTION
## Summary
- Guard create completion package-manager formatting with the shared package-manager parser instead of an unsafe cast.
- Preserve existing doctor command output for bun, npm, pnpm, and yarn.
- Add focused coverage for supported and unknown package-manager completion payloads.

## Validation
- bun test packages/wp-typia/tests/completion-output.test.ts
- bun run format:check
- bun run typecheck
- bun run changesets:validate
- bun run --filter wp-typia build
- bun run manifest-policy:validate
- git diff --check
- bun run lint:repo

Fixes #816


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for package manager input in the create completion step to ensure proper formatting before building next-step commands.
  * Improved error messages when unsupported package managers are encountered.

* **Tests**
  * Added test coverage for package manager validation across all supported options (bun, npm, pnpm, yarn) and error handling for unsupported values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->