### PR TITLE
refactor(template-validation): share close id suggestions

### DIFF
--- a/.sampo/changesets/817-shared-close-id-suggestions.md
+++ b/.sampo/changesets/817-shared-close-id-suggestions.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Share close-id template suggestions across create and add-block validation paths.

--- a/packages/wp-typia-project-tools/package.json
+++ b/packages/wp-typia-project-tools/package.json
@@ -52,6 +52,11 @@
       "import": "./dist/runtime/create-template-validation.js",
       "default": "./dist/runtime/create-template-validation.js"
     },
+    "./id-suggestions": {
+      "types": "./dist/runtime/id-suggestions.d.ts",
+      "import": "./dist/runtime/id-suggestions.js",
+      "default": "./dist/runtime/id-suggestions.js"
+    },
     "./ai-artifacts": {
       "types": "./dist/runtime/ai-artifacts.d.ts",
       "import": "./dist/runtime/ai-artifacts.js",

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-block.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-block.ts
@@ -40,6 +40,7 @@ import {
 	rollbackWorkspaceMutation,
 	type WorkspaceMutationSnapshot,
 	snapshotWorkspaceFiles,
+	suggestAddBlockTemplateId,
 } from "./cli-add-shared.js";
 import {
 	resolveNonEmptyNormalizedBlockSlug,
@@ -175,6 +176,14 @@ async function assertWorkspaceDependenciesInstalled(workspace: {
 	);
 }
 
+function getMistypedAddBlockTemplateMessage(templateId: string): string | null {
+	const suggestion = suggestAddBlockTemplateId(templateId);
+	if (!suggestion) {
+		return null;
+	}
+
+	return `Unknown add-block template "${templateId}". Did you mean "${suggestion}"? Use \`--template ${suggestion}\`, or run \`wp-typia templates list\` to inspect available templates.`;
+}
 
 async function copyScaffoldedBlockSlice(
 	projectDir: string,
@@ -547,6 +556,12 @@ export async function runAddBlockCommand({
 		);
 	}
 	if (!isAddBlockTemplateId(templateId)) {
+		const mistypedAddBlockTemplateMessage =
+			getMistypedAddBlockTemplateMessage(templateId);
+		if (mistypedAddBlockTemplateMessage) {
+			throw new Error(mistypedAddBlockTemplateMessage);
+		}
+
 		throw new Error(
 			`Unknown add-block template "${templateId}". Expected one of: ${ADD_BLOCK_TEMPLATE_IDS.join(", ")}. Run \`wp-typia templates list\` to inspect available templates.`,
 		);

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-types.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-types.ts
@@ -1,3 +1,5 @@
+import { suggestCloseId } from "./id-suggestions.js";
+
 export { ADD_KIND_IDS } from "./cli-add-kind-ids.js";
 export type { AddKindId } from "./cli-add-kind-ids.js";
 
@@ -70,6 +72,19 @@ export const ADD_BLOCK_TEMPLATE_IDS = [
  * Union of supported built-in block template ids.
  */
 export type AddBlockTemplateId = (typeof ADD_BLOCK_TEMPLATE_IDS)[number];
+
+/**
+ * Suggest the closest supported add-block template id for typo diagnostics.
+ *
+ * @param templateId Raw `wp-typia add block --template` value.
+ * @returns The closest supported template id when it is within the shared
+ * close-id threshold, otherwise `null`.
+ */
+export function suggestAddBlockTemplateId(
+	templateId: string,
+): AddBlockTemplateId | null {
+	return suggestCloseId(templateId, ADD_BLOCK_TEMPLATE_IDS);
+}
 
 /**
  * Options for `wp-typia add variation`.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add.ts
@@ -13,6 +13,7 @@ export {
 	EDITOR_PLUGIN_SLOT_IDS,
 	formatAddHelpText,
 	isAddBlockTemplateId,
+	suggestAddBlockTemplateId,
 } from "./cli-add-shared.js";
 export type {
 	AddBlockTemplateId,

--- a/packages/wp-typia-project-tools/src/runtime/create-template-validation.ts
+++ b/packages/wp-typia-project-tools/src/runtime/create-template-validation.ts
@@ -16,6 +16,7 @@ import {
 	isRemovedBuiltInTemplateId,
 } from "./template-defaults.js";
 import { parseNpmTemplateLocator } from "./template-source-locators.js";
+import { suggestCloseId } from "./id-suggestions.js";
 
 export const CREATE_TEMPLATE_SELECTION_HINT = `--template <${[
 	...TEMPLATE_IDS,
@@ -67,30 +68,6 @@ function looksLikeExplicitCreateExternalTemplateLocator(
 	);
 }
 
-function getEditDistance(left: string, right: string): number {
-	const previous = Array.from({ length: right.length + 1 }, (_, index) => index);
-	const current = new Array<number>(right.length + 1);
-
-	for (let leftIndex = 0; leftIndex < left.length; leftIndex += 1) {
-		current[0] = leftIndex + 1;
-
-		for (let rightIndex = 0; rightIndex < right.length; rightIndex += 1) {
-			const substitutionCost = left[leftIndex] === right[rightIndex] ? 0 : 1;
-			current[rightIndex + 1] = Math.min(
-				current[rightIndex] + 1,
-				previous[rightIndex + 1] + 1,
-				previous[rightIndex] + substitutionCost,
-			);
-		}
-
-		for (let index = 0; index < current.length; index += 1) {
-			previous[index] = current[index] as number;
-		}
-	}
-
-	return previous[right.length] as number;
-}
-
 function findMistypedBuiltInTemplateSuggestion(templateId: string): string | null {
 	const normalizedTemplateId = templateId.trim().toLowerCase();
 	if (
@@ -100,21 +77,7 @@ function findMistypedBuiltInTemplateSuggestion(templateId: string): string | nul
 		return null;
 	}
 
-	let bestCandidate: { distance: number; id: string } | null = null;
-
-	for (const candidateId of TEMPLATE_SUGGESTION_IDS) {
-		const distance = getEditDistance(normalizedTemplateId, candidateId);
-		if (bestCandidate === null || distance < bestCandidate.distance) {
-			bestCandidate = {
-				distance,
-				id: candidateId,
-			};
-		}
-	}
-
-	return bestCandidate && bestCandidate.distance <= 2
-		? bestCandidate.id
-		: null;
+	return suggestCloseId(normalizedTemplateId, TEMPLATE_SUGGESTION_IDS);
 }
 
 function getMistypedBuiltInTemplateMessage(templateId: string): string | null {

--- a/packages/wp-typia-project-tools/src/runtime/id-suggestions.ts
+++ b/packages/wp-typia-project-tools/src/runtime/id-suggestions.ts
@@ -1,0 +1,81 @@
+export interface SuggestCloseIdOptions {
+	/**
+	 * Maximum edit distance accepted for a suggestion.
+	 *
+	 * Defaults to `2`, matching the create-template typo guard.
+	 */
+	maxDistance?: number;
+	/**
+	 * Normalizes user input and candidates before comparing them.
+	 *
+	 * Defaults to trimming and lowercasing for CLI id-like values.
+	 */
+	normalize?: (value: string) => string;
+}
+
+function normalizeCloseId(value: string): string {
+	return value.trim().toLowerCase();
+}
+
+function getEditDistance(left: string, right: string): number {
+	const previous = Array.from({ length: right.length + 1 }, (_, index) => index);
+	const current = new Array<number>(right.length + 1);
+
+	for (let leftIndex = 0; leftIndex < left.length; leftIndex += 1) {
+		current[0] = leftIndex + 1;
+
+		for (let rightIndex = 0; rightIndex < right.length; rightIndex += 1) {
+			const substitutionCost = left[leftIndex] === right[rightIndex] ? 0 : 1;
+			current[rightIndex + 1] = Math.min(
+				current[rightIndex] + 1,
+				previous[rightIndex + 1] + 1,
+				previous[rightIndex] + substitutionCost,
+			);
+		}
+
+		for (let index = 0; index < current.length; index += 1) {
+			previous[index] = current[index] as number;
+		}
+	}
+
+	return previous[right.length] as number;
+}
+
+/**
+ * Suggest the closest known id for a user-provided CLI value.
+ *
+ * This helper is intentionally generic so command-specific validation can keep
+ * its own wording and special-case handling while sharing typo thresholds.
+ */
+export function suggestCloseId<const TCandidate extends string>(
+	input: string,
+	candidates: readonly TCandidate[],
+	options: SuggestCloseIdOptions = {},
+): TCandidate | null {
+	const normalize = options.normalize ?? normalizeCloseId;
+	const normalizedInput = normalize(input);
+	if (normalizedInput.length === 0) {
+		return null;
+	}
+
+	const maxDistance = options.maxDistance ?? 2;
+	if (maxDistance < 0) {
+		return null;
+	}
+
+	let bestCandidate: { distance: number; id: TCandidate } | null = null;
+
+	for (const candidateId of candidates) {
+		const distance = getEditDistance(normalizedInput, normalize(candidateId));
+		if (bestCandidate === null || distance < bestCandidate.distance) {
+			bestCandidate = {
+				distance,
+				id: candidateId,
+			};
+		}
+	}
+
+	return bestCandidate && bestCandidate.distance <= maxDistance
+		? bestCandidate.id
+		: null;
+}

--- a/packages/wp-typia-project-tools/src/runtime/index.ts
+++ b/packages/wp-typia-project-tools/src/runtime/index.ts
@@ -141,6 +141,8 @@ export {
 	getPackageManagerSelectOptions,
 	transformPackageManagerText,
 } from "./package-managers.js";
+export { suggestCloseId } from "./id-suggestions.js";
+export type { SuggestCloseIdOptions } from "./id-suggestions.js";
 export {
 	clearPackageVersionsCache,
 	getPackageVersions,

--- a/packages/wp-typia-project-tools/tests/cli-entry.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-entry.test.ts
@@ -1531,6 +1531,38 @@ test("node entry rejects unknown add-block templates before workspace dependency
   expect(errorMessage).not.toContain("Interactive answers require a promptText callback");
 });
 
+test("node entry suggests close add-block template ids before workspace dependency checks", async () => {
+  const targetDir = path.join(tempRoot, "node-workspace-add-template-suggestion");
+
+  await scaffoldOfficialWorkspace(targetDir);
+
+  const errorMessage = getCommandErrorMessage(() =>
+    runCli(
+      "node",
+      [
+        entryPath,
+        "add",
+        "block",
+        "counter-card",
+        "--template",
+        "basicc",
+        "--format",
+        "json",
+      ],
+      {
+        cwd: targetDir,
+        stdio: "pipe",
+      }
+    )
+  );
+
+  expect(errorMessage).toContain('"code": "unknown-template"');
+  expect(errorMessage).toContain(
+    'Unknown add-block template \\"basicc\\". Did you mean \\"basic\\"? Use `--template basic`'
+  );
+  expect(errorMessage).not.toContain("Workspace dependencies have not been installed yet.");
+});
+
 test("node entry rejects missing values for identifier override flags", () => {
   expect(() => {
     runCli(

--- a/packages/wp-typia/src/add-kind-registry.ts
+++ b/packages/wp-typia/src/add-kind-registry.ts
@@ -244,6 +244,18 @@ function formatAddBlockTemplateIds(addRuntime: AddRuntime): string {
   return addRuntime.ADD_BLOCK_TEMPLATE_IDS.join(', ');
 }
 
+function getMistypedAddBlockTemplateMessage(
+  addRuntime: AddRuntime,
+  templateId: string,
+): string | null {
+  const suggestion = addRuntime.suggestAddBlockTemplateId(templateId);
+  if (!suggestion) {
+    return null;
+  }
+
+  return `Unknown add-block template "${templateId}". Did you mean "${suggestion}"? Use \`--template ${suggestion}\`, or run \`wp-typia templates list\` to inspect available templates.`;
+}
+
 function assertAddBlockTemplateId(
   context: AddKindExecutionContext,
   templateId: string,
@@ -256,6 +268,17 @@ function assertAddBlockTemplateId(
     throw createCliDiagnosticCodeError(
       CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
       '`wp-typia add block --template query-loop` is not supported. Query Loop is a create-time `core/query` variation scaffold, so use `wp-typia create <project-dir> --template query-loop` instead.',
+    );
+  }
+
+  const mistypedAddBlockTemplateMessage = getMistypedAddBlockTemplateMessage(
+    context.addRuntime,
+    templateId,
+  );
+  if (mistypedAddBlockTemplateMessage) {
+    throw createCliDiagnosticCodeError(
+      CLI_DIAGNOSTIC_CODES.UNKNOWN_TEMPLATE,
+      mistypedAddBlockTemplateMessage,
     );
   }
 

--- a/packages/wp-typia/tests/add-command.test.ts
+++ b/packages/wp-typia/tests/add-command.test.ts
@@ -202,6 +202,16 @@ describe('wp-typia add command bridge', () => {
     });
   });
 
+  test('suggests close add block template ids before workspace mutation', async () => {
+    await expectRejectedAddBlockTemplate({
+      code: CLI_DIAGNOSTIC_CODES.UNKNOWN_TEMPLATE,
+      interactive: false,
+      message:
+        'Unknown add-block template "basicc". Did you mean "basic"? Use `--template basic`',
+      template: 'basicc',
+    });
+  });
+
   test('rejects query-loop add block templates with create-time guidance', async () => {
     await expectRejectedAddBlockTemplate({
       code: CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,


### PR DESCRIPTION
## Summary
- Extract a reusable `suggestCloseId` helper for id-like CLI typo suggestions.
- Reuse the shared helper from create template validation and add-block template validation.
- Preserve query-loop create-only guidance while adding close-id suggestions for add-block typos such as `basicc`.

## Validation
- bun run --filter @wp-typia/project-tools build
- bun run --filter wp-typia build
- bun test packages/wp-typia-project-tools/tests/create-template-validation.test.ts
- bun test packages/wp-typia-project-tools/tests/cli-entry.test.ts -t "node entry suggests close add-block template ids before workspace dependency checks"
- bun test packages/wp-typia-project-tools/tests/cli-entry.test.ts -t "node entry rejects unknown add-block templates before workspace dependency checks"
- bun test packages/wp-typia/tests/add-command.test.ts -t "suggests close add block template ids before workspace mutation"
- bun run format:check
- bun run typecheck
- bun run changesets:validate
- bun run manifest-policy:validate
- git diff --check
- bun run lint:repo

Fixes #817
