### PR TITLE
fix(add): align missing kind help output

### DIFF
--- a/.sampo/changesets/818-align-add-missing-kind-help.md
+++ b/.sampo/changesets/818-align-add-missing-kind-help.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Align add missing-kind help output between Bunli bridge and Node fallback paths.

--- a/packages/wp-typia/src/cli-error-messages.ts
+++ b/packages/wp-typia/src/cli-error-messages.ts
@@ -13,6 +13,17 @@ export function buildMissingAddKindDetailLines(): string[] {
   return [formatMissingAddKindDetailLine()];
 }
 
+export function shouldPrintMissingAddKindHelp(options: {
+  emitOutput?: boolean;
+  format?: unknown;
+}): boolean {
+  if (typeof options.emitOutput === 'boolean') {
+    return options.emitOutput;
+  }
+
+  return options.format !== 'json';
+}
+
 export function buildMissingCreateProjectDirDetailLines(): string[] {
   return [...MISSING_CREATE_PROJECT_DIR_DETAIL_LINES];
 }

--- a/packages/wp-typia/src/node-fallback/dispatchers/add.ts
+++ b/packages/wp-typia/src/node-fallback/dispatchers/add.ts
@@ -2,7 +2,10 @@ import {
   CLI_DIAGNOSTIC_CODES,
   createCliCommandError,
 } from '@wp-typia/project-tools/cli-diagnostics';
-import { buildMissingAddKindDetailLines } from '../../cli-error-messages';
+import {
+  buildMissingAddKindDetailLines,
+  shouldPrintMissingAddKindHelp,
+} from '../../cli-error-messages';
 import { executeAddCommand } from '../../runtime-bridge';
 import {
   buildStructuredCompletionSuccessPayload,
@@ -17,7 +20,7 @@ export async function dispatchNodeFallbackAdd({
   printLine,
 }: NodeFallbackDispatchContext): Promise<void> {
   if (!positionals[1]) {
-    if (mergedFlags.format !== 'json') {
+    if (shouldPrintMissingAddKindHelp({ format: mergedFlags.format })) {
       const { formatAddHelpText } =
         await import('@wp-typia/project-tools/cli-add');
       printLine(formatAddHelpText());

--- a/packages/wp-typia/src/runtime-bridge.ts
+++ b/packages/wp-typia/src/runtime-bridge.ts
@@ -13,7 +13,10 @@ import {
   isAddKindId,
   supportsAddKindDryRun,
 } from './add-kind-registry';
-import { formatMissingAddKindDetailLine } from './cli-error-messages';
+import {
+  formatMissingAddKindDetailLine,
+  shouldPrintMissingAddKindHelp,
+} from './cli-error-messages';
 import { simulateWorkspaceAddDryRun } from './runtime-bridge-add-dry-run';
 import type { AlternateBufferCompletionPayload } from './ui/alternate-buffer-lifecycle';
 import {
@@ -471,7 +474,7 @@ export async function executeAddCommand({
     const isInteractiveSession = interactive ?? isInteractiveTerminal();
 
     if (!kind) {
-      if (emitOutput) {
+      if (shouldPrintMissingAddKindHelp({ emitOutput })) {
         printLine(addRuntime.formatAddHelpText());
       }
       throw createCliDiagnosticCodeError(

--- a/packages/wp-typia/tests/add-command.test.ts
+++ b/packages/wp-typia/tests/add-command.test.ts
@@ -467,6 +467,51 @@ describe('wp-typia add command bridge', () => {
     expect(selectedPrompts).toEqual([]);
   }, 15_000);
 
+  test('aligns missing kind help output with the bridge emitOutput context', async () => {
+    const printedHumanLines: string[] = [];
+    let humanError: unknown;
+
+    try {
+      await executeAddCommand({
+        cwd: tempRoot,
+        emitOutput: true,
+        flags: {},
+        interactive: false,
+        printLine: (line) => printedHumanLines.push(line),
+      });
+    } catch (error) {
+      humanError = error;
+    }
+
+    expect(humanError).toBeInstanceOf(Error);
+    expect((humanError as { code?: string }).code).toBe(
+      CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
+    );
+    expect(printedHumanLines.join('\n')).toContain('Usage:');
+    expect(printedHumanLines.join('\n')).toContain('wp-typia add block <name>');
+
+    const printedStructuredLines: string[] = [];
+    let structuredError: unknown;
+
+    try {
+      await executeAddCommand({
+        cwd: tempRoot,
+        emitOutput: false,
+        flags: {},
+        interactive: false,
+        printLine: (line) => printedStructuredLines.push(line),
+      });
+    } catch (error) {
+      structuredError = error;
+    }
+
+    expect(structuredError).toBeInstanceOf(Error);
+    expect((structuredError as { code?: string }).code).toBe(
+      CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
+    );
+    expect(printedStructuredLines).toEqual([]);
+  });
+
   test('named add commands validate the missing name before flag-specific errors', async () => {
     const projectDir = path.join(
       tempRoot,

--- a/packages/wp-typia/tests/node-cli-core.test.ts
+++ b/packages/wp-typia/tests/node-cli-core.test.ts
@@ -205,6 +205,7 @@ describe('Node fallback CLI core routing', () => {
       'export async function dispatchNodeFallbackAdd',
     );
     expect(addDispatcherSource).toContain('buildMissingAddKindDetailLines');
+    expect(addDispatcherSource).toContain('shouldPrintMissingAddKindHelp');
     expect(addDispatcherSource).not.toContain('formatAddKindUsagePlaceholder');
     expect(createDispatcherSource).toContain(
       'export async function dispatchNodeFallbackCreate',
@@ -216,8 +217,12 @@ describe('Node fallback CLI core routing', () => {
       'buildMissingCreateProjectDirDetailLines',
     );
     expect(runtimeBridgeSource).toContain('formatMissingAddKindDetailLine');
+    expect(runtimeBridgeSource).toContain('shouldPrintMissingAddKindHelp');
     expect(cliErrorMessagesSource).toContain(
       'export function formatMissingAddKindDetailLine',
+    );
+    expect(cliErrorMessagesSource).toContain(
+      'export function shouldPrintMissingAddKindHelp',
     );
     expect(cliErrorMessagesSource).toContain(
       'export function buildMissingCreateProjectDirDetailLines',


### PR DESCRIPTION
## Summary
- Share the missing add-kind help output decision between the Bunli bridge and Node fallback dispatcher.
- Keep human-readable `wp-typia add` invocations printing add help while structured/JSON mode suppresses extra help text.
- Add bridge-adjacent and Node fallback coverage for missing add-kind behavior.

## Validation
- bun test packages/wp-typia/tests/add-command.test.ts -t "aligns missing kind help output"
- bun test packages/wp-typia/tests/node-cli-core.test.ts -t "keeps add dispatch on stdout help and command diagnostics for missing kinds"
- bun test packages/wp-typia/tests/node-cli-core.test.ts -t "keeps missing add kinds machine-readable in structured mode"
- bun test packages/wp-typia/tests/cli-package.test.ts -t "treats missing add kinds as an error while still printing help text"
- bun test packages/wp-typia/tests/cli-package.test.ts -t "node fallback source entry treats missing add kinds as an error while printing add help"
- bun test packages/wp-typia/tests/node-cli-core.test.ts -t "keeps Node fallback dispatcher and help modules focused"
- bun run --filter wp-typia build
- bun run format:check
- bun run typecheck
- bun run changesets:validate
- bun run manifest-policy:validate
- git diff --check
- bun run lint:repo

Fixes #818


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Aligned "missing-kind" help output behavior between the Bunli bridge path and Node fallback path to provide consistent guidance to users.

* **Tests**
  * Added test coverage to verify help text appears correctly based on output context settings.
  * Updated existing tests to verify consistent help output behavior across execution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->