### PR TITLE
fix(sync): classify malformed package json

### DIFF
--- a/.sampo/changesets/833-sync-malformed-package-json.md
+++ b/.sampo/changesets/833-sync-malformed-package-json.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Classify malformed `package.json` parse failures in `wp-typia sync` with a stable invalid-argument diagnostic.

--- a/packages/wp-typia/src/runtime-bridge-sync.ts
+++ b/packages/wp-typia/src/runtime-bridge-sync.ts
@@ -36,6 +36,11 @@ type SyncProjectContext = {
   scripts: Partial<Record<SyncScriptName, SyncScriptDefinition>>;
 };
 
+type SyncPackageJson = {
+  packageManager?: string;
+  scripts?: Record<string, unknown>;
+};
+
 export type SyncPlannedCommand = {
   args: string[];
   command: string;
@@ -92,16 +97,28 @@ function getSyncRootError(cwd: string): Error {
   );
 }
 
+function readSyncPackageJson(packageJsonPath: string): SyncPackageJson {
+  const source = fs.readFileSync(packageJsonPath, 'utf8');
+
+  try {
+    return JSON.parse(source) as SyncPackageJson;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw createCliDiagnosticCodeError(
+      CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
+      `Unable to parse ${packageJsonPath}: ${message}`,
+      error instanceof Error ? { cause: error } : undefined,
+    );
+  }
+}
+
 function resolveSyncProjectContext(cwd: string): SyncProjectContext {
   const packageJsonPath = path.join(cwd, 'package.json');
   if (!fs.existsSync(packageJsonPath)) {
     throw getSyncRootError(cwd);
   }
 
-  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as {
-    packageManager?: string;
-    scripts?: Record<string, unknown>;
-  };
+  const packageJson = readSyncPackageJson(packageJsonPath);
   const scripts = packageJson.scripts ?? {};
   const syncScripts = {
     sync:

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -1409,6 +1409,50 @@ process.exit(0);
     }
   });
 
+  test('emits a machine-readable malformed package JSON code for sync in Node fallback JSON mode', () => {
+    const tempRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'wp-typia-sync-malformed-json-'),
+    );
+    const packageJsonPath = path.join(tempRoot, 'package.json');
+
+    try {
+      fs.writeFileSync(packageJsonPath, '{\n', 'utf8');
+
+      const result = runCapturedCommand(
+        'node',
+        [entryPath, 'sync', '--format', 'json'],
+        {
+          cwd: tempRoot,
+          env: {
+            ...withoutAIAgentEnv(),
+            BUN_BIN: path.join(os.tmpdir(), 'wp-typia-missing-bun'),
+          },
+        },
+      );
+      const parsed = parseJsonObjectFromOutput<{
+        error?: {
+          code?: string;
+          command?: string;
+          detailLines?: string[];
+          kind?: string;
+        };
+        ok?: boolean;
+      }>(result.stderr);
+
+      expect(result.status).toBe(1);
+      expect(result.stdout).toBe('');
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error?.kind).toBe('command-execution');
+      expect(parsed.error?.command).toBe('sync');
+      expect(parsed.error?.code).toBe('invalid-argument');
+      expect(parsed.error?.detailLines?.join('\n')).toContain(
+        `Unable to parse ${fs.realpathSync(packageJsonPath)}`,
+      );
+    } finally {
+      fs.rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
   test('emits a machine-readable invalid-command error code for sync subcommands in Node fallback JSON mode', () => {
     const result = runCapturedCommand(
       process.execPath,

--- a/packages/wp-typia/tests/runtime-bridge-sync.test.ts
+++ b/packages/wp-typia/tests/runtime-bridge-sync.test.ts
@@ -66,6 +66,21 @@ test('sync fails early with install guidance when local dependencies are missing
   expect((error as Error).message).toContain('tsx');
 });
 
+test('malformed package JSON carries a stable invalid-argument code', async () => {
+  const projectDir = path.join(tempRoot, 'demo-sync-invalid-package-json');
+  const packageJsonPath = path.join(projectDir, 'package.json');
+  fs.mkdirSync(projectDir, { recursive: true });
+  fs.writeFileSync(packageJsonPath, '{\n', 'utf8');
+
+  const error = await executeSyncCommand({ cwd: projectDir }).catch(
+    (thrown) => thrown,
+  );
+
+  expect(error).toBeInstanceOf(Error);
+  expect((error as { code?: string }).code).toBe('invalid-argument');
+  expect((error as Error).message).toContain(`Unable to parse ${packageJsonPath}`);
+});
+
 test('dry-run sync previews commands without requiring installed dependencies', async () => {
   const projectDir = writeSyncFixture({
     name: 'demo-sync-dry-run-preview',


### PR DESCRIPTION
Fixes #833.

## Summary
- wrap sync project package.json parse failures in an invalid-argument diagnostic
- keep structured Node fallback JSON errors tagged with command: sync
- add bridge and package-level regression coverage

## Validation
- bun run --filter wp-typia build
- bun test packages/wp-typia/tests/runtime-bridge-sync.test.ts packages/wp-typia/tests/cli-package.test.ts
- bun run typecheck
- bun run format:check
- bun run changesets:validate
- bun run manifest-policy:validate
- bun run lint:repo
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when `package.json` is malformed during sync operations. The tool now provides clearer diagnostic messages with parsing error details.

* **Tests**
  * Added test coverage for malformed `package.json` error scenarios in both CLI and runtime contexts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/849)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->