### PR TITLE
dx(mcp): route human output through printline

### DIFF
--- a/.sampo/changesets/834-mcp-printline-output.md
+++ b/.sampo/changesets/834-mcp-printline-output.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Route MCP command human output through injectable PrintLine helpers instead of direct console logging.

--- a/packages/wp-typia/src/commands/mcp.ts
+++ b/packages/wp-typia/src/commands/mcp.ts
@@ -11,6 +11,48 @@ import {
 } from '../command-option-metadata';
 import { getMcpSchemaSources } from '../config';
 import { loadMcpToolGroups, syncMcpSchemas } from '../mcp';
+import type { PrintLine } from '../print-line';
+
+type McpToolGroupSummary = {
+  namespace: string;
+  toolCount: number;
+  tools: string[];
+};
+
+type McpCommandArgsWithPrintLine = {
+  printLine?: PrintLine;
+};
+
+type McpSyncResult = Awaited<ReturnType<typeof syncMcpSchemas>>;
+
+const defaultPrintLine: PrintLine = (line) => {
+  process.stdout.write(`${line}\n`);
+};
+
+function resolveMcpPrintLine(args: McpCommandArgsWithPrintLine): PrintLine {
+  return args.printLine ?? defaultPrintLine;
+}
+
+export function printMcpToolGroupSummary(
+  summary: McpToolGroupSummary[],
+  printLine: PrintLine,
+): void {
+  for (const group of summary) {
+    printLine(`${group.namespace} (${group.toolCount})`);
+    for (const tool of group.tools) {
+      printLine(`  - ${tool}`);
+    }
+  }
+}
+
+export function printMcpSyncSummary(
+  result: McpSyncResult,
+  printLine: PrintLine,
+): void {
+  printLine(
+    `Synced ${result.commandCount} MCP tools across ${result.groups.length} namespaces into ${result.outputDir}.`,
+  );
+}
 
 export const mcpCommand = defineCommand({
   defaultFormat: 'json',
@@ -18,6 +60,7 @@ export const mcpCommand = defineCommand({
   handler: async (args) => {
     const subcommand = args.positional[0] ?? 'list';
     const prefersStructuredOutput = prefersStructuredCliOutput(args);
+    const printLine = resolveMcpPrintLine(args as McpCommandArgsWithPrintLine);
     const userConfig =
       args.context?.store?.wpTypiaUserConfig &&
       typeof args.context.store.wpTypiaUserConfig === 'object'
@@ -48,12 +91,7 @@ export const mcpCommand = defineCommand({
           args.output({ groups: summary });
           return;
         }
-        for (const group of summary) {
-          console.log(`${group.namespace} (${group.toolCount})`);
-          for (const tool of group.tools) {
-            console.log(`  - ${tool}`);
-          }
-        }
+        printMcpToolGroupSummary(summary, printLine);
         return;
       }
 
@@ -66,9 +104,7 @@ export const mcpCommand = defineCommand({
           args.output({ sync: result });
           return;
         }
-        console.log(
-          `Synced ${result.commandCount} MCP tools across ${result.groups.length} namespaces into ${result.outputDir}.`,
-        );
+        printMcpSyncSummary(result, printLine);
         return;
       }
 

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -280,6 +280,8 @@ describe('wp-typia package', () => {
     expect(migrateCommandSource).toContain('resolveCommandOptionValues');
     expect(mcpCommandSource).toContain('buildCommandOptions');
     expect(mcpCommandSource).toContain('MCP_OPTION_METADATA');
+    expect(mcpCommandSource).toContain('printMcpToolGroupSummary');
+    expect(mcpCommandSource).not.toContain('console.log');
     expect(mcpCommandSource).not.toContain('schema: z.string().optional()');
   });
 

--- a/packages/wp-typia/tests/mcp-command.test.ts
+++ b/packages/wp-typia/tests/mcp-command.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from 'bun:test';
+
+import {
+  printMcpSyncSummary,
+  printMcpToolGroupSummary,
+} from '../src/commands/mcp';
+
+test('MCP list human output uses an injected PrintLine', () => {
+  const lines: string[] = [];
+
+  printMcpToolGroupSummary(
+    [
+      {
+        namespace: 'demo',
+        toolCount: 2,
+        tools: ['ping', 'pong'],
+      },
+    ],
+    (line) => lines.push(line),
+  );
+
+  expect(lines).toEqual(['demo (2)', '  - ping', '  - pong']);
+});
+
+test('MCP sync human output uses an injected PrintLine', () => {
+  const lines: string[] = [];
+
+  printMcpSyncSummary(
+    {
+      commandCount: 2,
+      groups: [
+        {
+          namespace: 'demo',
+          tools: [],
+        },
+      ],
+      outputDir: '/tmp/wp-typia-mcp',
+    },
+    (line) => lines.push(line),
+  );
+
+  expect(lines).toEqual([
+    'Synced 2 MCP tools across 1 namespaces into /tmp/wp-typia-mcp.',
+  ]);
+});


### PR DESCRIPTION
Fixes #834.

## Summary
- route MCP list/sync human output through injectable PrintLine helpers
- keep structured MCP output unchanged
- add focused helper coverage and a package-level source invariant against direct console.log usage

## Validation
- bun run --filter wp-typia build
- bun test packages/wp-typia/tests/mcp-command.test.ts packages/wp-typia/tests/cli-package.test.ts
- bun run typecheck
- bun run format:check
- bun run changesets:validate
- bun run manifest-policy:validate
- bun run lint:repo
- git diff --check