### PR TITLE
refactor(project-tools): consolidate filesystem helpers

### DIFF
--- a/.sampo/changesets/836-consolidate-fs-helpers.md
+++ b/.sampo/changesets/836-consolidate-fs-helpers.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Consolidate optional file reads and Node error-code handling through shared runtime filesystem helpers.

--- a/packages/wp-typia-project-tools/src/runtime/ai-artifacts.ts
+++ b/packages/wp-typia-project-tools/src/runtime/ai-artifacts.ts
@@ -7,6 +7,10 @@ import {
   buildWordPressAiArtifacts,
   type ProjectedWordPressAbilitiesDocument,
 } from './wordpress-ai.js';
+import {
+  getOptionalNodeErrorCode,
+  isFileNotFoundError,
+} from './fs-async.js';
 
 export {
   buildWordPressAiArtifacts,
@@ -94,16 +98,12 @@ async function reconcileGeneratedAiArtifacts(
         issues.push(`- ${artifact.filePath} (stale)`);
       }
     } catch (error) {
-      const code =
-        error && typeof error === 'object' && 'code' in error
-          ? (error as { code?: string }).code
-          : undefined;
-
-      if (code === 'ENOENT') {
+      if (isFileNotFoundError(error)) {
         issues.push(`- ${artifact.filePath} (missing)`);
         continue;
       }
 
+      const code = getOptionalNodeErrorCode(error);
       issues.push(
         `- ${artifact.filePath} (unreadable: ${error instanceof Error ? error.message : code ?? 'unknown'})`,
       );

--- a/packages/wp-typia-project-tools/src/runtime/ai-feature-artifacts.ts
+++ b/packages/wp-typia-project-tools/src/runtime/ai-feature-artifacts.ts
@@ -10,6 +10,7 @@ import {
 } from "@wp-typia/block-runtime/metadata-core";
 
 import { projectWordPressAiSchema } from "./ai-artifacts.js";
+import { isFileNotFoundError } from "./fs-async.js";
 import type { JsonSchemaDocument } from "./schema-core.js";
 
 interface AiFeatureTemplateVariablesLike {
@@ -78,11 +79,7 @@ async function reconcileGeneratedArtifact(options: {
 			);
 		}
 	} catch (error) {
-		const code =
-			error && typeof error === "object" && "code" in error
-				? (error as { code?: string }).code
-				: undefined;
-		if (code === "ENOENT") {
+		if (isFileNotFoundError(error)) {
 			throw new Error(
 				`Generated AI feature artifact is missing: ${options.label} (${options.filePath}).`,
 			);

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-filesystem.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-filesystem.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import type {
 	WorkspaceMutationSnapshot,
 } from "./cli-add-types.js";
+import { readOptionalUtf8File } from "./fs-async.js";
 import type {
 	WorkspaceProject,
 } from "./workspace-project.js";
@@ -37,14 +38,7 @@ export async function patchFile(
  * Read a file when it exists and otherwise return `null`.
  */
 export async function readOptionalFile(filePath: string): Promise<string | null> {
-	try {
-		return await fsp.readFile(filePath, "utf8");
-	} catch (error) {
-		if (isFileNotFoundError(error)) {
-			return null;
-		}
-		throw error;
-	}
+	return readOptionalUtf8File(filePath);
 }
 
 /**
@@ -88,13 +82,4 @@ export async function rollbackWorkspaceMutation(snapshot: WorkspaceMutationSnaps
 	for (const { filePath, source } of snapshot.fileSources) {
 		await restoreOptionalFile(filePath, source);
 	}
-}
-
-function isFileNotFoundError(error: unknown): boolean {
-	return (
-		typeof error === "object" &&
-		error !== null &&
-		"code" in error &&
-		(error as { code?: unknown }).code === "ENOENT"
-	);
 }

--- a/packages/wp-typia-project-tools/src/runtime/fs-async.ts
+++ b/packages/wp-typia-project-tools/src/runtime/fs-async.ts
@@ -39,9 +39,19 @@ export async function readOptionalUtf8File(filePath: string): Promise<string | n
  * @returns The string error code, or an empty string when unavailable.
  */
 export function getNodeErrorCode(error: unknown): string {
+	return getOptionalNodeErrorCode(error) ?? "";
+}
+
+/**
+ * Extract a Node.js error code from an unknown thrown value when available.
+ *
+ * @param error Unknown error value.
+ * @returns The string error code, or `undefined` when unavailable.
+ */
+export function getOptionalNodeErrorCode(error: unknown): string | undefined {
 	return typeof error === "object" && error !== null && "code" in error
 		? String((error as { code: unknown }).code)
-		: "";
+		: undefined;
 }
 
 /**
@@ -51,5 +61,5 @@ export function getNodeErrorCode(error: unknown): string {
  * @returns `true` when the error has Node.js code `ENOENT`.
  */
 export function isFileNotFoundError(error: unknown): boolean {
-	return getNodeErrorCode(error) === "ENOENT";
+	return getOptionalNodeErrorCode(error) === "ENOENT";
 }

--- a/packages/wp-typia-project-tools/src/runtime/package-versions.ts
+++ b/packages/wp-typia-project-tools/src/runtime/package-versions.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import { createRequire } from 'node:module';
 import path from 'node:path';
 
+import { getOptionalNodeErrorCode } from './fs-async.js';
 import { PROJECT_TOOLS_PACKAGE_ROOT } from './template-registry.js';
 
 interface PackageManifest {
@@ -53,12 +54,6 @@ let cachedPackageVersions: {
   cacheKey: string;
   versions: PackageVersions;
 } | null = null;
-
-function getErrorCode(error: unknown): string | undefined {
-  return typeof error === 'object' && error !== null && 'code' in error
-    ? String((error as { code: unknown }).code)
-    : undefined;
-}
 
 function normalizeVersionRange(value: string | undefined): string {
   const trimmed = value?.trim();
@@ -129,7 +124,7 @@ function resolvePackageManifestLocation(
       source,
     };
   } catch (error) {
-    if (getErrorCode(error) === 'ENOENT') {
+    if (getOptionalNodeErrorCode(error) === 'ENOENT') {
       return {
         cacheKey: `missing-file:${packageJsonPath}`,
         packageJsonPath: null,
@@ -172,7 +167,7 @@ function resolveInstalledPackageManifestLocation(
       require.resolve(`${packageName}/package.json`),
     );
   } catch (error) {
-    if (getErrorCode(error) === 'MODULE_NOT_FOUND') {
+    if (getOptionalNodeErrorCode(error) === 'MODULE_NOT_FOUND') {
       return {
         cacheKey: `missing-module:${packageName}`,
         packageJsonPath: null,

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-repository-reference.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-repository-reference.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
 
+import { getOptionalNodeErrorCode } from "./fs-async.js";
 import { PROJECT_TOOLS_PACKAGE_ROOT } from "./template-registry.js";
 
 interface RepositoryPackageManifest {
@@ -21,12 +22,6 @@ const require = createRequire(import.meta.url);
  */
 export const DEFAULT_SCAFFOLD_REPOSITORY_REFERENCE = "imjlk/wp-typia";
 
-function getErrorCode(error: unknown): string | undefined {
-	return typeof error === "object" && error !== null && "code" in error
-		? String((error as { code: unknown }).code)
-		: undefined;
-}
-
 function readRepositoryPackageManifest(
 	packageJsonPath: string,
 ): RepositoryPackageManifest | null {
@@ -35,7 +30,7 @@ function readRepositoryPackageManifest(
 			fs.readFileSync(packageJsonPath, "utf8"),
 		) as RepositoryPackageManifest;
 	} catch (error) {
-		if (getErrorCode(error) === "ENOENT") {
+		if (getOptionalNodeErrorCode(error) === "ENOENT") {
 			return null;
 		}
 
@@ -49,7 +44,7 @@ function resolveInstalledPackageManifestPath(
 	try {
 		return require.resolve(`${packageName}/package.json`);
 	} catch (error) {
-		if (getErrorCode(error) === "MODULE_NOT_FOUND") {
+		if (getOptionalNodeErrorCode(error) === "MODULE_NOT_FOUND") {
 			return null;
 		}
 

--- a/packages/wp-typia-project-tools/src/runtime/typia-llm.ts
+++ b/packages/wp-typia-project-tools/src/runtime/typia-llm.ts
@@ -7,6 +7,10 @@ import type {
   EndpointManifestEndpointDefinition,
 } from '@wp-typia/block-runtime/metadata-core';
 import type { ILlmFunction, ILlmSchema, ILlmStructuredOutput } from 'typia';
+import {
+  getOptionalNodeErrorCode,
+  isFileNotFoundError,
+} from './fs-async.js';
 import { cloneJsonValue } from './json-utils.js';
 import {
   normalizeEndpointAuthDefinition,
@@ -860,16 +864,12 @@ async function reconcileGeneratedTypiaLlmArtifacts(
         issues.push(`- ${artifact.filePath} (stale)`);
       }
     } catch (error) {
-      const code =
-        error && typeof error === 'object' && 'code' in error
-          ? (error as { code?: string }).code
-          : undefined;
-
-      if (code === 'ENOENT') {
+      if (isFileNotFoundError(error)) {
         issues.push(`- ${artifact.filePath} (missing)`);
         continue;
       }
 
+      const code = getOptionalNodeErrorCode(error);
       issues.push(
         `- ${artifact.filePath} (unreadable: ${error instanceof Error ? error.message : code ?? 'unknown'})`,
       );

--- a/packages/wp-typia-project-tools/src/runtime/workspace-inventory-read.ts
+++ b/packages/wp-typia-project-tools/src/runtime/workspace-inventory-read.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { readFile } from "node:fs/promises";
 
+import { isFileNotFoundError } from "./fs-async.js";
 import { parseWorkspaceInventorySource } from "./workspace-inventory-parser.js";
 import type {
 	WorkspaceBlockInventoryEntry,
@@ -26,12 +27,7 @@ export function readWorkspaceInventory(projectDir: string): WorkspaceInventory {
 	try {
 		source = readFileSync(blockConfigPath, "utf8");
 	} catch (error) {
-		if (
-			typeof error === "object" &&
-			error !== null &&
-			"code" in error &&
-			error.code === "ENOENT"
-		) {
+		if (isFileNotFoundError(error)) {
 			throw new Error(
 				`Workspace inventory file is missing at ${blockConfigPath}. Expected scripts/block-config.ts to exist.`,
 			);
@@ -60,12 +56,7 @@ export async function readWorkspaceInventoryAsync(
 	try {
 		source = await readFile(blockConfigPath, "utf8");
 	} catch (error) {
-		if (
-			typeof error === "object" &&
-			error !== null &&
-			"code" in error &&
-			error.code === "ENOENT"
-		) {
+		if (isFileNotFoundError(error)) {
 			throw new Error(
 				`Workspace inventory file is missing at ${blockConfigPath}. Expected scripts/block-config.ts to exist.`,
 			);

--- a/packages/wp-typia-project-tools/tests/cli-add-shared.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-add-shared.test.ts
@@ -113,6 +113,7 @@ test('focused add runtime modules own their helper categories', () => {
   expect(validationSource).toContain('export function assertValidEditorPluginSlot');
   expect(filesystemSource).toContain('export async function snapshotWorkspaceFiles');
   expect(filesystemSource).toContain('export async function rollbackWorkspaceMutation');
+  expect(filesystemSource).not.toContain('function isFileNotFoundError');
   expect(blockJsonSource).toContain('export async function readWorkspaceBlockJson');
   expect(blockJsonSource).toContain('export function getMutableBlockHooks');
   expect(collisionSource).toContain('function assertAddKindScaffoldDoesNotExist');

--- a/packages/wp-typia-project-tools/tests/runtime-helper-consolidation.test.ts
+++ b/packages/wp-typia-project-tools/tests/runtime-helper-consolidation.test.ts
@@ -9,7 +9,13 @@ import {
   resolveWorkspaceBlockTargetName,
   resolveWorkspaceTargetBlockName,
 } from '../src/runtime/block-targets.js';
-import { getNodeErrorCode, pathExists } from '../src/runtime/fs-async.js';
+import {
+  getNodeErrorCode,
+  getOptionalNodeErrorCode,
+  isFileNotFoundError,
+  pathExists,
+  readOptionalUtf8File,
+} from '../src/runtime/fs-async.js';
 import { getPropertyNameText } from '../src/runtime/ts-property-names.js';
 
 const runtimeRoot = path.join(import.meta.dir, '..', 'src', 'runtime');
@@ -53,10 +59,22 @@ test('shared async filesystem helpers expose path existence and node error codes
 
   await expect(pathExists(existingPath)).resolves.toBe(true);
   await expect(pathExists(path.join(tempRoot, 'missing.txt'))).resolves.toBe(false);
+  await expect(readOptionalUtf8File(existingPath)).resolves.toBe('ok');
+  await expect(
+    readOptionalUtf8File(path.join(tempRoot, 'missing.txt')),
+  ).resolves.toBeNull();
   expect(getNodeErrorCode(Object.assign(new Error('denied'), { code: 'EACCES' }))).toBe(
     'EACCES',
   );
+  expect(getOptionalNodeErrorCode(Object.assign(new Error('denied'), { code: 'EACCES' }))).toBe(
+    'EACCES',
+  );
+  expect(getOptionalNodeErrorCode(new Error('plain'))).toBeUndefined();
   expect(getNodeErrorCode(new Error('plain'))).toBe('');
+  expect(isFileNotFoundError(Object.assign(new Error('missing'), { code: 'ENOENT' }))).toBe(
+    true,
+  );
+  expect(isFileNotFoundError(new Error('plain'))).toBe(false);
 });
 
 test('shared TypeScript property-name helper aligns literal property support', () => {

--- a/tests/unit/package-versions.test.ts
+++ b/tests/unit/package-versions.test.ts
@@ -16,6 +16,13 @@ const PACKAGE_VERSIONS_SOURCE = fs.readFileSync(
 	),
 	"utf8",
 );
+const FS_ASYNC_SOURCE = fs.readFileSync(
+	path.resolve(
+		import.meta.dir,
+		"../../packages/wp-typia-project-tools/src/runtime/fs-async.ts",
+	),
+	"utf8",
+);
 
 async function importPackageVersionsModule(options: {
 	createPackageRoot: string;
@@ -44,6 +51,7 @@ async function importPackageVersionsModule(options: {
 		path.join(runtimeDir, "package-versions.ts"),
 		PACKAGE_VERSIONS_SOURCE,
 	);
+	writeTextFile(path.join(runtimeDir, "fs-async.ts"), FS_ASYNC_SOURCE);
 	writeTextFile(
 		path.join(runtimeDir, "template-registry.js"),
 		`export const PROJECT_TOOLS_PACKAGE_ROOT = ${JSON.stringify(options.createPackageRoot)};\n`,


### PR DESCRIPTION
Closes #836

## Summary
- add a shared optional Node error-code helper in `fs-async` while preserving the existing string-returning helper
- route optional UTF-8 reads and file-not-found checks through shared filesystem helpers
- remove local `getErrorCode` and `isFileNotFoundError` duplicates from project-tools runtime modules
- add focused tests for optional reads, optional error codes, and the add filesystem helper boundary

## Notes
- The remaining `ENOENT` check is inside generated `sync-project.ts` template source, where importing project-tools runtime helpers would make the generated workspace script less standalone.

## Verification
- bun test packages/wp-typia-project-tools/tests/runtime-helper-consolidation.test.ts packages/wp-typia-project-tools/tests/cli-add-shared.test.ts
- bun run --filter @wp-typia/project-tools build
- bun run --filter @wp-typia/project-tools test:quick
- bun run changesets:validate
- bun run format:check
- bun run manifest-policy:validate
- bun run runtime-coupling:validate
- bun run typescript-runtime:validate
- bun run typescript-strictness:validate
- bun run lint:repo
- bun run typecheck
- git diff --check
- git diff --cached --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated filesystem error-handling and optional file-reading utilities into shared runtime helpers, eliminating duplicate code across multiple modules.
  * Enhanced error-code handling with support for optional error-code retrieval.

* **Tests**
  * Expanded test coverage for filesystem helper functionality, including error detection scenarios and module boundary validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/853)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->