### PR TITLE
refactor(cli): split command option metadata

### DIFF
--- a/.sampo/changesets/839-split-command-options.md
+++ b/.sampo/changesets/839-split-command-options.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Split shared CLI command option metadata into command-focused modules while keeping parser and routing aggregation behavior centralized.

--- a/packages/wp-typia/scripts/generate-routing-metadata.mjs
+++ b/packages/wp-typia/scripts/generate-routing-metadata.mjs
@@ -19,6 +19,21 @@ const commandOptionMetadataModulePath = path.join(
   'src',
   'command-option-metadata.ts',
 );
+const commandOptionMetadataSiblingModulePaths = [
+  'index.ts',
+  'types.ts',
+  'add.ts',
+  'create.ts',
+  'doctor.ts',
+  'global.ts',
+  'init.ts',
+  'mcp.ts',
+  'migrate.ts',
+  'sync.ts',
+  'templates.ts',
+].map((fileName) =>
+  path.join(packageRoot, 'src', 'command-options', fileName),
+);
 const commandRegistryModulePath = path.join(
   packageRoot,
   'src',
@@ -163,6 +178,13 @@ async function importTranspiledTypeScriptModule(
     tempDir,
     path.basename(modulePath).replace(/\.ts$/u, '.js'),
   );
+  const resolveSiblingTempFile = (siblingPath) =>
+    path.join(
+      tempDir,
+      path
+        .relative(path.dirname(modulePath), siblingPath)
+        .replace(/\.ts$/u, '.js'),
+    );
 
   await Promise.all([
     fs.writeFile(
@@ -171,9 +193,12 @@ async function importTranspiledTypeScriptModule(
       'utf8',
     ),
     fs.writeFile(tempFile, transpiled.outputText, 'utf8'),
-    ...siblingModules.map((siblingPath, index) =>
-      fs.writeFile(
-        path.join(tempDir, path.basename(siblingPath).replace(/\.ts$/u, '.js')),
+    ...siblingModules.map(async (siblingPath, index) => {
+      const siblingTempFile = resolveSiblingTempFile(siblingPath);
+
+      await fs.mkdir(path.dirname(siblingTempFile), { recursive: true });
+      await fs.writeFile(
+        siblingTempFile,
         ts.transpileModule(siblingSources[index], {
           compilerOptions: {
             module: ts.ModuleKind.CommonJS,
@@ -182,8 +207,8 @@ async function importTranspiledTypeScriptModule(
           fileName: siblingPath,
         }).outputText,
         'utf8',
-      ),
-    ),
+      );
+    }),
     ...externalModules.map(async (externalModule, index) => {
       const parts = externalModule.specifier.split('/');
       const packageName = externalModule.specifier.startsWith('@')
@@ -297,7 +322,10 @@ const [
   { COMMAND_ROUTING_METADATA },
   projectToolsAddKindIdsExternalModule,
 ] = await Promise.all([
-  importTranspiledTypeScriptModule(commandOptionMetadataModulePath),
+  importTranspiledTypeScriptModule(
+    commandOptionMetadataModulePath,
+    commandOptionMetadataSiblingModulePaths,
+  ),
   resolveProjectToolsAddKindIdsExternalModule(),
 ]);
 

--- a/packages/wp-typia/src/command-option-metadata.ts
+++ b/packages/wp-typia/src/command-option-metadata.ts
@@ -3,355 +3,45 @@ import {
   CLI_DIAGNOSTIC_CODES,
   createCliDiagnosticCodeError,
 } from '@wp-typia/project-tools/cli-diagnostics';
+import {
+  ADD_OPTION_METADATA,
+  CREATE_OPTION_METADATA,
+  DOCTOR_OPTION_METADATA,
+  GLOBAL_OPTION_METADATA,
+  INIT_OPTION_METADATA,
+  MCP_OPTION_METADATA,
+  MIGRATE_OPTION_METADATA,
+  SYNC_OPTION_METADATA,
+  TEMPLATES_OPTION_METADATA,
+} from './command-options';
+import type {
+  CommandOptionGroupName,
+  CommandOptionMetadata,
+  CommandOptionMetadataMap,
+  CommandOptionParser,
+  ParsedCommandArgv,
+  ShortOptionDescriptor,
+} from './command-options/types';
 
-export type CommandOptionMetadata = {
-  argumentKind?: 'flag';
-  description: string;
-  short?: string;
-  type: 'boolean' | 'string';
-};
-
-export type CommandOptionMetadataMap = Record<string, CommandOptionMetadata>;
-export type ParsedCommandArgv = {
-  flags: Record<string, unknown>;
-  positionals: string[];
-};
-export type ShortOptionDescriptor = {
-  name: string;
-  type: CommandOptionMetadata['type'];
-};
-export type CommandOptionParser = {
-  booleanOptionNames: Set<string>;
-  shortFlagMap: Map<string, ShortOptionDescriptor>;
-  stringOptionNames: Set<string>;
-};
-export type CommandOptionGroupName =
-  | 'global'
-  | 'create'
-  | 'add'
-  | 'init'
-  | 'migrate'
-  | 'mcp'
-  | 'sync'
-  | 'doctor'
-  | 'templates';
-
-/**
- * Shared `wp-typia create` option metadata used by both the Bunli command
- * definitions and the Node fallback parser/help surface.
- */
-export const CREATE_OPTION_METADATA = {
-  'alternate-render-targets': {
-    description:
-      'Comma-separated alternate render targets for dynamic block scaffolds (email,mjml,plain-text).',
-    type: 'string',
-  },
-  'data-storage': {
-    description: 'Persistence storage mode for persistence-capable templates.',
-    type: 'string',
-  },
-  'dry-run': {
-    argumentKind: 'flag',
-    description:
-      'Preview scaffold output for a logical <project-dir> without writing files to the target directory.',
-    type: 'boolean',
-  },
-  'external-layer-id': {
-    description:
-      'Explicit layer id when an external layer package exposes multiple selectable layers.',
-    type: 'string',
-  },
-  'external-layer-source': {
-    description:
-      'Local path, GitHub locator, or npm package that exposes wp-typia.layers.json for built-in templates.',
-    type: 'string',
-  },
-  'inner-blocks-preset': {
-    description:
-      'Compound-only InnerBlocks preset (freeform, ordered, horizontal, locked-structure).',
-    type: 'string',
-  },
-  namespace: {
-    description: 'Override the default block namespace.',
-    type: 'string',
-  },
-  'no-install': {
-    argumentKind: 'flag',
-    description: 'Skip dependency installation after scaffold.',
-    type: 'boolean',
-  },
-  'package-manager': {
-    description: 'Package manager to use for install and scripts.',
-    short: 'p',
-    type: 'string',
-  },
-  'persistence-policy': {
-    description:
-      'Authenticated or public write policy for persistence-capable templates.',
-    type: 'string',
-  },
-  'php-prefix': {
-    description: 'Custom PHP symbol prefix.',
-    type: 'string',
-  },
-  'query-post-type': {
-    description:
-      'Default post type assigned to Query Loop variation scaffolds.',
-    type: 'string',
-  },
-  template: {
-    description: 'Template id or external template package.',
-    short: 't',
-    type: 'string',
-  },
-  'text-domain': {
-    description: 'Custom text domain for the generated project.',
-    type: 'string',
-  },
-  variant: {
-    description: 'Optional template variant identifier.',
-    type: 'string',
-  },
-  'with-migration-ui': {
-    argumentKind: 'flag',
-    description: 'Enable migration UI support when the template supports it.',
-    type: 'boolean',
-  },
-  'with-test-preset': {
-    argumentKind: 'flag',
-    description: 'Include the Playwright smoke-test preset.',
-    type: 'boolean',
-  },
-  'with-wp-env': {
-    argumentKind: 'flag',
-    description: 'Include a local wp-env preset.',
-    type: 'boolean',
-  },
-  yes: {
-    argumentKind: 'flag',
-    description: 'Accept defaults without prompt fallbacks.',
-    short: 'y',
-    type: 'boolean',
-  },
-} as const satisfies CommandOptionMetadataMap;
-
-/**
- * Shared `wp-typia add` option metadata used by both runtime entry paths.
- */
-export const ADD_OPTION_METADATA = {
-  'alternate-render-targets': {
-    description:
-      'Comma-separated alternate render targets for dynamic block scaffolds (email,mjml,plain-text).',
-    type: 'string',
-  },
-  anchor: {
-    description: 'Anchor block name for hooked-block workflows.',
-    type: 'string',
-  },
-  attribute: {
-    description:
-      'Target block attribute for end-to-end binding-source workflows.',
-    type: 'string',
-  },
-  block: {
-    description:
-      'Target block slug for variation, style, and end-to-end binding-source workflows.',
-    type: 'string',
-  },
-  'data-storage': {
-    description: 'Persistence storage mode for persistence-capable templates.',
-    type: 'string',
-  },
-  'dry-run': {
-    argumentKind: 'flag',
-    description:
-      'Preview workspace file updates and completion guidance without writing them.',
-    type: 'boolean',
-  },
-  'external-layer-id': {
-    description:
-      'Explicit layer id when an external layer package exposes multiple selectable layers.',
-    type: 'string',
-  },
-  'external-layer-source': {
-    description:
-      'Local path, GitHub locator, or npm package that exposes wp-typia.layers.json for built-in block templates.',
-    type: 'string',
-  },
-  from: {
-    description:
-      'Source full block name (namespace/block) for transform workflows.',
-    type: 'string',
-  },
-  'inner-blocks-preset': {
-    description:
-      'Compound-only InnerBlocks preset (freeform, ordered, horizontal, locked-structure).',
-    type: 'string',
-  },
-  methods: {
-    description:
-      'Comma-separated REST resource methods for rest-resource workflows.',
-    type: 'string',
-  },
-  namespace: {
-    description: 'REST namespace for rest-resource and ai-feature workflows.',
-    type: 'string',
-  },
-  'persistence-policy': {
-    description: 'Persistence write policy for persistence-capable templates.',
-    type: 'string',
-  },
-  position: {
-    description: 'Hook position for hooked-block workflows.',
-    type: 'string',
-  },
-  slot: {
-    description:
-      'Document editor shell slot for editor-plugin workflows (sidebar or document-setting-panel).',
-    type: 'string',
-  },
-  source: {
-    description:
-      'Optional data source locator for admin-view workflows, such as rest-resource:products or core-data:postType/post.',
-    type: 'string',
-  },
-  template: {
-    description:
-      'Optional built-in block family for the new block; interactive flows let you choose it when omitted and non-interactive runs default to basic.',
-    type: 'string',
-  },
-  to: {
-    description:
-      'Target workspace block slug or full block name for transform workflows.',
-    type: 'string',
-  },
-} as const satisfies CommandOptionMetadataMap;
-
-/**
- * Shared `wp-typia init` option metadata used by both runtime entry paths.
- */
-export const INIT_OPTION_METADATA = {
-  apply: {
-    argumentKind: 'flag',
-    description:
-      'Write the planned package.json updates and retrofit helper files instead of previewing only.',
-    type: 'boolean',
-  },
-  'package-manager': {
-    description: 'Package manager to use for emitted scripts and next steps.',
-    short: 'p',
-    type: 'string',
-  },
-} as const satisfies CommandOptionMetadataMap;
-
-/**
- * Shared `wp-typia migrate` option metadata used by both runtime entry paths.
- */
-export const MIGRATE_OPTION_METADATA = {
-  all: {
-    argumentKind: 'flag',
-    description:
-      'Run across every configured migration version and block target.',
-    type: 'boolean',
-  },
-  'current-migration-version': {
-    description: 'Current migration version label for `migrate init`.',
-    type: 'string',
-  },
-  force: {
-    argumentKind: 'flag',
-    description: 'Force overwrite behavior where supported.',
-    type: 'boolean',
-  },
-  'from-migration-version': {
-    description: 'Source migration version label.',
-    type: 'string',
-  },
-  iterations: {
-    description: 'Iteration count for `migrate fuzz`.',
-    type: 'string',
-  },
-  'migration-version': {
-    description: 'Version label to capture with `migrate snapshot`.',
-    type: 'string',
-  },
-  seed: {
-    description: 'Deterministic fuzz seed.',
-    type: 'string',
-  },
-  'to-migration-version': {
-    description: 'Target migration version label.',
-    type: 'string',
-  },
-} as const satisfies CommandOptionMetadataMap;
-
-/**
- * Shared `wp-typia mcp` option metadata.
- */
-export const MCP_OPTION_METADATA = {
-  'output-dir': {
-    description: 'Output directory for generated MCP metadata.',
-    type: 'string',
-  },
-} as const satisfies CommandOptionMetadataMap;
-
-/**
- * Shared `wp-typia sync` option metadata used by both runtime entry paths.
- */
-export const SYNC_OPTION_METADATA = {
-  check: {
-    argumentKind: 'flag',
-    description:
-      'Check generated artifacts without writing changes. Advanced sync-types-only flags stay on sync-types.',
-    type: 'boolean',
-  },
-  'dry-run': {
-    argumentKind: 'flag',
-    description:
-      'Preview the generated sync commands that would run without executing them.',
-    type: 'boolean',
-  },
-} as const satisfies CommandOptionMetadataMap;
-
-/**
- * Shared `wp-typia doctor` option metadata.
- */
-export const DOCTOR_OPTION_METADATA = {
-  format: {
-    description:
-      'Use `json` for machine-readable doctor check output or `text` for human-readable output.',
-    type: 'string',
-  },
-} as const satisfies CommandOptionMetadataMap;
-
-/**
- * Shared `wp-typia templates` option metadata.
- */
-export const TEMPLATES_OPTION_METADATA = {
-  id: {
-    description: 'Template id for `templates inspect`.',
-    type: 'string',
-  },
-} as const satisfies CommandOptionMetadataMap;
-
-/**
- * Global option metadata used by Node fallback parsing before command dispatch.
- */
-export const GLOBAL_OPTION_METADATA = {
-  config: {
-    description: 'Config override file path.',
-    short: 'c',
-    type: 'string',
-  },
-  format: {
-    description: 'Output format for supported commands (`json` or `text`).',
-    type: 'string',
-  },
-  id: {
-    description: 'Template id for top-level `templates inspect` convenience.',
-    type: 'string',
-  },
-} as const satisfies CommandOptionMetadataMap;
+export type {
+  CommandOptionGroupName,
+  CommandOptionMetadata,
+  CommandOptionMetadataMap,
+  CommandOptionParser,
+  ParsedCommandArgv,
+  ShortOptionDescriptor,
+} from './command-options/types';
+export {
+  ADD_OPTION_METADATA,
+  CREATE_OPTION_METADATA,
+  DOCTOR_OPTION_METADATA,
+  GLOBAL_OPTION_METADATA,
+  INIT_OPTION_METADATA,
+  MCP_OPTION_METADATA,
+  MIGRATE_OPTION_METADATA,
+  SYNC_OPTION_METADATA,
+  TEMPLATES_OPTION_METADATA,
+} from './command-options';
 
 export const COMMAND_OPTION_METADATA_BY_GROUP = {
   add: ADD_OPTION_METADATA,

--- a/packages/wp-typia/src/command-options/add.ts
+++ b/packages/wp-typia/src/command-options/add.ts
@@ -1,0 +1,93 @@
+import type { CommandOptionMetadataMap } from './types';
+
+/**
+ * Shared `wp-typia add` option metadata used by both runtime entry paths.
+ */
+export const ADD_OPTION_METADATA = {
+  'alternate-render-targets': {
+    description:
+      'Comma-separated alternate render targets for dynamic block scaffolds (email,mjml,plain-text).',
+    type: 'string',
+  },
+  anchor: {
+    description: 'Anchor block name for hooked-block workflows.',
+    type: 'string',
+  },
+  attribute: {
+    description:
+      'Target block attribute for end-to-end binding-source workflows.',
+    type: 'string',
+  },
+  block: {
+    description:
+      'Target block slug for variation, style, and end-to-end binding-source workflows.',
+    type: 'string',
+  },
+  'data-storage': {
+    description: 'Persistence storage mode for persistence-capable templates.',
+    type: 'string',
+  },
+  'dry-run': {
+    argumentKind: 'flag',
+    description:
+      'Preview workspace file updates and completion guidance without writing them.',
+    type: 'boolean',
+  },
+  'external-layer-id': {
+    description:
+      'Explicit layer id when an external layer package exposes multiple selectable layers.',
+    type: 'string',
+  },
+  'external-layer-source': {
+    description:
+      'Local path, GitHub locator, or npm package that exposes wp-typia.layers.json for built-in block templates.',
+    type: 'string',
+  },
+  from: {
+    description:
+      'Source full block name (namespace/block) for transform workflows.',
+    type: 'string',
+  },
+  'inner-blocks-preset': {
+    description:
+      'Compound-only InnerBlocks preset (freeform, ordered, horizontal, locked-structure).',
+    type: 'string',
+  },
+  methods: {
+    description:
+      'Comma-separated REST resource methods for rest-resource workflows.',
+    type: 'string',
+  },
+  namespace: {
+    description: 'REST namespace for rest-resource and ai-feature workflows.',
+    type: 'string',
+  },
+  'persistence-policy': {
+    description: 'Persistence write policy for persistence-capable templates.',
+    type: 'string',
+  },
+  position: {
+    description: 'Hook position for hooked-block workflows.',
+    type: 'string',
+  },
+  slot: {
+    description:
+      'Document editor shell slot for editor-plugin workflows (sidebar or document-setting-panel).',
+    type: 'string',
+  },
+  source: {
+    description:
+      'Optional data source locator for admin-view workflows, such as rest-resource:products or core-data:postType/post.',
+    type: 'string',
+  },
+  template: {
+    description:
+      'Optional built-in block family for the new block; interactive flows let you choose it when omitted and non-interactive runs default to basic.',
+    type: 'string',
+  },
+  to: {
+    description:
+      'Target workspace block slug or full block name for transform workflows.',
+    type: 'string',
+  },
+} as const satisfies CommandOptionMetadataMap;

--- a/packages/wp-typia/src/command-options/create.ts
+++ b/packages/wp-typia/src/command-options/create.ts
@@ -1,0 +1,99 @@
+import type { CommandOptionMetadataMap } from './types';
+
+/**
+ * Shared `wp-typia create` option metadata used by both the Bunli command
+ * definitions and the Node fallback parser/help surface.
+ */
+export const CREATE_OPTION_METADATA = {
+  'alternate-render-targets': {
+    description:
+      'Comma-separated alternate render targets for dynamic block scaffolds (email,mjml,plain-text).',
+    type: 'string',
+  },
+  'data-storage': {
+    description: 'Persistence storage mode for persistence-capable templates.',
+    type: 'string',
+  },
+  'dry-run': {
+    argumentKind: 'flag',
+    description:
+      'Preview scaffold output for a logical <project-dir> without writing files to the target directory.',
+    type: 'boolean',
+  },
+  'external-layer-id': {
+    description:
+      'Explicit layer id when an external layer package exposes multiple selectable layers.',
+    type: 'string',
+  },
+  'external-layer-source': {
+    description:
+      'Local path, GitHub locator, or npm package that exposes wp-typia.layers.json for built-in templates.',
+    type: 'string',
+  },
+  'inner-blocks-preset': {
+    description:
+      'Compound-only InnerBlocks preset (freeform, ordered, horizontal, locked-structure).',
+    type: 'string',
+  },
+  namespace: {
+    description: 'Override the default block namespace.',
+    type: 'string',
+  },
+  'no-install': {
+    argumentKind: 'flag',
+    description: 'Skip dependency installation after scaffold.',
+    type: 'boolean',
+  },
+  'package-manager': {
+    description: 'Package manager to use for install and scripts.',
+    short: 'p',
+    type: 'string',
+  },
+  'persistence-policy': {
+    description:
+      'Authenticated or public write policy for persistence-capable templates.',
+    type: 'string',
+  },
+  'php-prefix': {
+    description: 'Custom PHP symbol prefix.',
+    type: 'string',
+  },
+  'query-post-type': {
+    description: 'Default post type assigned to Query Loop variation scaffolds.',
+    type: 'string',
+  },
+  template: {
+    description: 'Template id or external template package.',
+    short: 't',
+    type: 'string',
+  },
+  'text-domain': {
+    description: 'Custom text domain for the generated project.',
+    type: 'string',
+  },
+  variant: {
+    description: 'Optional template variant identifier.',
+    type: 'string',
+  },
+  'with-migration-ui': {
+    argumentKind: 'flag',
+    description: 'Enable migration UI support when the template supports it.',
+    type: 'boolean',
+  },
+  'with-test-preset': {
+    argumentKind: 'flag',
+    description: 'Include the Playwright smoke-test preset.',
+    type: 'boolean',
+  },
+  'with-wp-env': {
+    argumentKind: 'flag',
+    description: 'Include a local wp-env preset.',
+    type: 'boolean',
+  },
+  yes: {
+    argumentKind: 'flag',
+    description: 'Accept defaults without prompt fallbacks.',
+    short: 'y',
+    type: 'boolean',
+  },
+} as const satisfies CommandOptionMetadataMap;

--- a/packages/wp-typia/src/command-options/doctor.ts
+++ b/packages/wp-typia/src/command-options/doctor.ts
@@ -1,0 +1,12 @@
+import type { CommandOptionMetadataMap } from './types';
+
+/**
+ * Shared `wp-typia doctor` option metadata.
+ */
+export const DOCTOR_OPTION_METADATA = {
+  format: {
+    description:
+      'Use `json` for machine-readable doctor check output or `text` for human-readable output.',
+    type: 'string',
+  },
+} as const satisfies CommandOptionMetadataMap;

--- a/packages/wp-typia/src/command-options/global.ts
+++ b/packages/wp-typia/src/command-options/global.ts
@@ -1,0 +1,20 @@
+import type { CommandOptionMetadataMap } from './types';
+
+/**
+ * Global option metadata used by Node fallback parsing before command dispatch.
+ */
+export const GLOBAL_OPTION_METADATA = {
+  config: {
+    description: 'Config override file path.',
+    short: 'c',
+    type: 'string',
+  },
+  format: {
+    description: 'Output format for supported commands (`json` or `text`).',
+    type: 'string',
+  },
+  id: {
+    description: 'Template id for top-level `templates inspect` convenience.',
+    type: 'string',
+  },
+} as const satisfies CommandOptionMetadataMap;

--- a/packages/wp-typia/src/command-options/index.ts
+++ b/packages/wp-typia/src/command-options/index.ts
@@ -1,0 +1,9 @@
+export { ADD_OPTION_METADATA } from './add';
+export { CREATE_OPTION_METADATA } from './create';
+export { DOCTOR_OPTION_METADATA } from './doctor';
+export { GLOBAL_OPTION_METADATA } from './global';
+export { INIT_OPTION_METADATA } from './init';
+export { MCP_OPTION_METADATA } from './mcp';
+export { MIGRATE_OPTION_METADATA } from './migrate';
+export { SYNC_OPTION_METADATA } from './sync';
+export { TEMPLATES_OPTION_METADATA } from './templates';

--- a/packages/wp-typia/src/command-options/init.ts
+++ b/packages/wp-typia/src/command-options/init.ts
@@ -1,0 +1,18 @@
+import type { CommandOptionMetadataMap } from './types';
+
+/**
+ * Shared `wp-typia init` option metadata used by both runtime entry paths.
+ */
+export const INIT_OPTION_METADATA = {
+  apply: {
+    argumentKind: 'flag',
+    description:
+      'Write the planned package.json updates and retrofit helper files instead of previewing only.',
+    type: 'boolean',
+  },
+  'package-manager': {
+    description: 'Package manager to use for emitted scripts and next steps.',
+    short: 'p',
+    type: 'string',
+  },
+} as const satisfies CommandOptionMetadataMap;

--- a/packages/wp-typia/src/command-options/mcp.ts
+++ b/packages/wp-typia/src/command-options/mcp.ts
@@ -1,0 +1,11 @@
+import type { CommandOptionMetadataMap } from './types';
+
+/**
+ * Shared `wp-typia mcp` option metadata.
+ */
+export const MCP_OPTION_METADATA = {
+  'output-dir': {
+    description: 'Output directory for generated MCP metadata.',
+    type: 'string',
+  },
+} as const satisfies CommandOptionMetadataMap;

--- a/packages/wp-typia/src/command-options/migrate.ts
+++ b/packages/wp-typia/src/command-options/migrate.ts
@@ -1,0 +1,42 @@
+import type { CommandOptionMetadataMap } from './types';
+
+/**
+ * Shared `wp-typia migrate` option metadata used by both runtime entry paths.
+ */
+export const MIGRATE_OPTION_METADATA = {
+  all: {
+    argumentKind: 'flag',
+    description:
+      'Run across every configured migration version and block target.',
+    type: 'boolean',
+  },
+  'current-migration-version': {
+    description: 'Current migration version label for `migrate init`.',
+    type: 'string',
+  },
+  force: {
+    argumentKind: 'flag',
+    description: 'Force overwrite behavior where supported.',
+    type: 'boolean',
+  },
+  'from-migration-version': {
+    description: 'Source migration version label.',
+    type: 'string',
+  },
+  iterations: {
+    description: 'Iteration count for `migrate fuzz`.',
+    type: 'string',
+  },
+  'migration-version': {
+    description: 'Version label to capture with `migrate snapshot`.',
+    type: 'string',
+  },
+  seed: {
+    description: 'Deterministic fuzz seed.',
+    type: 'string',
+  },
+  'to-migration-version': {
+    description: 'Target migration version label.',
+    type: 'string',
+  },
+} as const satisfies CommandOptionMetadataMap;

--- a/packages/wp-typia/src/command-options/sync.ts
+++ b/packages/wp-typia/src/command-options/sync.ts
@@ -1,0 +1,19 @@
+import type { CommandOptionMetadataMap } from './types';
+
+/**
+ * Shared `wp-typia sync` option metadata used by both runtime entry paths.
+ */
+export const SYNC_OPTION_METADATA = {
+  check: {
+    argumentKind: 'flag',
+    description:
+      'Check generated artifacts without writing changes. Advanced sync-types-only flags stay on sync-types.',
+    type: 'boolean',
+  },
+  'dry-run': {
+    argumentKind: 'flag',
+    description:
+      'Preview the generated sync commands that would run without executing them.',
+    type: 'boolean',
+  },
+} as const satisfies CommandOptionMetadataMap;

--- a/packages/wp-typia/src/command-options/templates.ts
+++ b/packages/wp-typia/src/command-options/templates.ts
@@ -1,0 +1,11 @@
+import type { CommandOptionMetadataMap } from './types';
+
+/**
+ * Shared `wp-typia templates` option metadata.
+ */
+export const TEMPLATES_OPTION_METADATA = {
+  id: {
+    description: 'Template id for `templates inspect`.',
+    type: 'string',
+  },
+} as const satisfies CommandOptionMetadataMap;

--- a/packages/wp-typia/src/command-options/types.ts
+++ b/packages/wp-typia/src/command-options/types.ts
@@ -1,0 +1,35 @@
+export type CommandOptionMetadata = {
+  argumentKind?: 'flag';
+  description: string;
+  short?: string;
+  type: 'boolean' | 'string';
+};
+
+export type CommandOptionMetadataMap = Record<string, CommandOptionMetadata>;
+
+export type ParsedCommandArgv = {
+  flags: Record<string, unknown>;
+  positionals: string[];
+};
+
+export type ShortOptionDescriptor = {
+  name: string;
+  type: CommandOptionMetadata['type'];
+};
+
+export type CommandOptionParser = {
+  booleanOptionNames: Set<string>;
+  shortFlagMap: Map<string, ShortOptionDescriptor>;
+  stringOptionNames: Set<string>;
+};
+
+export type CommandOptionGroupName =
+  | 'global'
+  | 'create'
+  | 'add'
+  | 'init'
+  | 'migrate'
+  | 'mcp'
+  | 'sync'
+  | 'doctor'
+  | 'templates';

--- a/packages/wp-typia/tests/command-option-metadata.test.ts
+++ b/packages/wp-typia/tests/command-option-metadata.test.ts
@@ -14,10 +14,21 @@ import {
   GLOBAL_OPTION_METADATA,
   INIT_OPTION_METADATA,
   MCP_OPTION_METADATA,
+  MIGRATE_OPTION_METADATA,
   parseCommandArgvWithMetadata,
   resolveCommandOptionValues,
   SYNC_OPTION_METADATA,
+  TEMPLATES_OPTION_METADATA,
 } from '../src/command-option-metadata';
+import { ADD_OPTION_METADATA as FOCUSED_ADD_OPTION_METADATA } from '../src/command-options/add';
+import { CREATE_OPTION_METADATA as FOCUSED_CREATE_OPTION_METADATA } from '../src/command-options/create';
+import { DOCTOR_OPTION_METADATA as FOCUSED_DOCTOR_OPTION_METADATA } from '../src/command-options/doctor';
+import { GLOBAL_OPTION_METADATA as FOCUSED_GLOBAL_OPTION_METADATA } from '../src/command-options/global';
+import { INIT_OPTION_METADATA as FOCUSED_INIT_OPTION_METADATA } from '../src/command-options/init';
+import { MCP_OPTION_METADATA as FOCUSED_MCP_OPTION_METADATA } from '../src/command-options/mcp';
+import { MIGRATE_OPTION_METADATA as FOCUSED_MIGRATE_OPTION_METADATA } from '../src/command-options/migrate';
+import { SYNC_OPTION_METADATA as FOCUSED_SYNC_OPTION_METADATA } from '../src/command-options/sync';
+import { TEMPLATES_OPTION_METADATA as FOCUSED_TEMPLATES_OPTION_METADATA } from '../src/command-options/templates';
 
 describe('command option metadata helpers', () => {
   function expectDiagnosticCode(
@@ -37,6 +48,24 @@ describe('command option metadata helpers', () => {
       message,
     });
   }
+
+  test('keeps command option declarations single-sourced in focused modules', () => {
+    expect(CREATE_OPTION_METADATA).toBe(FOCUSED_CREATE_OPTION_METADATA);
+    expect(ADD_OPTION_METADATA).toBe(FOCUSED_ADD_OPTION_METADATA);
+    expect(INIT_OPTION_METADATA).toBe(FOCUSED_INIT_OPTION_METADATA);
+    expect(SYNC_OPTION_METADATA).toBe(FOCUSED_SYNC_OPTION_METADATA);
+    expect(DOCTOR_OPTION_METADATA).toBe(FOCUSED_DOCTOR_OPTION_METADATA);
+    expect(MIGRATE_OPTION_METADATA).toBe(FOCUSED_MIGRATE_OPTION_METADATA);
+    expect(MCP_OPTION_METADATA).toBe(FOCUSED_MCP_OPTION_METADATA);
+    expect(GLOBAL_OPTION_METADATA).toBe(FOCUSED_GLOBAL_OPTION_METADATA);
+    expect(TEMPLATES_OPTION_METADATA).toBe(FOCUSED_TEMPLATES_OPTION_METADATA);
+    expect(COMMAND_OPTION_METADATA_BY_GROUP.create).toBe(
+      FOCUSED_CREATE_OPTION_METADATA,
+    );
+    expect(COMMAND_OPTION_METADATA_BY_GROUP.add).toBe(
+      FOCUSED_ADD_OPTION_METADATA,
+    );
+  });
 
   test('parses string and boolean flags from shared metadata', () => {
     const parsed = parseCommandArgvWithMetadata(

--- a/packages/wp-typia/tests/command-option-metadata.test.ts
+++ b/packages/wp-typia/tests/command-option-metadata.test.ts
@@ -65,6 +65,27 @@ describe('command option metadata helpers', () => {
     expect(COMMAND_OPTION_METADATA_BY_GROUP.add).toBe(
       FOCUSED_ADD_OPTION_METADATA,
     );
+    expect(COMMAND_OPTION_METADATA_BY_GROUP.init).toBe(
+      FOCUSED_INIT_OPTION_METADATA,
+    );
+    expect(COMMAND_OPTION_METADATA_BY_GROUP.sync).toBe(
+      FOCUSED_SYNC_OPTION_METADATA,
+    );
+    expect(COMMAND_OPTION_METADATA_BY_GROUP.doctor).toBe(
+      FOCUSED_DOCTOR_OPTION_METADATA,
+    );
+    expect(COMMAND_OPTION_METADATA_BY_GROUP.migrate).toBe(
+      FOCUSED_MIGRATE_OPTION_METADATA,
+    );
+    expect(COMMAND_OPTION_METADATA_BY_GROUP.mcp).toBe(
+      FOCUSED_MCP_OPTION_METADATA,
+    );
+    expect(COMMAND_OPTION_METADATA_BY_GROUP.global).toBe(
+      FOCUSED_GLOBAL_OPTION_METADATA,
+    );
+    expect(COMMAND_OPTION_METADATA_BY_GROUP.templates).toBe(
+      FOCUSED_TEMPLATES_OPTION_METADATA,
+    );
   });
 
   test('parses string and boolean flags from shared metadata', () => {


### PR DESCRIPTION
## Summary
- move command-specific option metadata into focused command-options modules
- keep command-option-metadata as the public parser/aggregation facade
- teach routing metadata generation to transpile focused sibling modules in its temporary validation tree
- add invariants that facade exports point at the focused metadata objects

## Validation
- bun run format:check -- packages/wp-typia/src/command-option-metadata.ts packages/wp-typia/src/command-options packages/wp-typia/tests/command-option-metadata.test.ts packages/wp-typia/scripts/generate-routing-metadata.mjs .sampo/changesets/839-split-command-options.md && git diff --check
- bun test packages/wp-typia/tests/command-option-metadata.test.ts packages/wp-typia/tests/command-registry.test.ts packages/wp-typia/tests/bunli-prep.test.ts
- bun run typecheck
- bun run --filter wp-typia test
- bun run --filter wp-typia build
- bun run --filter wp-typia validate:routing && bun run changesets:validate && git diff --check
- bun run lint:repo

Closes #839

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized CLI command option metadata into dedicated command-focused modules for improved organization and maintainability.
  * Updated metadata generation process to handle the new module structure.

* **Tests**
  * Added verification ensuring command option metadata is consistently single-sourced across modules.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/856)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->