### PR TITLE
refactor(add-kinds): single-source missing name messages

### DIFF
--- a/.sampo/changesets/840-single-source-add-kind-messages.md
+++ b/.sampo/changesets/840-single-source-add-kind-messages.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Single-source add-kind missing-name messages so direct validation and execution-plan validation stay aligned.

--- a/packages/wp-typia/src/add-kinds/ability.ts
+++ b/packages/wp-typia/src/add-kinds/ability.ts
@@ -5,6 +5,9 @@ import {
   type AddAbilityResult,
 } from '../add-kind-registry-shared';
 
+const ABILITY_MISSING_NAME_MESSAGE =
+  '`wp-typia add ability` requires <name>. Usage: wp-typia add ability <name>.';
+
 export const abilityAddKindEntry =
   defineAddKindRegistryEntry<AddAbilityResult>({
     completion: {
@@ -31,8 +34,7 @@ export const abilityAddKindEntry =
           abilitySlug: result.abilitySlug,
         }),
         getWarnings: (result) => result.warnings,
-        missingNameMessage:
-          '`wp-typia add ability` requires <name>. Usage: wp-typia add ability <name>.',
+        missingNameMessage: ABILITY_MISSING_NAME_MESSAGE,
         warnLine: context.warnLine,
       });
     },

--- a/packages/wp-typia/src/add-kinds/admin-view.ts
+++ b/packages/wp-typia/src/add-kinds/admin-view.ts
@@ -7,6 +7,9 @@ import {
   type AddAdminViewResult,
 } from '../add-kind-registry-shared';
 
+const ADMIN_VIEW_MISSING_NAME_MESSAGE =
+  '`wp-typia add admin-view` requires <name>. Usage: wp-typia add admin-view <name> [--source <rest-resource:slug|core-data:kind/name>].';
+
 export const adminViewAddKindEntry =
   defineAddKindRegistryEntry<AddAdminViewResult>({
     completion: {
@@ -26,7 +29,7 @@ export const adminViewAddKindEntry =
     async prepareExecution(context) {
       const name = requireAddKindName(
         context,
-        '`wp-typia add admin-view` requires <name>. Usage: wp-typia add admin-view <name> [--source <rest-resource:slug|core-data:kind/name>].',
+        ADMIN_VIEW_MISSING_NAME_MESSAGE,
       );
       const source = readOptionalStrictStringFlag(context.flags, 'source');
 
@@ -41,8 +44,7 @@ export const adminViewAddKindEntry =
           adminViewSlug: result.adminViewSlug,
           ...(result.source ? { source: result.source } : {}),
         }),
-        missingNameMessage:
-          '`wp-typia add admin-view` requires <name>. Usage: wp-typia add admin-view <name> [--source <rest-resource:slug|core-data:kind/name>].',
+        missingNameMessage: ADMIN_VIEW_MISSING_NAME_MESSAGE,
         name,
       });
     },

--- a/packages/wp-typia/src/add-kinds/ai-feature.ts
+++ b/packages/wp-typia/src/add-kinds/ai-feature.ts
@@ -7,6 +7,9 @@ import {
   type AddAiFeatureResult,
 } from '../add-kind-registry-shared';
 
+const AI_FEATURE_MISSING_NAME_MESSAGE =
+  '`wp-typia add ai-feature` requires <name>. Usage: wp-typia add ai-feature <name> [--namespace <vendor/v1>].';
+
 export const aiFeatureAddKindEntry =
   defineAddKindRegistryEntry<AddAiFeatureResult>({
     completion: {
@@ -26,7 +29,7 @@ export const aiFeatureAddKindEntry =
     async prepareExecution(context) {
       const name = requireAddKindName(
         context,
-        '`wp-typia add ai-feature` requires <name>. Usage: wp-typia add ai-feature <name> [--namespace <vendor/v1>].',
+        AI_FEATURE_MISSING_NAME_MESSAGE,
       );
       const namespace = readOptionalStrictStringFlag(context.flags, 'namespace');
 
@@ -42,8 +45,7 @@ export const aiFeatureAddKindEntry =
           namespace: result.namespace,
         }),
         getWarnings: (result) => result.warnings,
-        missingNameMessage:
-          '`wp-typia add ai-feature` requires <name>. Usage: wp-typia add ai-feature <name> [--namespace <vendor/v1>].',
+        missingNameMessage: AI_FEATURE_MISSING_NAME_MESSAGE,
         name,
         warnLine: context.warnLine,
       });

--- a/packages/wp-typia/src/add-kinds/binding-source.ts
+++ b/packages/wp-typia/src/add-kinds/binding-source.ts
@@ -7,6 +7,9 @@ import {
   type AddBindingSourceResult,
 } from '../add-kind-registry-shared';
 
+const BINDING_SOURCE_MISSING_NAME_MESSAGE =
+  '`wp-typia add binding-source` requires <name>. Usage: wp-typia add binding-source <name> [--block <block-slug|namespace/block-slug> --attribute <attribute>].';
+
 export const bindingSourceAddKindEntry =
   defineAddKindRegistryEntry<AddBindingSourceResult>({
     completion: {
@@ -33,7 +36,7 @@ export const bindingSourceAddKindEntry =
     async prepareExecution(context) {
       const name = requireAddKindName(
         context,
-        '`wp-typia add binding-source` requires <name>. Usage: wp-typia add binding-source <name> [--block <block-slug|namespace/block-slug> --attribute <attribute>].',
+        BINDING_SOURCE_MISSING_NAME_MESSAGE,
       );
       const [blockName, attributeName] = readOptionalPairedStrictStringFlags(
         context.flags,
@@ -57,8 +60,7 @@ export const bindingSourceAddKindEntry =
           ...(result.blockSlug ? { blockSlug: result.blockSlug } : {}),
           bindingSourceSlug: result.bindingSourceSlug,
         }),
-        missingNameMessage:
-          '`wp-typia add binding-source` requires <name>. Usage: wp-typia add binding-source <name> [--block <block-slug|namespace/block-slug> --attribute <attribute>].',
+        missingNameMessage: BINDING_SOURCE_MISSING_NAME_MESSAGE,
         name,
       });
     },

--- a/packages/wp-typia/src/add-kinds/block.ts
+++ b/packages/wp-typia/src/add-kinds/block.ts
@@ -12,6 +12,9 @@ import {
   type AddBlockResult,
 } from '../add-kind-registry-shared';
 
+const BLOCK_MISSING_NAME_MESSAGE =
+  '`wp-typia add block` requires <name>. Usage: wp-typia add block <name> [--template <basic|interactivity|persistence|compound>]';
+
 export const blockAddKindEntry = defineAddKindRegistryEntry<AddBlockResult>({
   completion: {
     nextSteps: () => [
@@ -31,7 +34,7 @@ export const blockAddKindEntry = defineAddKindRegistryEntry<AddBlockResult>({
   async prepareExecution(context) {
     const name = requireAddKindName(
       context,
-      '`wp-typia add block` requires <name>. Usage: wp-typia add block <name> [--template <basic|interactivity|persistence|compound>]',
+      BLOCK_MISSING_NAME_MESSAGE,
     );
     const externalLayerId = readOptionalStrictStringFlag(
       context.flags,
@@ -111,8 +114,7 @@ export const blockAddKindEntry = defineAddKindRegistryEntry<AddBlockResult>({
         templateId: result.templateId,
       }),
       getWarnings: (result) => result.warnings,
-      missingNameMessage:
-        '`wp-typia add block` requires <name>. Usage: wp-typia add block <name> [--template <basic|interactivity|persistence|compound>]',
+      missingNameMessage: BLOCK_MISSING_NAME_MESSAGE,
       name,
       warnLine: context.warnLine,
     });

--- a/packages/wp-typia/src/add-kinds/editor-plugin.ts
+++ b/packages/wp-typia/src/add-kinds/editor-plugin.ts
@@ -7,6 +7,9 @@ import {
   type AddEditorPluginResult,
 } from '../add-kind-registry-shared';
 
+const EDITOR_PLUGIN_MISSING_NAME_MESSAGE =
+  '`wp-typia add editor-plugin` requires <name>. Usage: wp-typia add editor-plugin <name> [--slot <sidebar|document-setting-panel>].';
+
 export const editorPluginAddKindEntry =
   defineAddKindRegistryEntry<AddEditorPluginResult>({
     completion: {
@@ -26,7 +29,7 @@ export const editorPluginAddKindEntry =
     async prepareExecution(context) {
       const name = requireAddKindName(
         context,
-        '`wp-typia add editor-plugin` requires <name>. Usage: wp-typia add editor-plugin <name> [--slot <sidebar|document-setting-panel>].',
+        EDITOR_PLUGIN_MISSING_NAME_MESSAGE,
       );
       const slot = readOptionalStrictStringFlag(context.flags, 'slot');
 
@@ -41,8 +44,7 @@ export const editorPluginAddKindEntry =
           editorPluginSlug: result.editorPluginSlug,
           slot: result.slot,
         }),
-        missingNameMessage:
-          '`wp-typia add editor-plugin` requires <name>. Usage: wp-typia add editor-plugin <name> [--slot <sidebar|document-setting-panel>].',
+        missingNameMessage: EDITOR_PLUGIN_MISSING_NAME_MESSAGE,
         name,
       });
     },

--- a/packages/wp-typia/src/add-kinds/hooked-block.ts
+++ b/packages/wp-typia/src/add-kinds/hooked-block.ts
@@ -7,6 +7,9 @@ import {
   type AddHookedBlockResult,
 } from '../add-kind-registry-shared';
 
+const HOOKED_BLOCK_MISSING_NAME_MESSAGE =
+  '`wp-typia add hooked-block` requires <block-slug>. Usage: wp-typia add hooked-block <block-slug> --anchor <anchor-block-name> --position <before|after|firstChild|lastChild>.';
+
 export const hookedBlockAddKindEntry =
   defineAddKindRegistryEntry<AddHookedBlockResult>({
     completion: {
@@ -27,7 +30,7 @@ export const hookedBlockAddKindEntry =
     async prepareExecution(context) {
       const name = requireAddKindName(
         context,
-        '`wp-typia add hooked-block` requires <block-slug>. Usage: wp-typia add hooked-block <block-slug> --anchor <anchor-block-name> --position <before|after|firstChild|lastChild>.',
+        HOOKED_BLOCK_MISSING_NAME_MESSAGE,
       );
       const anchorBlockName = requireStrictStringFlag(
         context.flags,
@@ -53,8 +56,7 @@ export const hookedBlockAddKindEntry =
           blockSlug: result.blockSlug,
           position: result.position,
         }),
-        missingNameMessage:
-          '`wp-typia add hooked-block` requires <block-slug>. Usage: wp-typia add hooked-block <block-slug> --anchor <anchor-block-name> --position <before|after|firstChild|lastChild>.',
+        missingNameMessage: HOOKED_BLOCK_MISSING_NAME_MESSAGE,
         name,
       });
     },

--- a/packages/wp-typia/src/add-kinds/pattern.ts
+++ b/packages/wp-typia/src/add-kinds/pattern.ts
@@ -5,6 +5,9 @@ import {
   type AddPatternResult,
 } from '../add-kind-registry-shared';
 
+const PATTERN_MISSING_NAME_MESSAGE =
+  '`wp-typia add pattern` requires <name>. Usage: wp-typia add pattern <name>.';
+
 export const patternAddKindEntry =
   defineAddKindRegistryEntry<AddPatternResult>({
     completion: {
@@ -30,8 +33,7 @@ export const patternAddKindEntry =
         getValues: (result) => ({
           patternSlug: result.patternSlug,
         }),
-        missingNameMessage:
-          '`wp-typia add pattern` requires <name>. Usage: wp-typia add pattern <name>.',
+        missingNameMessage: PATTERN_MISSING_NAME_MESSAGE,
       });
     },
     sortOrder: 60,

--- a/packages/wp-typia/src/add-kinds/rest-resource.ts
+++ b/packages/wp-typia/src/add-kinds/rest-resource.ts
@@ -7,6 +7,9 @@ import {
   type AddRestResourceResult,
 } from '../add-kind-registry-shared';
 
+const REST_RESOURCE_MISSING_NAME_MESSAGE =
+  '`wp-typia add rest-resource` requires <name>. Usage: wp-typia add rest-resource <name> [--namespace <vendor/v1>] [--methods <list,read,create,update,delete>].';
+
 export const restResourceAddKindEntry =
   defineAddKindRegistryEntry<AddRestResourceResult>({
     completion: {
@@ -27,7 +30,7 @@ export const restResourceAddKindEntry =
     async prepareExecution(context) {
       const name = requireAddKindName(
         context,
-        '`wp-typia add rest-resource` requires <name>. Usage: wp-typia add rest-resource <name> [--namespace <vendor/v1>] [--methods <list,read,create,update,delete>].',
+        REST_RESOURCE_MISSING_NAME_MESSAGE,
       );
       const methods = readOptionalStrictStringFlag(context.flags, 'methods');
       const namespace = readOptionalStrictStringFlag(context.flags, 'namespace');
@@ -45,8 +48,7 @@ export const restResourceAddKindEntry =
           namespace: result.namespace,
           restResourceSlug: result.restResourceSlug,
         }),
-        missingNameMessage:
-          '`wp-typia add rest-resource` requires <name>. Usage: wp-typia add rest-resource <name> [--namespace <vendor/v1>] [--methods <list,read,create,update,delete>].',
+        missingNameMessage: REST_RESOURCE_MISSING_NAME_MESSAGE,
         name,
       });
     },

--- a/packages/wp-typia/src/add-kinds/style.ts
+++ b/packages/wp-typia/src/add-kinds/style.ts
@@ -7,6 +7,9 @@ import {
   type AddBlockStyleResult,
 } from '../add-kind-registry-shared';
 
+const STYLE_MISSING_NAME_MESSAGE =
+  '`wp-typia add style` requires <name>. Usage: wp-typia add style <name> --block <block-slug>.';
+
 export const styleAddKindEntry =
   defineAddKindRegistryEntry<AddBlockStyleResult>({
     completion: {
@@ -26,7 +29,7 @@ export const styleAddKindEntry =
     async prepareExecution(context) {
       const name = requireAddKindName(
         context,
-        '`wp-typia add style` requires <name>. Usage: wp-typia add style <name> --block <block-slug>.',
+        STYLE_MISSING_NAME_MESSAGE,
       );
       const blockSlug = requireStrictStringFlag(
         context.flags,
@@ -45,8 +48,7 @@ export const styleAddKindEntry =
           blockSlug: result.blockSlug,
           styleSlug: result.styleSlug,
         }),
-        missingNameMessage:
-          '`wp-typia add style` requires <name>. Usage: wp-typia add style <name> --block <block-slug>.',
+        missingNameMessage: STYLE_MISSING_NAME_MESSAGE,
         name,
       });
     },

--- a/packages/wp-typia/src/add-kinds/transform.ts
+++ b/packages/wp-typia/src/add-kinds/transform.ts
@@ -7,6 +7,9 @@ import {
   type AddBlockTransformResult,
 } from '../add-kind-registry-shared';
 
+const TRANSFORM_MISSING_NAME_MESSAGE =
+  '`wp-typia add transform` requires <name>. Usage: wp-typia add transform <name> --from <namespace/block> --to <block-slug|namespace/block-slug>.';
+
 export const transformAddKindEntry =
   defineAddKindRegistryEntry<AddBlockTransformResult>({
     completion: {
@@ -27,7 +30,7 @@ export const transformAddKindEntry =
     async prepareExecution(context) {
       const name = requireAddKindName(
         context,
-        '`wp-typia add transform` requires <name>. Usage: wp-typia add transform <name> --from <namespace/block> --to <block-slug|namespace/block-slug>.',
+        TRANSFORM_MISSING_NAME_MESSAGE,
       );
       const fromBlockName = requireStrictStringFlag(
         context.flags,
@@ -54,8 +57,7 @@ export const transformAddKindEntry =
           toBlockName: result.toBlockName,
           transformSlug: result.transformSlug,
         }),
-        missingNameMessage:
-          '`wp-typia add transform` requires <name>. Usage: wp-typia add transform <name> --from <namespace/block> --to <block-slug|namespace/block-slug>.',
+        missingNameMessage: TRANSFORM_MISSING_NAME_MESSAGE,
         name,
       });
     },

--- a/packages/wp-typia/src/add-kinds/variation.ts
+++ b/packages/wp-typia/src/add-kinds/variation.ts
@@ -7,6 +7,9 @@ import {
   type AddVariationResult,
 } from '../add-kind-registry-shared';
 
+const VARIATION_MISSING_NAME_MESSAGE =
+  '`wp-typia add variation` requires <name>. Usage: wp-typia add variation <name> --block <block-slug>';
+
 export const variationAddKindEntry =
   defineAddKindRegistryEntry<AddVariationResult>({
     completion: {
@@ -26,7 +29,7 @@ export const variationAddKindEntry =
     async prepareExecution(context) {
       const name = requireAddKindName(
         context,
-        '`wp-typia add variation` requires <name>. Usage: wp-typia add variation <name> --block <block-slug>',
+        VARIATION_MISSING_NAME_MESSAGE,
       );
       const blockSlug = requireStrictStringFlag(
         context.flags,
@@ -45,8 +48,7 @@ export const variationAddKindEntry =
           blockSlug: result.blockSlug,
           variationSlug: result.variationSlug,
         }),
-        missingNameMessage:
-          '`wp-typia add variation` requires <name>. Usage: wp-typia add variation <name> --block <block-slug>',
+        missingNameMessage: VARIATION_MISSING_NAME_MESSAGE,
         name,
       });
     },

--- a/packages/wp-typia/tests/add-kind-source.test.ts
+++ b/packages/wp-typia/tests/add-kind-source.test.ts
@@ -24,3 +24,40 @@ test('single-sources add-kind ids from project-tools metadata', () => {
   expect(ADD_KIND_IDS).toEqual([...PROJECT_TOOLS_ADD_KIND_IDS]);
   expect(addCommand?.subcommands).toEqual([...PROJECT_TOOLS_ADD_KIND_IDS]);
 });
+
+test('single-sources add-kind missing-name messages inside kind modules', () => {
+  const addKindSourceDir = path.join(packageRoot, 'src', 'add-kinds');
+  const offenders: string[] = [];
+
+  for (const filename of fs
+    .readdirSync(addKindSourceDir)
+    .filter((name) => name.endsWith('.ts'))) {
+    const source = fs.readFileSync(
+      path.join(addKindSourceDir, filename),
+      'utf8',
+    );
+    if (!source.includes('missingNameMessage')) {
+      continue;
+    }
+
+    const definitions = [
+      ...source.matchAll(/const\s+([A-Z0-9_]+_MISSING_NAME_MESSAGE)\s*=/g),
+    ].map((match) => match[1]);
+    const [constantName] = definitions;
+    const hasInlinePlanMessage = /missingNameMessage:\s*['"`]/.test(source);
+    const hasInlineRequireMessage =
+      /requireAddKindName\(\s*context,\s*['"`]/.test(source);
+
+    if (
+      definitions.length !== 1 ||
+      !constantName ||
+      !source.includes(`missingNameMessage: ${constantName}`) ||
+      hasInlinePlanMessage ||
+      hasInlineRequireMessage
+    ) {
+      offenders.push(filename);
+    }
+  }
+
+  expect(offenders).toEqual([]);
+});

--- a/packages/wp-typia/tests/add-kind-source.test.ts
+++ b/packages/wp-typia/tests/add-kind-source.test.ts
@@ -45,15 +45,23 @@ test('single-sources add-kind missing-name messages inside kind modules', () => 
     ].map((match) => match[1]);
     const [constantName] = definitions;
     const hasInlinePlanMessage = /missingNameMessage:\s*['"`]/.test(source);
-    const hasInlineRequireMessage =
-      /requireAddKindName\(\s*context,\s*['"`]/.test(source);
+    const requireAddKindNameArguments = [
+      ...source.matchAll(/requireAddKindName\(\s*[^,]+,\s*([^),]+)\s*[),]/gs),
+    ].map((match) => match[1]?.trim());
+    const hasInlineRequireMessage = requireAddKindNameArguments.some(
+      (argument) => /^['"`]/.test(argument ?? ''),
+    );
+    const hasMismatchedRequireMessage = requireAddKindNameArguments.some(
+      (argument) => argument !== constantName,
+    );
 
     if (
       definitions.length !== 1 ||
       !constantName ||
       !source.includes(`missingNameMessage: ${constantName}`) ||
       hasInlinePlanMessage ||
-      hasInlineRequireMessage
+      hasInlineRequireMessage ||
+      hasMismatchedRequireMessage
     ) {
       offenders.push(filename);
     }


### PR DESCRIPTION
## Summary
- define one missing-name message constant per add-kind module
- reuse each constant for direct name validation and execution-plan validation
- add a source guard so future add-kind modules keep the same pattern

## Validation
- bun run format:check -- packages/wp-typia/src/add-kinds packages/wp-typia/tests/add-kind-source.test.ts .sampo/changesets/840-single-source-add-kind-messages.md
- bun test packages/wp-typia/tests/add-kind-source.test.ts packages/wp-typia/tests/add-kind-registry.test.ts
- bun run typecheck
- bun run --filter wp-typia test
- bun run --filter wp-typia build
- bun run changesets:validate
- bun run lint:repo

Closes #840

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized error message handling across all add-kind commands by centralizing "missing name" messages into shared constants.

* **Tests**
  * Added validation test to enforce consistent message patterns in add-kind modules, ensuring direct validation and execution-plan validation remain aligned.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/857)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->