### PR TITLE
fix(add): pass warnLine through pattern plan

### DIFF
--- a/.sampo/changesets/841-pattern-warnline.md
+++ b/.sampo/changesets/841-pattern-warnline.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Pass the pattern add-kind warning printer through its execution plan so warning output uses the expected channel.

--- a/packages/wp-typia/src/add-kinds/pattern.ts
+++ b/packages/wp-typia/src/add-kinds/pattern.ts
@@ -34,6 +34,7 @@ export const patternAddKindEntry =
           patternSlug: result.patternSlug,
         }),
         missingNameMessage: PATTERN_MISSING_NAME_MESSAGE,
+        warnLine: context.warnLine,
       });
     },
     sortOrder: 60,

--- a/packages/wp-typia/tests/add-kind-registry.test.ts
+++ b/packages/wp-typia/tests/add-kind-registry.test.ts
@@ -4,6 +4,7 @@ import {
   ADD_KIND_IDS,
   ADD_KIND_REGISTRY,
   type AddKindId,
+  type AddKindExecutionContext,
   type AddKindExecutionPlanFor,
   getAddVisibleFieldNames,
 } from '../src/add-kind-registry';
@@ -214,4 +215,28 @@ test('keeps shared visible-field groups aligned for refactored add kinds', () =>
     'data-storage',
     'persistence-policy',
   ]);
+});
+
+test('passes the warning line printer through the pattern execution plan', async () => {
+  const warnLine = () => {};
+  const context = {
+    addRuntime: {
+      runAddPatternCommand: async ({ cwd, patternName }) => ({
+        patternSlug: patternName,
+        projectDir: cwd,
+      }),
+    } as AddKindExecutionContext['addRuntime'],
+    cwd: '/tmp/wp-typia-pattern-test',
+    flags: {},
+    getOrCreatePrompt: async () => {
+      throw new Error('pattern add-kind should not prompt in this test');
+    },
+    isInteractiveSession: false,
+    name: 'sample-pattern',
+    warnLine,
+  } satisfies AddKindExecutionContext;
+
+  const plan = await ADD_KIND_REGISTRY.pattern.prepareExecution(context);
+
+  expect(plan.warnLine).toBe(warnLine);
 });


### PR DESCRIPTION
## Summary
- pass context.warnLine through the pattern add-kind execution plan
- add a focused registry regression test for pattern warning-printer propagation
- add a patch changeset for wp-typia

## Validation
- bun run format:check -- packages/wp-typia/src/add-kinds/pattern.ts packages/wp-typia/tests/add-kind-registry.test.ts .sampo/changesets/841-pattern-warnline.md
- bun test packages/wp-typia/tests/add-kind-registry.test.ts packages/wp-typia/tests/add-command.test.ts
- bun run typecheck
- bun run --filter wp-typia test
- bun run --filter wp-typia build
- bun run changesets:validate
- bun run lint:repo

Closes #841

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pattern add-kind warning output to be correctly emitted to the expected output channel.

* **Tests**
  * Added test coverage for pattern add-kind warning behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/858)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->