### PR TITLE
fix(add): suggest close block template ids

### DIFF
--- a/.sampo/changesets/842-add-block-template-suggestions.md
+++ b/.sampo/changesets/842-add-block-template-suggestions.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Expand add-block template typo suggestions so near-miss ids like `interactiv` point users to the intended built-in template.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-types.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-types.ts
@@ -83,7 +83,9 @@ export type AddBlockTemplateId = (typeof ADD_BLOCK_TEMPLATE_IDS)[number];
 export function suggestAddBlockTemplateId(
 	templateId: string,
 ): AddBlockTemplateId | null {
-	return suggestCloseId(templateId, ADD_BLOCK_TEMPLATE_IDS);
+	return suggestCloseId(templateId, ADD_BLOCK_TEMPLATE_IDS, {
+		maxDistance: 3,
+	});
 }
 
 /**

--- a/packages/wp-typia-project-tools/tests/cli-entry.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-entry.test.ts
@@ -1545,7 +1545,7 @@ test("node entry suggests close add-block template ids before workspace dependen
         "block",
         "counter-card",
         "--template",
-        "basicc",
+        "interactiv",
         "--format",
         "json",
       ],
@@ -1558,7 +1558,7 @@ test("node entry suggests close add-block template ids before workspace dependen
 
   expect(errorMessage).toContain('"code": "unknown-template"');
   expect(errorMessage).toContain(
-    'Unknown add-block template \\"basicc\\". Did you mean \\"basic\\"? Use `--template basic`'
+    'Unknown add-block template \\"interactiv\\". Did you mean \\"interactivity\\"? Use `--template interactivity`'
   );
   expect(errorMessage).not.toContain("Workspace dependencies have not been installed yet.");
 });

--- a/packages/wp-typia/tests/add-command.test.ts
+++ b/packages/wp-typia/tests/add-command.test.ts
@@ -203,13 +203,27 @@ describe('wp-typia add command bridge', () => {
   });
 
   test('suggests close add block template ids before workspace mutation', async () => {
-    await expectRejectedAddBlockTemplate({
-      code: CLI_DIAGNOSTIC_CODES.UNKNOWN_TEMPLATE,
-      interactive: false,
-      message:
-        'Unknown add-block template "basicc". Did you mean "basic"? Use `--template basic`',
-      template: 'basicc',
-    });
+    const cases = [
+      {
+        message:
+          'Unknown add-block template "basicc". Did you mean "basic"? Use `--template basic`',
+        template: 'basicc',
+      },
+      {
+        message:
+          'Unknown add-block template "interactiv". Did you mean "interactivity"? Use `--template interactivity`',
+        template: 'interactiv',
+      },
+    ];
+
+    for (const { message, template } of cases) {
+      await expectRejectedAddBlockTemplate({
+        code: CLI_DIAGNOSTIC_CODES.UNKNOWN_TEMPLATE,
+        interactive: false,
+        message,
+        template,
+      });
+    }
   });
 
   test('rejects query-loop add block templates with create-time guidance', async () => {


### PR DESCRIPTION
## Summary
- expand add-block template typo suggestions to cover near-miss ids like `interactiv`
- keep unknown-template diagnostics while preserving removed/deprecated template guidance
- add bridge and Node entry regression coverage for the `interactiv` -> `interactivity` suggestion

## Validation
- `bun run format:check -- packages/wp-typia-project-tools/src/runtime/cli-add-types.ts packages/wp-typia/tests/add-command.test.ts packages/wp-typia-project-tools/tests/cli-entry.test.ts .sampo/changesets/842-add-block-template-suggestions.md`
- `bun test packages/wp-typia/tests/add-command.test.ts packages/wp-typia-project-tools/tests/cli-entry.test.ts --test-name-pattern "add-block template|close add-block template|invalid block template|suggests close"`
- `bun test packages/wp-typia-project-tools/tests/create-template-validation.test.ts packages/wp-typia/tests/create-command.test.ts`
- `bun run typecheck`
- `bun run --filter @wp-typia/project-tools test`
- `bun run --filter wp-typia test`
- `bun run --filter @wp-typia/project-tools build`
- `bun run --filter wp-typia build`
- `bun run changesets:validate`
- `bun run lint:repo`
- `git diff --check`

Closes #842