### PR TITLE
refactor(doctor): clarify async boundaries

### DIFF
--- a/.sampo/changesets/843-doctor-async-boundaries.md
+++ b/.sampo/changesets/843-doctor-async-boundaries.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Clarify doctor async/sync boundaries while moving workspace doctor inventory reads onto the async inventory API.

--- a/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace-shared.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace-shared.ts
@@ -113,6 +113,9 @@ export function checkExistingFiles(
 	label: string,
 	filePaths: Array<string | undefined>,
 ): DoctorCheck {
+	// Workspace category collectors remain synchronous pure mappers after the
+	// async inventory snapshot is loaded, so these small existence probes stay
+	// sync to preserve their current non-Promise APIs and output ordering.
 	const missing = filePaths
 		.filter((filePath): filePath is string => typeof filePath === "string")
 		.filter((filePath) => !fs.existsSync(path.join(projectDir, filePath)));

--- a/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace.ts
@@ -15,7 +15,10 @@ import {
 	createDoctorCheck,
 	createDoctorScopeCheck,
 } from "./cli-doctor-workspace-shared.js";
-import { readWorkspaceInventory, type WorkspaceInventory } from "./workspace-inventory.js";
+import {
+	readWorkspaceInventoryAsync,
+	type WorkspaceInventory,
+} from "./workspace-inventory.js";
 import {
 	getInvalidWorkspaceProjectReason,
 	parseWorkspacePackageJson,
@@ -58,12 +61,14 @@ function formatWorkspaceInventorySummary(inventory: WorkspaceInventory): string 
  * @param cwd Working directory expected to host an official workspace.
  * @returns Ordered workspace check rows ready for CLI rendering.
  */
-export function getWorkspaceDoctorChecks(cwd: string): DoctorCheck[] {
+export async function getWorkspaceDoctorChecks(cwd: string): Promise<DoctorCheck[]> {
 	const checks: DoctorCheck[] = [];
 
 	let workspace: WorkspaceProject | null = null;
 	let invalidWorkspaceReason: string | null = null;
 	try {
+		// Workspace discovery and package parsing intentionally stay synchronous
+		// because they share compatibility helpers with sync add/migration callers.
 		invalidWorkspaceReason = getInvalidWorkspaceProjectReason(cwd);
 		workspace = tryResolveWorkspaceProject(cwd);
 	} catch (error) {
@@ -117,6 +122,9 @@ export function getWorkspaceDoctorChecks(cwd: string): DoctorCheck[] {
 
 	let workspacePackageJson: WorkspacePackageJson;
 	try {
+		// Keep package metadata parsing sync until workspace-project exposes an
+		// async companion; the surrounding doctor orchestration already awaits
+		// async inventory reads below.
 		workspacePackageJson = parseWorkspacePackageJson(workspace.projectDir);
 	} catch (error) {
 		checks.push(
@@ -132,9 +140,7 @@ export function getWorkspaceDoctorChecks(cwd: string): DoctorCheck[] {
 	checks.push(getWorkspacePackageMetadataCheck(workspace, workspacePackageJson));
 
 	try {
-		// Doctor checks expose a synchronous API so callers can collect a stable
-		// snapshot without mixing async inventory reads into check aggregation.
-		const inventory = readWorkspaceInventory(workspace.projectDir);
+		const inventory = await readWorkspaceInventoryAsync(workspace.projectDir);
 		checks.push(
 			createDoctorCheck(
 				"Workspace inventory",

--- a/packages/wp-typia-project-tools/src/runtime/cli-doctor.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-doctor.ts
@@ -41,7 +41,7 @@ interface RunDoctorOptions {
 export async function getDoctorChecks(cwd: string): Promise<DoctorCheck[]> {
 	return [
 		...(await getEnvironmentDoctorChecks(cwd)),
-		...getWorkspaceDoctorChecks(cwd),
+		...(await getWorkspaceDoctorChecks(cwd)),
 	];
 }
 

--- a/packages/wp-typia-project-tools/src/runtime/migration-maintenance-verify.ts
+++ b/packages/wp-typia-project-tools/src/runtime/migration-maintenance-verify.ts
@@ -131,6 +131,9 @@ function recordWorkspaceMigrationTargetAlignment(
   state: MigrationProjectState,
   recordCheck: (status: 'fail' | 'pass', label: string, detail: string) => void,
 ): void {
+  // `migrate doctor` is still a synchronous maintenance command: it shares
+  // sync migration project loading, generated artifact comparisons, and
+  // execFileSync verification with the rest of migration maintenance.
   let invalidWorkspaceReason: string | null = null
   let workspace
   try {

--- a/packages/wp-typia-project-tools/tests/cli-doctor-boundaries.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-doctor-boundaries.test.ts
@@ -32,18 +32,31 @@ test("cli-doctor keeps environment and workspace checks in dedicated modules", (
 		resolve(sourceRoot, "cli-doctor-workspace-package.ts"),
 		"utf8",
 	);
+	const workspaceSharedSource = readFileSync(
+		resolve(sourceRoot, "cli-doctor-workspace-shared.ts"),
+		"utf8",
+	);
+	const migrationDoctorSource = readFileSync(
+		resolve(sourceRoot, "migration-maintenance-verify.ts"),
+		"utf8",
+	);
 
 	expect(cliDoctorSource).toContain('from "./cli-doctor-environment.js"');
 	expect(cliDoctorSource).toContain('from "./cli-doctor-workspace.js"');
+	expect(cliDoctorSource).toContain("...(await getWorkspaceDoctorChecks(cwd)),");
 	expect(cliDoctorSource).not.toContain("function readCommandVersion(");
 	expect(cliDoctorSource).not.toContain("function checkWorkspacePackageMetadata(");
 	expect(cliDoctorSource).not.toContain("function checkWorkspaceBindingBootstrap(");
 	expect(environmentSource).toContain("export async function getEnvironmentDoctorChecks(");
-	expect(workspaceSource).toContain("export function getWorkspaceDoctorChecks(");
+	expect(workspaceSource).toContain("export async function getWorkspaceDoctorChecks(");
+	expect(workspaceSource).toContain("readWorkspaceInventoryAsync(");
 	expect(workspaceSource).toContain('from "./cli-doctor-workspace-bindings.js"');
 	expect(workspaceSource).toContain('from "./cli-doctor-workspace-blocks.js"');
 	expect(workspaceSource).toContain('from "./cli-doctor-workspace-features.js"');
 	expect(workspaceSource).toContain('from "./cli-doctor-workspace-package.js"');
+	expect(workspaceSource).toContain("intentionally stay synchronous");
+	expect(workspaceSharedSource).toContain("category collectors remain synchronous");
+	expect(migrationDoctorSource).toContain("synchronous maintenance command");
 	expect(workspaceSource).not.toContain("function checkWorkspaceBlockMetadata(");
 	expect(workspaceSource).not.toContain("function checkWorkspaceBindingBootstrap(");
 	expect(workspaceSource).not.toContain("function checkWorkspaceAbilityBootstrap(");


### PR DESCRIPTION
## Summary
- move workspace doctor inventory loading onto `readWorkspaceInventoryAsync()` now that doctor orchestration is async
- document the doctor paths that intentionally remain synchronous for compatibility and deterministic maintenance checks
- extend boundary coverage so the async/sync split stays explicit

## Validation
- `bun test packages/wp-typia-project-tools/tests/cli-doctor-boundaries.test.ts packages/wp-typia-project-tools/tests/workspace-doctor.test.ts packages/wp-typia-project-tools/tests/migration-doctor.test.ts`
- `bun run format:check -- packages/wp-typia-project-tools/src/runtime/cli-doctor.ts packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace.ts packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace-shared.ts packages/wp-typia-project-tools/src/runtime/migration-maintenance-verify.ts packages/wp-typia-project-tools/tests/cli-doctor-boundaries.test.ts .sampo/changesets/843-doctor-async-boundaries.md`
- `bun run typecheck`
- `bun run changesets:validate`
- `bun run --filter @wp-typia/project-tools test`
- `bun run --filter wp-typia test`
- `bun run --filter @wp-typia/project-tools build`
- `bun run --filter wp-typia build`
- `bun run lint:repo`
- `git diff --check`

Closes #843

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Workspace doctor checks now use asynchronous inventory loading for improved responsiveness during diagnostics.
  * Doctor command properly awaits all workspace checks before displaying results.

* **Chores**
  * Enhanced inline documentation to clarify async/sync execution boundaries in doctor commands and migration processes.
  * Updated tests to reflect updated execution signatures and guarantees.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/860)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->