### PR TITLE
[codex] Align Node fallback warning output

### DIFF
--- a/.sampo/changesets/844-node-fallback-warn-line.md
+++ b/.sampo/changesets/844-node-fallback-warn-line.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Route Node fallback completion warnings through an explicit warning printer while preserving normal stdout output.

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -70,6 +70,9 @@ const NODE_FALLBACK_BOOLEAN_OPTION_NAMES = ['help', 'version'] as const;
 const printLine: PrintLine = (line) => {
   console.log(line);
 };
+const warnLine: PrintLine = (line) => {
+  console.warn(line);
+};
 
 export function hasFlagBeforeTerminator(argv: string[], flag: string): boolean {
   for (const arg of argv) {
@@ -275,6 +278,8 @@ const NODE_FALLBACK_COMMAND_DISPATCHERS = {
     cwd,
     mergedFlags,
     positionals,
+    printLine,
+    warnLine,
   }: NodeFallbackDispatchContext) => {
     const plan = await executeInitCommand(
       {
@@ -288,6 +293,8 @@ const NODE_FALLBACK_COMMAND_DISPATCHERS = {
       },
       {
         emitOutput: mergedFlags.format !== 'json',
+        printLine,
+        warnLine,
       },
     );
     if (mergedFlags.format === 'json') {
@@ -311,6 +318,8 @@ const NODE_FALLBACK_COMMAND_DISPATCHERS = {
     cwd,
     mergedFlags,
     positionals,
+    printLine,
+    warnLine,
   }: NodeFallbackDispatchContext) => {
     try {
       const syncTarget = resolveSyncExecutionTarget(positionals[1]);
@@ -343,6 +352,10 @@ const NODE_FALLBACK_COMMAND_DISPATCHERS = {
             projectDir: sync.projectDir,
             target: sync.target,
           }),
+          {
+            printLine,
+            warnLine,
+          },
         );
       }
     } catch (error) {
@@ -471,6 +484,7 @@ export async function runNodeCli(argv = process.argv.slice(2)): Promise<void> {
       mergedFlags,
       positionals,
       printLine,
+      warnLine,
     });
     return;
   }

--- a/packages/wp-typia/src/node-fallback/dispatchers/add.ts
+++ b/packages/wp-typia/src/node-fallback/dispatchers/add.ts
@@ -18,6 +18,7 @@ export async function dispatchNodeFallbackAdd({
   mergedFlags,
   positionals,
   printLine,
+  warnLine,
 }: NodeFallbackDispatchContext): Promise<void> {
   if (!positionals[1]) {
     if (shouldPrintMissingAddKindHelp({ format: mergedFlags.format })) {
@@ -44,6 +45,8 @@ export async function dispatchNodeFallbackAdd({
         interactive: false,
         kind: positionals[1],
         name: positionals[2],
+        printLine,
+        warnLine,
       });
     } catch (error) {
       throw createCliCommandError({
@@ -72,5 +75,7 @@ export async function dispatchNodeFallbackAdd({
     interactive: undefined,
     kind: positionals[1],
     name: positionals[2],
+    printLine,
+    warnLine,
   });
 }

--- a/packages/wp-typia/src/node-fallback/dispatchers/create.ts
+++ b/packages/wp-typia/src/node-fallback/dispatchers/create.ts
@@ -15,6 +15,7 @@ export async function dispatchNodeFallbackCreate({
   mergedFlags,
   positionals,
   printLine,
+  warnLine,
 }: NodeFallbackDispatchContext): Promise<void> {
   const projectDir = positionals[1];
   if (!projectDir) {
@@ -34,7 +35,9 @@ export async function dispatchNodeFallbackCreate({
       emitOutput: mergedFlags.format !== 'json',
       flags: mergedFlags,
       interactive: mergedFlags.format === 'json' ? false : undefined,
+      printLine,
       projectDir,
+      warnLine,
     });
   } catch (error) {
     throw createCliCommandError({

--- a/packages/wp-typia/src/node-fallback/types.ts
+++ b/packages/wp-typia/src/node-fallback/types.ts
@@ -19,6 +19,7 @@ export type NodeFallbackDispatchContext = {
   mergedFlags: Record<string, unknown>;
   positionals: string[];
   printLine: PrintLine;
+  warnLine: PrintLine;
 };
 
 export type NodeFallbackCommandDispatcher = (

--- a/packages/wp-typia/src/runtime-output/print.ts
+++ b/packages/wp-typia/src/runtime-output/print.ts
@@ -21,6 +21,8 @@ export function printCompletionPayload(
   } = {},
 ): void {
   const printLine = options.printLine ?? (console.log as PrintLine);
+  // Callers that only provide stdout intentionally keep warnings on stdout.
+  // Runtime entrypoints with distinct warning channels should pass warnLine.
   const warnLine = options.warnLine ?? printLine;
 
   for (const line of payload.preambleLines ?? []) {

--- a/packages/wp-typia/tests/node-cli-core.test.ts
+++ b/packages/wp-typia/tests/node-cli-core.test.ts
@@ -315,6 +315,33 @@ describe('Node fallback CLI core routing', () => {
     }
   });
 
+  test('routes Node fallback completion warnings through stderr', async () => {
+    const tempRoot = createTempRoot('wp-typia-node-init-warning-');
+    writeJson(path.join(tempRoot, 'package.json'), {
+      name: 'node-init-warning',
+      private: true,
+    });
+
+    try {
+      const result = await captureNodeCli(['init'], { cwd: tempRoot });
+
+      expect(result.error).toBeUndefined();
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).toContain(
+        'Preview only: `wp-typia init` does not write files yet.',
+      );
+      expect(result.stderr).toContain(
+        'package.json and generated helper files are snapshotted',
+      );
+      expect(result.stdout).toContain('Retrofit init plan for node-init-warning');
+      expect(result.stdout).not.toContain(
+        'Preview only: `wp-typia init` does not write files yet.',
+      );
+    } finally {
+      removeTempRoot(tempRoot);
+    }
+  });
+
   test('keeps add dispatch on stdout help and command diagnostics for missing kinds', async () => {
     const result = await captureNodeCli(['add']);
 


### PR DESCRIPTION
## Summary
- Add an explicit `warnLine` printer to the Node fallback runtime.
- Pass the warning printer into create/add/init and sync dry-run completion paths that support warnings.
- Keep normal stdout output unchanged and document the completion-printer stdout fallback.

## Validation
- `bun test packages/wp-typia/tests/node-cli-core.test.ts`
- `bun run format:check`
- `bun run changesets:validate`
- `bun run typecheck`
- `bun run --filter wp-typia test`
- `git diff --check`
- `bun run runtime-coupling:validate`

Closes #844
