### PR TITLE
[codex] Handle create completion package manager metadata

### DIFF
--- a/.sampo/changesets/845-create-package-manager-completion.md
+++ b/.sampo/changesets/845-create-package-manager-completion.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Normalize recognizable create completion package-manager metadata before formatting follow-up commands.

--- a/packages/wp-typia/src/runtime-output/create.ts
+++ b/packages/wp-typia/src/runtime-output/create.ts
@@ -16,8 +16,14 @@ import {
 } from '../output-markers';
 import type { CreateProgressPayload } from './types';
 
-const LOOSE_CREATE_COMPLETION_PACKAGE_MANAGER_PATTERN =
-  /^(?:corepack\s+)?(bun|npm|pnpm|yarn)(?=$|[@:/+\s])/iu;
+function escapeRegExp(source: string): string {
+  return source.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+}
+
+const LOOSE_CREATE_COMPLETION_PACKAGE_MANAGER_PATTERN = new RegExp(
+  `^(?:corepack\\s+)?(${PACKAGE_MANAGER_IDS.map(escapeRegExp).join('|')})(?=$|[@:/+\\s])`,
+  'iu',
+);
 
 function parseCreateCompletionPackageManager(
   packageManager: string,

--- a/packages/wp-typia/src/runtime-output/create.ts
+++ b/packages/wp-typia/src/runtime-output/create.ts
@@ -16,10 +16,35 @@ import {
 } from '../output-markers';
 import type { CreateProgressPayload } from './types';
 
+const LOOSE_CREATE_COMPLETION_PACKAGE_MANAGER_PATTERN =
+  /^(?:corepack\s+)?(bun|npm|pnpm|yarn)(?=$|[@:/+\s])/iu;
+
+function parseCreateCompletionPackageManager(
+  packageManager: string,
+): PackageManagerId | null {
+  const normalizedPackageManager = packageManager.trim();
+  const parsedPackageManager = parsePackageManagerField(
+    normalizedPackageManager,
+  );
+  if (parsedPackageManager) {
+    return parsedPackageManager;
+  }
+
+  const looseMatch = LOOSE_CREATE_COMPLETION_PACKAGE_MANAGER_PATTERN.exec(
+    normalizedPackageManager,
+  );
+  const loosePackageManager = looseMatch?.[1]?.toLowerCase();
+
+  return PACKAGE_MANAGER_IDS.includes(loosePackageManager as PackageManagerId)
+    ? (loosePackageManager as PackageManagerId)
+    : null;
+}
+
 function resolveCreateCompletionPackageManager(
   packageManager: string,
 ): PackageManagerId {
-  const parsedPackageManager = parsePackageManagerField(packageManager);
+  const parsedPackageManager =
+    parseCreateCompletionPackageManager(packageManager);
   if (parsedPackageManager) {
     return parsedPackageManager;
   }

--- a/packages/wp-typia/tests/completion-output.test.ts
+++ b/packages/wp-typia/tests/completion-output.test.ts
@@ -173,6 +173,28 @@ describe('alternate-buffer completion output helpers', () => {
     }
   });
 
+  test('create completion payload normalizes recognizable package-manager metadata', () => {
+    const payload = buildCreateCompletionPayload({
+      nextSteps: ['cd demo-block'],
+      optionalOnboarding: {
+        note: 'Run sync when needed.',
+        steps: [],
+      },
+      packageManager: 'corepack pnpm@9.12.3 workspace-root',
+      projectDir: '/tmp/demo-block',
+      result: {
+        variables: {
+          title: 'Demo Block',
+        },
+        warnings: [],
+      },
+    });
+
+    expect(payload.optionalLines?.[0]).toBe(
+      `pnpm dlx wp-typia@${packageJson.version} doctor`,
+    );
+  });
+
   test('create completion payload rejects unknown package managers clearly', () => {
     let error: Error | undefined;
     try {


### PR DESCRIPTION
## Summary
- Normalize recognizable create completion package-manager metadata before formatting doctor commands.
- Keep package-manager-specific guidance for known managers while preserving clear failures for unsupported values.
- Add a focused completion output regression test and Sampo changeset.

## Validation
- `bun test packages/wp-typia/tests/completion-output.test.ts`
- `bun run format:check`
- `bun run changesets:validate`
- `bun run typecheck`
- `bun run --filter wp-typia test`
- `git diff --check`
- `bun run runtime-coupling:validate`

Closes #845


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package manager detection for create-completion payloads to handle extended metadata formats (e.g., `corepack pnpm@... workspace-root`), normalizing them into the correct onboarding commands.

* **Tests**
  * Added test case verifying package manager metadata normalization.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/862)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->