### PR TITLE
[codex] Move add-kind formatting to leaf module

### DIFF
--- a/.sampo/changesets/846-add-kind-format-leaf.md
+++ b/.sampo/changesets/846-add-kind-format-leaf.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Move add-kind list and usage formatting helpers into the add-kind id leaf module to avoid registry coupling from shared CLI diagnostics.

--- a/packages/wp-typia/src/add-kind-ids.ts
+++ b/packages/wp-typia/src/add-kind-ids.ts
@@ -1,2 +1,13 @@
+import { ADD_KIND_IDS } from '@wp-typia/project-tools/cli-add-kind-ids';
 export { ADD_KIND_IDS } from '@wp-typia/project-tools/cli-add-kind-ids';
 export type { AddKindId } from '@wp-typia/project-tools/cli-add-kind-ids';
+
+// Keep display helpers in this leaf module so shared CLI diagnostics do not
+// need to import the execution registry and risk future circular dependencies.
+export function formatAddKindList(): string {
+  return ADD_KIND_IDS.join(', ');
+}
+
+export function formatAddKindUsagePlaceholder(): string {
+  return `<${ADD_KIND_IDS.join('|')}>`;
+}

--- a/packages/wp-typia/src/add-kind-registry.ts
+++ b/packages/wp-typia/src/add-kind-registry.ts
@@ -19,6 +19,10 @@ import type {
 
 export { ADD_KIND_IDS } from './add-kind-ids';
 export type { AddKindId } from './add-kind-ids';
+export {
+  formatAddKindList,
+  formatAddKindUsagePlaceholder,
+} from './add-kind-ids';
 export { isAddPersistenceTemplate } from './add-kind-registry-shared';
 export type {
   AddFieldName,
@@ -76,14 +80,6 @@ export function buildAddKindCompletionDetails(
     summaryLines: descriptor.summaryLines(options.values, options.projectDir),
     title: descriptor.title,
   };
-}
-
-export function formatAddKindList(): string {
-  return ADD_KIND_IDS.join(', ');
-}
-
-export function formatAddKindUsagePlaceholder(): string {
-  return `<${ADD_KIND_IDS.join('|')}>`;
 }
 
 export function getAddKindUsage(kind: AddKindId): string {

--- a/packages/wp-typia/src/cli-error-messages.ts
+++ b/packages/wp-typia/src/cli-error-messages.ts
@@ -1,4 +1,4 @@
-import { formatAddKindUsagePlaceholder } from './add-kind-registry';
+import { formatAddKindUsagePlaceholder } from './add-kind-ids';
 
 const MISSING_CREATE_PROJECT_DIR_DETAIL_LINES = [
   '`wp-typia create` requires <project-dir>.',

--- a/packages/wp-typia/src/node-fallback/help.ts
+++ b/packages/wp-typia/src/node-fallback/help.ts
@@ -1,5 +1,5 @@
 import packageJson from '../../package.json';
-import { formatAddKindList } from '../add-kind-registry';
+import { formatAddKindList } from '../add-kind-ids';
 import {
   ADD_OPTION_METADATA,
   CREATE_OPTION_METADATA,

--- a/packages/wp-typia/tests/add-kind-source.test.ts
+++ b/packages/wp-typia/tests/add-kind-source.test.ts
@@ -69,3 +69,40 @@ test('single-sources add-kind missing-name messages inside kind modules', () => 
 
   expect(offenders).toEqual([]);
 });
+
+test('keeps add-kind formatting helpers below the execution registry', () => {
+  const leafSource = fs.readFileSync(
+    path.join(packageRoot, 'src', 'add-kind-ids.ts'),
+    'utf8',
+  );
+  const registrySource = fs.readFileSync(
+    path.join(packageRoot, 'src', 'add-kind-registry.ts'),
+    'utf8',
+  );
+  const cliErrorMessagesSource = fs.readFileSync(
+    path.join(packageRoot, 'src', 'cli-error-messages.ts'),
+    'utf8',
+  );
+  const nodeFallbackHelpSource = fs.readFileSync(
+    path.join(packageRoot, 'src', 'node-fallback', 'help.ts'),
+    'utf8',
+  );
+
+  expect(leafSource).toContain('export function formatAddKindList');
+  expect(leafSource).toContain('export function formatAddKindUsagePlaceholder');
+  expect(registrySource).toContain("} from './add-kind-ids';");
+  expect(registrySource).not.toContain('export function formatAddKindList');
+  expect(registrySource).not.toContain(
+    'export function formatAddKindUsagePlaceholder',
+  );
+  expect(cliErrorMessagesSource).toContain(
+    "from './add-kind-ids'",
+  );
+  expect(cliErrorMessagesSource).not.toContain(
+    "from './add-kind-registry'",
+  );
+  expect(nodeFallbackHelpSource).toContain("from '../add-kind-ids'");
+  expect(nodeFallbackHelpSource).not.toContain(
+    "from '../add-kind-registry'",
+  );
+});


### PR DESCRIPTION
## Summary
- move add-kind list and usage placeholder helpers into the add-kind id leaf module
- keep registry exports compatible while removing shared CLI diagnostics from registry imports
- add a source invariant test for the dependency direction

## Validation
- bun test packages/wp-typia/tests/add-kind-source.test.ts packages/wp-typia/tests/node-cli-core.test.ts packages/wp-typia/tests/add-command-package.test.ts packages/wp-typia/tests/add-kind-registry.test.ts
- bun run format:check
- bun run changesets:validate
- bun run typecheck
- bun run runtime-coupling:validate
- bun run --filter wp-typia test
- git diff --check

Closes #846