### PR TITLE
[codex] Add ABSPATH guards to generated PHP artifacts

### DIFF
--- a/.sampo/changesets/864-php-artifact-abspath-guard.md
+++ b/.sampo/changesets/864-php-artifact-abspath-guard.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/block-runtime: patch
+npm/@wp-typia/project-tools: patch
+---
+
+Add WordPress direct-access guards to generated PHP validator and migration registry artifacts.

--- a/examples/compound-patterns/src/blocks/compound-patterns-item/typia-validator.php
+++ b/examples/compound-patterns/src/blocks/compound-patterns-item/typia-validator.php
@@ -1,6 +1,10 @@
 <?php
 declare(strict_types=1);
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Generated from typia.manifest.json. Do not edit manually.
  */

--- a/examples/compound-patterns/src/blocks/compound-patterns/typia-validator.php
+++ b/examples/compound-patterns/src/blocks/compound-patterns/typia-validator.php
@@ -1,6 +1,10 @@
 <?php
 declare(strict_types=1);
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Generated from typia.manifest.json. Do not edit manually.
  */

--- a/examples/my-typia-block/typia-migration-registry.php
+++ b/examples/my-typia-block/typia-migration-registry.php
@@ -1,6 +1,10 @@
 <?php
 declare(strict_types=1);
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Generated from advanced migration snapshots. Do not edit manually.
  */

--- a/examples/my-typia-block/typia-validator.php
+++ b/examples/my-typia-block/typia-validator.php
@@ -1,6 +1,10 @@
 <?php
 declare(strict_types=1);
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Generated from typia.manifest.json. Do not edit manually.
  */

--- a/examples/persistence-examples/src/blocks/counter/typia-validator.php
+++ b/examples/persistence-examples/src/blocks/counter/typia-validator.php
@@ -1,6 +1,10 @@
 <?php
 declare(strict_types=1);
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Generated from typia.manifest.json. Do not edit manually.
  */

--- a/examples/persistence-examples/src/blocks/like-button/typia-validator.php
+++ b/examples/persistence-examples/src/blocks/like-button/typia-validator.php
@@ -1,6 +1,10 @@
 <?php
 declare(strict_types=1);
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Generated from typia.manifest.json. Do not edit manually.
  */

--- a/packages/wp-typia-block-runtime/src/metadata-php-render.ts
+++ b/packages/wp-typia-block-runtime/src/metadata-php-render.ts
@@ -46,6 +46,10 @@ export function renderPhpValidator(manifest: ManifestDocument): {
 		source: `<?php
 declare(strict_types=1);
 
+if ( ! defined( 'ABSPATH' ) ) {
+\texit;
+}
+
 /**
  * Generated from typia.manifest.json. Do not edit manually.
  */

--- a/packages/wp-typia-project-tools/src/runtime/migration-render-generated.ts
+++ b/packages/wp-typia-project-tools/src/runtime/migration-render-generated.ts
@@ -295,6 +295,10 @@ export function renderPhpMigrationRegistryFile(
 	return `<?php
 declare(strict_types=1);
 
+if ( ! defined( 'ABSPATH' ) ) {
+\texit;
+}
+
 /**
  * Generated from advanced migration snapshots. Do not edit manually.
  */

--- a/packages/wp-typia-project-tools/tests/migration-scaffold-diff.test.ts
+++ b/packages/wp-typia-project-tools/tests/migration-scaffold-diff.test.ts
@@ -46,6 +46,7 @@ test("scaffold and verify generate auto-migration artifacts for additive schema 
 	expect(deprecatedSource).toContain("deprecated_0");
 	expect(Array.isArray(fixtureSource.cases)).toBe(true);
 	expect(fixtureSource.cases[0].name).toBe("default");
+	expect(phpRegistrySource).toContain("if ( ! defined( 'ABSPATH' ) ) {\n\texit;\n}");
 	expect(phpRegistrySource).toContain("'currentMigrationVersion' => 'v3'");
 	expect(phpRegistrySource).toContain("'legacyMigrationVersions' =>");
 	expect(phpRegistrySource).toContain("'v1'");

--- a/tests/unit/block-attributes.contract.test.ts
+++ b/tests/unit/block-attributes.contract.test.ts
@@ -131,6 +131,10 @@ function loadPhpValidatorPath() {
 	return path.join(getExampleShowcaseDir(), 'typia-validator.php');
 }
 
+function escapePhpSingleQuotedString(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+}
+
 function validatePayload(
   manifest: ContractManifest,
   payload: Record<string, unknown>,
@@ -248,8 +252,8 @@ function runPhpValidator<T extends Record<string, unknown> | unknown[]>(
   payload: Record<string, unknown>,
 ): T {
   const validatorPath = loadPhpValidatorPath();
-  const encodedPayload = JSON.stringify(payload).replace(/\\/g, '\\\\').replace(/'/g, "\\'");
-  const phpSource = `$validator = require '${validatorPath.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'; $payload = json_decode('${encodedPayload}', true); echo json_encode($validator->${method}($payload), JSON_UNESCAPED_SLASHES);`;
+  const encodedPayload = escapePhpSingleQuotedString(JSON.stringify(payload));
+  const phpSource = `if (!defined('ABSPATH')) { define('ABSPATH', '/tmp/wp-typia-test/'); } $validator = require '${escapePhpSingleQuotedString(validatorPath)}'; $payload = json_decode('${encodedPayload}', true); echo json_encode($validator->${method}($payload), JSON_UNESCAPED_SLASHES);`;
 
   return JSON.parse(execFileSync('php', ['-r', phpSource], { encoding: 'utf8' })) as T;
 }

--- a/tests/unit/metadata-php-render.test.ts
+++ b/tests/unit/metadata-php-render.test.ts
@@ -124,6 +124,15 @@ describe("metadata-php-render", () => {
 		const result = renderPhpValidator(manifest);
 
 		expect(result.warnings).toEqual([]);
+		expect(result.source.startsWith("<?php\ndeclare(strict_types=1);\n\n")).toBe(
+			true,
+		);
+		expect(result.source).toContain(
+			"if ( ! defined( 'ABSPATH' ) ) {\n\texit;\n}",
+		);
+		expect(result.source.indexOf("declare(strict_types=1);")).toBeLessThan(
+			result.source.indexOf("if ( ! defined( 'ABSPATH' ) ) {"),
+		);
 		expect(result.source).toContain("private array $manifest = [");
 		expect(result.source).toContain("'sourceType' => 'DemoBlockAttributes'");
 		expect(result.source).toContain("private function validateAttribute");

--- a/tests/unit/validators.test.ts
+++ b/tests/unit/validators.test.ts
@@ -13,6 +13,17 @@ function createFixture(files: Record<string, string>) {
   });
 }
 
+function escapePhpSingleQuotedString(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+}
+
+function buildPhpValidatorRequireSource(phpValidatorPath: string): string {
+  return [
+    "if (!defined('ABSPATH')) { define('ABSPATH', '/tmp/wp-typia-test/'); }",
+    `$validator = require '${escapePhpSingleQuotedString(phpValidatorPath)}';`,
+  ].join(' ');
+}
+
 describe('Typia metadata generator', () => {
   afterAll(() => {
     const baseDir = getExampleShowcaseFixtureRoot('.tmp-metadata-fixtures');
@@ -738,7 +749,7 @@ export interface BlockAttributes {
         'php',
         [
           '-r',
-          `$validator = require '${phpValidatorPath.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'; $payload = json_decode('${invalidArrayPayload}', true); echo json_encode($validator->validate($payload), JSON_UNESCAPED_SLASHES);`,
+          `${buildPhpValidatorRequireSource(phpValidatorPath)} $payload = json_decode('${invalidArrayPayload}', true); echo json_encode($validator->validate($payload), JSON_UNESCAPED_SLASHES);`,
         ],
         { encoding: 'utf8' },
       ),
@@ -748,7 +759,7 @@ export interface BlockAttributes {
         'php',
         [
           '-r',
-          `$validator = require '${phpValidatorPath.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'; $payload = json_decode('${invalidObjectPayload}', true); echo json_encode($validator->validate($payload), JSON_UNESCAPED_SLASHES);`,
+          `${buildPhpValidatorRequireSource(phpValidatorPath)} $payload = json_decode('${invalidObjectPayload}', true); echo json_encode($validator->validate($payload), JSON_UNESCAPED_SLASHES);`,
         ],
         { encoding: 'utf8' },
       ),
@@ -863,7 +874,7 @@ export interface BlockAttributes {
         'php',
         [
           '-r',
-          `$validator = require '${phpValidatorPath.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'; echo json_encode($validator->validate(["link" => ["kind" => "post", "postId" => 12]]), JSON_UNESCAPED_SLASHES);`,
+          `${buildPhpValidatorRequireSource(phpValidatorPath)} echo json_encode($validator->validate(["link" => ["kind" => "post", "postId" => 12]]), JSON_UNESCAPED_SLASHES);`,
         ],
         { encoding: 'utf8' },
       ),
@@ -873,7 +884,7 @@ export interface BlockAttributes {
         'php',
         [
           '-r',
-          `$validator = require '${phpValidatorPath.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'; echo json_encode($validator->validate(["link" => ["kind" => "missing", "href" => "https://example.com"]]), JSON_UNESCAPED_SLASHES);`,
+          `${buildPhpValidatorRequireSource(phpValidatorPath)} echo json_encode($validator->validate(["link" => ["kind" => "missing", "href" => "https://example.com"]]), JSON_UNESCAPED_SLASHES);`,
         ],
         { encoding: 'utf8' },
       ),
@@ -1010,7 +1021,7 @@ export interface BlockAttributes {
         'php',
         [
           '-r',
-          `$validator = require '${phpValidatorPath.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'; $payload = json_decode('${invalidPayload}', true); echo json_encode($validator->validate($payload), JSON_UNESCAPED_SLASHES);`,
+          `${buildPhpValidatorRequireSource(phpValidatorPath)} $payload = json_decode('${invalidPayload}', true); echo json_encode($validator->validate($payload), JSON_UNESCAPED_SLASHES);`,
         ],
         { encoding: 'utf8' },
       ),


### PR DESCRIPTION
## Summary
- add WordPress direct-access guards to generated `typia-validator.php` output while keeping `declare(strict_types=1)` first
- apply the same guard to generated `typia-migration-registry.php` output for consistency across generated PHP artifacts
- refresh checked-in example generated PHP artifacts and update tests that load validators outside WordPress to define `ABSPATH`

## Validation
- bun test tests/unit/metadata-php-render.test.ts tests/unit/validators.test.ts tests/unit/block-attributes.contract.test.ts packages/wp-typia-project-tools/tests/migration-scaffold-diff.test.ts
- bun run format:check
- bun run changesets:validate
- bun run typecheck
- bun run --filter @wp-typia/project-tools test:migration-execution
- bun run --filter @wp-typia/block-runtime test
- bun run sync --check (examples/my-typia-block, examples/persistence-examples, examples/compound-patterns)
- bun test tests/unit/sync-types.test.ts
- bun run --filter @wp-typia/project-tools test:scaffold-core
- php -l for checked-in generated PHP validator and migration registry files
- git diff --check

Closes #864

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Generated PHP validator and migration registry artifact files now include environment checks to ensure proper execution in WordPress contexts, enhancing robustness and preventing unexpected behavior outside the expected environment.

* **Tests**
  * Enhanced test suite with new assertions to verify that generated PHP artifacts correctly include required environment checks during initialization.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/865)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->