### PR TITLE
[codex] Clarify no-command help exit reason

### DIFF
--- a/.sampo/changesets/848-no-command-help-reason.md
+++ b/.sampo/changesets/848-no-command-help-reason.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Clarify why no-command Node fallback help exits with a non-zero status.

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -55,6 +55,7 @@ import {
   NODE_FALLBACK_HELP_RENDERERS,
   STANDALONE_GUIDANCE_LINE,
   renderGeneralHelp,
+  renderNoCommandHelp,
 } from './node-fallback/help';
 import type {
   NodeFallbackCommandDispatcher,
@@ -428,7 +429,7 @@ export async function runNodeCli(argv = process.argv.slice(2)): Promise<void> {
     hasFlagBeforeTerminator(cliArgv, '--version') || command === 'version';
 
   if (cliArgv.length === 0) {
-    renderGeneralHelp(printLine);
+    renderNoCommandHelp(printLine);
     process.exitCode = 1;
     return;
   }

--- a/packages/wp-typia/src/node-fallback/help.ts
+++ b/packages/wp-typia/src/node-fallback/help.ts
@@ -31,6 +31,9 @@ export const NODE_FALLBACK_RUNTIME_SUMMARY_LINES = [
   'Output markers: WP_TYPIA_ASCII=1 forces ASCII markers, WP_TYPIA_ASCII=0 opts back into Unicode markers, and non-empty NO_COLOR requests ASCII markers when WP_TYPIA_ASCII is unset.',
 ];
 
+export const NODE_FALLBACK_NO_COMMAND_REASON_LINE =
+  'No command provided. Run wp-typia --help for usage information.';
+
 export type NodeFallbackCommandHelpConfig = {
   bodyLines?: string[];
   heading: string;
@@ -56,6 +59,11 @@ export function renderGeneralHelp(printLine: PrintLine) {
     `- ${WP_TYPIA_CANONICAL_MIGRATE_USAGE}`,
     `- ${WP_TYPIA_POSITIONAL_ALIAS_USAGE}`,
   ]);
+}
+
+export function renderNoCommandHelp(printLine: PrintLine) {
+  printBlock(printLine, [NODE_FALLBACK_NO_COMMAND_REASON_LINE, '']);
+  renderGeneralHelp(printLine);
 }
 
 export function renderNodeFallbackCommandHelp(

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -791,9 +791,13 @@ process.exit(0);
     expect(noCommandResult.stdout).toContain(
       'Canonical CLI package for wp-typia scaffolding',
     );
+    expect(noCommandResult.stdout).toContain(
+      'No command provided. Run wp-typia --help for usage information.',
+    );
     expect(noCommandResult.stdout).toContain('Runtime: Node fallback');
     expect(helpResult.status).toBe(0);
     expect(helpResult.stderr).toBe('');
+    expect(helpResult.stdout).not.toContain('No command provided.');
     expect(helpResult.stdout).toContain(
       'Canonical CLI package for wp-typia scaffolding',
     );

--- a/packages/wp-typia/tests/node-cli-core.test.ts
+++ b/packages/wp-typia/tests/node-cli-core.test.ts
@@ -107,6 +107,9 @@ describe('Node fallback CLI core routing', () => {
 
     expect(result.error).toBeUndefined();
     expect(result.exitCode).toBe(1);
+    expect(result.stdout).toContain(
+      'No command provided. Run wp-typia --help for usage information.',
+    );
     expect(result.stdout).toContain(`wp-typia ${packageJson.version}`);
     expect(result.stdout).toContain(
       'Canonical CLI package for wp-typia scaffolding',
@@ -124,6 +127,7 @@ describe('Node fallback CLI core routing', () => {
     expect(generalHelp.exitCode).toBe(0);
     expect(generalHelp.stdout).toContain('Commands:');
     expect(generalHelp.stdout).toContain('standalone wp-typia binary');
+    expect(generalHelp.stdout).not.toContain('No command provided.');
 
     expect(createHelp.error).toBeUndefined();
     expect(createHelp.exitCode).toBe(0);


### PR DESCRIPTION
## Summary

- Add an explicit no-command reason line before Node fallback general help.
- Keep explicit `wp-typia --help` behavior unchanged with exit code 0.
- Cover both source-level Node fallback and canonical bin no-command behavior.

## Validation

- `bun test packages/wp-typia/tests/node-cli-core.test.ts`
- `bun test packages/wp-typia/tests/cli-package.test.ts --test-name-pattern "renders general and command help without requiring a local Bun binary"`
- `bun test packages/wp-typia/tests/cli-package.test.ts --test-name-pattern "renders help output through the canonical bin"`
- `bun run --filter wp-typia test`
- `bun run format:check`
- `bun run changesets:validate`
- `bun run typecheck`
- `git diff --check`

Closes #848