### PR TITLE
[codex] Report dry-run marker fallback failures

### DIFF
--- a/.sampo/changesets/847-dry-run-marker-fallback-reporting.md
+++ b/.sampo/changesets/847-dry-run-marker-fallback-reporting.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Report dry-run install marker setup failures when symlink, hard-link, and copy fallbacks all fail.

--- a/packages/wp-typia/src/runtime-bridge-add-dry-run.ts
+++ b/packages/wp-typia/src/runtime-bridge-add-dry-run.ts
@@ -5,6 +5,11 @@ import path from "node:path";
 import { createManagedTempRoot } from "@wp-typia/project-tools/temp-roots";
 
 type WorkspaceFileOperation = `delete ${string}` | `update ${string}` | `write ${string}`;
+type InstallMarkerFs = Pick<typeof fs, "copyFileSync" | "linkSync" | "symlinkSync">;
+type InstallMarkerFailure = {
+	operation: "copy" | "hard link" | "symlink";
+	reason: string;
+};
 
 const SKIPPED_COPY_ROOT_ENTRIES = new Set([".git", "node_modules"]);
 const SKIPPED_COMPARE_ROOT_ENTRIES = new Set([
@@ -29,6 +34,71 @@ async function copyWorkspaceProject(sourceDir: string, targetDir: string): Promi
 	});
 }
 
+function formatInstallMarkerError(error: unknown): string {
+	if (error instanceof Error) {
+		return error.message;
+	}
+
+	return String(error);
+}
+
+function formatInstallMarkerFailures(failures: InstallMarkerFailure[]): string {
+	return failures
+		.map((failure) => `${failure.operation}: ${failure.reason}`)
+		.join("; ");
+}
+
+export function ensureWorkspaceInstallMarker({
+	fsAdapter = fs,
+	sourceMarker,
+	targetMarker,
+}: {
+	fsAdapter?: InstallMarkerFs;
+	sourceMarker: string;
+	targetMarker: string;
+}): void {
+	const failures: InstallMarkerFailure[] = [];
+
+	try {
+		fsAdapter.symlinkSync(sourceMarker, targetMarker);
+		return;
+	} catch (error) {
+		failures.push({
+			operation: "symlink",
+			reason: formatInstallMarkerError(error),
+		});
+	}
+
+	try {
+		fsAdapter.linkSync(sourceMarker, targetMarker);
+		return;
+	} catch (error) {
+		failures.push({
+			operation: "hard link",
+			reason: formatInstallMarkerError(error),
+		});
+	}
+
+	try {
+		fsAdapter.copyFileSync(sourceMarker, targetMarker);
+		return;
+	} catch (error) {
+		failures.push({
+			operation: "copy",
+			reason: formatInstallMarkerError(error),
+		});
+	}
+
+	throw new Error(
+		[
+			"Failed to prepare dry-run install marker.",
+			`Source: ${sourceMarker}`,
+			`Target: ${targetMarker}`,
+			`Fallback failures: ${formatInstallMarkerFailures(failures)}`,
+		].join(" "),
+	);
+}
+
 function ensureWorkspaceInstallMarkers(sourceDir: string, targetDir: string): void {
 	const sourceNodeModules = path.join(sourceDir, "node_modules");
 	if (fs.existsSync(sourceNodeModules)) {
@@ -42,15 +112,7 @@ function ensureWorkspaceInstallMarkers(sourceDir: string, targetDir: string): vo
 		}
 
 		const targetMarker = path.join(targetDir, marker);
-		try {
-			fs.symlinkSync(sourceMarker, targetMarker);
-		} catch {
-			try {
-				fs.linkSync(sourceMarker, targetMarker);
-			} catch {
-				fs.copyFileSync(sourceMarker, targetMarker);
-			}
-		}
+		ensureWorkspaceInstallMarker({ sourceMarker, targetMarker });
 	}
 }
 

--- a/packages/wp-typia/tests/add-command.test.ts
+++ b/packages/wp-typia/tests/add-command.test.ts
@@ -11,6 +11,7 @@ import {
   executeAddCommand,
   loadAddWorkspaceBlockOptions,
 } from '../src/runtime-bridge';
+import { ensureWorkspaceInstallMarker } from '../src/runtime-bridge-add-dry-run';
 import {
   linkWorkspaceNodeModules,
   scaffoldOfficialWorkspace,
@@ -602,6 +603,48 @@ describe('wp-typia add command bridge', () => {
     expect(ADD_KIND_IDS.every((kind) => supportsAddKindDryRun(kind))).toBe(
       true,
     );
+  });
+
+  test('reports install marker setup context when every dry-run fallback fails', () => {
+    const calls: string[] = [];
+    const sourceMarker = path.join(tempRoot, 'demo-marker-source', '.pnp.cjs');
+    const targetMarker = path.join(tempRoot, 'demo-marker-target', '.pnp.cjs');
+    const fsAdapter = {
+      copyFileSync() {
+        calls.push('copy');
+        throw new Error('copy denied');
+      },
+      linkSync() {
+        calls.push('hard link');
+        throw new Error('hard link denied');
+      },
+      symlinkSync() {
+        calls.push('symlink');
+        throw new Error('symlink denied');
+      },
+    } satisfies Parameters<typeof ensureWorkspaceInstallMarker>[0]['fsAdapter'];
+
+    let error: unknown;
+
+    try {
+      ensureWorkspaceInstallMarker({
+        fsAdapter,
+        sourceMarker,
+        targetMarker,
+      });
+    } catch (caughtError) {
+      error = caughtError;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    const message = (error as Error).message;
+    expect(message).toContain('Failed to prepare dry-run install marker.');
+    expect(message).toContain(`Source: ${sourceMarker}`);
+    expect(message).toContain(`Target: ${targetMarker}`);
+    expect(message).toContain('symlink: symlink denied');
+    expect(message).toContain('hard link: hard link denied');
+    expect(message).toContain('copy: copy denied');
+    expect(calls).toEqual(['symlink', 'hard link', 'copy']);
   });
 
   test('keeps the canonical add kind order stable', () => {


### PR DESCRIPTION
## Summary

- Collect symlink, hard-link, and copy failures while preparing dry-run install markers.
- Throw a clear setup error when all marker fallback strategies fail, including source/target marker paths and per-operation failure details.
- Add focused coverage for the all-fallbacks-fail path.

## Validation

- `bun test packages/wp-typia/tests/add-command.test.ts`
- `bun test packages/wp-typia/tests/add-command-package.test.ts`
- `bun run changesets:validate`
- `bun run format:check`
- `bun run typecheck`
- `git diff --check`
- `bun run --filter wp-typia test`

Closes #847

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced dry-run install-marker setup error reporting. When all supported fallback mechanisms (symlink, hard-link, and file copy) fail to establish installation markers, the system now provides consolidated error messages with comprehensive diagnostic context. This clearly indicates which operations were attempted and why each failed, significantly improving diagnostics and troubleshooting for installation failures.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/867)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->