### PR TITLE
fix(add): pass warnLine through add-kind plans

### DIFF
--- a/.sampo/changesets/868-add-kind-warnline.md
+++ b/.sampo/changesets/868-add-kind-warnline.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Route add-kind warning output through the explicit warning printer for every shared execution plan.

--- a/packages/wp-typia/src/add-kinds/admin-view.ts
+++ b/packages/wp-typia/src/add-kinds/admin-view.ts
@@ -46,6 +46,7 @@ export const adminViewAddKindEntry =
         }),
         missingNameMessage: ADMIN_VIEW_MISSING_NAME_MESSAGE,
         name,
+        warnLine: context.warnLine,
       });
     },
     sortOrder: 10,

--- a/packages/wp-typia/src/add-kinds/binding-source.ts
+++ b/packages/wp-typia/src/add-kinds/binding-source.ts
@@ -62,6 +62,7 @@ export const bindingSourceAddKindEntry =
         }),
         missingNameMessage: BINDING_SOURCE_MISSING_NAME_MESSAGE,
         name,
+        warnLine: context.warnLine,
       });
     },
     sortOrder: 70,

--- a/packages/wp-typia/src/add-kinds/editor-plugin.ts
+++ b/packages/wp-typia/src/add-kinds/editor-plugin.ts
@@ -46,6 +46,7 @@ export const editorPluginAddKindEntry =
         }),
         missingNameMessage: EDITOR_PLUGIN_MISSING_NAME_MESSAGE,
         name,
+        warnLine: context.warnLine,
       });
     },
     sortOrder: 120,

--- a/packages/wp-typia/src/add-kinds/hooked-block.ts
+++ b/packages/wp-typia/src/add-kinds/hooked-block.ts
@@ -58,6 +58,7 @@ export const hookedBlockAddKindEntry =
         }),
         missingNameMessage: HOOKED_BLOCK_MISSING_NAME_MESSAGE,
         name,
+        warnLine: context.warnLine,
       });
     },
     sortOrder: 110,

--- a/packages/wp-typia/src/add-kinds/rest-resource.ts
+++ b/packages/wp-typia/src/add-kinds/rest-resource.ts
@@ -50,6 +50,7 @@ export const restResourceAddKindEntry =
         }),
         missingNameMessage: REST_RESOURCE_MISSING_NAME_MESSAGE,
         name,
+        warnLine: context.warnLine,
       });
     },
     sortOrder: 80,

--- a/packages/wp-typia/src/add-kinds/style.ts
+++ b/packages/wp-typia/src/add-kinds/style.ts
@@ -50,6 +50,7 @@ export const styleAddKindEntry =
         }),
         missingNameMessage: STYLE_MISSING_NAME_MESSAGE,
         name,
+        warnLine: context.warnLine,
       });
     },
     sortOrder: 40,

--- a/packages/wp-typia/src/add-kinds/transform.ts
+++ b/packages/wp-typia/src/add-kinds/transform.ts
@@ -59,6 +59,7 @@ export const transformAddKindEntry =
         }),
         missingNameMessage: TRANSFORM_MISSING_NAME_MESSAGE,
         name,
+        warnLine: context.warnLine,
       });
     },
     sortOrder: 50,

--- a/packages/wp-typia/src/add-kinds/variation.ts
+++ b/packages/wp-typia/src/add-kinds/variation.ts
@@ -50,6 +50,7 @@ export const variationAddKindEntry =
         }),
         missingNameMessage: VARIATION_MISSING_NAME_MESSAGE,
         name,
+        warnLine: context.warnLine,
       });
     },
     sortOrder: 30,

--- a/packages/wp-typia/tests/add-kind-registry.test.ts
+++ b/packages/wp-typia/tests/add-kind-registry.test.ts
@@ -217,26 +217,108 @@ test('keeps shared visible-field groups aligned for refactored add kinds', () =>
   ]);
 });
 
-test('passes the warning line printer through the pattern execution plan', async () => {
-  const warnLine = () => {};
-  const context = {
-    addRuntime: {
-      runAddPatternCommand: async ({ cwd, patternName }) => ({
-        patternSlug: patternName,
-        projectDir: cwd,
-      }),
-    } as AddKindExecutionContext['addRuntime'],
-    cwd: '/tmp/wp-typia-pattern-test',
+const warnLinePlanFixtures = {
+  'admin-view': {
     flags: {},
-    getOrCreatePrompt: async () => {
-      throw new Error('pattern add-kind should not prompt in this test');
+    name: 'sample-admin-view',
+  },
+  ability: {
+    flags: {},
+    name: 'sample-ability',
+  },
+  'ai-feature': {
+    flags: {},
+    name: 'sample-ai-feature',
+  },
+  'binding-source': {
+    flags: {},
+    name: 'sample-binding-source',
+  },
+  block: {
+    flags: {},
+    name: 'sample-block',
+  },
+  'editor-plugin': {
+    flags: {},
+    name: 'sample-editor-plugin',
+  },
+  'hooked-block': {
+    flags: {
+      anchor: 'core/post-content',
+      position: 'after',
     },
-    isInteractiveSession: false,
+    name: 'sample-block',
+  },
+  pattern: {
+    flags: {},
     name: 'sample-pattern',
-    warnLine,
-  } satisfies AddKindExecutionContext;
+  },
+  'rest-resource': {
+    flags: {},
+    name: 'sample-rest-resource',
+  },
+  style: {
+    flags: {
+      block: 'sample-block',
+    },
+    name: 'sample-style',
+  },
+  transform: {
+    flags: {
+      from: 'core/paragraph',
+      to: 'sample/block',
+    },
+    name: 'sample-transform',
+  },
+  variation: {
+    flags: {
+      block: 'sample-block',
+    },
+    name: 'sample-variation',
+  },
+} satisfies Record<
+  AddKindId,
+  {
+    flags: Record<string, unknown>;
+    name: string;
+  }
+>;
 
-  const plan = await ADD_KIND_REGISTRY.pattern.prepareExecution(context);
+test('passes the warning line printer through every add-kind execution plan', async () => {
+  const warnLine = () => {};
+  const planWarnLineResults = Object.fromEntries(
+    await Promise.all(
+      ADD_KIND_IDS.map(async (kind) => {
+        const fixture = warnLinePlanFixtures[kind];
+        const plan = await ADD_KIND_REGISTRY[kind].prepareExecution({
+          addRuntime: {} as AddKindExecutionContext['addRuntime'],
+          cwd: `/tmp/wp-typia-${kind}-test`,
+          flags: fixture.flags,
+          getOrCreatePrompt: async () => {
+            throw new Error(`${kind} add-kind should not prompt in this test`);
+          },
+          isInteractiveSession: false,
+          name: fixture.name,
+          warnLine,
+        });
 
-  expect(plan.warnLine).toBe(warnLine);
+        return [kind, plan.warnLine === warnLine];
+      }),
+    ),
+  );
+
+  expect(planWarnLineResults).toEqual({
+    'admin-view': true,
+    ability: true,
+    'ai-feature': true,
+    'binding-source': true,
+    block: true,
+    'editor-plugin': true,
+    'hooked-block': true,
+    pattern: true,
+    'rest-resource': true,
+    style: true,
+    transform: true,
+    variation: true,
+  });
 });


### PR DESCRIPTION
## Summary
- Pass the add command warnLine printer through every shared add-kind execution plan.
- Expand add-kind registry coverage so every registered add kind preserves the warning printer.
- Add a Sampo changeset for the CLI package.

Fixes #868

## Tests
- bun test packages/wp-typia/tests/add-kind-registry.test.ts
- bun run changesets:validate
- bun run --filter wp-typia test
- bun run format:check
- bun run typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced warning message display consistency across all add-kind configuration commands to ensure warnings are reliably routed through the warning system during code generation operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/880)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->