### PR TITLE
dx(migrate): route output through PrintLine

### DIFF
--- a/.sampo/changesets/869-migrate-printline.md
+++ b/.sampo/changesets/869-migrate-printline.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Route migrate command human output through injected line printers instead of bridge-level console output.

--- a/packages/wp-typia/src/commands/migrate.ts
+++ b/packages/wp-typia/src/commands/migrate.ts
@@ -8,11 +8,24 @@ import {
 	resolveCommandOptionValues,
 } from "../command-option-metadata";
 import { emitCliDiagnosticFailure } from "../cli-diagnostic-output";
+import type { PrintLine } from "../print-line";
 import { resolveBundledModuleHref } from "../render-loader";
 import { executeMigrateCommand } from "../runtime-bridge";
 import { supportsInteractiveTui } from "../runtime-capabilities";
 import type { WpTypiaRenderArgs } from "./render-types";
 import { LazyFlow } from "../ui/lazy-flow";
+
+type MigrateCommandArgsWithPrintLine = {
+	printLine?: PrintLine;
+};
+
+const defaultPrintLine: PrintLine = (line) => {
+	process.stdout.write(`${line}\n`);
+};
+
+function resolveMigratePrintLine(args: MigrateCommandArgsWithPrintLine): PrintLine {
+	return args.printLine ?? defaultPrintLine;
+}
 
 function loadMigrateFlow() {
 	return import(
@@ -32,11 +45,15 @@ export const migrateCommand = defineCommand({
 	defaultFormat: "toon",
 	description: "Run migration workflows for migration-capable wp-typia projects.",
 	handler: async (args) => {
+		const printLine = resolveMigratePrintLine(
+			args as MigrateCommandArgsWithPrintLine,
+		);
 		try {
 			await executeMigrateCommand({
 				command: args.positional[0],
 				cwd: args.cwd,
 				flags: args.flags as Record<string, unknown>,
+				printLine,
 			});
 		} catch (error) {
 			emitCliDiagnosticFailure(args, {

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -308,11 +308,13 @@ const NODE_FALLBACK_COMMAND_DISPATCHERS = {
     cwd,
     mergedFlags,
     positionals,
+    printLine,
   }: NodeFallbackDispatchContext) => {
     await executeMigrateCommand({
       command: positionals[1],
       cwd,
       flags: mergedFlags,
+      printLine,
     });
   },
   sync: async ({

--- a/packages/wp-typia/src/runtime-bridge-migrate.ts
+++ b/packages/wp-typia/src/runtime-bridge-migrate.ts
@@ -2,6 +2,7 @@ import type { ReadlinePrompt } from '@wp-typia/project-tools/cli-prompt';
 import type { AlternateBufferCompletionPayload } from './ui/alternate-buffer-lifecycle';
 import { buildMigrationCompletionPayload } from './runtime-bridge-output';
 import { readOptionalLooseStringFlag } from './cli-string-flags';
+import type { PrintLine } from './print-line';
 import {
   pushFlag,
   shouldWrapCliCommandError,
@@ -12,30 +13,32 @@ export type MigrateExecutionInput = {
   command?: string;
   cwd: string;
   flags: Record<string, unknown>;
+  printLine?: PrintLine;
   prompt?: ReadlinePrompt;
-  renderLine?: (line: string) => void;
+  renderLine?: PrintLine;
 };
 
 const loadMigrationsRuntime = () =>
   import('@wp-typia/project-tools/migrations');
+const defaultPrintLine: PrintLine = (line) => {
+  process.stdout.write(`${line}\n`);
+};
 
 export async function executeMigrateCommand({
   command,
   cwd,
   flags,
+  printLine = defaultPrintLine,
   prompt,
   renderLine,
 }: MigrateExecutionInput): Promise<AlternateBufferCompletionPayload | void> {
   try {
     const { formatMigrationHelpText, parseMigrationArgs, runMigrationCommand } =
       await loadMigrationsRuntime();
+    const outputLine = renderLine ?? printLine;
     if (!command) {
       const helpText = formatMigrationHelpText();
-      if (renderLine) {
-        renderLine(helpText);
-      } else {
-        console.log(helpText);
-      }
+      outputLine(helpText);
       return;
     }
 
@@ -73,11 +76,7 @@ export async function executeMigrateCommand({
     const lines: string[] | null = renderLine ? [] : null;
     const captureLine = (line: string) => {
       lines?.push(line);
-      if (renderLine) {
-        renderLine(line);
-        return;
-      }
-      console.log(line);
+      outputLine(line);
     };
     const result = await runMigrationCommand(parsed, cwd, {
       prompt,

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -935,6 +935,13 @@ process.exit(0);
     expect(migrateCommandSource).toContain(
       'buildCommandOptions(MIGRATE_OPTION_METADATA)',
     );
+    expect(migrateCommandSource).toContain('resolveMigratePrintLine');
+    expect(migrateCommandSource).toMatch(
+      /executeMigrateCommand\(\{[\s\S]*printLine,/,
+    );
+    expect(nodeCliSource).toMatch(
+      /migrate:\s*async\s*\(\{[\s\S]*printLine,[\s\S]*executeMigrateCommand\(\{[\s\S]*printLine,/,
+    );
     expect(templatesCommandSource).toContain(
       'buildCommandOptions(TEMPLATES_OPTION_METADATA)',
     );

--- a/packages/wp-typia/tests/completion-output.test.ts
+++ b/packages/wp-typia/tests/completion-output.test.ts
@@ -345,6 +345,29 @@ describe('alternate-buffer completion output helpers', () => {
     expect(lines[0]).toContain('wp-typia migrate init');
   });
 
+  test('migrate help output uses the injected printLine without console fallback', async () => {
+    const originalLog = console.log;
+    const lines: string[] = [];
+    console.log = () => {
+      throw new Error('migrate help should use the injected printLine');
+    };
+
+    try {
+      await executeMigrateCommand({
+        cwd: tempRoot,
+        flags: {},
+        printLine: (line) => {
+          lines.push(line);
+        },
+      });
+    } finally {
+      console.log = originalLog;
+    }
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('wp-typia migrate init');
+  });
+
   test('create progress formatter keeps fallback status lines readable', () => {
     expect(
       formatCreateProgressLine(

--- a/packages/wp-typia/tests/runtime-bridge-boundaries.test.ts
+++ b/packages/wp-typia/tests/runtime-bridge-boundaries.test.ts
@@ -109,6 +109,7 @@ test('runtime bridge delegates command, output, and sync helpers to focused modu
   expect(doctorSource).toContain('export async function executeDoctorCommand(');
   expect(initSource).toContain('export async function executeInitCommand(');
   expect(migrateSource).toContain('export async function executeMigrateCommand(');
+  expect(migrateSource).not.toContain('console.log');
   expect(sharedSource).toContain('export async function wrapCliCommandError(');
   expect(templatesSource).toContain(
     'export async function executeTemplatesCommand(',


### PR DESCRIPTION
## Summary
- Add a PrintLine path for migrate bridge output and remove bridge-level console.log calls.
- Pass explicit migrate printers from both the Bunli command handler and Node fallback dispatcher.
- Cover injected printLine capture and source-level routing regressions.

Fixes #869

## Tests
- bun test packages/wp-typia/tests/completion-output.test.ts packages/wp-typia/tests/runtime-bridge-boundaries.test.ts
- bun test packages/wp-typia/tests/cli-package.test.ts -t "derives Bunli and Node fallback option metadata from the same source"
- bun run format:check
- bun run changesets:validate
- bun run typecheck
- bun run --filter wp-typia test