### PR TITLE
dx(cli): pass Bunli output adapters

### DIFF
--- a/.sampo/changesets/870-bunli-output-adapters.md
+++ b/.sampo/changesets/870-bunli-output-adapters.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Pass explicit output adapters from Bunli command handlers into supported runtime bridges.

--- a/packages/wp-typia/src/commands/add.ts
+++ b/packages/wp-typia/src/commands/add.ts
@@ -13,6 +13,7 @@ import {
   prefersStructuredCliOutput,
 } from '../cli-diagnostic-output';
 import { getAddBlockDefaults } from '../config';
+import { resolveCommandOutputAdapters } from './output-adapters';
 import { resolveBundledModuleHref } from '../render-loader';
 import { executeAddCommand } from '../runtime-bridge';
 import {
@@ -43,6 +44,7 @@ export const addCommand = defineCommand({
     'Extend an official wp-typia workspace with blocks, variations, block styles, transforms, patterns, binding sources, plugin-level REST resources, workflow abilities, server-only AI features, editor plugins, or hooked blocks.',
   handler: async (args) => {
     const prefersStructuredOutput = prefersStructuredCliOutput(args);
+    const { printLine, warnLine } = resolveCommandOutputAdapters(args);
 
     try {
       if (prefersStructuredOutput) {
@@ -53,6 +55,8 @@ export const addCommand = defineCommand({
           interactive: false,
           kind: args.positional[0],
           name: args.positional[1],
+          printLine,
+          warnLine,
         });
         args.output(
           buildStructuredCompletionSuccessPayload('add', completion, {
@@ -70,6 +74,8 @@ export const addCommand = defineCommand({
         flags: args.flags as Record<string, unknown>,
         kind: args.positional[0],
         name: args.positional[1],
+        printLine,
+        warnLine,
       });
     } catch (error) {
       emitCliDiagnosticFailure(args, {

--- a/packages/wp-typia/src/commands/create.ts
+++ b/packages/wp-typia/src/commands/create.ts
@@ -14,6 +14,7 @@ import {
 } from "../cli-diagnostic-output";
 import { buildMissingCreateProjectDirDetailLines } from "../cli-error-messages";
 import { getCreateDefaults } from "../config";
+import { resolveCommandOutputAdapters } from "./output-adapters";
 import { resolveBundledModuleHref } from "../render-loader";
 import { executeCreateCommand } from "../runtime-bridge";
 import {
@@ -43,6 +44,7 @@ export const createCommand = defineCommand({
 	description: "Scaffold a new wp-typia project.",
 	handler: async (args) => {
 		const prefersStructuredOutput = prefersStructuredCliOutput(args);
+		const { printLine, warnLine } = resolveCommandOutputAdapters(args);
 		const projectDir = args.positional[0];
 		if (!projectDir) {
 			emitCliDiagnosticFailure(args, {
@@ -58,7 +60,9 @@ export const createCommand = defineCommand({
 				emitOutput: !prefersStructuredOutput,
 				flags: args.flags as Record<string, unknown>,
 				interactive: prefersStructuredOutput ? false : undefined,
+				printLine,
 				projectDir,
+				warnLine,
 			});
 			if (prefersStructuredOutput) {
 				args.output(

--- a/packages/wp-typia/src/commands/init.ts
+++ b/packages/wp-typia/src/commands/init.ts
@@ -8,6 +8,7 @@ import {
   emitCliDiagnosticFailure,
   prefersStructuredCliOutput,
 } from '../cli-diagnostic-output';
+import { resolveCommandOutputAdapters } from './output-adapters';
 import { executeInitCommand } from '../runtime-bridge';
 import { buildStructuredInitSuccessPayload } from '../runtime-bridge-output';
 
@@ -17,6 +18,7 @@ export const initCommand = defineCommand({
     'Preview or apply the minimum wp-typia retrofit plan for an existing project.',
   handler: async (args) => {
     const prefersStructuredOutput = prefersStructuredCliOutput(args);
+    const { printLine, warnLine } = resolveCommandOutputAdapters(args);
 
     try {
       const plan = await executeInitCommand(
@@ -29,7 +31,11 @@ export const initCommand = defineCommand({
               : undefined,
           projectDir: args.positional[0] as string | undefined,
         },
-        { emitOutput: !prefersStructuredOutput },
+        {
+          emitOutput: !prefersStructuredOutput,
+          printLine,
+          warnLine,
+        },
       );
       if (prefersStructuredOutput) {
         args.output(buildStructuredInitSuccessPayload(plan));

--- a/packages/wp-typia/src/commands/mcp.ts
+++ b/packages/wp-typia/src/commands/mcp.ts
@@ -11,6 +11,7 @@ import {
 } from '../command-option-metadata';
 import { getMcpSchemaSources } from '../config';
 import { loadMcpToolGroups, syncMcpSchemas } from '../mcp';
+import { resolveCommandPrintLine } from './output-adapters';
 import type { PrintLine } from '../print-line';
 
 type McpToolGroupSummary = {
@@ -19,19 +20,7 @@ type McpToolGroupSummary = {
   tools: string[];
 };
 
-type McpCommandArgsWithPrintLine = {
-  printLine?: PrintLine;
-};
-
 type McpSyncResult = Awaited<ReturnType<typeof syncMcpSchemas>>;
-
-const defaultPrintLine: PrintLine = (line) => {
-  process.stdout.write(`${line}\n`);
-};
-
-function resolveMcpPrintLine(args: McpCommandArgsWithPrintLine): PrintLine {
-  return args.printLine ?? defaultPrintLine;
-}
 
 export function printMcpToolGroupSummary(
   summary: McpToolGroupSummary[],
@@ -60,7 +49,7 @@ export const mcpCommand = defineCommand({
   handler: async (args) => {
     const subcommand = args.positional[0] ?? 'list';
     const prefersStructuredOutput = prefersStructuredCliOutput(args);
-    const printLine = resolveMcpPrintLine(args as McpCommandArgsWithPrintLine);
+    const printLine = resolveCommandPrintLine(args);
     const userConfig =
       args.context?.store?.wpTypiaUserConfig &&
       typeof args.context.store.wpTypiaUserConfig === 'object'

--- a/packages/wp-typia/src/commands/migrate.ts
+++ b/packages/wp-typia/src/commands/migrate.ts
@@ -8,24 +8,12 @@ import {
 	resolveCommandOptionValues,
 } from "../command-option-metadata";
 import { emitCliDiagnosticFailure } from "../cli-diagnostic-output";
-import type { PrintLine } from "../print-line";
+import { resolveCommandPrintLine } from "./output-adapters";
 import { resolveBundledModuleHref } from "../render-loader";
 import { executeMigrateCommand } from "../runtime-bridge";
 import { supportsInteractiveTui } from "../runtime-capabilities";
 import type { WpTypiaRenderArgs } from "./render-types";
 import { LazyFlow } from "../ui/lazy-flow";
-
-type MigrateCommandArgsWithPrintLine = {
-	printLine?: PrintLine;
-};
-
-const defaultPrintLine: PrintLine = (line) => {
-	process.stdout.write(`${line}\n`);
-};
-
-function resolveMigratePrintLine(args: MigrateCommandArgsWithPrintLine): PrintLine {
-	return args.printLine ?? defaultPrintLine;
-}
 
 function loadMigrateFlow() {
 	return import(
@@ -45,9 +33,7 @@ export const migrateCommand = defineCommand({
 	defaultFormat: "toon",
 	description: "Run migration workflows for migration-capable wp-typia projects.",
 	handler: async (args) => {
-		const printLine = resolveMigratePrintLine(
-			args as MigrateCommandArgsWithPrintLine,
-		);
+		const printLine = resolveCommandPrintLine(args);
 		try {
 			await executeMigrateCommand({
 				command: args.positional[0],

--- a/packages/wp-typia/src/commands/output-adapters.ts
+++ b/packages/wp-typia/src/commands/output-adapters.ts
@@ -1,0 +1,30 @@
+import type { PrintLine } from '../print-line';
+
+type CommandOutputAdapterArgs = {
+  printLine?: PrintLine;
+  warnLine?: PrintLine;
+};
+
+const defaultPrintLine: PrintLine = (line) => {
+  process.stdout.write(`${line}\n`);
+};
+
+const defaultWarnLine: PrintLine = (line) => {
+  process.stderr.write(`${line}\n`);
+};
+
+export function resolveCommandPrintLine(args: object): PrintLine {
+  return (args as CommandOutputAdapterArgs).printLine ?? defaultPrintLine;
+}
+
+export function resolveCommandOutputAdapters(args: object): {
+  printLine: PrintLine;
+  warnLine: PrintLine;
+} {
+  const adapters = args as CommandOutputAdapterArgs;
+
+  return {
+    printLine: adapters.printLine ?? defaultPrintLine,
+    warnLine: adapters.warnLine ?? defaultWarnLine,
+  };
+}

--- a/packages/wp-typia/src/commands/templates.ts
+++ b/packages/wp-typia/src/commands/templates.ts
@@ -11,6 +11,7 @@ import {
 	emitCliDiagnosticFailure,
 	prefersStructuredCliOutput,
 } from "../cli-diagnostic-output";
+import { resolveCommandPrintLine } from "./output-adapters";
 import { executeTemplatesCommand, listTemplatesForRuntime } from "../runtime-bridge";
 
 export const templatesCommand = defineCommand({
@@ -24,6 +25,7 @@ export const templatesCommand = defineCommand({
 				? "inspect"
 				: subcommand;
 		const prefersStructuredOutput = prefersStructuredCliOutput(args);
+		const printLine = resolveCommandPrintLine(args);
 
 		try {
 			if (prefersStructuredOutput) {
@@ -57,7 +59,7 @@ export const templatesCommand = defineCommand({
 
 			await executeTemplatesCommand({
 				flags: { id, subcommand: effectiveSubcommand },
-			});
+			}, printLine);
 		} catch (error) {
 			emitCliDiagnosticFailure(args, {
 				command: "templates",

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -371,6 +371,7 @@ const NODE_FALLBACK_COMMAND_DISPATCHERS = {
   templates: async ({
     mergedFlags,
     positionals,
+    printLine,
   }: NodeFallbackDispatchContext) => {
     const subcommand = positionals[1];
     const templateId =
@@ -402,7 +403,7 @@ const NODE_FALLBACK_COMMAND_DISPATCHERS = {
         id: templateId,
         subcommand: resolvedSubcommand,
       },
-    });
+    }, printLine);
   },
 } satisfies Record<
   NodeFallbackExecutableCommandName,

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -81,6 +81,10 @@ const templatesCommandSource = fs.readFileSync(
   path.join(packageRoot, 'src', 'commands', 'templates.ts'),
   'utf8',
 );
+const outputAdaptersSource = fs.readFileSync(
+  path.join(packageRoot, 'src', 'commands', 'output-adapters.ts'),
+  'utf8',
+);
 const mcpCommandSource = fs.readFileSync(
   path.join(packageRoot, 'src', 'commands', 'mcp.ts'),
   'utf8',
@@ -935,7 +939,7 @@ process.exit(0);
     expect(migrateCommandSource).toContain(
       'buildCommandOptions(MIGRATE_OPTION_METADATA)',
     );
-    expect(migrateCommandSource).toContain('resolveMigratePrintLine');
+    expect(migrateCommandSource).toContain('resolveCommandPrintLine');
     expect(migrateCommandSource).toMatch(
       /executeMigrateCommand\(\{[\s\S]*printLine,/,
     );
@@ -970,6 +974,33 @@ process.exit(0);
     );
     expect(nodeFallbackHelpSource).toContain(
       'optionMetadata: TEMPLATES_OPTION_METADATA',
+    );
+  });
+
+  test('passes explicit output adapters from Bunli command handlers into runtime bridges', () => {
+    expect(outputAdaptersSource).toContain('resolveCommandOutputAdapters');
+    expect(outputAdaptersSource).toContain('process.stdout.write');
+    expect(outputAdaptersSource).toContain('process.stderr.write');
+
+    expect(addCommandSource).toContain('resolveCommandOutputAdapters');
+    expect(addCommandSource).toMatch(
+      /executeAddCommand\(\{[\s\S]*printLine,[\s\S]*warnLine,/,
+    );
+    expect(createCommandSource).toContain('resolveCommandOutputAdapters');
+    expect(createCommandSource).toMatch(
+      /executeCreateCommand\(\{[\s\S]*printLine,[\s\S]*warnLine,/,
+    );
+    expect(initCommandSource).toContain('resolveCommandOutputAdapters');
+    expect(initCommandSource).toMatch(
+      /executeInitCommand\([\s\S]*\{[\s\S]*printLine,[\s\S]*warnLine,/,
+    );
+    expect(migrateCommandSource).toContain('resolveCommandPrintLine');
+    expect(migrateCommandSource).toMatch(
+      /executeMigrateCommand\(\{[\s\S]*printLine,/,
+    );
+    expect(templatesCommandSource).toContain('resolveCommandPrintLine');
+    expect(templatesCommandSource).toMatch(
+      /executeTemplatesCommand\(\{[\s\S]*\},\s*printLine\)/,
     );
   });
 


### PR DESCRIPTION
## Summary
- Add shared command output adapter helpers for Bunli command handlers.
- Pass explicit printLine/warnLine into add, create, and init runtime bridge calls.
- Pass explicit printLine into migrate/templates paths and keep MCP on the shared adapter helper.

Fixes #870

## Tests
- bun test packages/wp-typia/tests/cli-package.test.ts -t "passes explicit output adapters from Bunli command handlers into runtime bridges"
- bun test packages/wp-typia/tests/cli-package.test.ts -t "derives Bunli and Node fallback option metadata from the same source"
- bun run format:check
- bun run changesets:validate
- bun run typecheck
- bun run --filter wp-typia test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced standardized output adapter system for consistent command output and warning handling across all CLI commands.

* **Refactor**
  * Consolidated output adapter logic into a shared module, replacing individual command-specific implementations for improved maintainability.

* **Tests**
  * Added validation ensuring explicit output adapters are properly routed through command handlers into the runtime layer.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/883)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->