### PR TITLE
refactor(cli): share escapeRegExp helper

### DIFF
--- a/.sampo/changesets/871-share-escape-regexp.md
+++ b/.sampo/changesets/871-share-escape-regexp.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Share the CLI regular expression escaping helper across runtime output and marker formatting.

--- a/packages/wp-typia/src/output-markers.ts
+++ b/packages/wp-typia/src/output-markers.ts
@@ -1,3 +1,5 @@
+import { escapeRegExp } from './string-utils';
+
 export type OutputMarkerKind = 'dryRun' | 'progress' | 'success' | 'warning';
 
 export type OutputMarkerOptions = {
@@ -22,10 +24,6 @@ const ASCII_OUTPUT_MARKERS: Record<OutputMarkerKind, string> = {
 
 const ASCII_ENV_TRUTHY_VALUES = new Set(['1', 'on', 'true', 'yes']);
 const ASCII_ENV_FALSY_VALUES = new Set(['0', 'off', 'false', 'no']);
-
-function escapeRegExp(source: string): string {
-  return source.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
 
 function readAsciiPreferenceFromEnv(
   env: NodeJS.ProcessEnv,

--- a/packages/wp-typia/src/runtime-output/create.ts
+++ b/packages/wp-typia/src/runtime-output/create.ts
@@ -14,11 +14,8 @@ import {
   formatOutputMarker,
   type OutputMarkerOptions,
 } from '../output-markers';
+import { escapeRegExp } from '../string-utils';
 import type { CreateProgressPayload } from './types';
-
-function escapeRegExp(source: string): string {
-  return source.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
-}
 
 const LOOSE_CREATE_COMPLETION_PACKAGE_MANAGER_PATTERN = new RegExp(
   `^(?:corepack\\s+)?(${PACKAGE_MANAGER_IDS.map(escapeRegExp).join('|')})(?=$|[@:/+\\s])`,

--- a/packages/wp-typia/src/string-utils.ts
+++ b/packages/wp-typia/src/string-utils.ts
@@ -1,0 +1,3 @@
+export function escapeRegExp(source: string): string {
+  return source.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+}

--- a/packages/wp-typia/tests/string-utils.test.ts
+++ b/packages/wp-typia/tests/string-utils.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'bun:test';
+
+import { escapeRegExp } from '../src/string-utils';
+
+describe('string utilities', () => {
+  test('escapes regular expression metacharacters for dynamic patterns', () => {
+    const source = '[ok] .*+?^${}()|\\';
+    const escaped = escapeRegExp(source);
+
+    expect(new RegExp(`^${escaped}$`, 'u').test(source)).toBe(true);
+    expect(escaped).toBe('\\[ok\\] \\.\\*\\+\\?\\^\\$\\{\\}\\(\\)\\|\\\\');
+  });
+});


### PR DESCRIPTION
## Summary
- Move the CLI regular-expression escaping helper into shared string utilities.
- Import the shared helper from runtime create output and output marker formatting.
- Add a focused helper test while keeping existing marker/completion behavior covered.

Fixes #871

## Tests
- bun test packages/wp-typia/tests/string-utils.test.ts packages/wp-typia/tests/output-markers.test.ts packages/wp-typia/tests/completion-output.test.ts
- bun run format:check
- bun run changesets:validate
- bun run typecheck
- git diff --check
- bun run --filter wp-typia test