### PR TITLE
refactor(runtime): share init ENOENT helper

### DIFF
--- a/.sampo/changesets/872-shared-enoent-helper.md
+++ b/.sampo/changesets/872-shared-enoent-helper.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Route the generated init sync helper through a shared file-not-found error helper instead of an inline ENOENT code check.

--- a/packages/wp-typia-project-tools/src/runtime/cli-init-templates.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-init-templates.ts
@@ -193,6 +193,16 @@ function getSyncScriptEnv() {
 \treturn env;
 }
 
+function getOptionalNodeErrorCode( error: unknown ): string | undefined {
+\treturn typeof error === 'object' && error !== null && 'code' in error
+\t\t? String( ( error as { code: unknown } ).code )
+\t\t: undefined;
+}
+
+function isFileNotFoundError( error: unknown ): boolean {
+\treturn getOptionalNodeErrorCode( error ) === 'ENOENT';
+}
+
 function runSyncScript( scriptPath: string, options: SyncCliOptions ) {
 \tconst args = [ scriptPath ];
 \tif ( options.check ) {
@@ -207,7 +217,7 @@ function runSyncScript( scriptPath: string, options: SyncCliOptions ) {
 \t} );
 
 \tif ( result.error ) {
-\t\tif ( ( result.error as NodeJS.ErrnoException ).code === 'ENOENT' ) {
+\t\tif ( isFileNotFoundError( result.error ) ) {
 \t\t\tthrow new Error(
 \t\t\t\t'Unable to resolve \`tsx\` for project sync. Install project dependencies or rerun the command through your package manager.'
 \t\t\t);

--- a/packages/wp-typia-project-tools/tests/runtime-helper-consolidation.test.ts
+++ b/packages/wp-typia-project-tools/tests/runtime-helper-consolidation.test.ts
@@ -30,6 +30,8 @@ function readRuntimeSource(fileName: string): string {
 }
 
 test('runtime helper modules own filesystem and TypeScript property-name helpers', () => {
+  const initTemplatesSource = readRuntimeSource('cli-init-templates.ts');
+
   expect(readRuntimeSource('template-source-cache.ts')).not.toContain(
     'async function pathExists',
   );
@@ -51,6 +53,11 @@ test('runtime helper modules own filesystem and TypeScript property-name helpers
   expect(readRuntimeSource('cli-add-workspace-assets.ts')).not.toContain(
     'function resolveBindingTargetBlockSlug',
   );
+  expect(initTemplatesSource).not.toContain(
+    "( result.error as NodeJS.ErrnoException ).code === 'ENOENT'",
+  );
+  expect(initTemplatesSource).toContain('function isFileNotFoundError');
+  expect(initTemplatesSource).toContain('isFileNotFoundError( result.error )');
 });
 
 test('shared async filesystem helpers expose path existence and node error codes', async () => {


### PR DESCRIPTION
## Summary
- Route the generated init sync-project helper through isFileNotFoundError instead of checking result.error.code inline.
- Keep the tsx missing-binary fallback message unchanged.
- Add a runtime helper consolidation assertion for the init template source.

Fixes #872

## Tests
- bun test packages/wp-typia-project-tools/tests/runtime-helper-consolidation.test.ts
- bun test packages/wp-typia-project-tools/tests/init-command.test.ts
- bun run format:check
- bun run changesets:validate
- bun run typecheck
- git diff --check
- bun run --filter @wp-typia/project-tools test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of file-not-found error detection in the initialization helper to more reliably identify and handle missing files.

* **Tests**
  * Updated test suite to verify proper error handling implementation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/895)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->