### PR TITLE
refactor(template-render): rename sync pathExists helper

### DIFF
--- a/.sampo/changesets/873-template-render-path-exists-sync.md
+++ b/.sampo/changesets/873-template-render-path-exists-sync.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Rename the template renderer's synchronous path existence helper to `pathExistsSync` to avoid confusion with the canonical async helper.

--- a/packages/wp-typia-project-tools/src/runtime/template-render.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-render.ts
@@ -337,6 +337,6 @@ export async function listInterpolatedDirectoryOutputs(
 	return outputs.sort((left, right) => left.localeCompare(right));
 }
 
-export function pathExists(targetPath: string): boolean {
+export function pathExistsSync(targetPath: string): boolean {
 	return fs.existsSync(targetPath);
 }

--- a/packages/wp-typia-project-tools/tests/template-render.test.ts
+++ b/packages/wp-typia-project-tools/tests/template-render.test.ts
@@ -11,6 +11,7 @@ import {
 	copyInterpolatedDirectory,
 	copyRenderedDirectory,
 	listInterpolatedDirectoryOutputs,
+	pathExistsSync,
 	renderMustacheTemplateString,
 } from "../src/runtime/template-render.js";
 
@@ -27,6 +28,14 @@ describe("template render internals", () => {
 				value: "<demo>&",
 			}),
 		).toBe("<demo>& :: <demo>&");
+	});
+
+	test("pathExistsSync keeps the template renderer sync helper explicit", () => {
+		const targetPath = path.join(tempRoot, "path-exists-sync.txt");
+		fs.writeFileSync(targetPath, "ok", "utf8");
+
+		expect(pathExistsSync(targetPath)).toBe(true);
+		expect(pathExistsSync(path.join(tempRoot, "missing-path.txt"))).toBe(false);
 	});
 
 	test("copyRenderedDirectory and interpolation mode keep their semantics explicit", async () => {


### PR DESCRIPTION
## Summary
- Rename the synchronous template-render path existence helper to `pathExistsSync`
- Add a focused test that keeps the sync helper name and behavior explicit
- Add a Sampo patch changeset for `@wp-typia/project-tools`

Fixes #873

## Tests
- `bun test packages/wp-typia-project-tools/tests/template-render.test.ts`
- `bun run format:check`
- `bun run changesets:validate`
- `git diff --check`
- `bun run typecheck`
- `bun run --filter @wp-typia/project-tools test`