### PR TITLE
refactor(doctor): use shared check helper for environment rows

### DIFF
--- a/.sampo/changesets/874-doctor-environment-shared-check.md
+++ b/.sampo/changesets/874-doctor-environment-shared-check.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Route environment doctor checks through the shared doctor check helper to keep diagnostic row metadata consistent.

--- a/packages/wp-typia-project-tools/src/runtime/cli-doctor-environment.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-doctor-environment.ts
@@ -8,6 +8,7 @@ import {
 	getBuiltInTemplateLayerDirs,
 	isOmittableBuiltInTemplateLayerDir,
 } from "./template-builtins.js";
+import { createDoctorCheck } from "./cli-doctor-workspace-shared.js";
 import { isBuiltInTemplateId, listTemplates } from "./template-registry.js";
 
 import type { DoctorCheck } from "./cli-doctor.js";
@@ -46,14 +47,6 @@ async function checkTempDirectory(): Promise<boolean> {
 	} catch {
 		return false;
 	}
-}
-
-function createDoctorCheck(
-	label: string,
-	status: DoctorCheck["status"],
-	detail: string,
-): DoctorCheck {
-	return { detail, label, status };
 }
 
 function getTemplateDoctorChecks(): DoctorCheck[] {

--- a/packages/wp-typia-project-tools/tests/cli-doctor-boundaries.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-doctor-boundaries.test.ts
@@ -48,6 +48,8 @@ test("cli-doctor keeps environment and workspace checks in dedicated modules", (
 	expect(cliDoctorSource).not.toContain("function checkWorkspacePackageMetadata(");
 	expect(cliDoctorSource).not.toContain("function checkWorkspaceBindingBootstrap(");
 	expect(environmentSource).toContain("export async function getEnvironmentDoctorChecks(");
+	expect(environmentSource).toContain('from "./cli-doctor-workspace-shared.js"');
+	expect(environmentSource).not.toContain("function createDoctorCheck(");
 	expect(workspaceSource).toContain("export async function getWorkspaceDoctorChecks(");
 	expect(workspaceSource).toContain("readWorkspaceInventoryAsync(");
 	expect(workspaceSource).toContain('from "./cli-doctor-workspace-bindings.js"');


### PR DESCRIPTION
## Summary
- Import the shared `createDoctorCheck` helper in environment doctor checks
- Remove the local duplicate helper from `cli-doctor-environment.ts`
- Extend the doctor boundary test to keep environment checks on the shared helper
- Add a Sampo patch changeset for `@wp-typia/project-tools`

Fixes #874

## Tests
- `bun test packages/wp-typia-project-tools/tests/cli-doctor-boundaries.test.ts`
- `bun test packages/wp-typia-project-tools/tests/workspace-doctor.test.ts`
- `bun test packages/wp-typia-project-tools/tests/cli-entry.test.ts`
- `bun run format:check`
- `bun run changesets:validate`
- `git diff --check`
- `bun run typecheck`
- `bun run --filter @wp-typia/project-tools test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized environment diagnostic checks to improve consistency and maintainability throughout the codebase.

* **Tests**
  * Enhanced test coverage to verify proper module organization and correct dependency imports for environment checks.

* **Chores**
  * Released patch version update for the @wp-typia/project-tools package.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/897)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->