### PR TITLE
docs(api): clarify deprecated sync helper timeline

### DIFF
--- a/.sampo/changesets/875-deprecated-sync-helper-timeline.md
+++ b/.sampo/changesets/875-deprecated-sync-helper-timeline.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Document async replacements and no-removal-scheduled guidance for deprecated synchronous inventory and template-source helpers.

--- a/apps/docs/src/content/docs/reference/api.md
+++ b/apps/docs/src/content/docs/reference/api.md
@@ -276,6 +276,17 @@ the shared diagnostic block only when they fail.
 
 Compatibility note: `@wp-typia/project-tools` is the canonical programmatic package, `wp-typia` is the canonical CLI package, and `@wp-typia/block-runtime/*` is the maintained generated-project runtime helper surface.
 
+Deprecated synchronous helper policy: the `@wp-typia/project-tools` root still
+exports compatibility helpers such as `readWorkspaceInventory()` and
+`getWorkspaceBlockSelectOptions()`, while lower-level template-source modules
+still expose `getExternalTemplateEntry()`, `getDefaultCategory()`, and
+`getTemplateProjectType()`. Prefer the async replacements
+`readWorkspaceInventoryAsync()`, `getWorkspaceBlockSelectOptionsAsync()`,
+`findExternalTemplateEntry()`, `getDefaultCategoryAsync()`, and
+`getTemplateProjectTypeAsync()` for new async command paths. These synchronous
+helpers follow the same policy: Removal target: not currently scheduled. If
+removal is scheduled, the release notes will name the target version first.
+
 For the current generator architecture boundary, including the staged
 `BlockSpec` / `BlockGeneratorService` contract, the current phase status, and
 the split between emitter-owned built-in artifacts and Mustache-owned shared

--- a/packages/wp-typia-project-tools/src/runtime/template-source-external.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-external.ts
@@ -52,8 +52,10 @@ function resolveSourceSubpath(sourceDir: string, relativePath: string): string {
 /**
  * Search a source directory for the first supported external template entry.
  *
- * @deprecated Use `findExternalTemplateEntry()` from async template-source
- * paths. This synchronous helper remains only for compatibility callers.
+ * @deprecated Since 0.22.10. Use `findExternalTemplateEntry()` from async
+ * template-source paths. Removal target: not currently scheduled; this sync
+ * compatibility helper remains available until release notes announce a
+ * versioned target.
  *
  * @param sourceDir Directory that may contain an external template config entry.
  * @returns The first matching entry path, or null when no supported entry exists.

--- a/packages/wp-typia-project-tools/src/runtime/template-source-remote.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-remote.ts
@@ -92,8 +92,10 @@ async function readRemoteBlockJsonAsync(
 /**
  * Read a remote block source and return its default block category.
  *
- * @deprecated Use `getDefaultCategoryAsync()` from async template-source paths.
- * This synchronous helper remains only for compatibility callers.
+ * @deprecated Since 0.22.10. Use `getDefaultCategoryAsync()` from async
+ * template-source paths. Removal target: not currently scheduled; this sync
+ * compatibility helper remains available until release notes announce a
+ * versioned target.
  *
  * @param sourceDir Block source directory that may contain a block.json file.
  * @returns The declared block category, or "widgets" when detection fails.
@@ -200,8 +202,10 @@ async function readTemplatePackageJsonAsync(
  * Read `wpTypia.projectType` from a rendered or source template package
  * manifest and return it when present.
  *
- * @deprecated Use `getTemplateProjectTypeAsync()` from async template-source
- * paths. This synchronous helper remains only for compatibility callers.
+ * @deprecated Since 0.22.10. Use `getTemplateProjectTypeAsync()` from async
+ * template-source paths. Removal target: not currently scheduled; this sync
+ * compatibility helper remains available until release notes announce a
+ * versioned target.
  */
 export function getTemplateProjectType(sourceDir: string): string | null {
   const packageJsonEntry = readTemplatePackageJson(sourceDir)

--- a/packages/wp-typia-project-tools/src/runtime/workspace-inventory-read.ts
+++ b/packages/wp-typia-project-tools/src/runtime/workspace-inventory-read.ts
@@ -17,6 +17,11 @@ import type {
  * synchronous APIs. Prefer `readWorkspaceInventoryAsync()` from async command
  * paths so workspace reads do not block the event loop.
  *
+ * @deprecated Since 0.22.10. Use `readWorkspaceInventoryAsync()` from async
+ * command paths. Removal target: not currently scheduled; this sync
+ * compatibility helper remains available until release notes announce a
+ * versioned target.
+ *
  * @param projectDir Workspace root directory.
  * @returns Parsed `WorkspaceInventory` including the resolved `blockConfigPath`.
  * @throws {Error} When `scripts/block-config.ts` is missing or invalid.
@@ -86,8 +91,10 @@ function toWorkspaceBlockSelectOptions(
  * The `description` field mirrors `block.typesFile`, while `name` and `value`
  * both map to the block slug for use in interactive add flows.
  *
- * @deprecated Use `getWorkspaceBlockSelectOptionsAsync()` from async command
- * paths. This helper intentionally remains sync-only for compatibility callers.
+ * @deprecated Since 0.22.10. Use `getWorkspaceBlockSelectOptionsAsync()` from
+ * async command paths. Removal target: not currently scheduled; this sync
+ * compatibility helper remains available until release notes announce a
+ * versioned target.
  *
  * @param projectDir Workspace root directory.
  * @returns Block options for variation-target selection.

--- a/packages/wp-typia-project-tools/tests/runtime-helper-consolidation.test.ts
+++ b/packages/wp-typia-project-tools/tests/runtime-helper-consolidation.test.ts
@@ -84,6 +84,44 @@ test('shared async filesystem helpers expose path existence and node error codes
   expect(isFileNotFoundError(new Error('plain'))).toBe(false);
 });
 
+test('deprecated sync helpers document async replacements and removal policy', () => {
+  const inventorySource = readRuntimeSource('workspace-inventory-read.ts');
+  const externalTemplateSource = readRuntimeSource('template-source-external.ts');
+  const remoteTemplateSource = readRuntimeSource('template-source-remote.ts');
+  const apiGuideSource = fs.readFileSync(
+    path.join(
+      runtimeRoot,
+      '..',
+      '..',
+      '..',
+      '..',
+      'apps',
+      'docs',
+      'src',
+      'content',
+      'docs',
+      'reference',
+      'api.md',
+    ),
+    'utf8',
+  );
+
+  for (const source of [
+    inventorySource,
+    externalTemplateSource,
+    remoteTemplateSource,
+    apiGuideSource,
+  ]) {
+    expect(source).toContain('Removal target: not currently scheduled');
+  }
+  expect(inventorySource).toContain('Use `readWorkspaceInventoryAsync()`');
+  expect(inventorySource).toContain('Use `getWorkspaceBlockSelectOptionsAsync()`');
+  expect(externalTemplateSource).toContain('Use `findExternalTemplateEntry()`');
+  expect(remoteTemplateSource).toContain('Use `getDefaultCategoryAsync()`');
+  expect(remoteTemplateSource).toContain('Use `getTemplateProjectTypeAsync()`');
+  expect(apiGuideSource).toContain('Deprecated synchronous helper policy');
+});
+
 test('shared TypeScript property-name helper aligns literal property support', () => {
   const sourceFile = ts.createSourceFile(
     'fixture.ts',


### PR DESCRIPTION
## Summary
- Add no-removal-scheduled guidance to deprecated synchronous inventory helpers
- Add matching deprecation timeline guidance to synchronous template-source helpers
- Document the policy in the API guide and cover it with a source regression test
- Add a Sampo patch changeset for `@wp-typia/project-tools`

Fixes #875

## Tests
- `bun test packages/wp-typia-project-tools/tests/runtime-helper-consolidation.test.ts`
- `bun test packages/wp-typia-project-tools/tests/template-source.test.ts`
- `bun run format:check`
- `bun run changesets:validate`
- `bun run typecheck`
- `bun run --filter @wp-typia/project-tools test`
- `git diff --check`