### PR TITLE
refactor(doctor): snapshot workspace package checks

### DIFF
--- a/.sampo/changesets/876-doctor-package-async-snapshot.md
+++ b/.sampo/changesets/876-doctor-package-async-snapshot.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Move package-level workspace doctor filesystem probes behind an async snapshot while documenting the remaining synchronous doctor categories.

--- a/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace-package.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace-package.ts
@@ -10,10 +10,17 @@ import { WORKSPACE_TEMPLATE_PACKAGE } from "./workspace-project.js";
 import type { DoctorCheck } from "./cli-doctor.js";
 import type { WorkspacePackageJson, WorkspaceProject } from "./workspace-project.js";
 
+/**
+ * Snapshot of package-level filesystem doctor inputs prepared asynchronously.
+ */
 export interface WorkspacePackageDoctorSnapshot {
+	/** Whether the expected workspace bootstrap PHP file exists. */
 	bootstrapExists: boolean;
+	/** Relative path to the expected workspace bootstrap PHP file. */
 	bootstrapRelativePath: string;
+	/** Whether the migration config file exists. */
 	migrationConfigExists: boolean;
+	/** Relative path to the migration config file. */
 	migrationConfigRelativePath: string;
 }
 

--- a/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace-package.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace-package.ts
@@ -1,31 +1,68 @@
-import fs from "node:fs";
 import path from "node:path";
 
 import {
 	createDoctorCheck,
 	getWorkspaceBootstrapRelativePath,
 } from "./cli-doctor-workspace-shared.js";
+import { pathExists } from "./fs-async.js";
 import { WORKSPACE_TEMPLATE_PACKAGE } from "./workspace-project.js";
 
 import type { DoctorCheck } from "./cli-doctor.js";
 import type { WorkspacePackageJson, WorkspaceProject } from "./workspace-project.js";
+
+export interface WorkspacePackageDoctorSnapshot {
+	bootstrapExists: boolean;
+	bootstrapRelativePath: string;
+	migrationConfigExists: boolean;
+	migrationConfigRelativePath: string;
+}
+
+/**
+ * Prepare package-level workspace doctor inputs without blocking the event loop.
+ *
+ * @param workspace Resolved workspace metadata and filesystem paths.
+ * @param packageJson Parsed workspace package manifest.
+ * @returns Snapshot values consumed by synchronous doctor row mappers.
+ */
+export async function prepareWorkspacePackageDoctorSnapshot(
+	workspace: WorkspaceProject,
+	packageJson: WorkspacePackageJson,
+): Promise<WorkspacePackageDoctorSnapshot> {
+	const packageName = packageJson.name;
+	const bootstrapRelativePath = getWorkspaceBootstrapRelativePath(
+		typeof packageName === "string" && packageName.length > 0
+			? packageName
+			: workspace.packageName,
+	);
+	const migrationConfigRelativePath = path.join("src", "migrations", "config.ts");
+	const [bootstrapExists, migrationConfigExists] = await Promise.all([
+		pathExists(path.join(workspace.projectDir, bootstrapRelativePath)),
+		pathExists(path.join(workspace.projectDir, migrationConfigRelativePath)),
+	]);
+
+	return {
+		bootstrapExists,
+		bootstrapRelativePath,
+		migrationConfigExists,
+		migrationConfigRelativePath,
+	};
+}
 
 /**
  * Validate the package metadata that makes a project an official workspace.
  *
  * @param workspace Resolved workspace metadata and filesystem paths.
  * @param packageJson Parsed workspace package manifest.
+ * @param snapshot Async filesystem snapshot for package-level doctor inputs.
  * @returns A `DoctorCheck` describing whether package metadata matches the workspace contract.
  */
 export function getWorkspacePackageMetadataCheck(
 	workspace: WorkspaceProject,
 	packageJson: WorkspacePackageJson,
+	snapshot: WorkspacePackageDoctorSnapshot,
 ): DoctorCheck {
 	const issues: string[] = [];
 	const packageName = packageJson.name;
-	const bootstrapRelativePath = getWorkspaceBootstrapRelativePath(
-		typeof packageName === "string" && packageName.length > 0 ? packageName : workspace.packageName,
-	);
 	const wpTypia = packageJson.wpTypia;
 
 	if (typeof packageName !== "string" || packageName.length === 0) {
@@ -46,15 +83,15 @@ export function getWorkspacePackageMetadataCheck(
 	if (wpTypia?.phpPrefix !== workspace.workspace.phpPrefix) {
 		issues.push(`wpTypia.phpPrefix must equal "${workspace.workspace.phpPrefix}"`);
 	}
-	if (!fs.existsSync(path.join(workspace.projectDir, bootstrapRelativePath))) {
-		issues.push(`Missing bootstrap file ${bootstrapRelativePath}`);
+	if (!snapshot.bootstrapExists) {
+		issues.push(`Missing bootstrap file ${snapshot.bootstrapRelativePath}`);
 	}
 
 	return createDoctorCheck(
 		"Workspace package metadata",
 		issues.length === 0 ? "pass" : "fail",
 		issues.length === 0
-			? `package.json metadata aligns with ${workspace.packageName} and ${bootstrapRelativePath}`
+			? `package.json metadata aligns with ${workspace.packageName} and ${snapshot.bootstrapRelativePath}`
 			: issues.join("; "),
 	);
 }
@@ -62,29 +99,25 @@ export function getWorkspacePackageMetadataCheck(
 /**
  * Report whether a workspace configured for migrations exposes the expected doctor inputs.
  *
- * @param workspace Resolved workspace metadata and filesystem paths.
  * @param packageJson Parsed workspace package manifest.
+ * @param snapshot Async filesystem snapshot for package-level doctor inputs.
  * @returns A migration hint row when the workspace uses migrations, otherwise `null`.
  */
 export function getMigrationWorkspaceHintCheck(
-	workspace: WorkspaceProject,
 	packageJson: WorkspacePackageJson,
+	snapshot: WorkspacePackageDoctorSnapshot,
 ): DoctorCheck | null {
 	const hasMigrationScript = typeof packageJson.scripts?.["migration:doctor"] === "string";
-	const migrationConfigRelativePath = path.join("src", "migrations", "config.ts");
-	const hasMigrationConfig = fs.existsSync(
-		path.join(workspace.projectDir, migrationConfigRelativePath),
-	);
 
-	if (!hasMigrationScript && !hasMigrationConfig) {
+	if (!hasMigrationScript && !snapshot.migrationConfigExists) {
 		return null;
 	}
 
 	return createDoctorCheck(
 		"Migration workspace",
-		hasMigrationConfig ? "pass" : "fail",
-		hasMigrationConfig
+		snapshot.migrationConfigExists ? "pass" : "fail",
+		snapshot.migrationConfigExists
 			? "Run `wp-typia migrate doctor --all` for migration target, snapshot, fixture, and generated artifact checks"
-			: `Missing ${migrationConfigRelativePath} for the configured migration workspace`,
+			: `Missing ${snapshot.migrationConfigRelativePath} for the configured migration workspace`,
 	);
 }

--- a/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace.ts
@@ -10,6 +10,7 @@ import {
 import {
 	getMigrationWorkspaceHintCheck,
 	getWorkspacePackageMetadataCheck,
+	prepareWorkspacePackageDoctorSnapshot,
 } from "./cli-doctor-workspace-package.js";
 import {
 	createDoctorCheck,
@@ -137,7 +138,18 @@ export async function getWorkspaceDoctorChecks(cwd: string): Promise<DoctorCheck
 		return checks;
 	}
 
-	checks.push(getWorkspacePackageMetadataCheck(workspace, workspacePackageJson));
+	const packageDoctorSnapshot = await prepareWorkspacePackageDoctorSnapshot(
+		workspace,
+		workspacePackageJson,
+	);
+
+	checks.push(
+		getWorkspacePackageMetadataCheck(
+			workspace,
+			workspacePackageJson,
+			packageDoctorSnapshot,
+		),
+	);
 
 	try {
 		const inventory = await readWorkspaceInventoryAsync(workspace.projectDir);
@@ -148,13 +160,16 @@ export async function getWorkspaceDoctorChecks(cwd: string): Promise<DoctorCheck
 				formatWorkspaceInventorySummary(inventory),
 			),
 		);
+		// The highest-impact remaining probes live in block, binding, and feature
+		// categories; keep them synchronous until broader path/content snapshots
+		// can preserve their current row ordering and diagnostics.
 		checks.push(...getWorkspaceBlockDoctorChecks(workspace, inventory));
 		checks.push(...getWorkspaceBindingDoctorChecks(workspace, inventory));
 		checks.push(...getWorkspaceFeatureDoctorChecks(workspace, inventory));
 
 		const migrationWorkspaceCheck = getMigrationWorkspaceHintCheck(
-			workspace,
 			workspacePackageJson,
+			packageDoctorSnapshot,
 		);
 		if (migrationWorkspaceCheck) {
 			checks.push(migrationWorkspaceCheck);

--- a/packages/wp-typia-project-tools/tests/cli-doctor-boundaries.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-doctor-boundaries.test.ts
@@ -52,11 +52,13 @@ test("cli-doctor keeps environment and workspace checks in dedicated modules", (
 	expect(environmentSource).not.toContain("function createDoctorCheck(");
 	expect(workspaceSource).toContain("export async function getWorkspaceDoctorChecks(");
 	expect(workspaceSource).toContain("readWorkspaceInventoryAsync(");
+	expect(workspaceSource).toContain("prepareWorkspacePackageDoctorSnapshot(");
 	expect(workspaceSource).toContain('from "./cli-doctor-workspace-bindings.js"');
 	expect(workspaceSource).toContain('from "./cli-doctor-workspace-blocks.js"');
 	expect(workspaceSource).toContain('from "./cli-doctor-workspace-features.js"');
 	expect(workspaceSource).toContain('from "./cli-doctor-workspace-package.js"');
 	expect(workspaceSource).toContain("intentionally stay synchronous");
+	expect(workspaceSource).toContain("highest-impact remaining probes");
 	expect(workspaceSharedSource).toContain("category collectors remain synchronous");
 	expect(migrationDoctorSource).toContain("synchronous maintenance command");
 	expect(workspaceSource).not.toContain("function checkWorkspaceBlockMetadata(");
@@ -65,6 +67,14 @@ test("cli-doctor keeps environment and workspace checks in dedicated modules", (
 	expect(workspaceBlocksSource).toContain("export function getWorkspaceBlockDoctorChecks(");
 	expect(workspaceBindingsSource).toContain("export function getWorkspaceBindingDoctorChecks(");
 	expect(workspaceFeaturesSource).toContain("export function getWorkspaceFeatureDoctorChecks(");
+	expect(workspacePackageSource).toContain(
+		"export async function prepareWorkspacePackageDoctorSnapshot(",
+	);
+	expect(workspacePackageSource).toContain('from "./fs-async.js"');
+	expect(workspacePackageSource).toContain("Promise.all([");
+	expect(workspacePackageSource).not.toMatch(
+		/\bfs\.(?:existsSync|readFileSync|readdirSync)\b/u,
+	);
 	expect(workspacePackageSource).toContain("export function getWorkspacePackageMetadataCheck(");
 });
 

--- a/packages/wp-typia-project-tools/tests/cli-doctor-boundaries.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-doctor-boundaries.test.ts
@@ -58,12 +58,18 @@ test("cli-doctor keeps environment and workspace checks in dedicated modules", (
 	expect(workspaceSource).toContain('from "./cli-doctor-workspace-features.js"');
 	expect(workspaceSource).toContain('from "./cli-doctor-workspace-package.js"');
 	expect(workspaceSource).toContain("intentionally stay synchronous");
-	expect(workspaceSource).toContain("highest-impact remaining probes");
 	expect(workspaceSharedSource).toContain("category collectors remain synchronous");
 	expect(migrationDoctorSource).toContain("synchronous maintenance command");
 	expect(workspaceSource).not.toContain("function checkWorkspaceBlockMetadata(");
 	expect(workspaceSource).not.toContain("function checkWorkspaceBindingBootstrap(");
 	expect(workspaceSource).not.toContain("function checkWorkspaceAbilityBootstrap(");
+	expect(workspaceSource).toContain("getWorkspaceBlockDoctorChecks(workspace, inventory)");
+	expect(workspaceSource).toContain(
+		"getWorkspaceBindingDoctorChecks(workspace, inventory)",
+	);
+	expect(workspaceSource).toContain(
+		"getWorkspaceFeatureDoctorChecks(workspace, inventory)",
+	);
 	expect(workspaceBlocksSource).toContain("export function getWorkspaceBlockDoctorChecks(");
 	expect(workspaceBindingsSource).toContain("export function getWorkspaceBindingDoctorChecks(");
 	expect(workspaceFeaturesSource).toContain("export function getWorkspaceFeatureDoctorChecks(");


### PR DESCRIPTION
## Summary
- Add an async package-level workspace doctor snapshot for bootstrap and migration config probes
- Move workspace package metadata and migration hint checks to consume that snapshot instead of sync filesystem probes
- Document block, binding, and feature categories as the highest-impact remaining synchronous doctor probes for follow-up snapshot work
- Cover the boundary with a source regression test and add a Sampo patch changeset

Fixes #876

## Tests
- `bun test packages/wp-typia-project-tools/tests/cli-doctor-boundaries.test.ts packages/wp-typia-project-tools/tests/workspace-doctor.test.ts packages/wp-typia-project-tools/tests/cli-doctor-workspace-bindings.test.ts`
- `bun run format:check`
- `bun run changesets:validate`
- `bun run typecheck`
- `bun run --filter @wp-typia/project-tools test`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Package-level workspace doctor probes are now executed asynchronously for improved performance. Other doctor checks remain synchronous.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/899)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->