### PR TITLE
refactor(cli): route no-command through diagnostics

### DIFF
--- a/.sampo/changesets/879-no-command-diagnostic-flow.md
+++ b/.sampo/changesets/879-no-command-diagnostic-flow.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Route Node fallback no-command failures through the shared CLI diagnostic flow while preserving human-readable help output.

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -3,6 +3,7 @@ import {
   CLI_DIAGNOSTIC_CODES,
   createCliCommandError,
   formatCliDiagnosticError,
+  isCliDiagnosticError,
   serializeCliDiagnosticError,
 } from '@wp-typia/project-tools/cli-diagnostics';
 import {
@@ -53,6 +54,7 @@ import { dispatchNodeFallbackAdd } from './node-fallback/dispatchers/add';
 import { dispatchNodeFallbackCreate } from './node-fallback/dispatchers/create';
 import {
   NODE_FALLBACK_HELP_RENDERERS,
+  NODE_FALLBACK_NO_COMMAND_REASON_LINE,
   STANDALONE_GUIDANCE_LINE,
   renderGeneralHelp,
   renderNoCommandHelp,
@@ -74,6 +76,24 @@ const printLine: PrintLine = (line) => {
 const warnLine: PrintLine = (line) => {
   console.warn(line);
 };
+
+function createNoCommandCliError() {
+  return createCliCommandError({
+    code: CLI_DIAGNOSTIC_CODES.INVALID_COMMAND,
+    command: 'wp-typia',
+    detailLines: [NODE_FALLBACK_NO_COMMAND_REASON_LINE],
+    summary: 'No command was provided.',
+  });
+}
+
+function isNoCommandCliDiagnostic(error: unknown): boolean {
+  return (
+    isCliDiagnosticError(error) &&
+    error.code === CLI_DIAGNOSTIC_CODES.INVALID_COMMAND &&
+    error.command === 'wp-typia' &&
+    error.detailLines.includes(NODE_FALLBACK_NO_COMMAND_REASON_LINE)
+  );
+}
 
 export function hasFlagBeforeTerminator(argv: string[], flag: string): boolean {
   for (const arg of argv) {
@@ -432,9 +452,11 @@ export async function runNodeCli(argv = process.argv.slice(2)): Promise<void> {
     hasFlagBeforeTerminator(cliArgv, '--version') || command === 'version';
 
   if (cliArgv.length === 0) {
-    renderNoCommandHelp(printLine);
-    process.exitCode = 1;
-    return;
+    const noCommandError = createNoCommandCliError();
+    if (rawMergedFlags.format !== 'json') {
+      renderNoCommandHelp(printLine);
+    }
+    throw noCommandError;
   }
 
   if (helpRequested) {
@@ -519,6 +541,11 @@ export async function runNodeCliEntrypoint(
           2,
         )}\n`,
       );
+      process.exitCode = 1;
+      return;
+    }
+    if (isNoCommandCliDiagnostic(error)) {
+      // Human no-command output already includes the explanatory line and help.
       process.exitCode = 1;
       return;
     }

--- a/packages/wp-typia/tests/node-cli-core.test.ts
+++ b/packages/wp-typia/tests/node-cli-core.test.ts
@@ -4,6 +4,8 @@ import path from 'node:path';
 
 import { afterEach, describe, expect, test } from 'bun:test';
 
+import { CLI_DIAGNOSTIC_CODES } from '@wp-typia/project-tools/cli-diagnostics';
+
 import packageJson from '../package.json';
 import {
   buildMissingAddKindDetailLines,
@@ -103,10 +105,11 @@ describe('Node fallback CLI core routing', () => {
   });
 
   test('prints general help and marks no-command invocations as errors', async () => {
-    const result = await captureNodeCli([]);
+    const result = await captureNodeCli([], { entrypoint: true });
 
     expect(result.error).toBeUndefined();
     expect(result.exitCode).toBe(1);
+    expect(result.stderr).toBe('');
     expect(result.stdout).toContain(
       'No command provided. Run wp-typia --help for usage information.',
     );
@@ -116,6 +119,45 @@ describe('Node fallback CLI core routing', () => {
     );
     expect(result.stdout).toContain('Runtime: Node fallback');
     expect(result.stdout).toContain('Commands:');
+
+    const directResult = await captureNodeCli([]);
+    const directError = directResult.error as {
+      code?: string;
+      command?: string;
+      detailLines?: string[];
+    };
+
+    expect(directError.code).toBe(CLI_DIAGNOSTIC_CODES.INVALID_COMMAND);
+    expect(directError.command).toBe('wp-typia');
+    expect(directError.detailLines).toContain(
+      'No command provided. Run wp-typia --help for usage information.',
+    );
+    expect(directResult.stdout).toContain('Commands:');
+  });
+
+  test('serializes no-command failures when JSON output is requested', async () => {
+    const result = await captureNodeCli(['--format', 'json'], {
+      entrypoint: true,
+    });
+    const payload = JSON.parse(result.stderr) as {
+      error?: {
+        code?: string;
+        command?: string;
+        detailLines?: string[];
+        summary?: string;
+      };
+      ok?: boolean;
+    };
+
+    expect(result.error).toBeUndefined();
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe('');
+    expect(payload.ok).toBe(false);
+    expect(payload.error?.code).toBe(CLI_DIAGNOSTIC_CODES.INVALID_COMMAND);
+    expect(payload.error?.command).toBe('wp-typia');
+    expect(payload.error?.detailLines).toContain(
+      'No command provided. Run wp-typia --help for usage information.',
+    );
   });
 
   test('routes explicit help flags and help targets to the fallback help renderers', async () => {


### PR DESCRIPTION
## Summary
- route Node fallback no-command invocations through shared CLI diagnostic errors instead of setting exitCode inside the dispatcher
- preserve human-readable no-command help on stdout while keeping structured JSON failures clean
- cover direct dispatcher diagnostics and entrypoint JSON behavior in Node fallback tests

Fixes #879

## Tests
- bun test packages/wp-typia/tests/node-cli-core.test.ts packages/wp-typia/tests/cli-diagnostic-output.test.ts
- bun run changesets:validate
- bun test packages/wp-typia/tests/cli-package.test.ts
- bun run format:check
- bun run typecheck
- bun run --filter wp-typia test