### PR TITLE
feat(add): scaffold integration env starters

### DIFF
--- a/.sampo/changesets/887-integration-env-add.md
+++ b/.sampo/changesets/887-integration-env-add.md
@@ -1,0 +1,7 @@
+---
+npm/wp-typia: minor
+npm/@wp-typia/project-tools: minor
+npm/@wp-typia/create-workspace-template: patch
+---
+
+Added an opt-in `wp-typia add integration-env` workspace workflow that can generate local smoke-test starters, `.env.example`, optional `@wordpress/env` setup, and an optional docker-compose service scaffold.

--- a/.sampo/changesets/887-integration-env-add.md
+++ b/.sampo/changesets/887-integration-env-add.md
@@ -4,4 +4,4 @@ npm/@wp-typia/project-tools: minor
 npm/@wp-typia/create-workspace-template: patch
 ---
 
-Added an opt-in `wp-typia add integration-env` workspace workflow that can generate local smoke-test starters, `.env.example`, optional `@wordpress/env` setup, and an optional docker-compose service scaffold.
+Added an opt-in `wp-typia add integration-env <name>` workspace workflow that can generate local smoke-test starters, `.env.example`, optional `@wordpress/env` setup, and an optional docker-compose service scaffold.

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ cd my-plugin
 bun install
 wp-typia add block counter-card --template basic
 wp-typia add block faq-stack --template compound --persistence-policy public --data-storage custom-table
+wp-typia add integration-env local-smoke --wp-env --service docker-compose
 wp-typia add style callout-emphasis --block counter-card
 wp-typia add transform quote-to-counter --from core/quote --to counter-card
 wp-typia add binding-source hero-data
@@ -170,6 +171,7 @@ wp-typia add hooked-block counter-card --anchor core/post-content --position aft
 - Need a parent/child block system? Start with `compound`.
 - Need a branded Query Loop inserter variation? Start with `query-loop`.
 - Need an empty workspace that will grow through `wp-typia add ...` workflows? Start with `--template workspace`.
+- Need a local WordPress smoke starter later? Use `wp-typia add integration-env <name> --wp-env` from a workspace.
 - Need schema evolution for a long-lived block? Enable `--with-migration-ui`.
 
 ## Retrofitting Existing Projects

--- a/packages/create-workspace-template/README.md
+++ b/packages/create-workspace-template/README.md
@@ -12,6 +12,7 @@ The generated project starts with an empty `src/blocks/*` workspace shell and is
 
 ```bash
 wp-typia add block my-block --template basic
+wp-typia add integration-env local-smoke --wp-env --service docker-compose
 wp-typia add style callout-emphasis --block my-block
 wp-typia add transform quote-to-block --from core/quote --to my-block
 wp-typia add binding-source hero-data

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-help.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-help.ts
@@ -17,6 +17,7 @@ export function formatAddHelpText(): string {
 	return `Usage:
   wp-typia add admin-view <name> [--source <rest-resource:slug|core-data:kind/name>] [--dry-run]
   wp-typia add block <name> [--template <${ADD_BLOCK_TEMPLATE_IDS.join("|")}>] [--external-layer-source <./path|github:owner/repo/path[#ref]|npm-package>] [--external-layer-id <layer-id>] [--inner-blocks-preset <freeform|ordered|horizontal|locked-structure>] [--alternate-render-targets <email,mjml,plain-text>] [--data-storage <post-meta|custom-table>] [--persistence-policy <authenticated|public>] [--dry-run]
+  wp-typia add integration-env <name> [--wp-env] [--service <none|docker-compose>] [--dry-run]
   wp-typia add variation <name> --block <block-slug> [--dry-run]
   wp-typia add style <name> --block <block-slug> [--dry-run]
   wp-typia add transform <name> --from <namespace/block> --to <block-slug|namespace/block-slug> [--dry-run]
@@ -36,6 +37,8 @@ Notes:
   Pass \`--source rest-resource:<slug>\` to reuse a list-capable REST resource.
   Pass \`--source core-data:postType/post\` or \`--source core-data:taxonomy/category\` to bind a WordPress-owned entity collection.
   Generated admin-view workspaces add \`@wp-typia/dataviews\` and the needed WordPress DataViews packages as opt-in dependencies.
+  \`add integration-env\` generates an opt-in local smoke starter under \`scripts/integration-smoke/\`, updates \`.env.example\`, and can add \`@wordpress/env\` plus \`.wp-env.json\` when \`--wp-env\` is passed.
+  Pass \`--service docker-compose\` to include a placeholder local service stack that can be adapted to project-specific dependencies.
   \`query-loop\` is a create-time scaffold family. Use \`wp-typia create <project-dir> --template query-loop\` instead of \`wp-typia add block\`.
   \`add variation\` targets an existing block slug from \`scripts/block-config.ts\`.
   \`add style\` registers a Block Styles option for an existing generated block.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-kind-ids.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-kind-ids.ts
@@ -7,6 +7,7 @@
 export const ADD_KIND_IDS = [
 	"admin-view",
 	"block",
+	"integration-env",
 	"variation",
 	"style",
 	"transform",

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-types.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-types.ts
@@ -60,6 +60,20 @@ export function resolveEditorPluginSlotAlias(
 }
 
 /**
+ * Optional local service starter ids accepted by
+ * `wp-typia add integration-env --service`.
+ */
+export const INTEGRATION_ENV_SERVICE_IDS = [
+	"none",
+	"docker-compose",
+] as const;
+/**
+ * Union of supported local service starter ids.
+ */
+export type IntegrationEnvServiceId =
+	(typeof INTEGRATION_ENV_SERVICE_IDS)[number];
+
+/**
  * Supported built-in block families accepted by `wp-typia add block --template`.
  */
 export const ADD_BLOCK_TEMPLATE_IDS = [
@@ -248,6 +262,23 @@ export interface RunAddEditorPluginCommandOptions {
 	cwd?: string;
 	editorPluginName: string;
 	slot?: string;
+}
+
+/**
+ * Options for `wp-typia add integration-env`.
+ *
+ * @property cwd Working directory used to resolve the nearest official workspace.
+ * Defaults to `process.cwd()`.
+ * @property integrationEnvName Human-entered environment name that will be
+ * normalized into script and documentation paths.
+ * @property service Optional local service starter. Defaults to `none`.
+ * @property withWpEnv Whether to add a local `@wordpress/env` preset and scripts.
+ */
+export interface RunAddIntegrationEnvCommandOptions {
+	cwd?: string;
+	integrationEnvName: string;
+	service?: string;
+	withWpEnv?: boolean;
 }
 
 /**

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-validation.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-validation.ts
@@ -11,6 +11,8 @@ import {
 	type AddBlockTemplateId,
 	EDITOR_PLUGIN_SLOT_IDS,
 	type EditorPluginSlotId,
+	INTEGRATION_ENV_SERVICE_IDS,
+	type IntegrationEnvServiceId,
 	REST_RESOURCE_METHOD_IDS,
 	type RestResourceMethodId,
 	resolveEditorPluginSlotAlias,
@@ -202,5 +204,25 @@ export function assertValidEditorPluginSlot(slot = "sidebar"): EditorPluginSlotI
 
 	throw new Error(
 		`Editor plugin slot must be one of: ${EDITOR_PLUGIN_SLOT_IDS.join(", ")}. Legacy aliases: PluginSidebar, PluginDocumentSettingPanel.`,
+	);
+}
+
+/**
+ * Validate and normalize the optional integration environment service starter.
+ *
+ * @param service Optional service starter id. Defaults to `none`.
+ * @returns The canonical integration environment service id.
+ * @throws {Error} When the service starter is unsupported.
+ */
+export function assertValidIntegrationEnvService(
+	service = "none",
+): IntegrationEnvServiceId {
+	const trimmed = service.trim();
+	if ((INTEGRATION_ENV_SERVICE_IDS as readonly string[]).includes(trimmed)) {
+		return trimmed as IntegrationEnvServiceId;
+	}
+
+	throw new Error(
+		`Integration environment service must be one of: ${INTEGRATION_ENV_SERVICE_IDS.join(", ")}.`,
 	);
 }

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-integration-env.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-integration-env.ts
@@ -22,6 +22,17 @@ interface IntegrationEnvPackageJson {
 	scripts?: Record<string, string>;
 }
 
+/**
+ * Runtime result returned after adding an integration environment starter.
+ *
+ * @property integrationEnvSlug Normalized slug used for generated script and
+ * documentation paths.
+ * @property projectDir Absolute official workspace directory that was updated.
+ * @property service Canonical local service starter id selected for the scaffold.
+ * @property warnings Optional non-fatal preservation notices for existing files
+ * or scripts.
+ * @property withWpEnv Whether the generated scaffold included the wp-env preset.
+ */
 export interface RunAddIntegrationEnvCommandResult {
 	integrationEnvSlug: string;
 	projectDir: string;
@@ -131,6 +142,16 @@ function getEnv(name, fallback) {
 	return process.env[name] ?? envFile[name] ?? fallback;
 }
 
+function resolveEndpointUrl(baseUrl, endpointPath) {
+	const normalizedBaseUrl = new URL(baseUrl);
+	if (!normalizedBaseUrl.pathname.endsWith("/")) {
+		normalizedBaseUrl.pathname = \`\${normalizedBaseUrl.pathname}/\`;
+	}
+
+	const relativePath = endpointPath.replace(/^\\/+/u, "");
+	return new URL(relativePath, normalizedBaseUrl);
+}
+
 async function assertJsonEndpoint(label, url) {
 	const response = await fetch(url, {
 		headers: {
@@ -161,13 +182,13 @@ const serviceUrl = getEnv("WP_TYPIA_SERVICE_URL", "").trim();
 
 await assertJsonEndpoint(
 	"WordPress REST index",
-	new URL("/wp-json/", baseUrl),
+	resolveEndpointUrl(baseUrl, "wp-json/"),
 );
 
 if (serviceUrl.length > 0) {
 	await assertJsonEndpoint(
 		"Local integration service healthcheck",
-		new URL("/health", serviceUrl),
+		resolveEndpointUrl(serviceUrl, "health"),
 	);
 }
 
@@ -354,10 +375,13 @@ function addIntegrationEnvPackageJsonEntries({
 	warnings: string[];
 	withWpEnv: boolean;
 }) {
-	packageJson.devDependencies = {
+	const devDependencies = {
 		...(packageJson.devDependencies ?? {}),
-		...(withWpEnv ? { "@wordpress/env": WP_ENV_PACKAGE_VERSION } : {}),
 	};
+	if (withWpEnv && devDependencies["@wordpress/env"] === undefined) {
+		devDependencies["@wordpress/env"] = WP_ENV_PACKAGE_VERSION;
+	}
+	packageJson.devDependencies = devDependencies;
 	const scripts = {
 		...(packageJson.scripts ?? {}),
 	};

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-integration-env.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-integration-env.ts
@@ -1,0 +1,522 @@
+import { promises as fsp } from "node:fs";
+import path from "node:path";
+
+import {
+	assertValidGeneratedSlug,
+	assertValidIntegrationEnvService,
+	normalizeBlockSlug,
+	type IntegrationEnvServiceId,
+	type RunAddIntegrationEnvCommandOptions,
+} from "./cli-add-shared.js";
+import {
+	formatRunScript,
+	type PackageManagerId,
+} from "./package-managers.js";
+import { pathExists, readOptionalUtf8File } from "./fs-async.js";
+import { executeWorkspaceMutationPlan } from "./cli-add-workspace-mutation.js";
+import { resolveWorkspaceProject } from "./workspace-project.js";
+import { toTitleCase } from "./string-case.js";
+
+interface IntegrationEnvPackageJson {
+	devDependencies?: Record<string, string>;
+	scripts?: Record<string, string>;
+}
+
+export interface RunAddIntegrationEnvCommandResult {
+	integrationEnvSlug: string;
+	projectDir: string;
+	service: IntegrationEnvServiceId;
+	warnings?: string[];
+	withWpEnv: boolean;
+}
+
+const WP_ENV_PACKAGE_VERSION = "^11.2.0";
+
+function buildWpEnvConfigSource(): string {
+	return `${JSON.stringify(
+		{
+			$schema: "https://schemas.wp.org/trunk/wp-env.json",
+			core: null,
+			port: 8888,
+			testsEnvironment: false,
+			plugins: ["."],
+			config: {
+				WP_DEBUG: true,
+				WP_DEBUG_LOG: true,
+				WP_DEBUG_DISPLAY: false,
+				SCRIPT_DEBUG: true,
+				WP_ENVIRONMENT_TYPE: "local",
+			},
+		},
+		null,
+		2,
+	)}\n`;
+}
+
+function buildDockerComposeSource(): string {
+	return `services:
+  integration-service:
+    image: node:22-alpine
+    working_dir: /workspace
+    volumes:
+      - .:/workspace
+    command: >
+      node -e "require('node:http').createServer((request, response) => {
+        response.writeHead(request.url === '/health' ? 200 : 404, {
+          'content-type': 'application/json'
+        });
+        response.end(JSON.stringify({
+          ok: request.url === '/health',
+          service: 'wp-typia-integration-starter'
+        }));
+      }).listen(3000, '0.0.0.0')"
+    ports:
+      - "3000:3000"
+`;
+}
+
+function buildIntegrationSmokeScriptSource(
+	integrationEnvSlug: string,
+): string {
+	return `import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT_DIR = path.resolve(
+	fileURLToPath(new URL("../..", import.meta.url)),
+);
+const ENV_FILE = path.join(ROOT_DIR, ".env");
+
+function parseEnvValue(value) {
+	const trimmed = value.trim();
+	if (
+		(trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+		(trimmed.startsWith("'") && trimmed.endsWith("'"))
+	) {
+		return trimmed.slice(1, -1);
+	}
+
+	return trimmed;
+}
+
+function readEnvFile(filePath) {
+	if (!fs.existsSync(filePath)) {
+		return {};
+	}
+
+	return Object.fromEntries(
+		fs
+			.readFileSync(filePath, "utf8")
+			.split(/\\r?\\n/u)
+			.map((line) => line.trim())
+			.filter((line) => line.length > 0 && !line.startsWith("#"))
+			.map((line) => {
+				const separatorIndex = line.indexOf("=");
+				if (separatorIndex === -1) {
+					return null;
+				}
+
+				return [
+					line.slice(0, separatorIndex).trim(),
+					parseEnvValue(line.slice(separatorIndex + 1)),
+				];
+			})
+			.filter(Boolean),
+	);
+}
+
+const envFile = readEnvFile(ENV_FILE);
+
+function getEnv(name, fallback) {
+	return process.env[name] ?? envFile[name] ?? fallback;
+}
+
+async function assertJsonEndpoint(label, url) {
+	const response = await fetch(url, {
+		headers: {
+			accept: "application/json",
+		},
+	});
+
+	if (!response.ok) {
+		throw new Error(
+			\`\${label} failed at \${url} with HTTP \${response.status}.\`,
+		);
+	}
+
+	const contentType = response.headers.get("content-type") ?? "";
+	if (!contentType.includes("application/json")) {
+		throw new Error(
+			\`\${label} at \${url} did not return JSON (content-type: \${contentType || "missing"}).\`,
+		);
+	}
+
+	return response.json();
+}
+
+const baseUrl = new URL(
+	getEnv("WP_TYPIA_SMOKE_BASE_URL", "http://localhost:8888"),
+);
+const serviceUrl = getEnv("WP_TYPIA_SERVICE_URL", "").trim();
+
+await assertJsonEndpoint(
+	"WordPress REST index",
+	new URL("/wp-json/", baseUrl),
+);
+
+if (serviceUrl.length > 0) {
+	await assertJsonEndpoint(
+		"Local integration service healthcheck",
+		new URL("/health", serviceUrl),
+	);
+}
+
+console.log("wp-typia integration smoke passed: ${integrationEnvSlug}");
+`;
+}
+
+function buildEnvExampleSource(service: IntegrationEnvServiceId): string {
+	return [
+		"# wp-typia integration smoke settings",
+		"WP_TYPIA_SMOKE_BASE_URL=http://localhost:8888",
+		"WP_TYPIA_SMOKE_USERNAME=admin",
+		"WP_TYPIA_SMOKE_PASSWORD=password",
+		...(service === "docker-compose"
+			? [
+					"",
+					"# Optional docker-compose integration service starter.",
+					"WP_TYPIA_SERVICE_URL=http://localhost:3000",
+			  ]
+			: [
+					"",
+					"# Set this when your smoke test needs a project-specific service.",
+					"# WP_TYPIA_SERVICE_URL=http://localhost:3000",
+			  ]),
+		"",
+	].join("\n");
+}
+
+function buildIntegrationEnvReadmeSource({
+	integrationEnvSlug,
+	service,
+	withWpEnv,
+}: {
+	integrationEnvSlug: string;
+	service: IntegrationEnvServiceId;
+	withWpEnv: boolean;
+}): string {
+	const title = toTitleCase(integrationEnvSlug);
+	const setupSteps = [
+		"Copy `.env.example` to `.env` and adjust the URLs or credentials for your local project.",
+		...(withWpEnv
+			? [
+					"Run `npm run wp-env:start` to start the generated WordPress environment.",
+			  ]
+			: [
+					"Point `WP_TYPIA_SMOKE_BASE_URL` at the WordPress environment you already run locally.",
+			  ]),
+		...(service === "docker-compose"
+			? [
+					"Run `npm run service:start` if you want the placeholder docker-compose service available at `WP_TYPIA_SERVICE_URL`.",
+			  ]
+			: [
+					"Set `WP_TYPIA_SERVICE_URL` only when your integration smoke needs a local service dependency.",
+			  ]),
+		`Run \`npm run smoke:${integrationEnvSlug}\` to execute the starter smoke check.`,
+	];
+
+	return `# ${title} Integration Environment
+
+This starter keeps local WordPress integration smoke checks opt-in and editable.
+It does not change default block scaffolds or require wp-env unless this add
+workflow was run with \`--wp-env\`.
+
+## Setup
+
+${setupSteps.map((step, index) => `${index + 1}. ${step}`).join("\n")}
+
+## Adapting the Starter
+
+- Extend \`scripts/integration-smoke/${integrationEnvSlug}.mjs\` with the REST,
+  editor, or service assertions that matter for this project.
+- Keep secrets in \`.env\`; \`.env.example\` should document only safe defaults.
+- If your project uses a real service stack, replace the placeholder
+  \`docker-compose.integration.yml\` service with your database, queue, API, or
+  emulator containers.
+- Keep the smoke script focused on high-signal integration checks so CI and
+  local debugging stay fast.
+`;
+}
+
+async function appendMissingLines(filePath: string, lines: readonly string[]) {
+	const current = (await readOptionalUtf8File(filePath)) ?? "";
+	const missingLines = lines.filter(
+		(line) =>
+			!current.includes(`${line}\n`) && !current.endsWith(line),
+	);
+	if (missingLines.length === 0) {
+		return;
+	}
+
+	const separator = current.length === 0 || current.endsWith("\n") ? "" : "\n";
+	await fsp.mkdir(path.dirname(filePath), { recursive: true });
+	await fsp.writeFile(
+		filePath,
+		`${current}${separator}${missingLines.join("\n")}\n`,
+		"utf8",
+	);
+}
+
+async function writeFileIfAbsent({
+	filePath,
+	source,
+	warnings,
+}: {
+	filePath: string;
+	source: string;
+	warnings: string[];
+}) {
+	if (await pathExists(filePath)) {
+		warnings.push(
+			`Preserved existing ${path.basename(filePath)}; review it manually if you need different local integration settings.`,
+		);
+		return;
+	}
+
+	await fsp.mkdir(path.dirname(filePath), { recursive: true });
+	await fsp.writeFile(filePath, source, "utf8");
+}
+
+async function writeNewScaffoldFile(filePath: string, source: string) {
+	if (await pathExists(filePath)) {
+		throw new Error(
+			`An integration environment scaffold already exists at ${filePath}. Choose a different name.`,
+		);
+	}
+
+	await fsp.mkdir(path.dirname(filePath), { recursive: true });
+	await fsp.writeFile(filePath, source, "utf8");
+}
+
+function addScriptIfMissing({
+	scriptName,
+	scripts,
+	scriptValue,
+	warnings,
+}: {
+	scriptName: string;
+	scripts: Record<string, string>;
+	scriptValue: string;
+	warnings: string[];
+}) {
+	if (scripts[scriptName] === undefined) {
+		scripts[scriptName] = scriptValue;
+		return;
+	}
+
+	if (scripts[scriptName] !== scriptValue) {
+		warnings.push(
+			`Preserved existing package script "${scriptName}"; add "${scriptValue}" manually if you want the generated integration command.`,
+		);
+	}
+}
+
+async function mutatePackageJson(
+	projectDir: string,
+	mutate: (packageJson: IntegrationEnvPackageJson) => void,
+) {
+	const packageJsonPath = path.join(projectDir, "package.json");
+	const packageJson = JSON.parse(
+		await fsp.readFile(packageJsonPath, "utf8"),
+	) as IntegrationEnvPackageJson;
+
+	mutate(packageJson);
+
+	await fsp.writeFile(
+		packageJsonPath,
+		`${JSON.stringify(packageJson, null, "\t")}\n`,
+		"utf8",
+	);
+}
+
+function addIntegrationEnvPackageJsonEntries({
+	integrationEnvSlug,
+	packageManager,
+	packageJson,
+	service,
+	warnings,
+	withWpEnv,
+}: {
+	integrationEnvSlug: string;
+	packageManager: PackageManagerId;
+	packageJson: IntegrationEnvPackageJson;
+	service: IntegrationEnvServiceId;
+	warnings: string[];
+	withWpEnv: boolean;
+}) {
+	packageJson.devDependencies = {
+		...(packageJson.devDependencies ?? {}),
+		...(withWpEnv ? { "@wordpress/env": WP_ENV_PACKAGE_VERSION } : {}),
+	};
+	const scripts = {
+		...(packageJson.scripts ?? {}),
+	};
+
+	addScriptIfMissing({
+		scriptName: `smoke:${integrationEnvSlug}`,
+		scriptValue: `node scripts/integration-smoke/${integrationEnvSlug}.mjs`,
+		scripts,
+		warnings,
+	});
+	addScriptIfMissing({
+		scriptName: "smoke:integration",
+		scriptValue: formatRunScript(packageManager, `smoke:${integrationEnvSlug}`),
+		scripts,
+		warnings,
+	});
+
+	if (withWpEnv) {
+		addScriptIfMissing({
+			scriptName: "wp-env:start",
+			scriptValue: "wp-env start",
+			scripts,
+			warnings,
+		});
+		addScriptIfMissing({
+			scriptName: "wp-env:stop",
+			scriptValue: "wp-env stop",
+			scripts,
+			warnings,
+		});
+		addScriptIfMissing({
+			scriptName: "wp-env:reset",
+			scriptValue: "wp-env destroy all && wp-env start",
+			scripts,
+			warnings,
+		});
+	}
+
+	if (service === "docker-compose") {
+		addScriptIfMissing({
+			scriptName: "service:start",
+			scriptValue: "docker compose -f docker-compose.integration.yml up -d",
+			scripts,
+			warnings,
+		});
+		addScriptIfMissing({
+			scriptName: "service:stop",
+			scriptValue: "docker compose -f docker-compose.integration.yml down",
+			scripts,
+			warnings,
+		});
+	}
+
+	packageJson.scripts = scripts;
+}
+
+/**
+ * Add an opt-in local WordPress integration environment starter to an official
+ * workspace.
+ */
+export async function runAddIntegrationEnvCommand({
+	cwd = process.cwd(),
+	integrationEnvName,
+	service,
+	withWpEnv = false,
+}: RunAddIntegrationEnvCommandOptions): Promise<RunAddIntegrationEnvCommandResult> {
+	const workspace = resolveWorkspaceProject(cwd);
+	const integrationEnvSlug = assertValidGeneratedSlug(
+		"Integration environment name",
+		normalizeBlockSlug(integrationEnvName),
+		"wp-typia add integration-env <name> [--wp-env]",
+	);
+	const serviceId = assertValidIntegrationEnvService(service);
+	const warnings: string[] = [];
+
+	const packageJsonPath = path.join(workspace.projectDir, "package.json");
+	const gitignorePath = path.join(workspace.projectDir, ".gitignore");
+	const envExamplePath = path.join(workspace.projectDir, ".env.example");
+	const wpEnvPath = path.join(workspace.projectDir, ".wp-env.json");
+	const dockerComposePath = path.join(
+		workspace.projectDir,
+		"docker-compose.integration.yml",
+	);
+	const smokeDir = path.join(
+		workspace.projectDir,
+		"scripts",
+		"integration-smoke",
+	);
+	const docsDir = path.join(workspace.projectDir, "docs", "integration-env");
+	const smokeScriptPath = path.join(smokeDir, `${integrationEnvSlug}.mjs`);
+	const docsPath = path.join(docsDir, `${integrationEnvSlug}.md`);
+	const shouldRemoveSmokeDirOnRollback = !(await pathExists(smokeDir));
+	const shouldRemoveDocsDirOnRollback = !(await pathExists(docsDir));
+
+	await executeWorkspaceMutationPlan({
+		filePaths: [
+			packageJsonPath,
+			gitignorePath,
+			envExamplePath,
+			...(withWpEnv ? [wpEnvPath] : []),
+			...(serviceId === "docker-compose" ? [dockerComposePath] : []),
+		],
+		targetPaths: [
+			smokeScriptPath,
+			docsPath,
+			...(shouldRemoveSmokeDirOnRollback ? [smokeDir] : []),
+			...(shouldRemoveDocsDirOnRollback ? [docsDir] : []),
+		],
+		run: async () => {
+			await writeNewScaffoldFile(
+				smokeScriptPath,
+				buildIntegrationSmokeScriptSource(integrationEnvSlug),
+			);
+			await writeNewScaffoldFile(
+				docsPath,
+				buildIntegrationEnvReadmeSource({
+					integrationEnvSlug,
+					service: serviceId,
+					withWpEnv,
+				}),
+			);
+			await appendMissingLines(envExamplePath, [
+				...buildEnvExampleSource(serviceId).trimEnd().split("\n"),
+			]);
+			await appendMissingLines(gitignorePath, [".env", ".env.local"]);
+
+			if (withWpEnv) {
+				await writeFileIfAbsent({
+					filePath: wpEnvPath,
+					source: buildWpEnvConfigSource(),
+					warnings,
+				});
+			}
+			if (serviceId === "docker-compose") {
+				await writeFileIfAbsent({
+					filePath: dockerComposePath,
+					source: buildDockerComposeSource(),
+					warnings,
+				});
+			}
+
+			await mutatePackageJson(workspace.projectDir, (packageJson) =>
+				addIntegrationEnvPackageJsonEntries({
+					integrationEnvSlug,
+					packageManager: workspace.packageManager,
+					packageJson,
+					service: serviceId,
+					warnings,
+					withWpEnv,
+				}),
+			);
+		},
+	});
+
+	return {
+		integrationEnvSlug,
+		projectDir: workspace.projectDir,
+		service: serviceId,
+		warnings: warnings.length > 0 ? warnings : undefined,
+		withWpEnv,
+	};
+}

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace.ts
@@ -606,6 +606,11 @@ export {
 	runAddPatternCommand,
 } from "./cli-add-workspace-assets.js";
 /**
+ * Re-export the local integration environment scaffold workflow from the
+ * focused integration-env runtime helper module.
+ */
+export { runAddIntegrationEnvCommand } from "./cli-add-workspace-integration-env.js";
+/**
  * Re-export the plugin-level REST resource scaffold workflow from the focused
  * rest-resource runtime helper module.
  */

--- a/packages/wp-typia-project-tools/src/runtime/cli-add.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add.ts
@@ -33,6 +33,7 @@ export {
 	runAddBlockTransformCommand,
 	runAddEditorPluginCommand,
 	runAddHookedBlockCommand,
+	runAddIntegrationEnvCommand,
 	runAddPatternCommand,
 	runAddRestResourceCommand,
 	runAddVariationCommand,

--- a/packages/wp-typia-project-tools/src/runtime/cli-help.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-help.ts
@@ -21,6 +21,7 @@ export function formatHelpText(): string {
   wp-typia init [project-dir] [--apply] [--package-manager <id>]
   wp-typia add admin-view <name> [--source <rest-resource:slug|core-data:kind/name>]
   wp-typia add block <name> [--template <basic|interactivity|persistence|compound>] [--external-layer-source <./path|github:owner/repo/path[#ref]|npm-package>] [--external-layer-id <layer-id>] [--inner-blocks-preset <freeform|ordered|horizontal|locked-structure>] [--alternate-render-targets <email,mjml,plain-text>] [--data-storage <post-meta|custom-table>] [--persistence-policy <authenticated|public>]
+  wp-typia add integration-env <name> [--wp-env] [--service <none|docker-compose>]
   wp-typia add variation <name> --block <block-slug>
   wp-typia add style <name> --block <block-slug>
   wp-typia add transform <name> --from <namespace/block> --to <block-slug|namespace/block-slug>
@@ -54,6 +55,8 @@ Notes:
   Pass \`--source rest-resource:<slug>\` to reuse a list-capable REST resource.
   Pass \`--source core-data:postType/post\` or \`--source core-data:taxonomy/category\` to bind a WordPress-owned entity collection.
   Generated admin-view workspaces add \`@wp-typia/dataviews\` and the needed WordPress DataViews packages as opt-in dependencies.
+  \`add integration-env\` generates an opt-in local smoke starter under \`scripts/integration-smoke/\`, updates \`.env.example\`, and can add \`@wordpress/env\` plus \`.wp-env.json\` when \`--wp-env\` is passed.
+  Pass \`--service docker-compose\` to include a placeholder local service stack that can be adapted to project-specific dependencies.
   \`query-loop\` is create-only. Use \`wp-typia create <project-dir> --template query-loop\`; \`wp-typia add block\` accepts only basic, interactivity, persistence, and compound families.
   \`add variation\` uses an existing workspace block from \`scripts/block-config.ts\`.
   \`add style\` registers a Block Styles option for an existing generated block.

--- a/packages/wp-typia-project-tools/tests/cli-entry.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-entry.test.ts
@@ -1018,6 +1018,8 @@ test("formatHelpText keeps migration UI flags out of external template usage", (
   expect(helpText).toContain("src/admin-views/");
   expect(helpText).toContain("@wp-typia/dataviews");
   expect(helpText).toContain("opt-in dependencies");
+  expect(helpText).toContain("wp-typia add integration-env <name>");
+  expect(helpText).toContain("scripts/integration-smoke/");
   expect(helpText).not.toContain("Public installs currently gate");
   expect(helpText).toContain("wp-typia add ai-feature <name>");
   expect(helpText).toContain(

--- a/packages/wp-typia-project-tools/tests/workspace-add.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-add.test.ts
@@ -1153,6 +1153,92 @@ test("canonical CLI can dry-run an add block scaffold without mutating the works
   ).toBe(false);
 });
 
+test("canonical CLI can add an integration environment starter to an official workspace template", async () => {
+  const targetDir = path.join(tempRoot, "demo-workspace-add-integration-env");
+
+  await scaffoldOfficialWorkspace(targetDir, {
+    description: "Demo workspace add integration env",
+    slug: "demo-workspace-add-integration-env",
+    title: "Demo Workspace Add Integration Env",
+  });
+
+  linkWorkspaceNodeModules(targetDir);
+  const output = runCli(
+    "node",
+    [
+      entryPath,
+      "add",
+      "integration-env",
+      "local-smoke",
+      "--wp-env",
+      "--service",
+      "docker-compose",
+    ],
+    { cwd: targetDir }
+  );
+
+  expect(output).toContain("Added integration environment starter");
+  expect(output).toContain("Integration env: local-smoke");
+
+  const packageJson = JSON.parse(
+    fs.readFileSync(path.join(targetDir, "package.json"), "utf8")
+  ) as {
+    devDependencies: Record<string, string>;
+    scripts: Record<string, string>;
+  };
+  expect(packageJson.devDependencies["@wordpress/env"]).toBe("^11.2.0");
+  expect(packageJson.scripts["wp-env:start"]).toBe("wp-env start");
+  expect(packageJson.scripts["service:start"]).toBe(
+    "docker compose -f docker-compose.integration.yml up -d"
+  );
+  expect(packageJson.scripts["smoke:local-smoke"]).toBe(
+    "node scripts/integration-smoke/local-smoke.mjs"
+  );
+  expect(packageJson.scripts["smoke:integration"]).toBe(
+    "npm run smoke:local-smoke"
+  );
+
+  const envExampleSource = fs.readFileSync(
+    path.join(targetDir, ".env.example"),
+    "utf8"
+  );
+  expect(envExampleSource).toContain(
+    "WP_TYPIA_SMOKE_BASE_URL=http://localhost:8888"
+  );
+  expect(envExampleSource).toContain(
+    "WP_TYPIA_SERVICE_URL=http://localhost:3000"
+  );
+  expect(
+    fs.readFileSync(path.join(targetDir, ".gitignore"), "utf8")
+  ).toContain(".env");
+  expect(
+    fs.readFileSync(path.join(targetDir, ".wp-env.json"), "utf8")
+  ).toContain('"plugins": [');
+  expect(
+    fs.readFileSync(
+      path.join(targetDir, "docker-compose.integration.yml"),
+      "utf8"
+    )
+  ).toContain("integration-service");
+
+  const smokeScriptPath = path.join(
+    targetDir,
+    "scripts",
+    "integration-smoke",
+    "local-smoke.mjs"
+  );
+  const smokeScriptSource = fs.readFileSync(smokeScriptPath, "utf8");
+  expect(smokeScriptSource).toContain("WordPress REST index");
+  expect(smokeScriptSource).toContain("local-smoke");
+  runCli("node", ["--check", smokeScriptPath], { cwd: targetDir });
+  expect(
+    fs.readFileSync(
+      path.join(targetDir, "docs", "integration-env", "local-smoke.md"),
+      "utf8"
+    )
+  ).toContain("Adapting the Starter");
+});
+
 test("canonical CLI can dry-run hooked-block metadata updates without rewriting block.json", async () => {
   const targetDir = path.join(tempRoot, "demo-workspace-add-hooked-block-dry-run");
 

--- a/packages/wp-typia-project-tools/tests/workspace-add.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-add.test.ts
@@ -1230,6 +1230,13 @@ test("canonical CLI can add an integration environment starter to an official wo
   const smokeScriptSource = fs.readFileSync(smokeScriptPath, "utf8");
   expect(smokeScriptSource).toContain("WordPress REST index");
   expect(smokeScriptSource).toContain("local-smoke");
+  expect(smokeScriptSource).toContain("function resolveEndpointUrl");
+  expect(smokeScriptSource).toContain(
+    'resolveEndpointUrl(baseUrl, "wp-json/")'
+  );
+  expect(smokeScriptSource).toContain(
+    'resolveEndpointUrl(serviceUrl, "health")'
+  );
   runCli("node", ["--check", smokeScriptPath], { cwd: targetDir });
   expect(
     fs.readFileSync(
@@ -1238,6 +1245,48 @@ test("canonical CLI can add an integration environment starter to an official wo
     )
   ).toContain("Adapting the Starter");
 });
+
+test("canonical CLI preserves an existing wp-env dependency when adding an integration environment", async () => {
+  const targetDir = path.join(
+    tempRoot,
+    "demo-workspace-add-integration-env-existing-wp-env"
+  );
+
+  await scaffoldOfficialWorkspace(targetDir, {
+    description: "Demo workspace add integration env existing wp-env",
+    slug: "demo-workspace-add-integration-env-existing-wp-env",
+    title: "Demo Workspace Add Integration Env Existing Wp Env",
+  });
+
+  const packageJsonPath = path.join(targetDir, "package.json");
+  const packageJson = JSON.parse(
+    fs.readFileSync(packageJsonPath, "utf8")
+  ) as {
+    devDependencies?: Record<string, string>;
+  };
+  packageJson.devDependencies = {
+    ...(packageJson.devDependencies ?? {}),
+    "@wordpress/env": "^10.0.0",
+  };
+  fs.writeFileSync(
+    packageJsonPath,
+    `${JSON.stringify(packageJson, null, "\t")}\n`,
+    "utf8"
+  );
+
+  linkWorkspaceNodeModules(targetDir);
+  runCli("node", [entryPath, "add", "integration-env", "local-smoke", "--wp-env"], {
+    cwd: targetDir,
+  });
+
+  const updatedPackageJson = JSON.parse(
+    fs.readFileSync(packageJsonPath, "utf8")
+  ) as {
+    devDependencies: Record<string, string>;
+  };
+  expect(updatedPackageJson.devDependencies["@wordpress/env"]).toBe("^10.0.0");
+  expect(fs.existsSync(path.join(targetDir, ".wp-env.json"))).toBe(true);
+}, 20_000);
 
 test("canonical CLI can dry-run hooked-block metadata updates without rewriting block.json", async () => {
   const targetDir = path.join(tempRoot, "demo-workspace-add-hooked-block-dry-run");

--- a/packages/wp-typia/.bunli/commands.gen.ts
+++ b/packages/wp-typia/.bunli/commands.gen.ts
@@ -31,7 +31,7 @@ const modules: Record<GeneratedNames, Command<any>> = {
 const metadata: Record<GeneratedNames, GeneratedCommandMeta> = {
   'add': {
       name: 'add',
-      description: 'Extend an official wp-typia workspace with blocks, variations, block styles, transforms, patterns, binding sources, plugin-level REST resources, workflow abilities, server-only AI features, editor plugins, or hooked blocks.',
+      description: 'Extend an official wp-typia workspace with blocks, integration envs, variations, block styles, transforms, patterns, binding sources, plugin-level REST resources, workflow abilities, server-only AI features, editor plugins, or hooked blocks.',
       path: './src/commands/add'
     },
   'create': {

--- a/packages/wp-typia/README.md
+++ b/packages/wp-typia/README.md
@@ -13,6 +13,7 @@ Use this package for new projects:
 Extend an existing workspace with:
 
 - `wp-typia add block counter-card --template basic`
+- `wp-typia add integration-env local-smoke --wp-env --service docker-compose`
 - `wp-typia add style callout-emphasis --block counter-card`
 - `wp-typia add transform quote-to-counter --from core/quote --to counter-card`
 - `wp-typia add binding-source hero-data`

--- a/packages/wp-typia/bin/routing-metadata.generated.js
+++ b/packages/wp-typia/bin/routing-metadata.generated.js
@@ -38,6 +38,7 @@ export const longValueOptions = Object.freeze([
   '--position',
   '--query-post-type',
   '--seed',
+  '--service',
   '--slot',
   '--source',
   '--template',

--- a/packages/wp-typia/src/add-kind-registry-shared.ts
+++ b/packages/wp-typia/src/add-kind-registry-shared.ts
@@ -88,6 +88,9 @@ export type AddBlockResult = Awaited<ReturnType<AddRuntime['runAddBlockCommand']
 export type AddEditorPluginResult = Awaited<
   ReturnType<AddRuntime['runAddEditorPluginCommand']>
 >;
+export type AddIntegrationEnvResult = Awaited<
+  ReturnType<AddRuntime['runAddIntegrationEnvCommand']>
+>;
 export type AddAiFeatureResult = Awaited<
   ReturnType<AddRuntime['runAddAiFeatureCommand']>
 >;
@@ -118,6 +121,7 @@ export type AddKindExecutionResultById = {
   block: AddBlockResult;
   'editor-plugin': AddEditorPluginResult;
   'hooked-block': AddHookedBlockResult;
+  'integration-env': AddIntegrationEnvResult;
   pattern: AddPatternResult;
   'rest-resource': AddRestResourceResult;
   style: AddBlockStyleResult;

--- a/packages/wp-typia/src/add-kind-registry.ts
+++ b/packages/wp-typia/src/add-kind-registry.ts
@@ -6,6 +6,7 @@ import { bindingSourceAddKindEntry } from './add-kinds/binding-source';
 import { blockAddKindEntry } from './add-kinds/block';
 import { editorPluginAddKindEntry } from './add-kinds/editor-plugin';
 import { hookedBlockAddKindEntry } from './add-kinds/hooked-block';
+import { integrationEnvAddKindEntry } from './add-kinds/integration-env';
 import { patternAddKindEntry } from './add-kinds/pattern';
 import { restResourceAddKindEntry } from './add-kinds/rest-resource';
 import { styleAddKindEntry } from './add-kinds/style';
@@ -34,6 +35,7 @@ export type {
 export const ADD_KIND_REGISTRY = {
   'admin-view': adminViewAddKindEntry,
   block: blockAddKindEntry,
+  'integration-env': integrationEnvAddKindEntry,
   variation: variationAddKindEntry,
   style: styleAddKindEntry,
   transform: transformAddKindEntry,

--- a/packages/wp-typia/src/add-kinds/integration-env.ts
+++ b/packages/wp-typia/src/add-kinds/integration-env.ts
@@ -1,0 +1,60 @@
+import { readOptionalStrictStringFlag } from '../cli-string-flags';
+import {
+  createNamedExecutionPlan,
+  defineAddKindRegistryEntry,
+  NAME_ONLY_VISIBLE_FIELDS,
+  type AddIntegrationEnvResult,
+} from '../add-kind-registry-shared';
+
+const INTEGRATION_ENV_MISSING_NAME_MESSAGE =
+  '`wp-typia add integration-env` requires <name>. Usage: wp-typia add integration-env <name> [--wp-env] [--service <none|docker-compose>].';
+
+export const integrationEnvAddKindEntry =
+  defineAddKindRegistryEntry<AddIntegrationEnvResult>({
+    completion: {
+      nextSteps: (values) => [
+        `Review scripts/integration-smoke/${values.integrationEnvSlug}.mjs and docs/integration-env/${values.integrationEnvSlug}.md.`,
+        'Copy `.env.example` to `.env`, adjust local URLs or credentials, then run the generated smoke script.',
+        ...(values.withWpEnv === 'true'
+          ? ['Run `npm run wp-env:start` before the smoke check when using the generated wp-env preset.']
+          : []),
+      ],
+      summaryLines: (values, projectDir) => [
+        `Integration env: ${values.integrationEnvSlug}`,
+        `wp-env preset: ${values.withWpEnv}`,
+        `Service starter: ${values.service}`,
+        `Project directory: ${projectDir}`,
+      ],
+      title: 'Added integration environment starter',
+    },
+    description:
+      'Add an opt-in local WordPress integration smoke environment starter',
+    nameLabel: 'Integration env name',
+    async prepareExecution(context) {
+      const service = readOptionalStrictStringFlag(context.flags, 'service');
+      const withWpEnv = Boolean(context.flags['wp-env']);
+
+      return createNamedExecutionPlan(context, {
+        execute: ({ cwd, name }) =>
+          context.addRuntime.runAddIntegrationEnvCommand({
+            cwd,
+            integrationEnvName: name,
+            service,
+            withWpEnv,
+          }),
+        getValues: (result) => ({
+          integrationEnvSlug: result.integrationEnvSlug,
+          service: result.service,
+          withWpEnv: String(result.withWpEnv),
+        }),
+        getWarnings: (result) => result.warnings,
+        missingNameMessage: INTEGRATION_ENV_MISSING_NAME_MESSAGE,
+        warnLine: context.warnLine,
+      });
+    },
+    sortOrder: 25,
+    supportsDryRun: true,
+    usage:
+      'wp-typia add integration-env <name> [--wp-env] [--service <none|docker-compose>] [--dry-run]',
+    visibleFieldNames: () => NAME_ONLY_VISIBLE_FIELDS,
+  });

--- a/packages/wp-typia/src/command-options/add.ts
+++ b/packages/wp-typia/src/command-options/add.ts
@@ -70,6 +70,11 @@ export const ADD_OPTION_METADATA = {
     description: 'Hook position for hooked-block workflows.',
     type: 'string',
   },
+  service: {
+    description:
+      'Optional local service starter for integration-env workflows (none or docker-compose).',
+    type: 'string',
+  },
   slot: {
     description:
       'Document editor shell slot for editor-plugin workflows (sidebar or document-setting-panel).',
@@ -89,5 +94,11 @@ export const ADD_OPTION_METADATA = {
     description:
       'Target workspace block slug or full block name for transform workflows.',
     type: 'string',
+  },
+  'wp-env': {
+    argumentKind: 'flag',
+    description:
+      'Add a local @wordpress/env preset for integration-env workflows.',
+    type: 'boolean',
   },
 } as const satisfies CommandOptionMetadataMap;

--- a/packages/wp-typia/src/commands/add.ts
+++ b/packages/wp-typia/src/commands/add.ts
@@ -41,7 +41,7 @@ const addOptions = buildCommandOptions(ADD_OPTION_METADATA);
 export const addCommand = defineCommand({
   defaultFormat: 'toon',
   description:
-    'Extend an official wp-typia workspace with blocks, variations, block styles, transforms, patterns, binding sources, plugin-level REST resources, workflow abilities, server-only AI features, editor plugins, or hooked blocks.',
+    'Extend an official wp-typia workspace with blocks, integration envs, variations, block styles, transforms, patterns, binding sources, plugin-level REST resources, workflow abilities, server-only AI features, editor plugins, or hooked blocks.',
   handler: async (args) => {
     const prefersStructuredOutput = prefersStructuredCliOutput(args);
     const { printLine, warnLine } = resolveCommandOutputAdapters(args);

--- a/packages/wp-typia/tests/add-command-package.test.ts
+++ b/packages/wp-typia/tests/add-command-package.test.ts
@@ -200,6 +200,9 @@ test('node fallback source entry treats missing add kinds as an error while prin
     expect(capturedStdout.join('\n')).toContain(
       'wp-typia add ai-feature <name>',
     );
+    expect(capturedStdout.join('\n')).toContain(
+      'wp-typia add integration-env <name>',
+    );
     expect(capturedStdout.join('\n')).toContain('wp-typia add style <name>');
     expect(capturedStdout.join('\n')).toContain(
       'wp-typia add transform <name>',

--- a/packages/wp-typia/tests/add-command.test.ts
+++ b/packages/wp-typia/tests/add-command.test.ts
@@ -651,6 +651,7 @@ describe('wp-typia add command bridge', () => {
     expect(ADD_KIND_IDS).toEqual([
       'admin-view',
       'block',
+      'integration-env',
       'variation',
       'style',
       'transform',

--- a/packages/wp-typia/tests/add-kind-registry.test.ts
+++ b/packages/wp-typia/tests/add-kind-registry.test.ts
@@ -101,6 +101,15 @@ type EditorPluginPlanCompatibility = ExpectTrue<
   >
 >;
 
+type IntegrationEnvPlanCompatibility = ExpectTrue<
+  IsEqual<
+    Awaited<
+      ReturnType<AddKindExecutionPlanFor<'integration-env'>['execute']>
+    >,
+    Parameters<AddKindExecutionPlanFor<'integration-env'>['getValues']>[0]
+  >
+>;
+
 type SharedAddKindIdCompatibility = ExpectTrue<
   IsEqual<keyof typeof ADD_KIND_REGISTRY, AddKindId>
 >;
@@ -108,6 +117,7 @@ type SharedAddKindIdCompatibility = ExpectTrue<
 const addKindPlanCompatibilityChecks = {
   'admin-view': true,
   block: true,
+  'integration-env': true,
   variation: true,
   style: true,
   transform: true,
@@ -122,6 +132,7 @@ const addKindPlanCompatibilityChecks = {
 } satisfies {
   'admin-view': AdminViewPlanCompatibility;
   block: BlockPlanCompatibility;
+  'integration-env': IntegrationEnvPlanCompatibility;
   variation: VariationPlanCompatibility;
   style: StylePlanCompatibility;
   transform: TransformPlanCompatibility;
@@ -139,6 +150,7 @@ test('preserves compile-time compatibility between execute and getValues for eve
   expect(addKindPlanCompatibilityChecks).toEqual({
     'admin-view': true,
     block: true,
+    'integration-env': true,
     variation: true,
     style: true,
     transform: true,
@@ -178,6 +190,10 @@ test('keeps shared visible-field groups aligned for refactored add kinds', () =>
     'kind',
     'name',
     'source',
+  ]);
+  expect(getAddVisibleFieldNames({ kind: 'integration-env' })).toEqual([
+    'kind',
+    'name',
   ]);
   expect(getAddVisibleFieldNames({ kind: 'style' })).toEqual([
     'kind',
@@ -237,6 +253,10 @@ const warnLinePlanFixtures = {
   block: {
     flags: {},
     name: 'sample-block',
+  },
+  'integration-env': {
+    flags: {},
+    name: 'sample-integration-env',
   },
   'editor-plugin': {
     flags: {},
@@ -313,6 +333,7 @@ test('passes the warning line printer through every add-kind execution plan', as
     'ai-feature': true,
     'binding-source': true,
     block: true,
+    'integration-env': true,
     'editor-plugin': true,
     'hooked-block': true,
     pattern: true,

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -351,6 +351,7 @@ describe('wp-typia package', () => {
     expect(addHelpOutput).toContain('admin-view');
     expect(addHelpOutput).toContain('ability');
     expect(addHelpOutput).toContain('ai-feature');
+    expect(addHelpOutput).toContain('integration-env');
     expect(addHelpOutput).toContain('editor-plugin');
     expect(doctorHelpOutput).toContain(
       '`json` for machine-readable doctor check output or `text` for human-readable output',

--- a/packages/wp-typia/tests/tui-interaction-models.test.ts
+++ b/packages/wp-typia/tests/tui-interaction-models.test.ts
@@ -31,6 +31,10 @@ describe("first-party TUI interaction models", () => {
 			"name",
 			"template",
 		]);
+		expect(getVisibleAddFieldNames({ kind: "integration-env" })).toEqual([
+			"kind",
+			"name",
+		]);
 		expect(
 			getVisibleAddFieldNames({ kind: "block", template: "persistence" }),
 		).toEqual([


### PR DESCRIPTION
## Summary
- Add `wp-typia add integration-env <name>` for opt-in local smoke starters in official workspaces.
- Generate `.env.example`, smoke script/docs, optional `.wp-env.json` + `@wordpress/env` scripts, and optional docker-compose service starter.
- Wire the new add kind through shared metadata, Node fallback/Bunli routing, help text, TUI visible fields, and docs.

Fixes #887

## Tests
- `bun test packages/wp-typia/tests/add-kind-registry.test.ts packages/wp-typia/tests/add-command.test.ts packages/wp-typia/tests/tui-interaction-models.test.ts`
- `bun test packages/wp-typia-project-tools/tests/workspace-add.test.ts --test-name-pattern "integration environment"`
- `bun test packages/wp-typia/tests/add-kind-registry.test.ts packages/wp-typia/tests/add-command.test.ts packages/wp-typia/tests/tui-interaction-models.test.ts packages/wp-typia/tests/add-command-package.test.ts`
- `bun run changesets:validate`
- `bun run format:check`
- `bun run typecheck`
- `git diff --check`
- `bun run --filter @wp-typia/project-tools test:workspace`
- `bun run --filter wp-typia test`

## Changeset
- `npm/wp-typia`: minor
- `npm/@wp-typia/project-tools`: minor
- `npm/@wp-typia/create-workspace-template`: patch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `wp-typia add integration-env` command to generate local integration environment starters within existing workspaces.
  * Generates smoke test scripts, documentation, and `.env.example` configuration files.
  * Supports optional `--wp-env` flag to include local WordPress environment setup.
  * Supports optional `--service docker-compose` flag to scaffold a Docker Compose service.
  * Automatically creates npm scripts for running integration smoke tests.

* **Documentation**
  * Updated READMEs with examples of the new integration environment workflow.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/903)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->