### PR TITLE
feat(contracts): add schema response test helpers

### DIFF
--- a/.sampo/changesets/890-contract-schema-test-helpers.md
+++ b/.sampo/changesets/890-contract-schema-test-helpers.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/block-runtime: minor
+---
+
+Added `@wp-typia/block-runtime/schema-test` helpers for validating smoke and integration response payloads against generated JSON Schema contract artifacts with field-level failure paths.

--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ wp-typia add hooked-block counter-card --anchor core/post-content --position aft
 - Need an empty workspace that will grow through `wp-typia add ...` workflows? Start with `--template workspace`.
 - Need a local WordPress smoke starter later? Use `wp-typia add integration-env <name> --wp-env` from a workspace.
 - Need schema evolution for a long-lived block? Enable `--with-migration-ui`.
+- Need smoke tests for external/manual payloads? Use `@wp-typia/block-runtime/schema-test`
+  to assert responses against generated `*.schema.json` contract artifacts.
 
 ## Retrofitting Existing Projects
 

--- a/apps/docs/src/content/docs/reference/api.md
+++ b/apps/docs/src/content/docs/reference/api.md
@@ -49,6 +49,9 @@ secondary imports compared with the core package roots and primary subpaths.
   Shared manifest and migration contract types.
 - `@wp-typia/block-runtime/schema-core`
   Shared schema/OpenAPI helpers.
+- `@wp-typia/block-runtime/schema-test`
+  Test helpers for validating smoke/integration response payloads against
+  generated JSON Schema artifacts.
 - `@wp-typia/block-runtime/metadata-core`
   Metadata sync and endpoint manifest helpers.
 - `@wp-typia/block-runtime/metadata-analysis`
@@ -712,6 +715,26 @@ wire schema but should not generate a WordPress REST route. Generated
 top of the same TypeScript-to-schema foundation; manual REST contract workflows
 can reference the same stable schema files when route ownership stays outside
 the scaffold.
+
+Node-based smoke tests can assert response payloads against those generated
+schemas without hand-checking individual keys:
+
+```ts
+import { assertResponseMatchesSchema } from '@wp-typia/block-runtime/schema-test';
+import externalRetrieveResponseSchema from './src/contracts/external-retrieve-response.schema.json';
+
+const payload = await fetchExternalRecord();
+
+assertResponseMatchesSchema('ExternalRetrieveResponse', payload, {
+  schemas: {
+    ExternalRetrieveResponse: externalRetrieveResponseSchema,
+  },
+});
+```
+
+Validation failures include normalized field paths such as `$.items[0]` or
+`$.status`, so CI output points at the field that drifted from the generated
+contract.
 
 ```ts
 await syncRestOpenApi({

--- a/bun.lock
+++ b/bun.lock
@@ -55,7 +55,6 @@
         "@wp-typia/api-client": "workspace:*",
         "@wp-typia/block-runtime": "workspace:*",
         "@wp-typia/project-tools": "workspace:*",
-        "ajv": "^8.18.0",
         "prettier": "3.8.2",
         "ts-patch": "^3.3.0",
         "tsx": "^4.20.5",
@@ -209,6 +208,7 @@
       "version": "0.5.0",
       "dependencies": {
         "@wp-typia/api-client": "^0.4.5",
+        "ajv": "^8.18.0",
         "typescript": "^5.9.2",
       },
       "devDependencies": {

--- a/examples/api-contract-adapter-poc/package.json
+++ b/examples/api-contract-adapter-poc/package.json
@@ -17,7 +17,6 @@
 	"devDependencies": {
 		"@wp-typia/api-client": "workspace:*",
 		"@wp-typia/block-runtime": "workspace:*",
-		"ajv": "^8.18.0",
 		"@types/node": "^24.0.0",
 		"@wp-typia/project-tools": "workspace:*",
 		"prettier": "3.8.2",

--- a/examples/api-contract-adapter-poc/src/contract-validation.ts
+++ b/examples/api-contract-adapter-poc/src/contract-validation.ts
@@ -1,6 +1,8 @@
-import Ajv2020, { type ErrorObject, type ValidateFunction } from 'ajv/dist/2020.js';
-
-import type { ValidationError, ValidationResult } from '@wp-typia/api-client';
+import {
+	createGeneratedSchemaValidator,
+	createResponseSchemaValidator,
+} from '@wp-typia/block-runtime/schema-test';
+import type { ValidationResult } from '@wp-typia/api-client';
 import counterBootstrapQuerySchema from '../../persistence-examples/src/blocks/counter/api-schemas/counter-bootstrap-query.schema.json';
 import counterBootstrapResponseSchema from '../../persistence-examples/src/blocks/counter/api-schemas/counter-bootstrap-response.schema.json';
 import counterQuerySchema from '../../persistence-examples/src/blocks/counter/api-schemas/counter-query.schema.json';
@@ -14,88 +16,42 @@ import type {
 	PersistenceCounterResponse,
 } from '../../persistence-examples/src/blocks/counter/api-types';
 
-const UINT32_MAX = 4_294_967_295;
-
-const ajv = new Ajv2020({
-	allErrors: true,
-	strict: false,
-});
-
-ajv.addKeyword({
-	keyword: 'x-typeTag',
-	schemaType: 'string',
-	validate(typeTag: string, data: unknown): boolean {
-		if (typeTag !== 'uint32') {
-			return false;
-		}
-
-		return (
-			typeof data === 'number' &&
-			Number.isInteger(data) &&
-			data >= 0 &&
-			data <= UINT32_MAX
-		);
-	},
-});
-
 const validateCounterQuerySchema =
-	ajv.compile<PersistenceCounterQuery>(counterQuerySchema);
+	createGeneratedSchemaValidator<PersistenceCounterQuery>(counterQuerySchema);
 const validateCounterBootstrapQuerySchema =
-	ajv.compile<PersistenceCounterBootstrapQuery>(counterBootstrapQuerySchema);
+	createGeneratedSchemaValidator<PersistenceCounterBootstrapQuery>(
+		counterBootstrapQuerySchema
+	);
 const validateIncrementRequestSchema =
-	ajv.compile<PersistenceCounterIncrementRequest>(incrementRequestSchema);
+	createGeneratedSchemaValidator<PersistenceCounterIncrementRequest>(
+		incrementRequestSchema
+	);
 const validateCounterBootstrapResponseSchema =
-	ajv.compile<PersistenceCounterBootstrapResponse>(counterBootstrapResponseSchema);
+	createResponseSchemaValidator<PersistenceCounterBootstrapResponse>(
+		counterBootstrapResponseSchema
+	);
 const validateCounterResponseSchema =
-	ajv.compile<PersistenceCounterResponse>(counterResponseSchema);
-
-function normalizeError(error: ErrorObject): ValidationError {
-	return {
-		description: error.message,
-		expected: error.keyword,
-		path: error.instancePath || '(root)',
-		value: error.params,
-	};
-}
-
-function runSchemaValidation<T>(
-	validator: ValidateFunction<T>,
-	input: unknown
-): ValidationResult<T> {
-	if (validator(input)) {
-		return {
-			data: input as T,
-			errors: [],
-			isValid: true,
-		};
-	}
-
-	return {
-		data: undefined,
-		errors: (validator.errors ?? []).map(normalizeError),
-		isValid: false,
-	};
-}
+	createResponseSchemaValidator<PersistenceCounterResponse>(counterResponseSchema);
 
 export const counterContractValidators = {
 	counterBootstrapQuery: (
 		input: unknown
 	): ValidationResult<PersistenceCounterBootstrapQuery> =>
-		runSchemaValidation(validateCounterBootstrapQuerySchema, input),
+		validateCounterBootstrapQuerySchema(input),
 	counterBootstrapResponse: (
 		input: unknown
 	): ValidationResult<PersistenceCounterBootstrapResponse> =>
-		runSchemaValidation(validateCounterBootstrapResponseSchema, input),
+		validateCounterBootstrapResponseSchema(input),
 	counterQuery: (input: unknown): ValidationResult<PersistenceCounterQuery> =>
-		runSchemaValidation(validateCounterQuerySchema, input),
+		validateCounterQuerySchema(input),
 	counterResponse: (
 		input: unknown
 	): ValidationResult<PersistenceCounterResponse> =>
-		runSchemaValidation(validateCounterResponseSchema, input),
+		validateCounterResponseSchema(input),
 	incrementRequest: (
 		input: unknown
 	): ValidationResult<PersistenceCounterIncrementRequest> =>
-		runSchemaValidation(validateIncrementRequestSchema, input),
+		validateIncrementRequestSchema(input),
 };
 
 export const counterOperationResponseValidators = {

--- a/packages/wp-typia-block-runtime/README.md
+++ b/packages/wp-typia-block-runtime/README.md
@@ -26,6 +26,7 @@ import {
   useEditorFields,
 } from '@wp-typia/block-runtime/inspector';
 import { collectPersistentBlockIdentityRepairs } from '@wp-typia/block-runtime/identifiers';
+import { assertResponseMatchesSchema } from '@wp-typia/block-runtime/schema-test';
 import { createNestedAttributeUpdater } from '@wp-typia/block-runtime/validation';
 import { runSyncBlockMetadata } from '@wp-typia/block-runtime/metadata-core';
 ```
@@ -39,9 +40,11 @@ and `@wp-typia/block-runtime/metadata-core`.
 Public subpaths such as `@wp-typia/block-runtime/inspector`,
 `@wp-typia/block-runtime/metadata-core`, and
 `@wp-typia/block-runtime/schema-core` stay stable even as their implementations
-are split into smaller focused modules internally. Consumers should keep
-importing the documented facade subpaths rather than reaching into those helper
-files directly.
+are split into smaller focused modules internally. `@wp-typia/block-runtime/schema-test`
+adds test-only helpers for asserting smoke/integration response payloads against
+generated `*.schema.json` artifacts. Consumers should keep importing the
+documented facade subpaths rather than reaching into those helper files
+directly.
 
 Advanced helper entrypoints such as `metadata-analysis`, `metadata-model`,
 `metadata-parser`, `metadata-php-render`, `metadata-projection`, `identifiers`,

--- a/packages/wp-typia-block-runtime/package.json
+++ b/packages/wp-typia-block-runtime/package.json
@@ -21,6 +21,11 @@
       "import": "./dist/schema-core.js",
       "default": "./dist/schema-core.js"
     },
+    "./schema-test": {
+      "types": "./dist/schema-test.d.ts",
+      "import": "./dist/schema-test.js",
+      "default": "./dist/schema-test.js"
+    },
     "./migration-types": {
       "types": "./dist/migration-types.d.ts",
       "import": "./dist/migration-types.js",
@@ -130,6 +135,7 @@
   },
   "dependencies": {
     "@wp-typia/api-client": "^0.4.5",
+    "ajv": "^8.18.0",
     "typescript": "^5.9.2"
   },
   "devDependencies": {

--- a/packages/wp-typia-block-runtime/src/schema-test.ts
+++ b/packages/wp-typia-block-runtime/src/schema-test.ts
@@ -40,6 +40,10 @@ const validatorCache = new WeakMap<
 	ValidateFunction<unknown>
 >();
 
+function isFiniteNumber(value: unknown): value is number {
+	return typeof value === "number" && Number.isFinite(value);
+}
+
 /**
  * Error thrown by `assertResponseMatchesSchema()` when a payload does not match
  * a generated JSON Schema artifact.
@@ -81,17 +85,31 @@ function getAjv(): Ajv2020 {
 		keyword: "x-typeTag",
 		schemaType: "string",
 		validate(typeTag: string, data: unknown): boolean {
-			if (typeof data !== "number" || !Number.isInteger(data)) {
-				return false;
-			}
-
 			switch (typeTag) {
 				case "int32":
-					return data >= INT32_MIN && data <= INT32_MAX;
+					return (
+						isFiniteNumber(data) &&
+						Number.isInteger(data) &&
+						data >= INT32_MIN &&
+						data <= INT32_MAX
+					);
 				case "uint32":
-					return data >= 0 && data <= UINT32_MAX;
+					return (
+						isFiniteNumber(data) &&
+						Number.isInteger(data) &&
+						data >= 0 &&
+						data <= UINT32_MAX
+					);
 				case "uint64":
-					return data >= 0 && data <= Number.MAX_SAFE_INTEGER;
+					return (
+						isFiniteNumber(data) &&
+						Number.isInteger(data) &&
+						data >= 0 &&
+						data <= Number.MAX_SAFE_INTEGER
+					);
+				case "float":
+				case "double":
+					return isFiniteNumber(data);
 				default:
 					return false;
 			}

--- a/packages/wp-typia-block-runtime/src/schema-test.ts
+++ b/packages/wp-typia-block-runtime/src/schema-test.ts
@@ -1,0 +1,292 @@
+import Ajv2020, {
+	type ErrorObject,
+	type ValidateFunction,
+} from "ajv/dist/2020.js";
+
+import type {
+	ValidationError,
+	ValidationResult,
+} from "@wp-typia/api-client";
+
+export type GeneratedSchemaDocument = Record<string, unknown>;
+
+export interface GeneratedSchemaValidatorOptions {
+	/** Human-readable contract name used in assertion failures. */
+	schemaName?: string;
+}
+
+export type GeneratedSchemaRegistry = Readonly<
+	Record<string, GeneratedSchemaDocument>
+>;
+
+export interface NamedGeneratedSchemaOptions
+	extends GeneratedSchemaValidatorOptions {
+	/** Registry keyed by TypeScript source type or another stable schema name. */
+	schemas?: GeneratedSchemaRegistry;
+}
+
+interface ResolvedGeneratedSchema {
+	schema: GeneratedSchemaDocument;
+	schemaName: string;
+}
+
+const INT32_MIN = -2_147_483_648;
+const INT32_MAX = 2_147_483_647;
+const UINT32_MAX = 4_294_967_295;
+
+let ajvInstance: Ajv2020 | null = null;
+const validatorCache = new WeakMap<
+	GeneratedSchemaDocument,
+	ValidateFunction<unknown>
+>();
+
+/**
+ * Error thrown by `assertResponseMatchesSchema()` when a payload does not match
+ * a generated JSON Schema artifact.
+ *
+ * @category Validation
+ */
+export class SchemaResponseValidationError extends Error {
+	readonly errors: ValidationError[];
+	readonly schemaName: string;
+
+	constructor(schemaName: string, errors: ValidationError[]) {
+		const summary = errors
+			.map((error) => {
+				const description = error.description ?? error.expected;
+				return `${error.path}: ${description}`;
+			})
+			.join("; ");
+
+		super(
+			`Response payload did not match generated schema "${schemaName}": ${summary}`,
+		);
+		this.name = "SchemaResponseValidationError";
+		this.errors = errors;
+		this.schemaName = schemaName;
+	}
+}
+
+function getAjv(): Ajv2020 {
+	if (ajvInstance !== null) {
+		return ajvInstance;
+	}
+
+	const ajv = new Ajv2020({
+		allErrors: true,
+		strict: false,
+	});
+
+	ajv.addKeyword({
+		keyword: "x-typeTag",
+		schemaType: "string",
+		validate(typeTag: string, data: unknown): boolean {
+			if (typeof data !== "number" || !Number.isInteger(data)) {
+				return false;
+			}
+
+			switch (typeTag) {
+				case "int32":
+					return data >= INT32_MIN && data <= INT32_MAX;
+				case "uint32":
+					return data >= 0 && data <= UINT32_MAX;
+				case "uint64":
+					return data >= 0 && data <= Number.MAX_SAFE_INTEGER;
+				default:
+					return false;
+			}
+		},
+	});
+
+	ajvInstance = ajv;
+	return ajv;
+}
+
+function getSchemaTitle(schema: GeneratedSchemaDocument): string | undefined {
+	return typeof schema.title === "string" && schema.title.length > 0
+		? schema.title
+		: undefined;
+}
+
+function resolveGeneratedSchema(
+	schemaOrName: GeneratedSchemaDocument | string,
+	options: NamedGeneratedSchemaOptions = {},
+): ResolvedGeneratedSchema {
+	if (typeof schemaOrName !== "string") {
+		return {
+			schema: schemaOrName,
+			schemaName:
+				options.schemaName ?? getSchemaTitle(schemaOrName) ?? "response",
+		};
+	}
+
+	const schema = options.schemas?.[schemaOrName];
+	if (!schema) {
+		throw new Error(
+			`Unable to find generated schema "${schemaOrName}". Pass it through the schemas option before asserting the response payload.`,
+		);
+	}
+
+	return {
+		schema,
+		schemaName: options.schemaName ?? schemaOrName,
+	};
+}
+
+function pointerSegmentToPath(segment: string): string {
+	const value = segment.replace(/~1/gu, "/").replace(/~0/gu, "~");
+	return /^\d+$/u.test(value) ? `[${value}]` : `.${value}`;
+}
+
+function jsonPointerToPath(pointer: string): string {
+	if (pointer.length === 0) {
+		return "$";
+	}
+
+	return `$${pointer
+		.split("/")
+		.slice(1)
+		.map(pointerSegmentToPath)
+		.join("")}`;
+}
+
+function appendPropertyPath(path: string, property: unknown): string {
+	if (typeof property !== "string" || property.length === 0) {
+		return path;
+	}
+
+	return /^\d+$/u.test(property) ? `${path}[${property}]` : `${path}.${property}`;
+}
+
+function normalizeAjvPath(error: ErrorObject): string {
+	const path = jsonPointerToPath(error.instancePath);
+
+	if (
+		error.keyword === "required" &&
+		typeof error.params.missingProperty === "string"
+	) {
+		return appendPropertyPath(path, error.params.missingProperty);
+	}
+
+	if (
+		error.keyword === "additionalProperties" &&
+		typeof error.params.additionalProperty === "string"
+	) {
+		return appendPropertyPath(path, error.params.additionalProperty);
+	}
+
+	return path;
+}
+
+function normalizeAjvError(error: ErrorObject): ValidationError {
+	return {
+		description: error.message,
+		expected: error.keyword,
+		path: normalizeAjvPath(error),
+		value: error.params,
+	};
+}
+
+function getValidator<T>(
+	schema: GeneratedSchemaDocument,
+): ValidateFunction<T> {
+	const cached = validatorCache.get(schema);
+	if (cached) {
+		return cached as ValidateFunction<T>;
+	}
+
+	const validator = getAjv().compile<T>(schema);
+	validatorCache.set(schema, validator as ValidateFunction<unknown>);
+	return validator;
+}
+
+/**
+ * Create a reusable validator for one generated JSON Schema document.
+ *
+ * @param schema Generated `*.schema.json` document.
+ * @returns A shared `ValidationResult`-shaped validator suitable for smoke tests.
+ * @category Validation
+ */
+export function createGeneratedSchemaValidator<T = unknown>(
+	schema: GeneratedSchemaDocument,
+	_options: GeneratedSchemaValidatorOptions = {},
+): (payload: unknown) => ValidationResult<T> {
+	const validator = getValidator<T>(schema);
+
+	return (payload: unknown): ValidationResult<T> => {
+		if (validator(payload)) {
+			return {
+				data: payload as T,
+				errors: [],
+				isValid: true,
+			};
+		}
+
+		return {
+			data: undefined,
+			errors: (validator.errors ?? []).map(normalizeAjvError),
+			isValid: false,
+		};
+	};
+}
+
+/**
+ * Create a reusable response validator for one generated JSON Schema document.
+ *
+ * @param schema Generated response `*.schema.json` document.
+ * @returns A shared `ValidationResult`-shaped validator suitable for smoke tests.
+ * @category Validation
+ */
+export function createResponseSchemaValidator<T = unknown>(
+	schema: GeneratedSchemaDocument,
+	options: GeneratedSchemaValidatorOptions = {},
+): (payload: unknown) => ValidationResult<T> {
+	return createGeneratedSchemaValidator<T>(schema, options);
+}
+
+/**
+ * Validate a response payload against a generated schema document or named
+ * schema registry entry.
+ *
+ * @param schemaOrName Generated schema document, or a schema name present in `options.schemas`.
+ * @param payload Untrusted response payload to validate.
+ * @param options Optional schema registry and display name.
+ * @returns Shared validation result with field-level paths such as `$.count`.
+ * @category Validation
+ */
+export function validateResponseMatchesSchema<T = unknown>(
+	schemaOrName: GeneratedSchemaDocument | string,
+	payload: unknown,
+	options: NamedGeneratedSchemaOptions = {},
+): ValidationResult<T> {
+	const { schema } = resolveGeneratedSchema(schemaOrName, options);
+	return createResponseSchemaValidator<T>(schema, options)(payload);
+}
+
+/**
+ * Assert that a response payload matches a generated schema document or named
+ * schema registry entry.
+ *
+ * @param schemaOrName Generated schema document, or a schema name present in `options.schemas`.
+ * @param payload Untrusted response payload to validate.
+ * @param options Optional schema registry and display name.
+ * @returns The validated payload typed as `T`.
+ * @throws {SchemaResponseValidationError} When validation fails.
+ * @category Validation
+ */
+export function assertResponseMatchesSchema<T = unknown>(
+	schemaOrName: GeneratedSchemaDocument | string,
+	payload: unknown,
+	options: NamedGeneratedSchemaOptions = {},
+): T {
+	const { schema, schemaName } = resolveGeneratedSchema(schemaOrName, options);
+	const validation = createResponseSchemaValidator<T>(schema, {
+		schemaName,
+	})(payload);
+
+	if (!validation.isValid) {
+		throw new SchemaResponseValidationError(schemaName, validation.errors);
+	}
+
+	return validation.data as T;
+}

--- a/packages/wp-typia-block-runtime/tests/block-runtime.test.ts
+++ b/packages/wp-typia-block-runtime/tests/block-runtime.test.ts
@@ -21,6 +21,7 @@ describe("@wp-typia/block-runtime", () => {
 			rootModule,
 			blocksModule,
 			schemaCoreModule,
+			schemaTestModule,
 			migrationTypesModule,
 			metadataCoreModule,
 			defaultsModule,
@@ -32,6 +33,7 @@ describe("@wp-typia/block-runtime", () => {
 			import("@wp-typia/block-runtime"),
 			import("@wp-typia/block-runtime/blocks"),
 			import("@wp-typia/block-runtime/schema-core"),
+			import("@wp-typia/block-runtime/schema-test"),
 			import("@wp-typia/block-runtime/migration-types"),
 			import("@wp-typia/block-runtime/metadata-core"),
 			import("@wp-typia/block-runtime/defaults"),
@@ -60,6 +62,8 @@ describe("@wp-typia/block-runtime", () => {
 		expect(typeof schemaCoreModule.manifestToJsonSchema).toBe("function");
 		expect(typeof schemaCoreModule.manifestToOpenApi).toBe("function");
 		expect(typeof schemaCoreModule.normalizeEndpointAuthDefinition).toBe("function");
+		expect(typeof schemaTestModule.assertResponseMatchesSchema).toBe("function");
+		expect(typeof schemaTestModule.createResponseSchemaValidator).toBe("function");
 		expect(Object.keys(migrationTypesModule)).toEqual([]);
 		expect(typeof metadataCoreModule.defineEndpointManifest).toBe("function");
 		expect(typeof metadataCoreModule.runSyncBlockMetadata).toBe("function");

--- a/packages/wp-typia-block-runtime/tests/schema-test.test.ts
+++ b/packages/wp-typia-block-runtime/tests/schema-test.test.ts
@@ -15,6 +15,11 @@ interface ExternalRetrieveResponse {
 	status: "ok";
 }
 
+interface MetricResponse {
+	ratio: number;
+	velocity: number;
+}
+
 const externalRetrieveResponseSchema = {
 	$schema: "https://json-schema.org/draft/2020-12/schema",
 	additionalProperties: false,
@@ -36,6 +41,24 @@ const externalRetrieveResponseSchema = {
 	},
 	required: ["count", "items", "status"],
 	title: "ExternalRetrieveResponse",
+	type: "object",
+} satisfies GeneratedSchemaDocument;
+
+const metricResponseSchema = {
+	$schema: "https://json-schema.org/draft/2020-12/schema",
+	additionalProperties: false,
+	properties: {
+		ratio: {
+			type: "number",
+			"x-typeTag": "double",
+		},
+		velocity: {
+			type: "number",
+			"x-typeTag": "float",
+		},
+	},
+	required: ["ratio", "velocity"],
+	title: "MetricResponse",
 	type: "object",
 } satisfies GeneratedSchemaDocument;
 
@@ -77,6 +100,35 @@ describe("@wp-typia/block-runtime/schema-test", () => {
 			"additionalProperties",
 			"x-typeTag",
 			"type",
+		]);
+	});
+
+	test("accepts floating-point type tags for generated response schemas", () => {
+		const validate =
+			createResponseSchemaValidator<MetricResponse>(metricResponseSchema);
+
+		const valid = validate({
+			ratio: 0.125,
+			velocity: -12.5,
+		});
+		expect(valid).toEqual({
+			data: {
+				ratio: 0.125,
+				velocity: -12.5,
+			},
+			errors: [],
+			isValid: true,
+		});
+
+		const invalid = validate({
+			ratio: Number.POSITIVE_INFINITY,
+			velocity: "fast",
+		});
+		expect(invalid.isValid).toBe(false);
+		expect(invalid.errors.map((error) => error.path)).toEqual([
+			"$.ratio",
+			"$.velocity",
+			"$.velocity",
 		]);
 	});
 

--- a/packages/wp-typia-block-runtime/tests/schema-test.test.ts
+++ b/packages/wp-typia-block-runtime/tests/schema-test.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+	SchemaResponseValidationError,
+	assertResponseMatchesSchema,
+	createGeneratedSchemaValidator,
+	createResponseSchemaValidator,
+	validateResponseMatchesSchema,
+	type GeneratedSchemaDocument,
+} from "../src/schema-test.js";
+
+interface ExternalRetrieveResponse {
+	count: number;
+	items: string[];
+	status: "ok";
+}
+
+const externalRetrieveResponseSchema = {
+	$schema: "https://json-schema.org/draft/2020-12/schema",
+	additionalProperties: false,
+	properties: {
+		count: {
+			type: "integer",
+			"x-typeTag": "uint32",
+		},
+		items: {
+			items: {
+				type: "string",
+			},
+			type: "array",
+		},
+		status: {
+			enum: ["ok"],
+			type: "string",
+		},
+	},
+	required: ["count", "items", "status"],
+	title: "ExternalRetrieveResponse",
+	type: "object",
+} satisfies GeneratedSchemaDocument;
+
+describe("@wp-typia/block-runtime/schema-test", () => {
+	test("validates generated response schemas through reusable validators", () => {
+		const validate =
+			createResponseSchemaValidator<ExternalRetrieveResponse>(
+				externalRetrieveResponseSchema,
+			);
+
+		const valid = validate({
+			count: 2,
+			items: ["first", "second"],
+			status: "ok",
+		});
+		expect(valid).toEqual({
+			data: {
+				count: 2,
+				items: ["first", "second"],
+				status: "ok",
+			},
+			errors: [],
+			isValid: true,
+		});
+
+		const invalid = validate({
+			count: -1,
+			items: ["first", 2],
+			status: "ok",
+			unexpected: true,
+		});
+		expect(invalid.isValid).toBe(false);
+		expect(invalid.errors.map((error) => error.path)).toEqual([
+			"$.unexpected",
+			"$.count",
+			"$.items[1]",
+		]);
+		expect(invalid.errors.map((error) => error.expected)).toEqual([
+			"additionalProperties",
+			"x-typeTag",
+			"type",
+		]);
+	});
+
+	test("validates named generated schemas from a registry", () => {
+		const valid = validateResponseMatchesSchema<ExternalRetrieveResponse>(
+			"ExternalRetrieveResponse",
+			{
+				count: 1,
+				items: [],
+				status: "ok",
+			},
+			{
+				schemas: {
+					ExternalRetrieveResponse: externalRetrieveResponseSchema,
+				},
+			},
+		);
+
+		expect(valid.isValid).toBe(true);
+
+		expect(() =>
+			validateResponseMatchesSchema("MissingResponse", {}, {
+				schemas: {
+					ExternalRetrieveResponse: externalRetrieveResponseSchema,
+				},
+			}),
+		).toThrow(
+			'Unable to find generated schema "MissingResponse". Pass it through the schemas option before asserting the response payload.',
+		);
+	});
+
+	test("asserts response schemas with field-level failure paths", () => {
+		const response = assertResponseMatchesSchema<ExternalRetrieveResponse>(
+			externalRetrieveResponseSchema,
+			{
+				count: 3,
+				items: ["first"],
+				status: "ok",
+			},
+		);
+
+		expect(response.count).toBe(3);
+
+		expect(() =>
+			assertResponseMatchesSchema(
+				"ExternalRetrieveResponse",
+				{
+					count: "3",
+					items: [],
+				},
+				{
+					schemas: {
+						ExternalRetrieveResponse: externalRetrieveResponseSchema,
+					},
+				},
+			),
+		).toThrow(SchemaResponseValidationError);
+
+		try {
+			assertResponseMatchesSchema(
+				"ExternalRetrieveResponse",
+				{
+					count: "3",
+					items: [],
+				},
+				{
+					schemas: {
+						ExternalRetrieveResponse: externalRetrieveResponseSchema,
+					},
+				},
+			);
+		} catch (error) {
+			expect(error).toBeInstanceOf(SchemaResponseValidationError);
+			expect((error as SchemaResponseValidationError).schemaName).toBe(
+				"ExternalRetrieveResponse",
+			);
+			expect((error as SchemaResponseValidationError).errors).toMatchObject([
+				{
+					expected: "required",
+					path: "$.status",
+				},
+				{
+					expected: "type",
+					path: "$.count",
+				},
+				{
+					expected: "x-typeTag",
+					path: "$.count",
+				},
+			]);
+			expect((error as Error).message).toContain(
+				'generated schema "ExternalRetrieveResponse"',
+			);
+		}
+	});
+
+	test("exposes a generic schema validator for non-response contract payloads", () => {
+		const validate =
+			createGeneratedSchemaValidator<ExternalRetrieveResponse>(
+				externalRetrieveResponseSchema,
+			);
+
+		expect(
+			validate({
+				count: 0,
+				items: [],
+				status: "ok",
+			}).isValid,
+		).toBe(true);
+	});
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,9 @@
       "@wp-typia/block-runtime/schema-core": [
         "packages/wp-typia-block-runtime/src/schema-core.ts"
       ],
+      "@wp-typia/block-runtime/schema-test": [
+        "packages/wp-typia-block-runtime/src/schema-test.ts"
+      ],
       "@wp-typia/block-runtime/migration-types": [
         "packages/wp-typia-block-runtime/src/migration-types.ts"
       ],

--- a/typedoc.public.json
+++ b/typedoc.public.json
@@ -11,6 +11,7 @@
     "packages/wp-typia-project-tools/src/runtime/index.ts",
     "packages/wp-typia-block-runtime/src/index.ts",
     "packages/wp-typia-block-runtime/src/schema-core.ts",
+    "packages/wp-typia-block-runtime/src/schema-test.ts",
     "packages/wp-typia-block-runtime/src/migration-types.ts",
     "packages/wp-typia-block-runtime/src/metadata-core.ts",
     "packages/wp-typia-block-runtime/src/identifiers.ts",


### PR DESCRIPTION
Closes #890

## Summary
- add @wp-typia/block-runtime/schema-test helpers for validating generated JSON Schema response artifacts
- normalize validation failures to field-level paths such as $.items[1] and $.status
- migrate the contract adapter PoC and docs to the shared helper path

## Tests
- bun install --frozen-lockfile
- bun test packages/wp-typia-block-runtime/tests/schema-test.test.ts
- bun run --filter @wp-typia/block-runtime build
- bun test packages/wp-typia-block-runtime/tests/block-runtime.test.ts
- bun run --filter api-contract-adapter-poc typecheck
- bun run typecheck
- bun run format:check
- bun run changesets:validate
- bun run manifest-policy:validate
- bun run runtime-coupling:validate
- bun run docs:build:site
- bun run publish:validate
- git diff --check

Note: bun run docs:build:api still reports pre-existing public docs audit gaps outside the new schema-test entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added schema validation helpers (`@wp-typia/block-runtime/schema-test`) to test API responses against generated JSON Schema artifacts
  * Field-level error reporting with normalized JSONPath-like failure paths (e.g., `$.items[0]`, `$.status`)

* **Documentation**
  * Updated README and API reference with schema validation examples and integration guidance

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/905)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->