### PR TITLE
feat(settings): add secret field contract metadata

### DIFF
--- a/.sampo/changesets/893-secret-settings-contracts.md
+++ b/.sampo/changesets/893-secret-settings-contracts.md
@@ -1,0 +1,7 @@
+---
+npm/@wp-typia/block-runtime: minor
+npm/@wp-typia/project-tools: minor
+npm/wp-typia: minor
+---
+
+Add first-class secret/write-only field metadata for settings-style REST contracts, including Typia tags, OpenAPI schema extensions, manual REST scaffold flags, and tests that keep raw secrets out of response contracts.

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ wp-typia add contract external-retrieve-response --type ExternalRetrieveResponse
 wp-typia add rest-resource snapshots --namespace my-plugin/v1 --methods list,read,create
 wp-typia add rest-resource snapshots --namespace my-plugin/v1 --methods read,update --route-pattern '/snapshots/(?P<id>[\d]+)' --permission-callback my_plugin_can_manage_snapshots
 wp-typia add rest-resource external-record --manual --namespace legacy/v1 --method GET --auth authenticated --path '/records/(?P<id>[\d]+)'
+wp-typia add rest-resource integration-settings --manual --namespace my-plugin/v1 --method POST --secret-field apiKey
 wp-typia add post-meta integration-state --post-type post --type IntegrationStateMeta
 wp-typia add editor-plugin review-workflow --slot sidebar
 wp-typia add editor-plugin seo-notes --slot document-setting-panel
@@ -179,6 +180,11 @@ wp-typia add hooked-block counter-card --anchor core/post-content --position aft
 - Need to describe a REST route owned by another plugin or legacy controller?
   Use `wp-typia add rest-resource <name> --manual` to generate TypeScript
   contracts, schemas, OpenAPI, and clients without PHP route glue.
+- Need settings contracts that accept secrets without returning them? Add
+  `--secret-field <field>` to a manual REST contract. The request body gets a
+  `tags.Secret<"has<Field>">` write-only field from
+  `@wp-typia/block-runtime/typia-tags`, while the response scaffold exposes
+  only a masked boolean such as `hasApiKey`.
 - Need generated REST contracts to fit an existing controller or permission
   model? Add `--route-pattern`, `--permission-callback`, or `--controller-class`
   while keeping generated OpenAPI and client paths aligned.

--- a/apps/docs/src/content/docs/architecture/runtime-import-policy.md
+++ b/apps/docs/src/content/docs/architecture/runtime-import-policy.md
@@ -42,6 +42,8 @@ surfaces.
   Shared manifest and migration contract implementation owner.
 - `@wp-typia/block-runtime/schema-core`
   Shared schema/OpenAPI implementation owner.
+- `@wp-typia/block-runtime/typia-tags`
+  Type-only Typia tag namespace for generated-project metadata tags.
 - `@wp-typia/block-runtime/metadata-core`
   Metadata sync and endpoint manifest helpers.
 - `@wp-typia/block-runtime/metadata-analysis`

--- a/apps/docs/src/content/docs/architecture/runtime-surface.md
+++ b/apps/docs/src/content/docs/architecture/runtime-surface.md
@@ -34,6 +34,7 @@ This document is descriptive, not normative. For support guarantees, see
   Generated-project helper root.
 - `@wp-typia/block-runtime/migration-types`
 - `@wp-typia/block-runtime/schema-core`
+- `@wp-typia/block-runtime/typia-tags`
 - `@wp-typia/block-runtime/metadata-core`
 - `@wp-typia/block-runtime/metadata-analysis`
 - `@wp-typia/block-runtime/metadata-model`
@@ -66,6 +67,7 @@ This document is descriptive, not normative. For support guarantees, see
 - `@wp-typia/project-tools/typia-llm`
 - `@wp-typia/block-runtime/migration-types`
 - `@wp-typia/block-runtime/schema-core`
+- `@wp-typia/block-runtime/typia-tags`
 - `@wp-typia/block-runtime/metadata-core`
 - `@wp-typia/block-runtime/blocks`
 - `@wp-typia/block-runtime/defaults`

--- a/apps/docs/src/content/docs/reference/api.md
+++ b/apps/docs/src/content/docs/reference/api.md
@@ -52,6 +52,9 @@ secondary imports compared with the core package roots and primary subpaths.
 - `@wp-typia/block-runtime/schema-test`
   Test helpers for validating smoke/integration response payloads against
   generated JSON Schema artifacts.
+- `@wp-typia/block-runtime/typia-tags`
+  Type-only Typia tag namespace that includes wp-typia metadata tags such as
+  `Secret`, `Source`, and `Selector`.
 - `@wp-typia/block-runtime/metadata-core`
   Metadata sync and endpoint manifest helpers.
 - `@wp-typia/block-runtime/metadata-analysis`
@@ -540,6 +543,7 @@ Generated projects can also import shared runtime helpers from `@wp-typia/block-
 - `@wp-typia/block-runtime/validation`
 - `@wp-typia/block-runtime/editor`
 - `@wp-typia/block-runtime/identifiers`
+- `@wp-typia/block-runtime/typia-tags`
 
 Use `@wp-typia/block-runtime/metadata-core` for metadata sync and
 `@wp-typia/block-runtime/*` for generated-project runtime helpers.

--- a/apps/docs/src/content/docs/reference/api.md
+++ b/apps/docs/src/content/docs/reference/api.md
@@ -54,7 +54,7 @@ secondary imports compared with the core package roots and primary subpaths.
   generated JSON Schema artifacts.
 - `@wp-typia/block-runtime/typia-tags`
   Type-only Typia tag namespace that includes wp-typia metadata tags such as
-  `Secret`, `Source`, and `Selector`.
+  `Secret`, `WriteOnly`, `Source`, and `Selector`.
 - `@wp-typia/block-runtime/metadata-core`
   Metadata sync and endpoint manifest helpers.
 - `@wp-typia/block-runtime/metadata-analysis`

--- a/apps/docs/src/content/docs/reference/cli.md
+++ b/apps/docs/src/content/docs/reference/cli.md
@@ -200,6 +200,7 @@ wp-typia add binding-source <name> --block <block-slug|namespace/block-slug> --a
 wp-typia add contract <name> --type <ExportedTypeName>
 wp-typia add rest-resource <name> --namespace <vendor/v1> --methods list,read,create
 wp-typia add rest-resource <name> --namespace <vendor/v1> --methods read,update --route-pattern '/records/(?P<id>[\d]+)' --permission-callback my_plugin_can_manage_records
+wp-typia add rest-resource integration-settings --manual --namespace <vendor/v1> --method POST --secret-field apiKey
 wp-typia add post-meta <name> --post-type post --type IntegrationStateMeta
 wp-typia add ability <name>
 wp-typia add ai-feature <name> --namespace <vendor/v1>
@@ -227,6 +228,8 @@ Common flags:
 | `--permission-callback <callback>`                               | PHP permission callback for generated REST resource route registrations.                                                                                                       |
 | `--controller-class <ClassName>`                                 | PHP controller class wrapper for generated REST resource route callbacks.                                                                                                      |
 | `--controller-extends <BaseClass>`                               | Optional base class for generated REST resource controller wrappers.                                                                                                           |
+| `--secret-field <field>`                                         | Write-only request body field for manual settings REST contracts.                                                                                                              |
+| `--secret-state-field <field>`                                   | Masked response boolean field for `--secret-field`; defaults to `has<SecretField>`.                                                                                            |
 | `--type <ExportedTypeName>`                                      | Exported TypeScript type or interface for standalone contract schema artifacts.                                                                                                |
 | `--post-type <post-type>`                                        | WordPress post type key for post-meta contract scaffolds.                                                                                                                      |
 | `--meta-key <meta-key>`                                          | Optional WordPress meta key for post-meta workflows. Defaults to `_<phpPrefix>_<name>`.                                                                                        |
@@ -260,6 +263,14 @@ named type in `scripts/block-config.ts`, and generate
 `src/contracts/<name>.schema.json`. They do not create PHP route glue. Use them
 for external WordPress routes, PHP assertions, or smoke tests that need a stable
 runtime schema before a full `rest-resource` or manual REST contract exists.
+
+Manual REST settings contracts can declare write-only secrets with
+`--secret-field <field>`. The generated request type marks that property with
+`tags.Secret<"has<Field>">` from
+`@wp-typia/block-runtime/typia-tags`, generated request schemas/OpenAPI include
+`writeOnly: true`, and the response scaffold exposes only the masked state
+field such as `hasApiKey`. Edit the PHP route owner to persist the raw secret
+server-side and never return it from response/client artifacts.
 
 Post-meta contract scaffolds create `src/post-meta/<name>/types.ts`, generate
 `meta.schema.json`, and wire `inc/post-meta/<name>.php` with a

--- a/packages/wp-typia-block-runtime/README.md
+++ b/packages/wp-typia-block-runtime/README.md
@@ -29,6 +29,7 @@ import { collectPersistentBlockIdentityRepairs } from '@wp-typia/block-runtime/i
 import { assertResponseMatchesSchema } from '@wp-typia/block-runtime/schema-test';
 import { createNestedAttributeUpdater } from '@wp-typia/block-runtime/validation';
 import { runSyncBlockMetadata } from '@wp-typia/block-runtime/metadata-core';
+import type { tags } from '@wp-typia/block-runtime/typia-tags';
 ```
 
 `wp-typia` remains the CLI package.

--- a/packages/wp-typia-block-runtime/package.json
+++ b/packages/wp-typia-block-runtime/package.json
@@ -26,6 +26,11 @@
       "import": "./dist/schema-test.js",
       "default": "./dist/schema-test.js"
     },
+    "./typia-tags": {
+      "types": "./dist/typia-tags.d.ts",
+      "import": "./dist/typia-tags.js",
+      "default": "./dist/typia-tags.js"
+    },
     "./migration-types": {
       "types": "./dist/migration-types.d.ts",
       "import": "./dist/migration-types.js",

--- a/packages/wp-typia-block-runtime/src/metadata-model.ts
+++ b/packages/wp-typia-block-runtime/src/metadata-model.ts
@@ -81,7 +81,10 @@ export interface AttributeNode {
 	union?: AttributeUnion | null;
 	wp: {
 		selector: string | null;
+		secret: boolean;
+		secretStateField: string | null;
 		source: WordPressAttributeSource | null;
+		writeOnly: boolean;
 	};
 }
 
@@ -131,8 +134,11 @@ export interface ManifestAttribute {
 		enum: Array<string | number | boolean> | null;
 		hasDefault: boolean;
 		selector?: string | null;
+		secret?: boolean;
+		secretStateField?: string | null;
 		source?: WordPressAttributeSource | null;
 		type: WordPressAttributeKind;
+		writeOnly?: boolean;
 	};
 }
 
@@ -209,7 +215,10 @@ export function baseNode(kind: AttributeKind, pathLabel: string): AttributeNode 
 		union: null,
 		wp: {
 			selector: null,
+			secret: false,
+			secretStateField: null,
 			source: null,
+			writeOnly: false,
 		},
 	};
 }

--- a/packages/wp-typia-block-runtime/src/metadata-parser-tags.ts
+++ b/packages/wp-typia-block-runtime/src/metadata-parser-tags.ts
@@ -350,9 +350,11 @@ export function applyTag(
 				pathLabel,
 			);
 			return;
-		case "WriteOnly":
-			node.wp.writeOnly = parseBooleanArgument(arg, tagName, pathLabel);
+		case "WriteOnly": {
+			const writeOnly = parseBooleanArgument(arg, tagName, pathLabel);
+			node.wp.writeOnly = node.wp.secret ? true : writeOnly;
 			return;
+		}
 		default:
 			return;
 	}

--- a/packages/wp-typia-block-runtime/src/metadata-parser-tags.ts
+++ b/packages/wp-typia-block-runtime/src/metadata-parser-tags.ts
@@ -23,8 +23,10 @@ const SUPPORTED_TAGS = new Set([
 	"MultipleOf",
 	"Pattern",
 	"Selector",
+	"Secret",
 	"Source",
 	"Type",
+	"WriteOnly",
 ]);
 
 export function mergePrimitiveIntersection(
@@ -279,6 +281,18 @@ export function applyTag(
 		case "Selector":
 			node.wp.selector = parseStringLikeArgument(arg, tagName, pathLabel);
 			return;
+		case "Secret": {
+			const secretStateField = parseStringLikeArgument(arg, tagName, pathLabel);
+			if (!secretStateField) {
+				throw new Error(
+					`Tag "Secret" expects a non-empty masked state field at ${pathLabel}`,
+				);
+			}
+			node.wp.secret = true;
+			node.wp.secretStateField = secretStateField;
+			node.wp.writeOnly = true;
+			return;
+		}
 		case "Source":
 			node.wp.source = parseWordPressAttributeSource(arg, pathLabel);
 			return;
@@ -335,6 +349,9 @@ export function applyTag(
 				tagName,
 				pathLabel,
 			);
+			return;
+		case "WriteOnly":
+			node.wp.writeOnly = parseBooleanArgument(arg, tagName, pathLabel);
 			return;
 		default:
 			return;
@@ -412,6 +429,20 @@ function parseStringLikeArgument(
 	if (typeof value !== "string") {
 		throw new Error(
 			`Tag "${tagName}" expects a string literal at ${pathLabel}`,
+		);
+	}
+	return value;
+}
+
+function parseBooleanArgument(
+	node: ts.TypeNode,
+	tagName: string,
+	pathLabel: string,
+): boolean {
+	const value = extractLiteralValue(node);
+	if (typeof value !== "boolean") {
+		throw new Error(
+			`Tag "${tagName}" expects a boolean literal at ${pathLabel}`,
 		);
 	}
 	return value;

--- a/packages/wp-typia-block-runtime/src/metadata-parser.ts
+++ b/packages/wp-typia-block-runtime/src/metadata-parser.ts
@@ -205,7 +205,10 @@ function parseInterfaceDeclaration(
 		union: null,
 		wp: {
 			selector: null,
+			secret: false,
+			secretStateField: null,
 			source: null,
+			writeOnly: false,
 		},
 	};
 }
@@ -253,7 +256,10 @@ export function parseTypeNode(
 			union: null,
 			wp: {
 				selector: null,
+				secret: false,
+				secretStateField: null,
 				source: null,
+				writeOnly: false,
 			},
 		};
 	}
@@ -378,7 +384,10 @@ function parseUnionType(
 			union: null,
 			wp: {
 				selector: null,
+				secret: false,
+				secretStateField: null,
 				source: null,
+				writeOnly: false,
 			},
 		};
 	}
@@ -454,7 +463,10 @@ function parseDiscriminatedUnion(
 		},
 		wp: {
 			selector: null,
+			secret: false,
+			secretStateField: null,
 			source: null,
+			writeOnly: false,
 		},
 	};
 }
@@ -528,7 +540,10 @@ function parseTypeLiteral(
 		union: null,
 		wp: {
 			selector: null,
+			secret: false,
+			secretStateField: null,
 			source: null,
+			writeOnly: false,
 		},
 	};
 }
@@ -553,7 +568,10 @@ function parseLiteralType(
 		union: null,
 		wp: {
 			selector: null,
+			secret: false,
+			secretStateField: null,
 			source: null,
+			writeOnly: false,
 		},
 	};
 }
@@ -582,7 +600,10 @@ function parseTypeReference(
 			union: null,
 			wp: {
 				selector: null,
+				secret: false,
+				secretStateField: null,
 				source: null,
+				writeOnly: false,
 			},
 		};
 	}

--- a/packages/wp-typia-block-runtime/src/metadata-projection.ts
+++ b/packages/wp-typia-block-runtime/src/metadata-projection.ts
@@ -52,6 +52,8 @@ export function createBlockJsonAttribute(
 	if (node.constraints.multipleOf !== null) reasons.push("multipleOf");
 	if (node.constraints.pattern !== null) reasons.push("pattern");
 	if (node.constraints.typeTag !== null) reasons.push("typeTag");
+	if (node.wp.secret) reasons.push("secret");
+	if (node.wp.writeOnly) reasons.push("writeOnly");
 	if (node.kind === "array" && node.items !== undefined) reasons.push("items");
 	if (node.kind === "object" && node.properties !== undefined)
 		reasons.push("properties");
@@ -109,8 +111,13 @@ export function createManifestAttribute(node: AttributeNode): ManifestAttribute 
 			enum: node.enumValues ? [...node.enumValues] : null,
 			hasDefault: node.defaultValue !== undefined,
 			...(node.wp.selector !== null ? { selector: node.wp.selector } : {}),
+			...(node.wp.secret ? { secret: true } : {}),
+			...(node.wp.secretStateField !== null
+				? { secretStateField: node.wp.secretStateField }
+				: {}),
 			...(node.wp.source !== null ? { source: node.wp.source } : {}),
 			type: getWordPressKind(node),
+			...(node.wp.writeOnly ? { writeOnly: true } : {}),
 		},
 	};
 }

--- a/packages/wp-typia-block-runtime/src/migration-types.ts
+++ b/packages/wp-typia-block-runtime/src/migration-types.ts
@@ -42,10 +42,24 @@ export interface ManifestWpMetadata {
 	enum?: JsonValue[] | null;
 	hasDefault?: boolean;
 	selector?: string | null;
+	/**
+	 * Marks a field as containing sensitive data such as an API key or token.
+	 * Secret fields are normally paired with `writeOnly` and excluded from
+	 * response contracts.
+	 */
 	secret?: boolean;
+	/**
+	 * Optional companion response field that exposes masked state for a secret,
+	 * for example `hasApiKey`, without returning the raw value.
+	 */
 	secretStateField?: string | null;
 	source?: "html" | "text" | "rich-text" | null;
 	type?: string | null;
+	/**
+	 * Marks a field as accepted in writes but not returned to clients. When
+	 * combined with `secret`, generated schemas describe the field as sensitive
+	 * and write-only.
+	 */
 	writeOnly?: boolean;
 }
 

--- a/packages/wp-typia-block-runtime/src/migration-types.ts
+++ b/packages/wp-typia-block-runtime/src/migration-types.ts
@@ -42,8 +42,11 @@ export interface ManifestWpMetadata {
 	enum?: JsonValue[] | null;
 	hasDefault?: boolean;
 	selector?: string | null;
+	secret?: boolean;
+	secretStateField?: string | null;
 	source?: "html" | "text" | "rich-text" | null;
 	type?: string | null;
+	writeOnly?: boolean;
 }
 
 export interface ManifestAttribute {

--- a/packages/wp-typia-block-runtime/src/schema-core-documents.ts
+++ b/packages/wp-typia-block-runtime/src/schema-core-documents.ts
@@ -31,6 +31,8 @@ const WP_TYPIA_OPENAPI_EXTENSION_KEYS = {
 	AUTH_INTENT: "x-typia-authIntent",
 	AUTH_POLICY: "x-wp-typia-authPolicy",
 	PUBLIC_TOKEN_FIELD: "x-wp-typia-publicTokenField",
+	SECRET: "x-wp-typia-secret",
+	SECRET_STATE_FIELD: "x-wp-typia-secretStateField",
 	TYPE_TAG: "x-typeTag",
 } as const;
 
@@ -86,6 +88,26 @@ function applyCommonConstraints(
 	applyConstraintIfNumber(schema, "multipleOf", constraints.multipleOf);
 	applyConstraintIfNumber(schema, "minItems", constraints.minItems);
 	applyConstraintIfNumber(schema, "maxItems", constraints.maxItems);
+}
+
+function applyWordPressFieldMetadata(
+	schema: JsonSchemaObject,
+	attribute: ManifestAttribute,
+): void {
+	if (attribute.wp.writeOnly) {
+		schema.writeOnly = true;
+	}
+	if (attribute.wp.secret) {
+		schema[WP_TYPIA_OPENAPI_EXTENSION_KEYS.SECRET] = true;
+		schema.description =
+			typeof schema.description === "string" && schema.description.length > 0
+				? `${schema.description} This value is write-only and must never be returned raw in responses.`
+				: "Write-only secret value. Responses should expose only masked state.";
+	}
+	if (attribute.wp.secretStateField) {
+		schema[WP_TYPIA_OPENAPI_EXTENSION_KEYS.SECRET_STATE_FIELD] =
+			attribute.wp.secretStateField;
+	}
 }
 
 function createUnionDiscriminatorProperty(branchKey: string): JsonSchemaObject {
@@ -221,6 +243,7 @@ export function manifestAttributeToJsonSchema(
 	}
 
 	applyCommonConstraints(schema, attribute.typia.constraints);
+	applyWordPressFieldMetadata(schema, attribute);
 	return schema;
 }
 

--- a/packages/wp-typia-block-runtime/src/schema-core-documents.ts
+++ b/packages/wp-typia-block-runtime/src/schema-core-documents.ts
@@ -180,14 +180,6 @@ function manifestUnionToJsonSchema(union: ManifestUnionMetadata): JsonSchemaObje
 export function manifestAttributeToJsonSchema(
 	attribute: ManifestAttribute,
 ): JsonSchemaObject {
-	if (attribute.ts.union) {
-		const schema = manifestUnionToJsonSchema(attribute.ts.union);
-		if (attribute.typia.hasDefault) {
-			schema.default = attribute.typia.defaultValue ?? null;
-		}
-		return schema;
-	}
-
 	const schema: JsonSchemaObject = {};
 	const enumValues = Array.isArray(attribute.wp.enum) ? attribute.wp.enum : null;
 	if (enumValues && enumValues.length > 0) {
@@ -233,9 +225,10 @@ export function manifestAttributeToJsonSchema(
 		}
 		case "union":
 			if (attribute.ts.union) {
-				return manifestUnionToJsonSchema(attribute.ts.union);
+				Object.assign(schema, manifestUnionToJsonSchema(attribute.ts.union));
+			} else {
+				schema.oneOf = [];
 			}
-			schema.oneOf = [];
 			break;
 		default:
 			schema.type = attribute.wp.type ?? "string";

--- a/packages/wp-typia-block-runtime/src/typia-tags.ts
+++ b/packages/wp-typia-block-runtime/src/typia-tags.ts
@@ -1,20 +1,87 @@
 /**
- * Augments `typia.tags` with wp-typia metadata tags consumed by the
- * block attribute projection pipeline.
+ * Exposes wp-typia metadata tags alongside Typia's built-in tags for the
+ * block attribute and REST contract projection pipeline.
  *
- * This module is imported for its declaration side effects so generated
- * projects can use `tags.Source` and `tags.Selector` during compile time.
+ * Generated projects can import `tags` from this module when they need
+ * wp-typia-only tags such as `Secret`, `Source`, or `Selector`.
  */
-import type {} from 'typia';
+import type { tags as TypiaTags } from 'typia';
+
+export namespace tags {
+  export type Default<Value extends boolean | bigint | number | string> =
+    TypiaTags.Default<Value>;
+
+  export type ExclusiveMaximum<Value extends bigint | number> =
+    TypiaTags.ExclusiveMaximum<Value>;
+
+  export type ExclusiveMinimum<Value extends bigint | number> =
+    TypiaTags.ExclusiveMinimum<Value>;
+
+  export type Format<Value extends TypiaTags.Format.Value> =
+    TypiaTags.Format<Value>;
+
+  export type MaxItems<Value extends number> = TypiaTags.MaxItems<Value>;
+
+  export type MaxLength<Value extends number> = TypiaTags.MaxLength<Value>;
+
+  export type Maximum<Value extends bigint | number> =
+    TypiaTags.Maximum<Value>;
+
+  export type MinItems<Value extends number> = TypiaTags.MinItems<Value>;
+
+  export type MinLength<Value extends number> = TypiaTags.MinLength<Value>;
+
+  export type Minimum<Value extends bigint | number> =
+    TypiaTags.Minimum<Value>;
+
+  export type MultipleOf<Value extends bigint | number> =
+    TypiaTags.MultipleOf<Value>;
+
+  export type Pattern<Value extends string> = TypiaTags.Pattern<Value>;
+
+  export type Type<
+    Value extends
+      | 'int32'
+      | 'uint32'
+      | 'int64'
+      | 'uint64'
+      | 'float'
+      | 'double',
+  > = TypiaTags.Type<Value>;
+
+  export type Secret<MaskedStateField extends string> = {
+    readonly __wpTypiaSecret?: MaskedStateField;
+  };
+
+  export type Source<Value extends 'html' | 'text' | 'rich-text'> = {
+    readonly __wpTypiaSource?: Value;
+  };
+
+  export type Selector<Value extends string> = {
+    readonly __wpTypiaSelector?: Value;
+  };
+
+  export type WriteOnly<Value extends true> = {
+    readonly __wpTypiaWriteOnly?: Value;
+  };
+}
 
 declare module 'typia' {
   export namespace tags {
+    export type Secret<MaskedStateField extends string> = {
+      readonly __wpTypiaSecret?: MaskedStateField;
+    };
+
     export type Source<Value extends 'html' | 'text' | 'rich-text'> = {
       readonly __wpTypiaSource?: Value;
     };
 
     export type Selector<Value extends string> = {
       readonly __wpTypiaSelector?: Value;
+    };
+
+    export type WriteOnly<Value extends true> = {
+      readonly __wpTypiaWriteOnly?: Value;
     };
   }
 }

--- a/packages/wp-typia-block-runtime/tests/block-runtime.test.ts
+++ b/packages/wp-typia-block-runtime/tests/block-runtime.test.ts
@@ -371,4 +371,118 @@ describe("@wp-typia/block-runtime", () => {
 			rmSync(projectRoot, { force: true, recursive: true });
 		}
 	});
+
+	test("REST schemas and OpenAPI document write-only secret fields", async () => {
+		const { defineEndpointManifest, syncRestOpenApi, syncTypeSchemas } =
+			await import("@wp-typia/block-runtime/metadata-core");
+		const packageRoot = resolve(import.meta.dir, "..");
+		const projectRoot = mkdtempSync(resolve(packageRoot, ".tmp-secret-schema-"));
+
+		try {
+			writeFileSync(
+				resolve(projectRoot, "api-types.ts"),
+				[
+					"import type { tags } from '@wp-typia/block-runtime/typia-tags';",
+					"",
+					"export interface SettingsUpdateRequest {",
+					"\tapiKey?: string & tags.MinLength< 1 > & tags.Secret< 'hasApiKey' >;",
+					"\twebhookSecret?: string & tags.WriteOnly< true >;",
+					"}",
+					"",
+					"export interface SettingsResponse {",
+					"\thasApiKey: boolean;",
+					"\twebhookConfigured: boolean;",
+					"}",
+					"",
+				].join("\n"),
+				"utf8",
+			);
+
+			await syncTypeSchemas({
+				jsonSchemaFile: "request.schema.json",
+				openApiFile: "request.openapi.json",
+				projectRoot,
+				sourceTypeName: "SettingsUpdateRequest",
+				typesFile: "api-types.ts",
+			});
+			await syncTypeSchemas({
+				jsonSchemaFile: "response.schema.json",
+				projectRoot,
+				sourceTypeName: "SettingsResponse",
+				typesFile: "api-types.ts",
+			});
+			await syncRestOpenApi({
+				manifest: defineEndpointManifest({
+					contracts: {
+						request: {
+							sourceTypeName: "SettingsUpdateRequest",
+						},
+						response: {
+							sourceTypeName: "SettingsResponse",
+						},
+					},
+					endpoints: [
+						{
+							auth: "authenticated",
+							bodyContract: "request",
+							method: "POST",
+							operationId: "updateSettings",
+							path: "/demo/v1/settings",
+							responseContract: "response",
+							tags: ["Settings"],
+							wordpressAuth: {
+								mechanism: "rest-nonce",
+							},
+						},
+					],
+				}),
+				openApiFile: "api.openapi.json",
+				projectRoot,
+				typesFile: "api-types.ts",
+			});
+
+			const requestSchema = JSON.parse(
+				readFileSync(resolve(projectRoot, "request.schema.json"), "utf8"),
+			) as {
+				properties: Record<string, Record<string, unknown>>;
+			};
+			const responseSchema = JSON.parse(
+				readFileSync(resolve(projectRoot, "response.schema.json"), "utf8"),
+			) as {
+				properties: Record<string, unknown>;
+			};
+			const openApi = JSON.parse(
+				readFileSync(resolve(projectRoot, "api.openapi.json"), "utf8"),
+			) as {
+				components: {
+					schemas: Record<string, { properties: Record<string, Record<string, unknown>> }>;
+				};
+			};
+
+			expect(requestSchema.properties.apiKey).toMatchObject({
+				"description":
+					"Write-only secret value. Responses should expose only masked state.",
+				writeOnly: true,
+				"x-wp-typia-secret": true,
+				"x-wp-typia-secretStateField": "hasApiKey",
+			});
+			expect(requestSchema.properties.webhookSecret).toMatchObject({
+				writeOnly: true,
+			});
+			expect(responseSchema.properties).not.toHaveProperty("apiKey");
+			expect(responseSchema.properties).toHaveProperty("hasApiKey");
+			expect(
+				openApi.components.schemas.SettingsUpdateRequest.properties.apiKey,
+			).toMatchObject({
+				writeOnly: true,
+				"x-wp-typia-secret": true,
+				"x-wp-typia-secretStateField": "hasApiKey",
+			});
+			expect(
+				openApi.components.schemas.SettingsResponse.properties,
+			).not.toHaveProperty("apiKey");
+		} finally {
+			rmSync(projectRoot, { force: true, recursive: true });
+		}
+	});
 });

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-types.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-types.ts
@@ -273,6 +273,10 @@ export interface RunAddPostMetaCommandOptions {
  * manual mode. Defaults to `<PascalName>Response`.
  * @property routePattern Optional generated item route pattern, relative to the
  * namespace. Defaults to `/<name>/item`.
+ * @property secretFieldName Optional write-only secret field name for manual
+ * settings contracts. Requires a request body.
+ * @property secretStateFieldName Optional masked response boolean field for
+ * `secretFieldName`. Defaults to `has<PascalSecretField>`.
  */
 export interface RunAddRestResourceCommandOptions {
 	auth?: string;
@@ -290,6 +294,8 @@ export interface RunAddRestResourceCommandOptions {
 	restResourceName: string;
 	responseTypeName?: string;
 	routePattern?: string;
+	secretFieldName?: string;
+	secretStateFieldName?: string;
 }
 
 /**

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest-source-emitters.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest-source-emitters.ts
@@ -154,6 +154,8 @@ export function buildManualRestContractConfigEntry(options: {
  * @param options.queryTypeName Exported query type name.
  * @param options.responseTypeName Exported response type name.
  * @param options.restResourceSlug Normalized workspace REST contract slug.
+ * @param options.secretFieldName Optional raw secret field included only in the request body.
+ * @param options.secretStateFieldName Optional masked response boolean field.
  * @returns TypeScript source for `api-types.ts`.
  */
 export function buildManualRestContractTypesSource(options: {
@@ -161,10 +163,12 @@ export function buildManualRestContractTypesSource(options: {
 	queryTypeName: string;
 	responseTypeName: string;
 	restResourceSlug: string;
+	secretFieldName?: string;
+	secretStateFieldName?: string;
 }): string {
 	const title = toTitleCase(options.restResourceSlug);
 	const lines = [
-		"import { tags } from 'typia';",
+		"import type { tags } from '@wp-typia/block-runtime/typia-tags';",
 		"",
 		`export interface ${options.queryTypeName} {`,
 		"\tid?: string & tags.MinLength< 1 >;",
@@ -173,9 +177,17 @@ export function buildManualRestContractTypesSource(options: {
 	];
 
 	if (options.bodyTypeName) {
+		const secretLines =
+			options.secretFieldName && options.secretStateFieldName
+				? [
+						`\t${options.secretFieldName}?: string & tags.MinLength< 1 > & tags.MaxLength< 4096 > & tags.Secret< ${quoteTsString(options.secretStateFieldName)} >;`,
+						`\t// ${options.secretFieldName} is write-only: persist it server-side and expose ${options.secretStateFieldName} in responses instead of returning the raw value.`,
+					]
+				: [];
 		lines.push(
 			"",
 			`export interface ${options.bodyTypeName} {`,
+			...secretLines,
 			"\tpayload: string & tags.MinLength< 1 >;",
 			"\tcomment?: string & tags.MaxLength< 500 >;",
 			"}",
@@ -185,6 +197,12 @@ export function buildManualRestContractTypesSource(options: {
 	lines.push(
 		"",
 		`export interface ${options.responseTypeName} {`,
+		...(options.secretStateFieldName
+			? [
+					`\t${options.secretStateFieldName}: boolean;`,
+					`\t// Raw secret fields such as ${options.secretFieldName ?? "the request secret"} must never be returned in this response.`,
+				]
+			: []),
 		"\tid: string & tags.MinLength< 1 >;",
 		"\tstatus: 'ok' | 'error';",
 		"\tmessage?: string;",

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest.ts
@@ -51,6 +51,14 @@ import {
 } from "./workspace-inventory.js";
 import { resolveWorkspaceProject } from "./workspace-project.js";
 
+const MANUAL_REST_REQUEST_BODY_FIELD_NAMES = new Set(["payload", "comment"]);
+const MANUAL_REST_RESPONSE_FIELD_NAMES = new Set([
+	"id",
+	"status",
+	"message",
+	"updatedAt",
+]);
+
 function buildRestResourceRouteRegistrations(
 	restResourceSlug: string,
 	methods: RestResourceMethodId[],
@@ -738,6 +746,26 @@ export async function runAddRestResourceCommand({
 					"wp-typia add rest-resource <name> --manual --method POST --secret-state-field <field>",
 				)
 			: undefined;
+		if (
+			resolvedSecretFieldName &&
+			MANUAL_REST_REQUEST_BODY_FIELD_NAMES.has(resolvedSecretFieldName)
+		) {
+			throw new Error(
+				`Manual REST contract secret field must not reuse scaffolded request body fields: ${Array.from(
+					MANUAL_REST_REQUEST_BODY_FIELD_NAMES,
+				).join(", ")}.`,
+			);
+		}
+		if (
+			resolvedSecretStateFieldName &&
+			MANUAL_REST_RESPONSE_FIELD_NAMES.has(resolvedSecretStateFieldName)
+		) {
+			throw new Error(
+				`Manual REST contract secret state field must not reuse scaffolded response fields: ${Array.from(
+					MANUAL_REST_RESPONSE_FIELD_NAMES,
+				).join(", ")}.`,
+			);
+		}
 		if (
 			resolvedSecretFieldName &&
 			resolvedSecretStateFieldName &&

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest.ts
@@ -634,6 +634,8 @@ export async function runAddRestResourceCommand({
 	restResourceName,
 	responseTypeName,
 	routePattern,
+	secretFieldName,
+	secretStateFieldName,
 }: RunAddRestResourceCommandOptions): Promise<{
 	auth?: ManualRestContractAuthId;
 	bodyTypeName?: string;
@@ -650,6 +652,8 @@ export async function runAddRestResourceCommand({
 	restResourceSlug: string;
 	responseTypeName?: string;
 	routePattern?: string;
+	secretFieldName?: string;
+	secretStateFieldName?: string;
 }> {
 	const workspace = resolveWorkspaceProject(cwd);
 	const restResourceSlug = assertValidGeneratedSlug(
@@ -710,6 +714,39 @@ export async function runAddRestResourceCommand({
 				"Manual REST contract GET routes cannot define a body type. Remove --body-type or use POST, PUT, or PATCH.",
 			);
 		}
+		if (secretStateFieldName && !secretFieldName) {
+			throw new Error(
+				"Manual REST contract --secret-state-field requires --secret-field.",
+			);
+		}
+		if (secretFieldName && !resolvedBodyTypeName) {
+			throw new Error(
+				"Manual REST contract secret fields require a request body. Use POST, PUT, or PATCH so a request body is generated.",
+			);
+		}
+		const resolvedSecretFieldName = secretFieldName
+			? assertValidTypeScriptIdentifier(
+					"Manual REST contract secret field",
+					secretFieldName,
+					"wp-typia add rest-resource <name> --manual --method POST --secret-field <field>",
+				)
+			: undefined;
+		const resolvedSecretStateFieldName = resolvedSecretFieldName
+			? assertValidTypeScriptIdentifier(
+					"Manual REST contract secret state field",
+					secretStateFieldName ?? `has${toPascalCase(resolvedSecretFieldName)}`,
+					"wp-typia add rest-resource <name> --manual --method POST --secret-state-field <field>",
+				)
+			: undefined;
+		if (
+			resolvedSecretFieldName &&
+			resolvedSecretStateFieldName &&
+			resolvedSecretFieldName === resolvedSecretStateFieldName
+		) {
+			throw new Error(
+				"Manual REST contract secret state field must be different from the raw secret field.",
+			);
+		}
 		const manualTypeNames = [
 			resolvedQueryTypeName,
 			resolvedResponseTypeName,
@@ -746,6 +783,12 @@ export async function runAddRestResourceCommand({
 					queryTypeName: resolvedQueryTypeName,
 					responseTypeName: resolvedResponseTypeName,
 					restResourceSlug,
+					...(resolvedSecretFieldName
+						? { secretFieldName: resolvedSecretFieldName }
+						: {}),
+					...(resolvedSecretStateFieldName
+						? { secretStateFieldName: resolvedSecretStateFieldName }
+						: {}),
 				}),
 				"utf8",
 			);
@@ -818,6 +861,12 @@ export async function runAddRestResourceCommand({
 				queryTypeName: resolvedQueryTypeName,
 				restResourceSlug,
 				responseTypeName: resolvedResponseTypeName,
+				...(resolvedSecretFieldName
+					? { secretFieldName: resolvedSecretFieldName }
+					: {}),
+				...(resolvedSecretStateFieldName
+					? { secretStateFieldName: resolvedSecretStateFieldName }
+					: {}),
 			};
 		} catch (error) {
 			await rollbackWorkspaceMutation(mutationSnapshot);

--- a/packages/wp-typia-project-tools/tests/workspace-add.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-add.test.ts
@@ -3622,6 +3622,8 @@ test("canonical CLI can add a type-only manual REST contract to an official work
       "ExternalRecordRequest",
       "--response-type",
       "ExternalRecordResponse",
+      "--secret-field",
+      "apiKey",
     ],
     {
       cwd: targetDir,
@@ -3660,6 +3662,14 @@ test("canonical CLI can add a type-only manual REST contract to an official work
     "api-schemas",
     "response.schema.json"
   );
+  const requestSchemaPath = path.join(
+    targetDir,
+    "src",
+    "rest",
+    "external-record",
+    "api-schemas",
+    "request.schema.json"
+  );
 
   expect(blockConfigSource).toContain('slug: "external-record"');
   expect(blockConfigSource).toContain("mode: 'manual'");
@@ -3681,7 +3691,11 @@ test("canonical CLI can add a type-only manual REST contract to an official work
   expect(syncRestSource).toContain("REST_RESOURCES.filter( isWorkspaceRestResource )");
   expect(typesSource).toContain("export interface ExternalRecordQuery");
   expect(typesSource).toContain("export interface ExternalRecordRequest");
+  expect(typesSource).toContain("apiKey?: string");
+  expect(typesSource).toContain('tags.Secret< "hasApiKey" >');
   expect(typesSource).toContain("export interface ExternalRecordResponse");
+  expect(typesSource).toContain("hasApiKey: boolean");
+  expect(typesSource).not.toContain("apiKey: boolean");
   expect(validatorsSource).toContain("query:");
   expect(validatorsSource).toContain("request:");
   expect(validatorsSource).toContain("response:");
@@ -3701,7 +3715,24 @@ test("canonical CLI can add a type-only manual REST contract to an official work
     "/legacy/v1/records/(?P<id>[\\\\d]+(?:-[\\\\d]+)*)"
   );
   expect(openApiSource).toContain('"x-typia-authIntent": "authenticated"');
+  expect(openApiSource).toContain('"writeOnly": true');
+  expect(openApiSource).toContain('"x-wp-typia-secret": true');
+  expect(openApiSource).toContain('"x-wp-typia-secretStateField": "hasApiKey"');
   expect(fs.existsSync(responseSchemaPath)).toBe(true);
+  expect(fs.existsSync(requestSchemaPath)).toBe(true);
+  const requestSchema = JSON.parse(
+    fs.readFileSync(requestSchemaPath, "utf8")
+  ) as { properties: Record<string, Record<string, unknown>> };
+  const responseSchema = JSON.parse(
+    fs.readFileSync(responseSchemaPath, "utf8")
+  ) as { properties: Record<string, unknown> };
+  expect(requestSchema.properties.apiKey).toMatchObject({
+    writeOnly: true,
+    "x-wp-typia-secret": true,
+    "x-wp-typia-secretStateField": "hasApiKey",
+  });
+  expect(responseSchema.properties).toHaveProperty("hasApiKey");
+  expect(responseSchema.properties).not.toHaveProperty("apiKey");
   expect(
     fs.existsSync(path.join(targetDir, "inc", "rest", "external-record.php"))
   ).toBe(false);
@@ -3736,7 +3767,7 @@ test("canonical CLI can add a type-only manual REST contract to an official work
   ).toThrow("Generated artifacts are missing or stale");
   runCli("npm", ["run", "sync-rest"], { cwd: targetDir });
   typecheckGeneratedProject(targetDir);
-}, 30_000);
+}, 60_000);
 
 test("manual REST contract workflow rejects duplicate type names before writing files", async () => {
   const targetDir = path.join(

--- a/packages/wp-typia-project-tools/tests/workspace-add.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-add.test.ts
@@ -3817,6 +3817,83 @@ test("manual REST contract workflow rejects duplicate type names before writing 
   ).toBe(false);
 }, 20_000);
 
+test("manual REST contract workflow rejects secret field name collisions before writing files", async () => {
+  const targetDir = path.join(
+    tempRoot,
+    "demo-workspace-add-manual-rest-contract-secret-collisions"
+  );
+
+  await scaffoldProject({
+    projectDir: targetDir,
+    templateId: workspaceTemplatePackageManifest.name,
+    packageManager: "npm",
+    noInstall: true,
+    answers: {
+      author: "Test Runner",
+      description: "Demo workspace manual rest secret collisions",
+      namespace: "demo-space",
+      phpPrefix: "demo_space",
+      slug: "demo-workspace-add-manual-rest-contract-secret-collisions",
+      textDomain: "demo-space",
+      title: "Demo Workspace Manual Rest Secret Collisions",
+    },
+  });
+
+  linkWorkspaceNodeModules(targetDir);
+
+  expect(
+    getCommandErrorMessage(() =>
+      runCli(
+        "node",
+        [
+          entryPath,
+          "add",
+          "rest-resource",
+          "external-record",
+          "--manual",
+          "--method",
+          "POST",
+          "--secret-field",
+          "payload",
+        ],
+        { cwd: targetDir }
+      )
+    )
+  ).toContain(
+    "Manual REST contract secret field must not reuse scaffolded request body fields"
+  );
+  expect(
+    fs.existsSync(path.join(targetDir, "src", "rest", "external-record"))
+  ).toBe(false);
+
+  expect(
+    getCommandErrorMessage(() =>
+      runCli(
+        "node",
+        [
+          entryPath,
+          "add",
+          "rest-resource",
+          "external-record",
+          "--manual",
+          "--method",
+          "POST",
+          "--secret-field",
+          "apiKey",
+          "--secret-state-field",
+          "status",
+        ],
+        { cwd: targetDir }
+      )
+    )
+  ).toContain(
+    "Manual REST contract secret state field must not reuse scaffolded response fields"
+  );
+  expect(
+    fs.existsSync(path.join(targetDir, "src", "rest", "external-record"))
+  ).toBe(false);
+}, 20_000);
+
 test("manual REST contract workflow rejects GET routes with body types before writing files", async () => {
   const targetDir = path.join(
     tempRoot,

--- a/packages/wp-typia/README.md
+++ b/packages/wp-typia/README.md
@@ -21,6 +21,7 @@ Extend an existing workspace with:
 - `wp-typia add rest-resource snapshots --namespace my-plugin/v1 --methods list,read,create`
 - `wp-typia add rest-resource snapshots --namespace my-plugin/v1 --methods read,update --route-pattern '/snapshots/(?P<id>[\d]+)' --permission-callback my_plugin_can_manage_snapshots`
 - `wp-typia add rest-resource external-record --manual --namespace legacy/v1 --method GET --auth authenticated --path '/records/(?P<id>[\d]+)'`
+- `wp-typia add rest-resource integration-settings --manual --namespace my-plugin/v1 --method POST --secret-field apiKey`
 - `wp-typia add post-meta integration-state --post-type post --type IntegrationStateMeta`
 - `wp-typia add ability review-workflow`
 - `wp-typia add ai-feature brief-suggestions --namespace my-plugin/v1`

--- a/packages/wp-typia/bin/routing-metadata.generated.js
+++ b/packages/wp-typia/bin/routing-metadata.generated.js
@@ -49,6 +49,8 @@ export const longValueOptions = Object.freeze([
   '--query-type',
   '--response-type',
   '--route-pattern',
+  '--secret-field',
+  '--secret-state-field',
   '--seed',
   '--service',
   '--slot',

--- a/packages/wp-typia/src/add-kinds/rest-resource.ts
+++ b/packages/wp-typia/src/add-kinds/rest-resource.ts
@@ -42,6 +42,11 @@ export const restResourceAddKindEntry =
           ? [
               `Route: ${values.method} /${values.namespace}${values.pathPattern}`,
               `Auth: ${values.auth}`,
+              ...(values.secretFieldName
+                ? [
+                    `Secret field: ${values.secretFieldName} -> ${values.secretStateFieldName}`,
+                  ]
+                : []),
             ]
           : [
               `Methods: ${values.methods}`,
@@ -72,6 +77,8 @@ export const restResourceAddKindEntry =
       'query-type',
       'response-type',
       'route-pattern',
+      'secret-field',
+      'secret-state-field',
     ],
     nameLabel: 'REST resource name',
     async prepareExecution(context) {
@@ -117,6 +124,16 @@ export const restResourceAddKindEntry =
         'route-pattern',
         'routePattern',
       );
+      const secretFieldName = readOptionalDashedOrCamelStringFlag(
+        context.flags,
+        'secret-field',
+        'secretField',
+      );
+      const secretStateFieldName = readOptionalDashedOrCamelStringFlag(
+        context.flags,
+        'secret-state-field',
+        'secretStateField',
+      );
 
       return createNamedExecutionPlan(context, {
         execute: ({ cwd, name }) =>
@@ -136,6 +153,8 @@ export const restResourceAddKindEntry =
             restResourceName: name,
             responseTypeName,
             routePattern,
+            secretFieldName,
+            secretStateFieldName,
           }),
         getValues: (result) => ({
           auth: result.auth ?? '',
@@ -148,6 +167,8 @@ export const restResourceAddKindEntry =
           permissionCallback: result.permissionCallback ?? '',
           restResourceSlug: result.restResourceSlug,
           routePattern: result.routePattern ?? '',
+          secretFieldName: result.secretFieldName ?? '',
+          secretStateFieldName: result.secretStateFieldName ?? '',
         }),
         missingNameMessage: REST_RESOURCE_MISSING_NAME_MESSAGE,
         name,
@@ -157,6 +178,6 @@ export const restResourceAddKindEntry =
     sortOrder: 80,
     supportsDryRun: true,
     usage:
-      'wp-typia add rest-resource <name> [--namespace <vendor/v1>] [--methods <list,read,create,update,delete>] [--route-pattern <route-pattern>] [--permission-callback <callback>] [--controller-class <ClassName>] [--controller-extends <BaseClass>] [--manual --method <GET|POST|PUT|PATCH|DELETE> --auth <public|authenticated|public-write-protected> --path <route-pattern> --query-type <Type> --body-type <Type> --response-type <Type>] [--dry-run]',
+      'wp-typia add rest-resource <name> [--namespace <vendor/v1>] [--methods <list,read,create,update,delete>] [--route-pattern <route-pattern>] [--permission-callback <callback>] [--controller-class <ClassName>] [--controller-extends <BaseClass>] [--manual --method <GET|POST|PUT|PATCH|DELETE> --auth <public|authenticated|public-write-protected> --path <route-pattern> --query-type <Type> --body-type <Type> --response-type <Type> --secret-field <field> --secret-state-field <field>] [--dry-run]',
     visibleFieldNames: () => NAME_NAMESPACE_METHODS_VISIBLE_FIELDS,
   });

--- a/packages/wp-typia/src/command-options/add.ts
+++ b/packages/wp-typia/src/command-options/add.ts
@@ -136,6 +136,16 @@ export const ADD_OPTION_METADATA = {
       'Generated REST resource item route pattern relative to the REST namespace.',
     type: 'string',
   },
+  'secret-field': {
+    description:
+      'Write-only request body field for manual settings REST contracts.',
+    type: 'string',
+  },
+  'secret-state-field': {
+    description:
+      'Masked response boolean field for --secret-field; defaults to has<SecretField>.',
+    type: 'string',
+  },
   service: {
     description:
       'Optional local service starter for integration-env workflows (none or docker-compose).',

--- a/packages/wp-typia/src/ui/add-flow-model.ts
+++ b/packages/wp-typia/src/ui/add-flow-model.ts
@@ -51,6 +51,8 @@ export const addFlowSchema = z.object({
   'query-type': z.string().optional(),
   'response-type': z.string().optional(),
   'route-pattern': z.string().optional(),
+  'secret-field': z.string().optional(),
+  'secret-state-field': z.string().optional(),
   slot: z.string().optional(),
   source: z.string().optional(),
   template: z.string().optional(),

--- a/packages/wp-typia/tests/command-option-metadata.test.ts
+++ b/packages/wp-typia/tests/command-option-metadata.test.ts
@@ -199,6 +199,40 @@ describe('command option metadata helpers', () => {
     expect(parsed.positionals).toEqual(['transform', 'quote-to-counter']);
   });
 
+  test('parses manual REST secret flags from shared add metadata', () => {
+    const parsed = parseCommandArgvWithMetadata(
+      [
+        'rest-resource',
+        'integration-settings',
+        '--manual',
+        '--method',
+        'POST',
+        '--secret-field',
+        'apiKey',
+        '--secret-state-field',
+        'hasApiKey',
+      ],
+      {
+        extraBooleanOptionNames: ['help', 'version'],
+        parser: buildCommandOptionParser(
+          GLOBAL_OPTION_METADATA,
+          ADD_OPTION_METADATA,
+        ),
+      },
+    );
+
+    expect(parsed.flags).toEqual({
+      manual: true,
+      method: 'POST',
+      'secret-field': 'apiKey',
+      'secret-state-field': 'hasApiKey',
+    });
+    expect(parsed.positionals).toEqual([
+      'rest-resource',
+      'integration-settings',
+    ]);
+  });
+
   test('parses sync preview flags from shared metadata', () => {
     const parsed = parseCommandArgvWithMetadata(['--dry-run', '--check'], {
       extraBooleanOptionNames: ['help', 'version'],

--- a/packages/wp-typia/tests/tui-interaction-models.test.ts
+++ b/packages/wp-typia/tests/tui-interaction-models.test.ts
@@ -316,11 +316,13 @@ describe("first-party TUI interaction models", () => {
 				namespace: " demo-space/v1 ",
 				path: " /records/(?P<id>[\\d]+) ",
 				position: "",
-				"query-type": " ExternalRecordQuery ",
-				"response-type": " ExternalRecordResponse ",
-				template: "persistence",
-			}),
-		).toEqual({
+					"query-type": " ExternalRecordQuery ",
+					"response-type": " ExternalRecordResponse ",
+					"secret-field": " apiKey ",
+					"secret-state-field": " hasApiKey ",
+					template: "persistence",
+				}),
+			).toEqual({
 			auth: "authenticated",
 			"body-type": "ExternalRecordRequest",
 			kind: "rest-resource",
@@ -329,10 +331,12 @@ describe("first-party TUI interaction models", () => {
 			methods: "list,read,create",
 			name: "snapshots",
 			namespace: "demo-space/v1",
-			path: "/records/(?P<id>[\\d]+)",
-			"query-type": "ExternalRecordQuery",
-			"response-type": "ExternalRecordResponse",
-		});
+				path: "/records/(?P<id>[\\d]+)",
+				"query-type": "ExternalRecordQuery",
+				"response-type": "ExternalRecordResponse",
+				"secret-field": "apiKey",
+				"secret-state-field": "hasApiKey",
+			});
 	});
 
 	test("migrate flow keeps visible field ordering stable across command switches", () => {

--- a/tests/unit/metadata-parser.test.ts
+++ b/tests/unit/metadata-parser.test.ts
@@ -25,7 +25,9 @@ function createParserFixtureRoot(): string {
 			'  export type Minimum<T extends number> = T & { readonly __minimum?: unique symbol };',
 			'  export type MinLength<T extends number> = T & { readonly __minLength?: unique symbol };',
 			'  export type Selector<T extends string> = T & { readonly __selector?: unique symbol };',
+			'  export type Secret<T extends string> = T & { readonly __secret?: unique symbol };',
 			'  export type Source<T extends string> = T & { readonly __source?: unique symbol };',
+			'  export type WriteOnly<T extends boolean> = T & { readonly __writeOnly?: unique symbol };',
 			"}",
 			"",
 		].join("\n"),
@@ -63,6 +65,7 @@ function createParserFixtureRoot(): string {
 			"  status: Status;",
 			"  body: EmailBody | SmsBody;",
 			'  excerpt: string & tags.Source<"text"> & tags.Selector<".demo__excerpt">;',
+			'  secret: string & tags.Secret<"hasSecret"> & tags.WriteOnly<false>;',
 			"  settings: { enabled: boolean } & tags.Default<{ enabled: true }>;",
 			'  labels: string[] & tags.Default<["one", "two"]>;',
 			"}",
@@ -129,6 +132,13 @@ describe("metadata-parser", () => {
 				secretStateField: null,
 				source: "text",
 				writeOnly: false,
+			});
+			expect(parserDemo.properties?.secret.wp).toEqual({
+				selector: null,
+				secret: true,
+				secretStateField: "hasSecret",
+				source: null,
+				writeOnly: true,
 			});
 
 			expect(parserDemo.properties?.settings.defaultValue).toEqual({

--- a/tests/unit/metadata-parser.test.ts
+++ b/tests/unit/metadata-parser.test.ts
@@ -125,7 +125,10 @@ describe("metadata-parser", () => {
 			const excerpt = parserDemo.properties?.excerpt;
 			expect(excerpt?.wp).toEqual({
 				selector: ".demo__excerpt",
+				secret: false,
+				secretStateField: null,
 				source: "text",
+				writeOnly: false,
 			});
 
 			expect(parserDemo.properties?.settings.defaultValue).toEqual({

--- a/tests/unit/metadata-projection.test.ts
+++ b/tests/unit/metadata-projection.test.ts
@@ -15,14 +15,16 @@ import {
 function createNode(
 	kind: AttributeNode["kind"],
 	pathLabel: string,
-	overrides: Partial<AttributeNode> = {},
+	overrides: Omit<Partial<AttributeNode>, "wp"> & {
+		wp?: Partial<AttributeNode["wp"]>;
+	} = {},
 ): AttributeNode {
+	const node = baseNode(kind, pathLabel);
 	return {
-		...baseNode(kind, pathLabel),
+		...node,
 		...overrides,
 		wp: {
-			selector: null,
-			source: null,
+			...node.wp,
 			...(overrides.wp ?? {}),
 		},
 		union: overrides.union ?? null,

--- a/tests/unit/schema-core.test.ts
+++ b/tests/unit/schema-core.test.ts
@@ -127,7 +127,12 @@ describe("schema-core", () => {
 					discriminator: "kind",
 				},
 			},
-			wp: { type: "object" },
+			wp: {
+				secret: true,
+				secretStateField: "hasTarget",
+				type: "object",
+				writeOnly: true,
+			},
 		});
 
 		const schema = manifestAttributeToJsonSchema(attribute);
@@ -135,6 +140,9 @@ describe("schema-core", () => {
 		expect(schema.discriminator).toEqual({ propertyName: "kind" });
 		expect(Array.isArray(schema.oneOf)).toBe(true);
 		expect((schema.oneOf as unknown[]).length).toBe(2);
+		expect(schema.writeOnly).toBe(true);
+		expect(schema["x-wp-typia-secret"]).toBe(true);
+		expect(schema["x-wp-typia-secretStateField"]).toBe("hasTarget");
 	});
 
 	test("manifestAttributeToJsonSchema rejects discriminated union branches that are not objects", () => {


### PR DESCRIPTION
## Summary
- Add public wp-typia tag metadata for secret/write-only fields and project it into JSON Schema/OpenAPI.
- Add manual REST scaffold flags for `--secret-field` / `--secret-state-field`, including masked response state and generated docs/tests.
- Document the new `@wp-typia/block-runtime/typia-tags` public subpath and add a Sampo changeset.

## Tests
- `bun run changesets:validate`
- `bun run format:check`
- `bun run manifest-policy:validate`
- `bun run --filter wp-typia validate:routing`
- `bun run typecheck`
- `bun run lint:repo`
- `bun run docs:build`
- `bun run --filter @wp-typia/block-runtime test`
- `bun run --filter @wp-typia/project-tools test:workspace`
- `bun run --filter wp-typia test`

Closes #893

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added first-class support for write-only secret fields in manual REST contracts. Use `--secret-field <name>` when creating REST resources to designate sensitive fields that appear only in requests and as masked boolean flags in responses.

* **Documentation**
  * Updated CLI reference and guides with secret field examples and usage instructions.
  * Added new public package export for metadata tag helpers.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/910)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->