### PR TITLE
dx(prompt): route prompt output through line printers

### DIFF
--- a/.sampo/changesets/912-prompt-line-printers.md
+++ b/.sampo/changesets/912-prompt-line-printers.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Route interactive prompt rendering and validation feedback through injectable line printers so tests and callers can capture output without monkeypatching global console methods.

--- a/.sampo/changesets/912-prompt-line-printers.md
+++ b/.sampo/changesets/912-prompt-line-printers.md
@@ -1,5 +1,6 @@
 ---
 npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
 ---
 
 Route interactive prompt rendering and validation feedback through injectable line printers so tests and callers can capture output without monkeypatching global console methods.

--- a/packages/wp-typia-project-tools/src/runtime/cli-prompt.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-prompt.ts
@@ -2,6 +2,7 @@ import readline from "node:readline";
 
 type ValidateInput = (value: string) => boolean | string;
 type PromptQuestion = (query: string) => Promise<string>;
+type PromptLinePrinter = (line: string) => void;
 
 interface PromptOption<T extends string> {
 	hint?: string;
@@ -16,6 +17,16 @@ export interface ReadlinePrompt {
 	close(): void;
 	select<T extends string>(message: string, options: PromptOption<T>[], defaultValue?: number): Promise<T>;
 	text(message: string, defaultValue: string, validate?: ValidateInput): Promise<string>;
+}
+
+/**
+ * Output adapters used by prompt rendering and validation feedback.
+ */
+export interface ReadlinePromptOutput {
+	/** Render one informational prompt line. */
+	printLine?: PromptLinePrinter;
+	/** Render one validation or selection error line. */
+	errorLine?: PromptLinePrinter;
 }
 
 /**
@@ -40,15 +51,16 @@ export interface ReadlineQuestionAdapter {
 /**
  * Create the default readline-backed prompt implementation for the CLI.
  *
+ * @param output Optional line printers for prompt and validation output.
  * @returns A prompt adapter that reads from stdin and writes to stdout.
  */
-export function createReadlinePrompt(): ReadlinePrompt {
+export function createReadlinePrompt(output: ReadlinePromptOutput = {}): ReadlinePrompt {
 	const rl = readline.createInterface({
 		input: process.stdin,
 		output: process.stdout,
 	});
 
-	return createReadlinePromptWithInterface(rl);
+	return createReadlinePromptWithInterface(rl, output);
 }
 
 /**
@@ -56,10 +68,15 @@ export function createReadlinePrompt(): ReadlinePrompt {
  *
  * This keeps the production CLI path unchanged while letting tests validate
  * retry behavior without stubbing global stdin/stdout.
+ *
+ * @param rl Readline-compatible question adapter.
+ * @param output Optional line printers for prompt and validation output.
  */
 export function createReadlinePromptWithInterface(
 	rl: ReadlineQuestionAdapter,
+	output: ReadlinePromptOutput = {},
 ): ReadlinePrompt {
+	const { errorLine, printLine } = resolveReadlinePromptOutput(output);
 	const askQuestion: PromptQuestion = (query) =>
 		new Promise<string>((resolve) => {
 			rl.question(query, resolve);
@@ -74,7 +91,7 @@ export function createReadlinePromptWithInterface(
 				if (validate) {
 					const result = validate(value);
 					if (result !== true) {
-						console.error(formatValidationError(message, result, defaultValue));
+						errorLine(formatValidationError(message, result, defaultValue));
 						continue;
 					}
 				}
@@ -92,7 +109,7 @@ export function createReadlinePromptWithInterface(
 			}
 
 			const resolvedDefaultIndex = getResolvedDefaultIndex(options, defaultValue);
-			renderSelectPrompt(message, options, resolvedDefaultIndex);
+			renderSelectPrompt(message, options, resolvedDefaultIndex, printLine);
 
 			while (true) {
 				const answer = normalizePromptAnswer(
@@ -109,17 +126,35 @@ export function createReadlinePromptWithInterface(
 				}
 
 				if (isPromptHelpToken(answer)) {
-					renderSelectPrompt(message, options, resolvedDefaultIndex);
+					renderSelectPrompt(message, options, resolvedDefaultIndex, printLine);
 					continue;
 				}
 
-				console.error(formatInvalidSelectionError(answer, options, resolvedDefaultIndex));
+				errorLine(formatInvalidSelectionError(answer, options, resolvedDefaultIndex));
 			}
 		},
 		close(): void {
 			rl.close();
 		},
 	};
+}
+
+function resolveReadlinePromptOutput({
+	errorLine,
+	printLine,
+}: ReadlinePromptOutput): Required<ReadlinePromptOutput> {
+	return {
+		errorLine: errorLine ?? writePromptErrorLine,
+		printLine: printLine ?? writePromptLine,
+	};
+}
+
+function writePromptLine(line: string): void {
+	process.stdout.write(`${line}\n`);
+}
+
+function writePromptErrorLine(line: string): void {
+	process.stderr.write(`${line}\n`);
 }
 
 function normalizePromptAnswer(value: string): string {
@@ -162,9 +197,10 @@ function renderSelectPrompt<T extends string>(
 	message: string,
 	options: PromptOption<T>[],
 	defaultIndex: number,
+	printLine: PromptLinePrinter,
 ): void {
-	console.log(message);
-	console.log(
+	printLine(message);
+	printLine(
 		"  Enter a number, option label, or option value. Press Enter to keep the default, or type ? to list choices again.",
 	);
 	options.forEach((option, index) => {
@@ -173,9 +209,9 @@ function renderSelectPrompt<T extends string>(
 			normalizePromptToken(option.label) === normalizePromptToken(option.value)
 				? ""
 				: ` [${option.value}]`;
-		console.log(`  ${index + 1}. ${option.label}${valueHint}${defaultMarker}`);
+		printLine(`  ${index + 1}. ${option.label}${valueHint}${defaultMarker}`);
 		if (option.hint) {
-			console.log(`     ${option.hint}`);
+			printLine(`     ${option.hint}`);
 		}
 	});
 }

--- a/packages/wp-typia-project-tools/src/runtime/cli-prompt.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-prompt.ts
@@ -2,7 +2,7 @@ import readline from "node:readline";
 
 type ValidateInput = (value: string) => boolean | string;
 type PromptQuestion = (query: string) => Promise<string>;
-type PromptLinePrinter = (line: string) => void;
+export type PromptLinePrinter = (line: string) => void;
 
 interface PromptOption<T extends string> {
 	hint?: string;

--- a/packages/wp-typia-project-tools/tests/cli-prompt.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-prompt.test.ts
@@ -30,119 +30,97 @@ describe("@wp-typia/project-tools cli prompt", () => {
 	test("text retries iteratively until validation passes", async () => {
 		const stub = createStubInterface(["a", "valid-name"]);
 		const errors: string[] = [];
-		const originalError = console.error;
-		console.error = (...args: unknown[]) => {
-			errors.push(args.join(" "));
-		};
 
-		try {
-			const prompt = createReadlinePromptWithInterface(stub.adapter);
-			const value = await prompt.text(
-				"Project name",
-				"demo",
-				(current) => current.length >= 4 || "Too short",
-			);
-			prompt.close();
+		const prompt = createReadlinePromptWithInterface(stub.adapter, {
+			errorLine: (line) => errors.push(line),
+		});
+		const value = await prompt.text(
+			"Project name",
+			"demo",
+			(current) => current.length >= 4 || "Too short",
+		);
+		prompt.close();
 
-			expect(value).toBe("valid-name");
-			expect(stub.prompts).toEqual([
-				"Project name [default: demo]: ",
-				"Project name [default: demo]: ",
-			]);
-			expect(errors).toEqual(["❌ Project name: Too short. Press Enter to keep \"demo\"."]);
-			expect(stub.closeCalls).toBe(1);
-		} finally {
-			console.error = originalError;
-		}
+		expect(value).toBe("valid-name");
+		expect(stub.prompts).toEqual([
+			"Project name [default: demo]: ",
+			"Project name [default: demo]: ",
+		]);
+		expect(errors).toEqual(["❌ Project name: Too short. Press Enter to keep \"demo\"."]);
+		expect(stub.closeCalls).toBe(1);
 	});
 
 	test("select retries iteratively until a valid choice is provided", async () => {
 		const stub = createStubInterface(["9", "persistence"]);
 		const errors: string[] = [];
 		const logs: string[] = [];
-		const originalError = console.error;
-		const originalLog = console.log;
-		console.error = (...args: unknown[]) => {
-			errors.push(args.join(" "));
-		};
-		console.log = (...args: unknown[]) => {
-			logs.push(args.join(" "));
-		};
 
-		try {
-			const prompt = createReadlinePromptWithInterface(stub.adapter);
-			const value = await prompt.select("Template", [
-				{ label: "Basic", value: "basic" },
-				{ label: "Persistence", value: "persistence" },
-			]);
-			prompt.close();
+		const prompt = createReadlinePromptWithInterface(stub.adapter, {
+			errorLine: (line) => errors.push(line),
+			printLine: (line) => logs.push(line),
+		});
+		const value = await prompt.select("Template", [
+			{ label: "Basic", value: "basic" },
+			{ label: "Persistence", value: "persistence" },
+		]);
+		prompt.close();
 
-			expect(value).toBe("persistence");
-			expect(stub.prompts).toEqual([
-				"Choice [default: 1, ? for options]: ",
-				"Choice [default: 1, ? for options]: ",
-			]);
-			expect(logs).toEqual([
-				"Template",
-				"  Enter a number, option label, or option value. Press Enter to keep the default, or type ? to list choices again.",
-				"  1. Basic (default)",
-				"  2. Persistence",
-			]);
-			expect(errors).toEqual([
-				"❌ Invalid selection: 9. Enter 1-2, one of: basic, persistence, or press Enter for \"Basic\".",
-			]);
-			expect(stub.closeCalls).toBe(1);
-		} finally {
-			console.error = originalError;
-			console.log = originalLog;
-		}
+		expect(value).toBe("persistence");
+		expect(stub.prompts).toEqual([
+			"Choice [default: 1, ? for options]: ",
+			"Choice [default: 1, ? for options]: ",
+		]);
+		expect(logs).toEqual([
+			"Template",
+			"  Enter a number, option label, or option value. Press Enter to keep the default, or type ? to list choices again.",
+			"  1. Basic (default)",
+			"  2. Persistence",
+		]);
+		expect(errors).toEqual([
+			"❌ Invalid selection: 9. Enter 1-2, one of: basic, persistence, or press Enter for \"Basic\".",
+		]);
+		expect(stub.closeCalls).toBe(1);
 	});
 
 	test("select accepts help tokens and case-insensitive labels", async () => {
 		const stub = createStubInterface(["?", "help", "list", "storage persistence"]);
 		const logs: string[] = [];
-		const originalLog = console.log;
-		console.log = (...args: unknown[]) => {
-			logs.push(args.join(" "));
-		};
 
-		try {
-			const prompt = createReadlinePromptWithInterface(stub.adapter);
-			const value = await prompt.select("Template", [
-				{ label: "Basic", value: "basic", hint: "Starter block" },
-				{ label: "Storage Persistence", value: "persistence", hint: "Storage helpers" },
-			]);
-			prompt.close();
+		const prompt = createReadlinePromptWithInterface(stub.adapter, {
+			printLine: (line) => logs.push(line),
+		});
+		const value = await prompt.select("Template", [
+			{ label: "Basic", value: "basic", hint: "Starter block" },
+			{ label: "Storage Persistence", value: "persistence", hint: "Storage helpers" },
+		]);
+		prompt.close();
 
-			expect(value).toBe("persistence");
-			expect(logs).toEqual([
-				"Template",
-				"  Enter a number, option label, or option value. Press Enter to keep the default, or type ? to list choices again.",
-				"  1. Basic (default)",
-				"     Starter block",
-				"  2. Storage Persistence [persistence]",
-				"     Storage helpers",
-				"Template",
-				"  Enter a number, option label, or option value. Press Enter to keep the default, or type ? to list choices again.",
-				"  1. Basic (default)",
-				"     Starter block",
-				"  2. Storage Persistence [persistence]",
-				"     Storage helpers",
-				"Template",
-				"  Enter a number, option label, or option value. Press Enter to keep the default, or type ? to list choices again.",
-				"  1. Basic (default)",
-				"     Starter block",
-				"  2. Storage Persistence [persistence]",
-				"     Storage helpers",
-				"Template",
-				"  Enter a number, option label, or option value. Press Enter to keep the default, or type ? to list choices again.",
-				"  1. Basic (default)",
-				"     Starter block",
-				"  2. Storage Persistence [persistence]",
-				"     Storage helpers",
-			]);
-		} finally {
-			console.log = originalLog;
-		}
+		expect(value).toBe("persistence");
+		expect(logs).toEqual([
+			"Template",
+			"  Enter a number, option label, or option value. Press Enter to keep the default, or type ? to list choices again.",
+			"  1. Basic (default)",
+			"     Starter block",
+			"  2. Storage Persistence [persistence]",
+			"     Storage helpers",
+			"Template",
+			"  Enter a number, option label, or option value. Press Enter to keep the default, or type ? to list choices again.",
+			"  1. Basic (default)",
+			"     Starter block",
+			"  2. Storage Persistence [persistence]",
+			"     Storage helpers",
+			"Template",
+			"  Enter a number, option label, or option value. Press Enter to keep the default, or type ? to list choices again.",
+			"  1. Basic (default)",
+			"     Starter block",
+			"  2. Storage Persistence [persistence]",
+			"     Storage helpers",
+			"Template",
+			"  Enter a number, option label, or option value. Press Enter to keep the default, or type ? to list choices again.",
+			"  1. Basic (default)",
+			"     Starter block",
+			"  2. Storage Persistence [persistence]",
+			"     Storage helpers",
+		]);
 	});
 });


### PR DESCRIPTION
## Summary

- add injectable prompt `printLine` and `errorLine` adapters to the readline prompt factory
- route select rendering, validation errors, and invalid-selection errors through those adapters
- update prompt tests to capture output through injected callbacks instead of monkeypatching global console methods
- add a Sampo patch changeset for `@wp-typia/project-tools`

Closes #912

## Validation

- `bun test packages/wp-typia-project-tools/tests/cli-prompt.test.ts --timeout=180000`
- `bun run --filter @wp-typia/project-tools build`
- `bun run format:check`
- `bun run lint:repo`
- `bun run typecheck`
- `bun run changesets:validate`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive prompt output and validation feedback can be routed through configurable callbacks, letting callers capture or redirect prompt lines without overriding global console methods.
* **Tests**
  * Prompt tests updated to capture output via the new callbacks instead of intercepting console I/O.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/924)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/924)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->