### PR TITLE
robustness(runtime): add safe JSON readers

### DIFF
--- a/.sampo/changesets/915-safe-json-parse-helpers.md
+++ b/.sampo/changesets/915-safe-json-parse-helpers.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Add path-aware safe JSON parse/read helpers for project-tools runtime JSON file readers.

--- a/packages/wp-typia-project-tools/src/runtime/ai-feature-artifacts.ts
+++ b/packages/wp-typia-project-tools/src/runtime/ai-feature-artifacts.ts
@@ -11,6 +11,7 @@ import {
 
 import { projectWordPressAiSchema } from "./ai-artifacts.js";
 import { isFileNotFoundError } from "./fs-async.js";
+import { readJsonFile } from "./json-utils.js";
 import type { JsonSchemaDocument } from "./schema-core.js";
 
 interface AiFeatureTemplateVariablesLike {
@@ -222,7 +223,9 @@ export async function syncAiFeatureSchemaArtifact({
 		"feature-result.schema.json",
 	);
 	const responseSchema = assertJsonObject(
-		JSON.parse(await readFile(sourceSchemaPath, "utf8")) as unknown,
+		await readJsonFile(sourceSchemaPath, {
+			context: "AI feature response schema",
+		}),
 		sourceSchemaPath,
 	);
 	const aiSchema = projectWordPressAiSchema(responseSchema);

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-block-json.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-block-json.ts
@@ -5,6 +5,7 @@ import type {
 	WorkspaceInventory,
 } from "./workspace-inventory.js";
 import { readOptionalUtf8File } from "./fs-async.js";
+import { safeJsonParse } from "./json-utils.js";
 
 /**
  * Resolve an existing workspace block inventory entry by slug.
@@ -53,7 +54,10 @@ export async function readWorkspaceBlockJson(
 	let blockJson: Record<string, unknown>;
 	try {
 		blockJson = parseScaffoldBlockMetadata<Record<string, unknown>>(
-			JSON.parse(source),
+			safeJsonParse(source, {
+				context: "workspace block metadata",
+				filePath: blockJsonPath,
+			}),
 		);
 	} catch (error) {
 		throw new Error(

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ability-scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ability-scaffold.ts
@@ -9,6 +9,7 @@ import {
 	readWorkspaceInventoryAsync,
 } from "./workspace-inventory.js";
 import { pathExists, readOptionalUtf8File } from "./fs-async.js";
+import { readJsonFile } from "./json-utils.js";
 import {
 	buildAbilityClientSource,
 	buildAbilityConfigEntry,
@@ -250,12 +251,12 @@ async function ensureAbilityPackageScripts(
 	workspace: WorkspaceProject,
 ): Promise<void> {
 	const packageJsonPath = path.join(workspace.projectDir, "package.json");
-	const packageJson = JSON.parse(
-		await fsp.readFile(packageJsonPath, "utf8"),
-	) as {
+	const packageJson = await readJsonFile<{
 		dependencies?: Record<string, string>;
 		scripts?: Record<string, string>;
-	};
+	}>(packageJsonPath, {
+		context: "workspace package manifest",
+	});
 
 	const nextScripts = {
 		...(packageJson.scripts ?? {}),

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-admin-view-scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-admin-view-scaffold.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 import type { WorkspaceProject } from './workspace-project.js';
 import { pathExists, readOptionalUtf8File } from './fs-async.js';
+import { safeJsonParse } from './json-utils.js';
 import {
   appendWorkspaceInventoryEntries,
   readWorkspaceInventoryAsync,
@@ -136,10 +137,13 @@ async function ensureAdminViewPackageDependencies(
   });
 
   await patchFile(packageJsonPath, (source) => {
-    const packageJson = JSON.parse(source) as {
+    const packageJson = safeJsonParse<{
       dependencies?: Record<string, string>;
       devDependencies?: Record<string, string>;
-    };
+    }>(source, {
+      context: 'admin view package manifest',
+      filePath: packageJsonPath,
+    });
     const needsDataViews = !isAdminViewManualSettingsRestResource(restResource);
     const coreDataDependencies: Record<string, string> =
       isAdminViewCoreDataSource(adminViewSource)

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai-anchors.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai-anchors.ts
@@ -10,6 +10,7 @@ import {
 	appendPhpSnippetBeforeClosingTag,
 	insertPhpSnippetBeforeWorkspaceAnchors,
 } from "./cli-add-workspace-mutation.js";
+import { readJsonFile } from "./json-utils.js";
 import { hasPhpFunctionDefinition } from "./php-utils.js";
 import type { WorkspaceProject } from "./workspace-project.js";
 
@@ -67,12 +68,12 @@ export async function ensureAiFeaturePackageScripts(
 	addedSyncAiScript: boolean;
 }> {
 	const packageJsonPath = path.join(workspace.projectDir, "package.json");
-	const packageJson = JSON.parse(
-		await fsp.readFile(packageJsonPath, "utf8"),
-	) as {
+	const packageJson = await readJsonFile<{
 		devDependencies?: Record<string, string>;
 		scripts?: Record<string, string>;
-	};
+	}>(packageJsonPath, {
+		context: "workspace package manifest",
+	});
 
 	const nextScripts = {
 		...(packageJson.scripts ?? {}),

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai-source-emitters.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai-source-emitters.ts
@@ -437,9 +437,18 @@ async function reconcileGeneratedArtifact( options: {
 }
 
 async function loadJsonDocument( filePath: string ) {
+\tlet source: string;
+\ttry {
+\t\tsource = await readFile( filePath, 'utf8' );
+\t} catch ( error ) {
+\t\tthrow new Error(
+\t\t\t\`Failed to read AI schema document at \${ filePath }: \${ error instanceof Error ? error.message : String( error ) }\`
+\t\t);
+\t}
+
 \tlet decoded: unknown;
 \ttry {
-\t\tdecoded = JSON.parse( await readFile( filePath, 'utf8' ) ) as unknown;
+\t\tdecoded = JSON.parse( source ) as unknown;
 \t} catch ( error ) {
 \t\tthrow new Error(
 \t\t\t\`Failed to parse AI schema document at \${ filePath }: \${ error instanceof Error ? error.message : String( error ) }\`

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai-source-emitters.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai-source-emitters.ts
@@ -437,7 +437,14 @@ async function reconcileGeneratedArtifact( options: {
 }
 
 async function loadJsonDocument( filePath: string ) {
-\tconst decoded = JSON.parse( await readFile( filePath, 'utf8' ) ) as unknown;
+\tlet decoded: unknown;
+\ttry {
+\t\tdecoded = JSON.parse( await readFile( filePath, 'utf8' ) ) as unknown;
+\t} catch ( error ) {
+\t\tthrow new Error(
+\t\t\t\`Failed to parse AI schema document at \${ filePath }: \${ error instanceof Error ? error.message : String( error ) }\`
+\t\t);
+\t}
 \tif ( ! decoded || typeof decoded !== 'object' || Array.isArray( decoded ) ) {
 \t\tthrow new Error( \`Expected \${ filePath } to decode to a JSON object.\` );
 \t}

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-integration-env.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-integration-env.ts
@@ -13,6 +13,7 @@ import {
 	type PackageManagerId,
 } from "./package-managers.js";
 import { pathExists, readOptionalUtf8File } from "./fs-async.js";
+import { readJsonFile } from "./json-utils.js";
 import { executeWorkspaceMutationPlan } from "./cli-add-workspace-mutation.js";
 import { resolveWorkspaceProject } from "./workspace-project.js";
 import { toTitleCase } from "./string-case.js";
@@ -347,9 +348,9 @@ async function mutatePackageJson(
 	mutate: (packageJson: IntegrationEnvPackageJson) => void,
 ) {
 	const packageJsonPath = path.join(projectDir, "package.json");
-	const packageJson = JSON.parse(
-		await fsp.readFile(packageJsonPath, "utf8"),
-	) as IntegrationEnvPackageJson;
+	const packageJson = await readJsonFile<IntegrationEnvPackageJson>(packageJsonPath, {
+		context: "integration env package manifest",
+	});
 
 	mutate(packageJson);
 

--- a/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace-bindings.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace-bindings.ts
@@ -11,6 +11,7 @@ import {
 	WORKSPACE_BINDING_EDITOR_SCRIPT,
 	WORKSPACE_BINDING_SERVER_GLOB,
 } from "./cli-doctor-workspace-shared.js";
+import { readJsonFileSync } from "./json-utils.js";
 import { escapeRegex } from "./php-utils.js";
 
 import type { DoctorCheck } from "./cli-doctor.js";
@@ -109,7 +110,9 @@ function checkWorkspaceBindingTarget(
 	const issues: string[] = [];
 	try {
 		const blockJson = parseScaffoldBlockMetadata<Record<string, unknown> & { attributes?: unknown }>(
-			JSON.parse(fs.readFileSync(blockJsonPath, "utf8")),
+			readJsonFileSync(blockJsonPath, {
+				context: "workspace block metadata",
+			}),
 		);
 		const attributes = blockJson.attributes;
 		if (!attributes || typeof attributes !== "object" || Array.isArray(attributes)) {

--- a/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace-blocks.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace-blocks.ts
@@ -14,6 +14,7 @@ import {
 	HOOKED_BLOCK_ANCHOR_PATTERN,
 	HOOKED_BLOCK_POSITION_SET,
 } from "./hooked-blocks.js";
+import { readJsonFileSync } from "./json-utils.js";
 import {
 	hasExecutablePattern,
 	hasUncommentedPattern,
@@ -115,7 +116,9 @@ function readWorkspaceBlockIframeMetadata(
 
 	try {
 		const document = parseScaffoldBlockMetadata<WorkspaceBlockIframeMetadata>(
-			JSON.parse(fs.readFileSync(blockJsonPath, "utf8")),
+			readJsonFileSync(blockJsonPath, {
+				context: "workspace block metadata",
+			}),
 		);
 		return {
 			blockJsonRelativePath,
@@ -304,7 +307,9 @@ function checkWorkspaceBlockMetadata(
 	let blockJson: { name: string; textdomain?: string };
 	try {
 		blockJson = parseScaffoldBlockMetadata<{ textdomain?: string }>(
-			JSON.parse(fs.readFileSync(blockJsonPath, "utf8")),
+			readJsonFileSync(blockJsonPath, {
+				context: "workspace block metadata",
+			}),
 		);
 	} catch (error) {
 		return createDoctorCheck(
@@ -350,7 +355,9 @@ function checkWorkspaceBlockHooks(
 	let blockJson: Record<string, unknown> & { blockHooks?: unknown };
 	try {
 		blockJson = parseScaffoldBlockMetadata<Record<string, unknown> & { blockHooks?: unknown }>(
-			JSON.parse(fs.readFileSync(blockJsonPath, "utf8")),
+			readJsonFileSync(blockJsonPath, {
+				context: "workspace block metadata",
+			}),
 		);
 	} catch (error) {
 		return createDoctorCheck(

--- a/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace-features.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-doctor-workspace-features.ts
@@ -33,6 +33,7 @@ import {
 	WORKSPACE_POST_META_GLOB,
 	WORKSPACE_REST_RESOURCE_GLOB,
 } from "./cli-doctor-workspace-shared.js";
+import { readJsonFileSync } from "./json-utils.js";
 import { escapeRegex } from "./php-utils.js";
 
 import type { DoctorCheck } from "./cli-doctor.js";
@@ -329,10 +330,12 @@ function checkWorkspaceAbilityConfig(
 	}
 
 	try {
-		const config = JSON.parse(fs.readFileSync(configPath, "utf8")) as {
+		const config = readJsonFileSync<{
 			abilityId?: unknown;
 			category?: { slug?: unknown };
-		};
+		}>(configPath, {
+			context: "workspace ability config",
+		});
 		const abilityId =
 			typeof config.abilityId === "string" ? config.abilityId.trim() : "";
 		const categorySlug =

--- a/packages/wp-typia-project-tools/src/runtime/cli-init-package-json.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-init-package-json.ts
@@ -11,6 +11,7 @@ import {
 	type PackageManagerId,
 } from "./package-managers.js";
 import { getPackageVersions } from "./package-versions.js";
+import { readJsonFileSync } from "./json-utils.js";
 import type {
 	InitDependencyChange,
 	InitPackageManagerFieldChange,
@@ -43,9 +44,10 @@ export function readProjectPackageJson(
 		return null;
 	}
 
-	const source = fs.readFileSync(packageJsonPath, "utf8");
 	try {
-		return JSON.parse(source) as ProjectPackageJson;
+		return readJsonFileSync<ProjectPackageJson>(packageJsonPath, {
+			context: "project package manifest",
+		});
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
 		throw createCliDiagnosticCodeError(

--- a/packages/wp-typia-project-tools/src/runtime/cli-scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-scaffold.ts
@@ -33,6 +33,7 @@ import {
 } from "./scaffold-onboarding.js";
 import { formatNonEmptyTargetDirectoryError } from "./scaffold-bootstrap.js";
 import { pathExists } from "./fs-async.js";
+import { readJsonFile } from "./json-utils.js";
 import {
 	OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE,
 	isBuiltInTemplateId,
@@ -782,11 +783,11 @@ export async function runScaffoldFlow({
 		let availableScripts: string[] | undefined;
 		if (!dryRun) {
 			try {
-				const parsedPackageJson = JSON.parse(
-					await fsp.readFile(path.join(projectDir, "package.json"), "utf8"),
-				) as {
+				const parsedPackageJson = await readJsonFile<{
 					scripts?: unknown;
-				};
+				}>(path.join(projectDir, "package.json"), {
+					context: "generated package manifest",
+				});
 				const scripts =
 					parsedPackageJson.scripts &&
 					typeof parsedPackageJson.scripts === "object" &&

--- a/packages/wp-typia-project-tools/src/runtime/external-template-guards.ts
+++ b/packages/wp-typia-project-tools/src/runtime/external-template-guards.ts
@@ -1,5 +1,7 @@
 import fs from "node:fs";
 
+import { safeJsonParse } from "./json-utils.js";
+
 export const TEMPLATE_SOURCE_TIMEOUT_CODE = "template-source-timeout" as const;
 export const TEMPLATE_SOURCE_TOO_LARGE_CODE = "template-source-too-large" as const;
 
@@ -219,15 +221,9 @@ export async function readJsonResponseWithLimit(
 	},
 ): Promise<Record<string, unknown>> {
 	const buffer = await readResponseBodyWithLimit(response, options);
-	try {
-		return JSON.parse(buffer.toString("utf8")) as Record<string, unknown>;
-	} catch (error) {
-		throw new Error(
-			`Failed to parse ${options.label}: ${
-				error instanceof Error ? error.message : String(error)
-			}`,
-		);
-	}
+	return safeJsonParse<Record<string, unknown>>(buffer.toString("utf8"), {
+		context: options.label,
+	});
 }
 
 export async function readBufferResponseWithLimit(

--- a/packages/wp-typia-project-tools/src/runtime/json-utils.ts
+++ b/packages/wp-typia-project-tools/src/runtime/json-utils.ts
@@ -34,8 +34,13 @@ export function cloneJsonValue<T>(value: T): T {
 	return JSON.parse(JSON.stringify(value)) as T;
 }
 
+/**
+ * Optional metadata used to enrich JSON parse errors.
+ */
 export interface SafeJsonParseOptions {
+	/** Human-readable operation label included in parse failures. */
 	context?: string;
+	/** Source file path included in parse failures when available. */
 	filePath?: string;
 }
 

--- a/packages/wp-typia-project-tools/src/runtime/json-utils.ts
+++ b/packages/wp-typia-project-tools/src/runtime/json-utils.ts
@@ -1,7 +1,90 @@
+import fs from "node:fs";
+import { promises as fsp } from "node:fs";
+
 /**
- * Re-exports JSON cloning helpers from `@wp-typia/block-runtime`.
- * This adapter keeps the existing project-tools module path stable while the
- * runtime implementation now lives in block-runtime.
+ * JSON helpers shared by project-tools runtime modules.
+ *
+ * File-backed runtime JSON readers should use `safeJsonParse`,
+ * `readJsonFileSync`, or `readJsonFile` so malformed JSON reports the file path
+ * and operation context. Raw `JSON.parse` remains intentional for trusted
+ * in-memory clones, subprocess output, test fixtures, generated workspace
+ * script templates that embed their own path-aware parse handling, and
+ * cache/discovery probes that immediately catch malformed documents to
+ * continue with fallback behavior.
+ *
+ * This module also re-exports JSON cloning helpers from
+ * `@wp-typia/block-runtime`. That adapter keeps the existing project-tools
+ * module path stable while the runtime implementation lives in block-runtime.
+ *
  * @module
  */
 export * from "@wp-typia/block-runtime/json-utils";
+
+export interface SafeJsonParseOptions {
+	context?: string;
+	filePath?: string;
+}
+
+function formatJsonParseTarget({ context, filePath }: SafeJsonParseOptions): string {
+	const operation = context?.trim() || "JSON";
+	return filePath ? `${operation} at ${filePath}` : operation;
+}
+
+/**
+ * Parse JSON and include operation/file context when decoding fails.
+ *
+ * @param source Raw JSON source text.
+ * @param options Optional file path and human-readable operation context.
+ * @returns Parsed JSON value cast to the caller-specified type.
+ * @throws {Error} When the source is malformed JSON.
+ */
+export function safeJsonParse<T = unknown>(
+	source: string,
+	options: SafeJsonParseOptions = {},
+): T {
+	try {
+		return JSON.parse(source) as T;
+	} catch (error) {
+		throw new Error(
+			`Failed to parse ${formatJsonParseTarget(options)}: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+		);
+	}
+}
+
+/**
+ * Read and parse a JSON file synchronously with path-aware parse errors.
+ *
+ * @param filePath JSON file path to read.
+ * @param options Optional parse context. `filePath` is always set from the
+ * reader argument.
+ * @returns Parsed JSON value cast to the caller-specified type.
+ */
+export function readJsonFileSync<T = unknown>(
+	filePath: string,
+	options: Omit<SafeJsonParseOptions, "filePath"> = {},
+): T {
+	return safeJsonParse<T>(fs.readFileSync(filePath, "utf8"), {
+		...options,
+		filePath,
+	});
+}
+
+/**
+ * Read and parse a JSON file asynchronously with path-aware parse errors.
+ *
+ * @param filePath JSON file path to read.
+ * @param options Optional parse context. `filePath` is always set from the
+ * reader argument.
+ * @returns Parsed JSON value cast to the caller-specified type.
+ */
+export async function readJsonFile<T = unknown>(
+	filePath: string,
+	options: Omit<SafeJsonParseOptions, "filePath"> = {},
+): Promise<T> {
+	return safeJsonParse<T>(await fsp.readFile(filePath, "utf8"), {
+		...options,
+		filePath,
+	});
+}

--- a/packages/wp-typia-project-tools/src/runtime/json-utils.ts
+++ b/packages/wp-typia-project-tools/src/runtime/json-utils.ts
@@ -13,13 +13,26 @@ import { promises as fsp } from "node:fs";
  * and cache/discovery probes that immediately catch malformed documents to
  * continue with fallback behavior.
  *
- * This module also re-exports JSON cloning helpers from
- * `@wp-typia/block-runtime`. That adapter keeps the existing project-tools
- * module path stable while the runtime implementation lives in block-runtime.
+ * This module keeps `cloneJsonValue` local instead of re-exporting the
+ * block-runtime helper so Bunli CLI bundles that only need project-tools JSON
+ * readers do not need to resolve the block-runtime subpath at runtime.
  *
  * @module
  */
-export * from "@wp-typia/block-runtime/json-utils";
+
+/**
+ * Create a deep clone of a JSON-serializable value.
+ *
+ * @remarks
+ * Values that are not JSON-serializable, such as functions, `undefined`,
+ * `BigInt`, class instances, and `Date` objects, are not preserved faithfully.
+ *
+ * @param value JSON-compatible data to clone.
+ * @returns A deep-cloned copy created with `JSON.parse(JSON.stringify(...))`.
+ */
+export function cloneJsonValue<T>(value: T): T {
+	return JSON.parse(JSON.stringify(value)) as T;
+}
 
 export interface SafeJsonParseOptions {
 	context?: string;

--- a/packages/wp-typia-project-tools/src/runtime/json-utils.ts
+++ b/packages/wp-typia-project-tools/src/runtime/json-utils.ts
@@ -8,8 +8,9 @@ import { promises as fsp } from "node:fs";
  * `readJsonFileSync`, or `readJsonFile` so malformed JSON reports the file path
  * and operation context. Raw `JSON.parse` remains intentional for trusted
  * in-memory clones, subprocess output, test fixtures, generated workspace
- * script templates that embed their own path-aware parse handling, and
- * cache/discovery probes that immediately catch malformed documents to
+ * script templates that embed their own path-aware parse handling,
+ * package-version manifest cache probes with colocated path-aware wrappers,
+ * and cache/discovery probes that immediately catch malformed documents to
  * continue with fallback behavior.
  *
  * This module also re-exports JSON cloning helpers from

--- a/packages/wp-typia-project-tools/src/runtime/local-dev-presets.ts
+++ b/packages/wp-typia-project-tools/src/runtime/local-dev-presets.ts
@@ -12,6 +12,7 @@ import {
 	formatRunScript,
 	type PackageManagerId,
 } from "./package-managers.js";
+import { readJsonFile } from "./json-utils.js";
 import {
 	OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE,
 	SHARED_TEST_PRESET_TEMPLATE_ROOT,
@@ -110,7 +111,9 @@ async function mutatePackageJson(
 	mutate: (packageJson: PackageJsonShape) => void,
 ): Promise<void> {
 	const packageJsonPath = path.join(projectDir, "package.json");
-	const packageJson = JSON.parse(await fsp.readFile(packageJsonPath, "utf8")) as PackageJsonShape;
+	const packageJson = await readJsonFile<PackageJsonShape>(packageJsonPath, {
+		context: "local dev package manifest",
+	});
 
 	mutate(packageJson);
 

--- a/packages/wp-typia-project-tools/src/runtime/migration-ui-capability.ts
+++ b/packages/wp-typia-project-tools/src/runtime/migration-ui-capability.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { getPackageVersions } from "./package-versions.js";
 import { formatPackageExecCommand } from "./package-managers.js";
 import type { PackageManagerId } from "./package-managers.js";
+import { readJsonFile } from "./json-utils.js";
 import { seedProjectMigrations } from "./migrations.js";
 import { copyInterpolatedDirectory } from "./template-render.js";
 import {
@@ -33,7 +34,9 @@ async function mutatePackageJson(
 	mutate: (packageJson: PackageJsonShape) => void,
 ): Promise<void> {
 	const packageJsonPath = path.join(projectDir, "package.json");
-	const packageJson = JSON.parse(await fsp.readFile(packageJsonPath, "utf8")) as PackageJsonShape;
+	const packageJson = await readJsonFile<PackageJsonShape>(packageJsonPath, {
+		context: "migration UI package manifest",
+	});
 	mutate(packageJson);
 	await fsp.writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, "\t")}\n`, "utf8");
 }

--- a/packages/wp-typia-project-tools/src/runtime/migration-utils.ts
+++ b/packages/wp-typia-project-tools/src/runtime/migration-utils.ts
@@ -14,6 +14,7 @@ import type {
   JsonObject,
 } from './migration-types.js';
 import { isPlainObject, type UnknownRecord } from './object-utils.js';
+import { readJsonFileSync } from './json-utils.js';
 export { cloneJsonValue } from './json-utils.js';
 
 const MIGRATION_VERSION_LABEL_PATTERN = /^v([1-9]\d*)$/;
@@ -100,7 +101,9 @@ export function createTransformFixtureValue(
 }
 
 export function readJson<T = unknown>(filePath: string): T {
-  return JSON.parse(fs.readFileSync(filePath, 'utf8')) as T;
+  return readJsonFileSync<T>(filePath, {
+    context: 'migration JSON file',
+  });
 }
 
 export function renderPhpValue(value: unknown, indentLevel: number): string {

--- a/packages/wp-typia-project-tools/src/runtime/package-managers.ts
+++ b/packages/wp-typia-project-tools/src/runtime/package-managers.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
 
+import { readJsonFileSync } from "./json-utils.js";
+
 export type PackageManagerId = "bun" | "npm" | "pnpm" | "yarn";
 
 export interface PackageManagerDefinition {
@@ -103,13 +105,17 @@ function readPackageManagerField(projectDir: string): string | undefined {
 			return undefined;
 		}
 
-		const manifest = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as {
+		const manifest = readJsonFileSync<{
 			packageManager?: unknown;
-		};
+		}>(packageJsonPath, {
+			context: "package manager manifest",
+		});
 		return typeof manifest.packageManager === "string"
 			? manifest.packageManager
 			: undefined;
 	} catch {
+		// Package manager inference intentionally falls back to lockfile signals
+		// when package.json is absent or malformed.
 		return undefined;
 	}
 }

--- a/packages/wp-typia-project-tools/src/runtime/package-versions.ts
+++ b/packages/wp-typia-project-tools/src/runtime/package-versions.ts
@@ -3,6 +3,7 @@ import { createRequire } from 'node:module';
 import path from 'node:path';
 
 import { getOptionalNodeErrorCode } from './fs-async.js';
+import { safeJsonParse } from './json-utils.js';
 import { PROJECT_TOOLS_PACKAGE_ROOT } from './template-registry.js';
 
 interface PackageManifest {
@@ -142,7 +143,10 @@ function readPackageManifest(
     return null;
   }
 
-  return JSON.parse(location.source) as PackageManifest;
+  return safeJsonParse<PackageManifest>(location.source, {
+    context: 'package version manifest',
+    filePath: location.packageJsonPath,
+  });
 }
 
 function tryReadPackageManifest(

--- a/packages/wp-typia-project-tools/src/runtime/package-versions.ts
+++ b/packages/wp-typia-project-tools/src/runtime/package-versions.ts
@@ -3,7 +3,6 @@ import { createRequire } from 'node:module';
 import path from 'node:path';
 
 import { getOptionalNodeErrorCode } from './fs-async.js';
-import { safeJsonParse } from './json-utils.js';
 import { PROJECT_TOOLS_PACKAGE_ROOT } from './template-registry.js';
 
 interface PackageManifest {
@@ -143,10 +142,15 @@ function readPackageManifest(
     return null;
   }
 
-  return safeJsonParse<PackageManifest>(location.source, {
-    context: 'package version manifest',
-    filePath: location.packageJsonPath,
-  });
+  try {
+    return JSON.parse(location.source) as PackageManifest;
+  } catch (error) {
+    throw new Error(
+      `Failed to parse package version manifest at ${
+        location.packageJsonPath
+      }: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
 }
 
 function tryReadPackageManifest(

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-bootstrap.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-bootstrap.ts
@@ -21,6 +21,7 @@ import type { BuiltInTemplateId } from "./template-registry.js";
 import { getScaffoldTemplateVariableGroups } from "./scaffold-template-variable-groups.js";
 import type { GeneratedPackageJson } from "./package-json-types.js";
 import { pathExists } from "./fs-async.js";
+import { readJsonFile, readJsonFileSync } from "./json-utils.js";
 
 const EPHEMERAL_NODE_MODULES_LINK_TYPE = process.platform === "win32" ? "junction" : "dir";
 
@@ -53,7 +54,9 @@ function readGeneratedPackageJson(projectDir: string): GeneratedPackageJson | nu
 		return null;
 	}
 
-	return JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as GeneratedPackageJson;
+	return readJsonFileSync<GeneratedPackageJson>(packageJsonPath, {
+		context: "generated package manifest",
+	});
 }
 
 /**
@@ -170,9 +173,9 @@ export async function applyWorkspaceMigrationCapability(
 	packageManager: PackageManagerId,
 ): Promise<void> {
 	const packageJsonPath = path.join(projectDir, "package.json");
-	const packageJson = JSON.parse(
-		await fsp.readFile(packageJsonPath, "utf8"),
-	) as GeneratedPackageJson;
+	const packageJson = await readJsonFile<GeneratedPackageJson>(packageJsonPath, {
+		context: "workspace package manifest",
+	});
 	const wpTypiaPackageVersion = getPackageVersions().wpTypiaPackageVersion;
 	const canonicalCliSpecifier =
 		wpTypiaPackageVersion === "^0.0.0"

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-package-manager-files.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-package-manager-files.ts
@@ -10,6 +10,7 @@ import {
 import type { PackageManagerId } from "./package-managers.js";
 import type { GeneratedPackageJson } from "./package-json-types.js";
 import { readOptionalUtf8File } from "./fs-async.js";
+import { safeJsonParse } from "./json-utils.js";
 
 const LOCKFILES: Record<PackageManagerId, string[]> = {
 	bun: ["bun.lock", "bun.lockb"],
@@ -57,7 +58,10 @@ export async function normalizePackageJson(
 	}
 
 	const packageManager = getPackageManager(packageManagerId);
-	const packageJson = JSON.parse(packageJsonSource) as GeneratedPackageJson;
+	const packageJson = safeJsonParse<GeneratedPackageJson>(packageJsonSource, {
+		context: "generated package manifest",
+		filePath: packageJsonPath,
+	});
 	if (packageManagerId === "npm") {
 		delete packageJson.packageManager;
 	} else {

--- a/packages/wp-typia-project-tools/src/runtime/scaffold-repository-reference.ts
+++ b/packages/wp-typia-project-tools/src/runtime/scaffold-repository-reference.ts
@@ -1,8 +1,8 @@
-import fs from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
 
 import { getOptionalNodeErrorCode } from "./fs-async.js";
+import { readJsonFileSync } from "./json-utils.js";
 import { PROJECT_TOOLS_PACKAGE_ROOT } from "./template-registry.js";
 
 interface RepositoryPackageManifest {
@@ -26,9 +26,9 @@ function readRepositoryPackageManifest(
 	packageJsonPath: string,
 ): RepositoryPackageManifest | null {
 	try {
-		return JSON.parse(
-			fs.readFileSync(packageJsonPath, "utf8"),
-		) as RepositoryPackageManifest;
+		return readJsonFileSync<RepositoryPackageManifest>(packageJsonPath, {
+			context: "repository package manifest",
+		});
 	} catch (error) {
 		if (getOptionalNodeErrorCode(error) === "ENOENT") {
 			return null;

--- a/packages/wp-typia-project-tools/src/runtime/template-layers.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-layers.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { promises as fsp } from "node:fs";
 
 import { pathExists } from "./fs-async.js";
+import { readJsonFile } from "./json-utils.js";
 import { isPlainObject } from "./object-utils.js";
 import {
 	getBuiltInSharedTemplateLayerDir,
@@ -123,9 +124,9 @@ export async function loadExternalTemplateLayerManifest(
 		return null;
 	}
 
-	const raw = JSON.parse(
-		await fsp.readFile(manifestPath, "utf8"),
-	) as Record<string, unknown>;
+	const raw = await readJsonFile<Record<string, unknown>>(manifestPath, {
+		context: "template layer manifest",
+	});
 	if (!isPlainObject(raw)) {
 		throw new Error(`${TEMPLATE_LAYER_MANIFEST_FILENAME} must export a JSON object.`);
 	}

--- a/packages/wp-typia-project-tools/src/runtime/template-registry.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-registry.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { readJsonFileSync } from "./json-utils.js";
 import { getBuiltInTemplateMetadataDefaults } from "./template-defaults.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -17,9 +18,11 @@ function resolveValidProjectToolsPackageRoot(
 	}
 
 	try {
-		const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as {
+		const packageJson = readJsonFileSync<{
 			name?: string;
-		};
+		}>(packageJsonPath, {
+			context: "project-tools package manifest override",
+		});
 		return packageJson.name === PROJECT_TOOLS_PACKAGE_NAME
 			? candidateRoot
 			: undefined;
@@ -52,12 +55,15 @@ export function resolvePackageRoot(startDir: string): string {
 		const packageJsonPath = path.join(currentDir, "package.json");
 		if (fs.existsSync(packageJsonPath)) {
 			try {
-				const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as { name?: string };
+				const packageJson = readJsonFileSync<{ name?: string }>(packageJsonPath, {
+					context: "project-tools package root discovery manifest",
+				});
 				if (packageJson.name === PROJECT_TOOLS_PACKAGE_NAME) {
 					return currentDir;
 				}
 			} catch {
-				// Ignore malformed package.json while walking upward.
+				// Ignore malformed package.json while walking upward; discovery should
+				// keep searching parent directories instead of failing on unrelated files.
 			}
 		}
 

--- a/packages/wp-typia-project-tools/src/runtime/template-source-remote.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-remote.ts
@@ -13,6 +13,11 @@ import {
 import { copyRawDirectory } from './template-render.js'
 import { createManagedTempRoot } from './temp-roots.js'
 import { pathExists } from './fs-async.js'
+import {
+  readJsonFile,
+  readJsonFileSync,
+  safeJsonParse,
+} from './json-utils.js'
 import type {
   ResolvedTemplateSource,
   SeedSource,
@@ -60,10 +65,9 @@ function readRemoteBlockJson(blockDir: string): Record<string, unknown> {
     path.join(sourceRoot, 'block.json'),
   ]) {
     if (fs.existsSync(candidate)) {
-      return JSON.parse(fs.readFileSync(candidate, 'utf8')) as Record<
-        string,
-        unknown
-      >
+      return readJsonFileSync<Record<string, unknown>>(candidate, {
+        context: 'remote block metadata',
+      })
     }
   }
 
@@ -79,10 +83,9 @@ async function readRemoteBlockJsonAsync(
     path.join(sourceRoot, 'block.json'),
   ]) {
     if (await pathExists(candidate)) {
-      return JSON.parse(await fsp.readFile(candidate, 'utf8')) as Record<
-        string,
-        unknown
-      >
+      return readJsonFile<Record<string, unknown>>(candidate, {
+        context: 'remote block metadata',
+      })
     }
   }
 
@@ -144,9 +147,12 @@ function readTemplatePackageJson(
         maxBytes: getExternalTemplatePackageJsonMaxBytes(),
       })
       return {
-        packageJson: JSON.parse(fs.readFileSync(candidate, 'utf8')) as {
+        packageJson: safeJsonParse<{
           wpTypia?: { projectType?: unknown }
-        },
+        }>(fs.readFileSync(candidate, 'utf8'), {
+          context: 'template metadata file',
+          filePath: candidate,
+        }),
         sourcePath: candidate,
       }
     } catch (error) {
@@ -181,9 +187,12 @@ async function readTemplatePackageJsonAsync(
         maxBytes: getExternalTemplatePackageJsonMaxBytes(),
       })
       return {
-        packageJson: JSON.parse(await fsp.readFile(candidate, 'utf8')) as {
+        packageJson: safeJsonParse<{
           wpTypia?: { projectType?: unknown }
-        },
+        }>(await fsp.readFile(candidate, 'utf8'), {
+          context: 'template metadata file',
+          filePath: candidate,
+        }),
         sourcePath: candidate,
       }
     } catch (error) {
@@ -444,12 +453,12 @@ async function patchRemotePackageJson(
   needsInteractivity: boolean,
 ): Promise<void> {
   const packageJsonPath = path.join(templateDir, 'package.json.mustache')
-  const packageJson = JSON.parse(
-    await fsp.readFile(packageJsonPath, 'utf8'),
-  ) as {
+  const packageJson = await readJsonFile<{
     dependencies?: Record<string, string>
     devDependencies?: Record<string, string>
-  }
+  }>(packageJsonPath, {
+    context: 'remote package template manifest',
+  })
   const existingDependencies = { ...(packageJson.dependencies ?? {}) }
   const existingDevDependencies = { ...(packageJson.devDependencies ?? {}) }
 

--- a/packages/wp-typia-project-tools/src/runtime/template-source-seeds.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-seeds.ts
@@ -26,6 +26,7 @@ import {
   createCliDiagnosticCodeError,
 } from './cli-diagnostics.js'
 import { pathExists } from './fs-async.js'
+import { readJsonFile, readJsonFileSync } from './json-utils.js'
 import {
   OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE,
   OFFICIAL_WORKSPACE_TEMPLATE_ALIAS,
@@ -328,9 +329,9 @@ function resolveInstalledNpmTemplateSource(
         continue
       }
 
-      const manifest = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as {
-        name?: string
-      }
+      const manifest = readJsonFileSync<{ name?: string }>(packageJsonPath, {
+        context: 'workspace template package manifest',
+      })
       if (manifest.name === locator.name) {
         return {
           blockDir: packageDir,
@@ -396,9 +397,9 @@ export function isOfficialWorkspaceTemplateSeed(seed: SeedSource): boolean {
   }
 
   try {
-    const packageJson = JSON.parse(
-      fs.readFileSync(packageJsonPath, 'utf8'),
-    ) as { name?: string }
+    const packageJson = readJsonFileSync<{ name?: string }>(packageJsonPath, {
+      context: 'workspace template seed manifest',
+    })
     return packageJson.name === OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE
   } catch {
     return false
@@ -420,9 +421,12 @@ export async function isOfficialWorkspaceTemplateSeedAsync(
   }
 
   try {
-    const packageJson = JSON.parse(
-      await fsp.readFile(packageJsonPath, 'utf8'),
-    ) as { name?: string }
+    const packageJson = await readJsonFile<{ name?: string }>(
+      packageJsonPath,
+      {
+        context: 'workspace template seed manifest',
+      },
+    )
     return packageJson.name === OFFICIAL_WORKSPACE_TEMPLATE_PACKAGE
   } catch {
     return false

--- a/packages/wp-typia-project-tools/src/runtime/workspace-project.ts
+++ b/packages/wp-typia-project-tools/src/runtime/workspace-project.ts
@@ -5,6 +5,7 @@ import {
 	parsePackageManagerField,
 	type PackageManagerId,
 } from "./package-managers.js";
+import { readJsonFileSync } from "./json-utils.js";
 
 export const WORKSPACE_TEMPLATE_PACKAGE = "@wp-typia/create-workspace-template";
 
@@ -48,15 +49,9 @@ export function parseWorkspacePackageJson(projectDirOrManifestPath: string): Wor
 			? projectDirOrManifestPath
 			: path.join(projectDirOrManifestPath, "package.json");
 
-	try {
-		return JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as WorkspacePackageJson;
-	} catch (error) {
-		throw new Error(
-			`Failed to parse workspace package manifest at ${packageJsonPath}: ${
-				error instanceof Error ? error.message : String(error)
-			}`,
-		);
-	}
+	return readJsonFileSync<WorkspacePackageJson>(packageJsonPath, {
+		context: "workspace package manifest",
+	});
 }
 
 function getWorkspaceMetadataIssues(packageJson: WorkspacePackageJson): string[] {

--- a/packages/wp-typia-project-tools/tests/json-utils.test.ts
+++ b/packages/wp-typia-project-tools/tests/json-utils.test.ts
@@ -1,0 +1,86 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+	readJsonFile,
+	readJsonFileSync,
+	safeJsonParse,
+} from "../src/runtime/json-utils.js";
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "wp-typia-json-utils-"));
+
+afterAll(() => {
+	fs.rmSync(tempRoot, { force: true, recursive: true });
+});
+
+function getThrownMessage(callback: () => void): string {
+	try {
+		callback();
+	} catch (error) {
+		return error instanceof Error ? error.message : String(error);
+	}
+
+	throw new Error("Expected callback to throw.");
+}
+
+async function getRejectedMessage(callback: () => Promise<void>): Promise<string> {
+	try {
+		await callback();
+	} catch (error) {
+		return error instanceof Error ? error.message : String(error);
+	}
+
+	throw new Error("Expected callback to reject.");
+}
+
+describe("project-tools JSON helpers", () => {
+	test("preserves valid JSON return values", () => {
+		expect(
+			safeJsonParse<{ ok: boolean }>('{"ok":true}', {
+				context: "inline config",
+			}),
+		).toEqual({ ok: true });
+	});
+
+	test("adds context and file path to malformed source errors", () => {
+		const filePath = path.join(tempRoot, "inline-bad.json");
+		const message = getThrownMessage(() => {
+			safeJsonParse("{", {
+				context: "workspace package manifest",
+				filePath,
+			});
+		});
+
+		expect(message).toContain(
+			`Failed to parse workspace package manifest at ${filePath}:`,
+		);
+	});
+
+	test("adds context and file path to malformed sync file reader errors", () => {
+		const filePath = path.join(tempRoot, "sync-bad.json");
+		fs.writeFileSync(filePath, "{", "utf8");
+
+		const message = getThrownMessage(() => {
+			readJsonFileSync(filePath, {
+				context: "bad fixture",
+			});
+		});
+
+		expect(message).toContain(`Failed to parse bad fixture at ${filePath}:`);
+	});
+
+	test("adds context and file path to malformed async file reader errors", async () => {
+		const filePath = path.join(tempRoot, "async-bad.json");
+		fs.writeFileSync(filePath, "{", "utf8");
+
+		const message = await getRejectedMessage(async () => {
+			await readJsonFile(filePath, {
+				context: "async fixture",
+			});
+		});
+
+		expect(message).toContain(`Failed to parse async fixture at ${filePath}:`);
+	});
+});


### PR DESCRIPTION
## Summary
- add shared project-tools safe JSON parse/read helpers with path-aware parse errors
- migrate high-impact runtime JSON file readers across workspace/project/template/doctor flows
- document intentional raw JSON.parse exceptions and add malformed JSON coverage

## Validation
- bun run format:check
- bun test packages/wp-typia-project-tools/tests/json-utils.test.ts
- bun run --filter @wp-typia/project-tools build
- bun test packages/wp-typia-project-tools/tests/package-managers.test.ts
- bun test packages/wp-typia-project-tools/tests/template-source.test.ts
- bun test packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
- bun test packages/wp-typia-project-tools/tests/template-layers.test.ts packages/wp-typia-project-tools/tests/cli-add-workspace-ability.test.ts packages/wp-typia-project-tools/tests/cli-add-workspace-ai.test.ts
- bun test packages/wp-typia-project-tools/tests/workspace-add.test.ts
- bun run typecheck
- bun run lint:repo
- bun run changesets:validate
- bun run runtime-coupling:validate
- git diff --check

Closes #915

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized JSON parsing and manifest reads across project tools to provide consistent, path-aware error messages and more robust handling of package/block manifests.

* **Tests**
  * Added tests ensuring JSON helpers return valid data and include parsing context and file path in error reports.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/935)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->