### PR TITLE
refactor(add): share rest-resource string flag reader

### DIFF
--- a/.sampo/changesets/916-rest-resource-shared-string-flags.md
+++ b/.sampo/changesets/916-rest-resource-shared-string-flags.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Use the shared dashed-or-camel string flag reader for rest-resource add-kind options.

--- a/packages/wp-typia/src/add-kinds/rest-resource.ts
+++ b/packages/wp-typia/src/add-kinds/rest-resource.ts
@@ -1,4 +1,7 @@
-import { readOptionalStrictStringFlag } from '../cli-string-flags';
+import {
+  readOptionalDashedOrCamelStringFlag,
+  readOptionalStrictStringFlag,
+} from '../cli-string-flags';
 import {
   createNamedExecutionPlan,
   defineAddKindRegistryEntry,
@@ -9,17 +12,6 @@ import {
 
 const REST_RESOURCE_MISSING_NAME_MESSAGE =
   '`wp-typia add rest-resource` requires <name>. Usage: wp-typia add rest-resource <name> [--namespace <vendor/v1>] [--methods <list,read,create,update,delete>] or wp-typia add rest-resource <name> --manual [--method GET] [--path /external].';
-
-function readOptionalDashedOrCamelStringFlag(
-  flags: Record<string, unknown>,
-  dashedName: string,
-  camelName: string,
-): string | undefined {
-  return (
-    readOptionalStrictStringFlag(flags, dashedName) ??
-    readOptionalStrictStringFlag(flags, camelName)
-  );
-}
 
 export const restResourceAddKindEntry =
   defineAddKindRegistryEntry<AddRestResourceResult>({

--- a/packages/wp-typia/tests/cli-string-flags.test.ts
+++ b/packages/wp-typia/tests/cli-string-flags.test.ts
@@ -3,6 +3,7 @@ import { expect, test } from 'bun:test';
 import { CLI_DIAGNOSTIC_CODES } from '@wp-typia/project-tools/cli-diagnostics';
 
 import {
+  readOptionalDashedOrCamelStringFlag,
   readOptionalLooseStringFlag,
   readOptionalPairedStrictStringFlags,
   readOptionalStrictStringFlag,
@@ -31,6 +32,39 @@ test('loose optional string flags trim values and collapse empty strings to unde
   );
   expect(readOptionalLooseStringFlag({ namespace: '   ' }, 'namespace')).toBeUndefined();
   expect(readOptionalLooseStringFlag({}, 'namespace')).toBeUndefined();
+});
+
+test('dashed-or-camel string flags preserve rest-resource alias behavior', () => {
+  expect(
+    readOptionalDashedOrCamelStringFlag(
+      { 'route-pattern': '/books/(?P<id>[\\d]+)', routePattern: '/ignored' },
+      'route-pattern',
+      'routePattern',
+    ),
+  ).toBe('/books/(?P<id>[\\d]+)');
+  expect(
+    readOptionalDashedOrCamelStringFlag(
+      { routePattern: '/books/(?P<id>[\\d]+)' },
+      'route-pattern',
+      'routePattern',
+    ),
+  ).toBe('/books/(?P<id>[\\d]+)');
+
+  try {
+    readOptionalDashedOrCamelStringFlag(
+      { routePattern: '   ' },
+      'route-pattern',
+      'routePattern',
+    );
+    throw new Error('Expected dashed-or-camel flag reader to throw.');
+  } catch (error) {
+    expect((error as { code?: string }).code).toBe(
+      CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
+    );
+    expect((error as Error).message).toContain(
+      '`--routePattern` requires a value.',
+    );
+  }
 });
 
 test('paired and required strict string flags keep current missing-argument diagnostics', () => {

--- a/packages/wp-typia/tests/cli-string-flags.test.ts
+++ b/packages/wp-typia/tests/cli-string-flags.test.ts
@@ -65,6 +65,22 @@ test('dashed-or-camel string flags preserve rest-resource alias behavior', () =>
       '`--routePattern` requires a value.',
     );
   }
+
+  try {
+    readOptionalDashedOrCamelStringFlag(
+      { 'route-pattern': '   ', routePattern: '/ignored' },
+      'route-pattern',
+      'routePattern',
+    );
+    throw new Error('Expected dashed-or-camel flag reader to throw.');
+  } catch (error) {
+    expect((error as { code?: string }).code).toBe(
+      CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
+    );
+    expect((error as Error).message).toContain(
+      '`--route-pattern` requires a value.',
+    );
+  }
 });
 
 test('paired and required strict string flags keep current missing-argument diagnostics', () => {


### PR DESCRIPTION
## Summary

- Replace the rest-resource add-kind local dashed/camel string flag helper with the shared cli-string-flags helper.
- Add focused coverage for dashed-name precedence, camel fallback, and missing-value diagnostics.
- Add a Sampo changeset for the wp-typia patch.

Closes #916.

## Validation

- bun test packages/wp-typia/tests/cli-string-flags.test.ts packages/wp-typia/tests/add-command.test.ts packages/wp-typia/tests/add-command-package.test.ts
- bun run format:check
- bun run changesets:validate
- git diff --check
- bun run typecheck
- bun run lint:repo
- bun run --filter wp-typia test
- bun run runtime-coupling:validate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped wp-typia to a patch version
  * Consolidated CLI flag handling for rest-resource add-kind options

* **Tests**
  * Added tests covering dashed vs. camel flag aliases and proper missing-argument behavior for whitespace-only values

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/936)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/936)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->