### PR TITLE
docs(diagnostics): document fallback classifier coupling

### DIFF
--- a/.sampo/changesets/917-diagnostic-fallback-docs.md
+++ b/.sampo/changesets/917-diagnostic-fallback-docs.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Document the diagnostic fallback classifier as a compatibility shim for message-based runtime validation errors.

--- a/apps/docs/src/content/docs/maintainers/bunli-cli-migration.md
+++ b/apps/docs/src/content/docs/maintainers/bunli-cli-migration.md
@@ -103,6 +103,14 @@ by using `createCliDiagnosticCodeError(code, message)` in shared runtime code or
 `inferCliDiagnosticCode()` classification is retained only as a compatibility
 fallback for legacy or third-party errors.
 
+Treat every regex in `inferCliDiagnosticCode()` as coupled to the exact
+project-tools runtime validation message it matches. Rewording one of those
+messages can silently change, downgrade, or remove the diagnostic code returned
+to JSON consumers. When adding a new user-facing runtime validation failure, use
+a diagnostic-coded error at the throw site instead of extending the fallback
+classifier, unless the failure truly comes from legacy or untyped code that
+cannot carry a code yet.
+
 Shorthand references like `npx wp-typia` and `bunx wp-typia` should still map
 to the canonical `create` surface in docs and review notes.
 

--- a/apps/docs/src/content/docs/reference/cli.md
+++ b/apps/docs/src/content/docs/reference/cli.md
@@ -92,8 +92,13 @@ improves.
 }
 ```
 
-Known throw sites attach an explicit diagnostic code. Message-based inference is
-kept only as a compatibility fallback for legacy or untyped errors.
+Known throw sites attach an explicit diagnostic code. Message-based inference in
+`inferCliDiagnosticCode()` is kept only as a compatibility fallback for legacy or
+untyped errors, and its regexes are coupled to the exact runtime validation
+messages they match. Rewording one of those messages can silently change,
+downgrade, or remove the diagnostic code returned to JSON consumers, so new
+user-facing runtime validation failures should use a diagnostic-coded error at
+the throw site instead of extending the fallback classifier.
 
 | Code                         | Typical cause                                            | Recovery                                                                |
 | ---------------------------- | -------------------------------------------------------- | ----------------------------------------------------------------------- |

--- a/packages/wp-typia-project-tools/src/runtime/cli-diagnostics.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-diagnostics.ts
@@ -326,9 +326,14 @@ export function createCliDiagnosticCodeError<TCode extends CliDiagnosticCode>(
 
 /**
  * Compatibility-only fallback for legacy or third-party errors that have not
- * yet been tagged by their throw site. New user-facing failures should pass an
- * explicit code through `createCliDiagnosticCodeError()` or
- * `createCliCommandError({ code })` instead of relying on message matching.
+ * yet been tagged by their throw site.
+ *
+ * The regexes below intentionally couple this classifier to existing
+ * project-tools runtime validation messages. Treat them as compatibility shims:
+ * changing a validation message can silently change, downgrade, or remove the
+ * inferred diagnostic code. New user-facing runtime validation failures should
+ * pass an explicit code through `createCliDiagnosticCodeError()` or
+ * `createCliCommandError({ code })` instead of adding new message patterns.
  */
 function inferCliDiagnosticCode(options: {
 	command: string;


### PR DESCRIPTION
## Summary
- document inferCliDiagnosticCode() as a compatibility-only fallback for untyped runtime validation errors
- call out the fragile regex/message coupling in maintainer and CLI reference docs
- add a Sampo changeset for the documentation update

## Validation
- bun run format:check
- bun run changesets:validate
- bun run lint:repo
- bun run typecheck
- git diff --check

Closes #917

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified CLI diagnostic code documentation with guidance on runtime validation failure handling and best practices for error implementation.
  * Updated developer guidelines on diagnostic-coded errors versus message-based fallback approaches.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/937)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->