### PR TITLE
dx(rest): split rest-resource usage guidance

### DIFF
--- a/.sampo/changesets/918-split-rest-resource-usage.md
+++ b/.sampo/changesets/918-split-rest-resource-usage.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Split rest-resource usage guidance into generated and manual mode lines for add-kind help and missing-name diagnostics.

--- a/packages/wp-typia/src/add-kinds/rest-resource.ts
+++ b/packages/wp-typia/src/add-kinds/rest-resource.ts
@@ -10,8 +10,16 @@ import {
   type AddRestResourceResult,
 } from '../add-kind-registry-shared';
 
-const REST_RESOURCE_MISSING_NAME_MESSAGE =
-  '`wp-typia add rest-resource` requires <name>. Usage: wp-typia add rest-resource <name> [--namespace <vendor/v1>] [--methods <list,read,create,update,delete>] or wp-typia add rest-resource <name> --manual [--method GET] [--path /external].';
+const REST_RESOURCE_GENERATED_USAGE =
+  'Generated: wp-typia add rest-resource <name> [--namespace <vendor/v1>] [--methods <list,read,create,update,delete>] [--route-pattern <route-pattern>] [--permission-callback <callback>] [--controller-class <ClassName>] [--controller-extends <BaseClass>] [--dry-run]';
+const REST_RESOURCE_MANUAL_USAGE =
+  'Manual: wp-typia add rest-resource <name> --manual [--method <GET|POST|PUT|PATCH|DELETE>] [--auth <public|authenticated|public-write-protected>] [--path <route-pattern>] [--query-type <Type>] [--body-type <Type>] [--response-type <Type>] [--secret-field <field>] [--secret-state-field <field>] [--dry-run]';
+const REST_RESOURCE_USAGE = `${REST_RESOURCE_GENERATED_USAGE}\n${REST_RESOURCE_MANUAL_USAGE}`;
+const REST_RESOURCE_MISSING_NAME_MESSAGE = [
+  '`wp-typia add rest-resource` requires <name>. Usage:',
+  `  ${REST_RESOURCE_GENERATED_USAGE}`,
+  `  ${REST_RESOURCE_MANUAL_USAGE}`,
+].join('\n');
 
 export const restResourceAddKindEntry =
   defineAddKindRegistryEntry<AddRestResourceResult>({
@@ -169,7 +177,6 @@ export const restResourceAddKindEntry =
     },
     sortOrder: 80,
     supportsDryRun: true,
-    usage:
-      'wp-typia add rest-resource <name> [--namespace <vendor/v1>] [--methods <list,read,create,update,delete>] [--route-pattern <route-pattern>] [--permission-callback <callback>] [--controller-class <ClassName>] [--controller-extends <BaseClass>] [--manual --method <GET|POST|PUT|PATCH|DELETE> --auth <public|authenticated|public-write-protected> --path <route-pattern> --query-type <Type> --body-type <Type> --response-type <Type> --secret-field <field> --secret-state-field <field>] [--dry-run]',
+    usage: REST_RESOURCE_USAGE,
     visibleFieldNames: () => NAME_NAMESPACE_METHODS_VISIBLE_FIELDS,
   });

--- a/packages/wp-typia/tests/add-command-package.test.ts
+++ b/packages/wp-typia/tests/add-command-package.test.ts
@@ -180,6 +180,28 @@ test('treats missing add kinds as an error while still printing help text', () =
   );
 });
 
+test('node fallback rest-resource missing-name output keeps usage split by mode', () => {
+  const result = runCapturedCommand(
+    process.execPath,
+    [entryPath, 'add', 'rest-resource'],
+    {
+      env: withoutLocalBunEnv(),
+    },
+  );
+
+  expect(result.status).toBe(1);
+  expect(result.stderr).toContain(
+    '`wp-typia add rest-resource` requires <name>. Usage:',
+  );
+  expect(result.stderr).toContain(
+    'Generated: wp-typia add rest-resource <name> [--namespace <vendor/v1>] [--methods <list,read,create,update,delete>]',
+  );
+  expect(result.stderr).toContain(
+    'Manual: wp-typia add rest-resource <name> --manual [--method <GET|POST|PUT|PATCH|DELETE>]',
+  );
+  expect(result.stderr).not.toContain(' or wp-typia add rest-resource ');
+});
+
 test('node fallback source entry treats missing add kinds as an error while printing add help', async () => {
   const originalLog = console.log;
   const capturedStdout: string[] = [];

--- a/packages/wp-typia/tests/add-command.test.ts
+++ b/packages/wp-typia/tests/add-command.test.ts
@@ -599,6 +599,36 @@ describe('wp-typia add command bridge', () => {
     }
   }, 15_000);
 
+  test('rest-resource missing-name guidance separates generated and manual modes', async () => {
+    let error: unknown;
+
+    try {
+      await executeAddCommand({
+        cwd: tempRoot,
+        emitOutput: false,
+        flags: {},
+        interactive: false,
+        kind: 'rest-resource',
+      });
+    } catch (caughtError) {
+      error = caughtError;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as { code?: string }).code).toBe(
+      CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
+    );
+    expect((error as Error).message).toContain(
+      '`wp-typia add rest-resource` requires <name>. Usage:',
+    );
+    expect((error as Error).message).toContain(
+      'Generated: wp-typia add rest-resource <name> [--namespace <vendor/v1>] [--methods <list,read,create,update,delete>] [--route-pattern <route-pattern>]',
+    );
+    expect((error as Error).message).toContain(
+      'Manual: wp-typia add rest-resource <name> --manual [--method <GET|POST|PUT|PATCH|DELETE>] [--auth <public|authenticated|public-write-protected>] [--path <route-pattern>]',
+    );
+  });
+
   test('every registered add kind currently advertises dry-run support', () => {
     expect(ADD_KIND_IDS.every((kind) => supportsAddKindDryRun(kind))).toBe(
       true,

--- a/packages/wp-typia/tests/add-kind-registry.test.ts
+++ b/packages/wp-typia/tests/add-kind-registry.test.ts
@@ -6,6 +6,7 @@ import {
   type AddKindId,
   type AddKindExecutionContext,
   type AddKindExecutionPlanFor,
+  getAddKindUsage,
   getAddVisibleFieldNames,
 } from '../src/add-kind-registry';
 
@@ -195,6 +196,13 @@ test('aggregates one registry entry for every canonical add kind', () => {
     expect(entry.description.length).toBeGreaterThan(0);
     expect(entry.usage).toContain(`wp-typia add ${kind}`);
   }
+});
+
+test('splits rest-resource usage by generated and manual modes', () => {
+  expect(getAddKindUsage('rest-resource').split('\n')).toEqual([
+    'Generated: wp-typia add rest-resource <name> [--namespace <vendor/v1>] [--methods <list,read,create,update,delete>] [--route-pattern <route-pattern>] [--permission-callback <callback>] [--controller-class <ClassName>] [--controller-extends <BaseClass>] [--dry-run]',
+    'Manual: wp-typia add rest-resource <name> --manual [--method <GET|POST|PUT|PATCH|DELETE>] [--auth <public|authenticated|public-write-protected>] [--path <route-pattern>] [--query-type <Type>] [--body-type <Type>] [--response-type <Type>] [--secret-field <field>] [--secret-state-field <field>] [--dry-run]',
+  ]);
 });
 
 test('keeps shared add-kind ids aligned with registry sort order', () => {


### PR DESCRIPTION
## Summary
- split rest-resource add-kind usage into generated and manual mode lines
- update missing-name diagnostics to show generated/manual guidance separately
- cover registry, bridge, and Node fallback package output with focused tests

## Validation
- bun run --filter wp-typia build
- bun test packages/wp-typia/tests/add-kind-registry.test.ts
- bun test packages/wp-typia/tests/add-command.test.ts
- bun test packages/wp-typia/tests/add-command-package.test.ts
- bun run format:check
- bun run changesets:validate
- bun run lint:repo
- bun run typecheck
- git diff --check

Closes #918

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI help text for the `add rest-resource` command with separate usage guidance for generated and manual modes
  * Enhanced error messages to clearly display distinct usage variants when the required name argument is missing

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/938)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->