### PR TITLE
refactor(cli): split node fallback entrypoint paths

### DIFF
--- a/.sampo/changesets/920-split-node-fallback-entrypoint.md
+++ b/.sampo/changesets/920-split-node-fallback-entrypoint.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Split Node fallback version, templates, doctor, and entrypoint error handling into focused modules.

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -1,11 +1,4 @@
-import packageJson from '../package.json';
-import {
-  CLI_DIAGNOSTIC_CODES,
-  createCliCommandError,
-  formatCliDiagnosticError,
-  isCliDiagnosticError,
-  serializeCliDiagnosticError,
-} from '@wp-typia/project-tools/cli-diagnostics';
+import { createCliCommandError } from '@wp-typia/project-tools/cli-diagnostics';
 import {
   ALL_COMMAND_OPTION_METADATA,
   ADD_OPTION_METADATA,
@@ -15,15 +8,10 @@ import {
   parseCommandArgvWithMetadata,
   resolveCommandOptionValues,
 } from './command-option-metadata';
-import { prefersStructuredCliArgv } from './cli-diagnostic-output';
 import {
   normalizeCliOutputFormatArgv,
   validateCliOutputFormatArgv,
 } from './cli-output-format';
-import {
-  getTemplateById,
-  listTemplates,
-} from '@wp-typia/project-tools/cli-templates';
 import {
   getAddBlockDefaults,
   getCreateDefaults,
@@ -34,11 +22,9 @@ import {
 import { extractWpTypiaConfigOverride } from './config-override';
 import type { PrintLine } from './print-line';
 import {
-  executeDoctorCommand,
   executeInitCommand,
   executeMigrateCommand,
   executeSyncCommand,
-  executeTemplatesCommand,
 } from './runtime-bridge';
 import {
   buildStructuredInitSuccessPayload,
@@ -46,25 +32,28 @@ import {
   printCompletionPayload,
 } from './runtime-bridge-output';
 import { resolveSyncExecutionTarget } from './runtime-bridge-sync';
-import {
-  normalizeWpTypiaArgv,
-  resolveCanonicalCommandContext,
-} from './command-contract';
+import { normalizeWpTypiaArgv } from './command-contract';
+import { dispatchNodeFallbackDoctor } from './node-fallback/doctor';
 import { dispatchNodeFallbackAdd } from './node-fallback/dispatchers/add';
 import { dispatchNodeFallbackCreate } from './node-fallback/dispatchers/create';
 import {
+  createNodeFallbackNoCommandCliError,
+  handleNodeFallbackEntrypointError,
+  throwUnsupportedNodeFallbackCommand,
+} from './node-fallback/errors';
+import {
   NODE_FALLBACK_HELP_RENDERERS,
-  NODE_FALLBACK_NO_COMMAND_REASON_LINE,
-  STANDALONE_GUIDANCE_LINE,
   renderGeneralHelp,
   renderNoCommandHelp,
 } from './node-fallback/help';
+import { dispatchNodeFallbackTemplates } from './node-fallback/templates';
 import type {
   NodeFallbackCommandDispatcher,
   NodeFallbackDispatchContext,
   NodeFallbackExecutableCommandName,
   NodeFallbackGlobalFlags,
 } from './node-fallback/types';
+import { renderNodeFallbackVersion } from './node-fallback/version';
 
 const NODE_FALLBACK_OPTION_PARSER = buildCommandOptionParser(
   ALL_COMMAND_OPTION_METADATA,
@@ -76,24 +65,6 @@ const printLine: PrintLine = (line) => {
 const warnLine: PrintLine = (line) => {
   console.warn(line);
 };
-
-function createNoCommandCliError() {
-  return createCliCommandError({
-    code: CLI_DIAGNOSTIC_CODES.INVALID_COMMAND,
-    command: 'wp-typia',
-    detailLines: [NODE_FALLBACK_NO_COMMAND_REASON_LINE],
-    summary: 'No command was provided.',
-  });
-}
-
-function isNoCommandCliDiagnostic(error: unknown): boolean {
-  return (
-    isCliDiagnosticError(error) &&
-    error.code === CLI_DIAGNOSTIC_CODES.INVALID_COMMAND &&
-    error.command === 'wp-typia' &&
-    error.detailLines.includes(NODE_FALLBACK_NO_COMMAND_REASON_LINE)
-  );
-}
 
 export function hasFlagBeforeTerminator(argv: string[], flag: string): boolean {
   for (const arg of argv) {
@@ -172,129 +143,10 @@ function parseArgv(argv: string[]) {
   });
 }
 
-function renderVersion(
-  options: {
-    format?: string;
-  } = {},
-) {
-  if (options.format === 'json') {
-    printLine(
-      JSON.stringify(
-        {
-          ok: true,
-          data: {
-            type: 'version',
-            name: packageJson.name,
-            version: packageJson.version,
-          },
-        },
-        null,
-        2,
-      ),
-    );
-    return;
-  }
-
-  printLine(`wp-typia ${packageJson.version}`);
-}
-
-function renderTemplatesJson(
-  flags: NodeFallbackGlobalFlags,
-  subcommand: string,
-) {
-  if (subcommand === 'list') {
-    printLine(
-      JSON.stringify(
-        {
-          templates: listTemplates(),
-        },
-        null,
-        2,
-      ),
-    );
-    return;
-  }
-
-  const templateId = flags.id;
-  if (!templateId) {
-    throw createCliCommandError({
-      code: CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
-      command: 'templates',
-      detailLines: ['`wp-typia templates inspect` requires <template-id>.'],
-    });
-  }
-  const template = getTemplateById(templateId);
-  if (!template) {
-    throw createCliCommandError({
-      code: CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
-      command: 'templates',
-      detailLines: [`Unknown template "${templateId}".`],
-    });
-  }
-  printLine(
-    JSON.stringify(
-      {
-        template,
-      },
-      null,
-      2,
-    ),
-  );
-}
-
-function renderUnsupportedCommand(command: string) {
-  throw createCliCommandError({
-    code: CLI_DIAGNOSTIC_CODES.UNSUPPORTED_COMMAND,
-    command: command,
-    detailLines: [
-      [
-        `The Bun-free fallback runtime does not support \`${command}\` yet.`,
-        'Supported without Bun: `--version`, `--help`, non-interactive `create`/`init`/`add`/`migrate`, `doctor`, `sync`, `templates list`, and `templates inspect`.',
-        `Install Bun 1.3.11+ or use \`bunx wp-typia ...\` for the full Bunli-powered runtime. ${STANDALONE_GUIDANCE_LINE}`,
-      ].join(' '),
-    ],
-    summary: 'This command requires the Bun-powered runtime.',
-  });
-}
-
-async function renderDoctorJson(): Promise<void> {
-  const [
-    { getDoctorChecks },
-    { createCliCommandError, getDoctorFailureDetailLines },
-  ] = await Promise.all([
-    import('@wp-typia/project-tools/cli-doctor'),
-    import('@wp-typia/project-tools/cli-diagnostics'),
-  ]);
-  const checks = await getDoctorChecks(process.cwd());
-  printLine(
-    JSON.stringify(
-      {
-        checks,
-      },
-      null,
-      2,
-    ),
-  );
-  if (checks.some((check) => check.status === 'fail')) {
-    throw createCliCommandError({
-      code: CLI_DIAGNOSTIC_CODES.DOCTOR_CHECK_FAILED,
-      command: 'doctor',
-      detailLines: getDoctorFailureDetailLines(checks),
-      summary: 'One or more doctor checks failed.',
-    });
-  }
-}
-
 const NODE_FALLBACK_COMMAND_DISPATCHERS = {
   add: dispatchNodeFallbackAdd,
   create: dispatchNodeFallbackCreate,
-  doctor: async ({ cwd, mergedFlags }: NodeFallbackDispatchContext) => {
-    if (mergedFlags.format === 'json') {
-      await renderDoctorJson();
-      return;
-    }
-    await executeDoctorCommand(cwd);
-  },
+  doctor: dispatchNodeFallbackDoctor,
   init: async ({
     cwd,
     mergedFlags,
@@ -388,43 +240,7 @@ const NODE_FALLBACK_COMMAND_DISPATCHERS = {
       });
     }
   },
-  templates: async ({
-    mergedFlags,
-    positionals,
-    printLine,
-  }: NodeFallbackDispatchContext) => {
-    const subcommand = positionals[1];
-    const templateId =
-      typeof mergedFlags.id === 'string'
-        ? mergedFlags.id
-        : (positionals[2] as string | undefined);
-    const resolvedSubcommand = templateId ? 'inspect' : (subcommand ?? 'list');
-    if (resolvedSubcommand !== 'list' && resolvedSubcommand !== 'inspect') {
-      throw createCliCommandError({
-        code: CLI_DIAGNOSTIC_CODES.INVALID_COMMAND,
-        command: 'templates',
-        detailLines: [
-          `Unknown templates subcommand "${resolvedSubcommand}". Expected list or inspect.`,
-        ],
-      });
-    }
-    if (mergedFlags.format === 'json') {
-      renderTemplatesJson(
-        {
-          format: mergedFlags.format as string | undefined,
-          id: templateId,
-        },
-        resolvedSubcommand,
-      );
-      return;
-    }
-    await executeTemplatesCommand({
-      flags: {
-        id: templateId,
-        subcommand: resolvedSubcommand,
-      },
-    }, printLine);
-  },
+  templates: dispatchNodeFallbackTemplates,
 } satisfies Record<
   NodeFallbackExecutableCommandName,
   NodeFallbackCommandDispatcher
@@ -452,7 +268,7 @@ export async function runNodeCli(argv = process.argv.slice(2)): Promise<void> {
     hasFlagBeforeTerminator(cliArgv, '--version') || command === 'version';
 
   if (cliArgv.length === 0) {
-    const noCommandError = createNoCommandCliError();
+    const noCommandError = createNodeFallbackNoCommandCliError();
     if (rawMergedFlags.format !== 'json') {
       renderNoCommandHelp(printLine);
     }
@@ -482,7 +298,7 @@ export async function runNodeCli(argv = process.argv.slice(2)): Promise<void> {
   }
 
   if (versionRequested) {
-    renderVersion({
+    renderNodeFallbackVersion(printLine, {
       format:
         typeof rawMergedFlags.format === 'string'
           ? rawMergedFlags.format
@@ -515,41 +331,15 @@ export async function runNodeCli(argv = process.argv.slice(2)): Promise<void> {
     return;
   }
 
-  renderUnsupportedCommand(command ?? '(missing)');
+  throwUnsupportedNodeFallbackCommand(command ?? '(missing)');
 }
 
 export async function runNodeCliEntrypoint(
   argv = process.argv.slice(2),
 ): Promise<void> {
-  const prefersStructuredErrorOutput = prefersStructuredCliArgv(argv);
-
   try {
     await runNodeCli(argv);
   } catch (error) {
-    if (prefersStructuredErrorOutput) {
-      const diagnostic = createCliCommandError({
-        command: resolveCanonicalCommandContext(argv),
-        error,
-      });
-      process.stderr.write(
-        `${JSON.stringify(
-          {
-            ok: false,
-            error: serializeCliDiagnosticError(diagnostic),
-          },
-          null,
-          2,
-        )}\n`,
-      );
-      process.exitCode = 1;
-      return;
-    }
-    if (isNoCommandCliDiagnostic(error)) {
-      // Human no-command output already includes the explanatory line and help.
-      process.exitCode = 1;
-      return;
-    }
-    console.error(`Error: ${await formatCliDiagnosticError(error)}`);
-    process.exitCode = 1;
+    await handleNodeFallbackEntrypointError(error, argv);
   }
 }

--- a/packages/wp-typia/src/node-fallback/doctor.ts
+++ b/packages/wp-typia/src/node-fallback/doctor.ts
@@ -1,0 +1,48 @@
+import {
+  CLI_DIAGNOSTIC_CODES,
+  createCliCommandError,
+} from '@wp-typia/project-tools/cli-diagnostics';
+import { executeDoctorCommand } from '../runtime-bridge';
+import type { PrintLine } from '../print-line';
+import type { NodeFallbackDispatchContext } from './types';
+
+async function renderNodeFallbackDoctorJson(
+  cwd: string,
+  printLine: PrintLine,
+): Promise<void> {
+  const [{ getDoctorChecks }, { getDoctorFailureDetailLines }] =
+    await Promise.all([
+      import('@wp-typia/project-tools/cli-doctor'),
+      import('@wp-typia/project-tools/cli-diagnostics'),
+    ]);
+  const checks = await getDoctorChecks(cwd);
+  printLine(
+    JSON.stringify(
+      {
+        checks,
+      },
+      null,
+      2,
+    ),
+  );
+  if (checks.some((check) => check.status === 'fail')) {
+    throw createCliCommandError({
+      code: CLI_DIAGNOSTIC_CODES.DOCTOR_CHECK_FAILED,
+      command: 'doctor',
+      detailLines: getDoctorFailureDetailLines(checks),
+      summary: 'One or more doctor checks failed.',
+    });
+  }
+}
+
+export async function dispatchNodeFallbackDoctor({
+  cwd,
+  mergedFlags,
+  printLine,
+}: NodeFallbackDispatchContext): Promise<void> {
+  if (mergedFlags.format === 'json') {
+    await renderNodeFallbackDoctorJson(cwd, printLine);
+    return;
+  }
+  await executeDoctorCommand(cwd);
+}

--- a/packages/wp-typia/src/node-fallback/errors.ts
+++ b/packages/wp-typia/src/node-fallback/errors.ts
@@ -1,0 +1,77 @@
+import {
+  CLI_DIAGNOSTIC_CODES,
+  createCliCommandError,
+  formatCliDiagnosticError,
+  isCliDiagnosticError,
+  serializeCliDiagnosticError,
+} from '@wp-typia/project-tools/cli-diagnostics';
+import { prefersStructuredCliArgv } from '../cli-diagnostic-output';
+import { resolveCanonicalCommandContext } from '../command-contract';
+import {
+  NODE_FALLBACK_NO_COMMAND_REASON_LINE,
+  STANDALONE_GUIDANCE_LINE,
+} from './help';
+
+export function createNodeFallbackNoCommandCliError() {
+  return createCliCommandError({
+    code: CLI_DIAGNOSTIC_CODES.INVALID_COMMAND,
+    command: 'wp-typia',
+    detailLines: [NODE_FALLBACK_NO_COMMAND_REASON_LINE],
+    summary: 'No command was provided.',
+  });
+}
+
+function isNodeFallbackNoCommandCliDiagnostic(error: unknown): boolean {
+  return (
+    isCliDiagnosticError(error) &&
+    error.code === CLI_DIAGNOSTIC_CODES.INVALID_COMMAND &&
+    error.command === 'wp-typia' &&
+    error.detailLines.includes(NODE_FALLBACK_NO_COMMAND_REASON_LINE)
+  );
+}
+
+export function throwUnsupportedNodeFallbackCommand(command: string): never {
+  throw createCliCommandError({
+    code: CLI_DIAGNOSTIC_CODES.UNSUPPORTED_COMMAND,
+    command: command,
+    detailLines: [
+      [
+        `The Bun-free fallback runtime does not support \`${command}\` yet.`,
+        'Supported without Bun: `--version`, `--help`, non-interactive `create`/`init`/`add`/`migrate`, `doctor`, `sync`, `templates list`, and `templates inspect`.',
+        `Install Bun 1.3.11+ or use \`bunx wp-typia ...\` for the full Bunli-powered runtime. ${STANDALONE_GUIDANCE_LINE}`,
+      ].join(' '),
+    ],
+    summary: 'This command requires the Bun-powered runtime.',
+  });
+}
+
+export async function handleNodeFallbackEntrypointError(
+  error: unknown,
+  argv: string[],
+): Promise<void> {
+  if (prefersStructuredCliArgv(argv)) {
+    const diagnostic = createCliCommandError({
+      command: resolveCanonicalCommandContext(argv),
+      error,
+    });
+    process.stderr.write(
+      `${JSON.stringify(
+        {
+          ok: false,
+          error: serializeCliDiagnosticError(diagnostic),
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+  if (isNodeFallbackNoCommandCliDiagnostic(error)) {
+    // Human no-command output already includes the explanatory line and help.
+    process.exitCode = 1;
+    return;
+  }
+  console.error(`Error: ${await formatCliDiagnosticError(error)}`);
+  process.exitCode = 1;
+}

--- a/packages/wp-typia/src/node-fallback/templates.ts
+++ b/packages/wp-typia/src/node-fallback/templates.ts
@@ -1,0 +1,97 @@
+import {
+  CLI_DIAGNOSTIC_CODES,
+  createCliCommandError,
+} from '@wp-typia/project-tools/cli-diagnostics';
+import {
+  getTemplateById,
+  listTemplates,
+} from '@wp-typia/project-tools/cli-templates';
+import { executeTemplatesCommand } from '../runtime-bridge';
+import type { NodeFallbackDispatchContext, NodeFallbackGlobalFlags } from './types';
+
+function renderNodeFallbackTemplatesJson(
+  printLine: NodeFallbackDispatchContext['printLine'],
+  flags: NodeFallbackGlobalFlags,
+  subcommand: string,
+) {
+  if (subcommand === 'list') {
+    printLine(
+      JSON.stringify(
+        {
+          templates: listTemplates(),
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  const templateId = flags.id;
+  if (!templateId) {
+    throw createCliCommandError({
+      code: CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
+      command: 'templates',
+      detailLines: ['`wp-typia templates inspect` requires <template-id>.'],
+    });
+  }
+  const template = getTemplateById(templateId);
+  if (!template) {
+    throw createCliCommandError({
+      code: CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
+      command: 'templates',
+      detailLines: [`Unknown template "${templateId}".`],
+    });
+  }
+  printLine(
+    JSON.stringify(
+      {
+        template,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+export async function dispatchNodeFallbackTemplates({
+  mergedFlags,
+  positionals,
+  printLine,
+}: NodeFallbackDispatchContext): Promise<void> {
+  const subcommand = positionals[1];
+  const templateId =
+    typeof mergedFlags.id === 'string'
+      ? mergedFlags.id
+      : (positionals[2] as string | undefined);
+  const resolvedSubcommand = templateId ? 'inspect' : (subcommand ?? 'list');
+  if (resolvedSubcommand !== 'list' && resolvedSubcommand !== 'inspect') {
+    throw createCliCommandError({
+      code: CLI_DIAGNOSTIC_CODES.INVALID_COMMAND,
+      command: 'templates',
+      detailLines: [
+        `Unknown templates subcommand "${resolvedSubcommand}". Expected list or inspect.`,
+      ],
+    });
+  }
+  if (mergedFlags.format === 'json') {
+    renderNodeFallbackTemplatesJson(
+      printLine,
+      {
+        format: mergedFlags.format as string | undefined,
+        id: templateId,
+      },
+      resolvedSubcommand,
+    );
+    return;
+  }
+  await executeTemplatesCommand(
+    {
+      flags: {
+        id: templateId,
+        subcommand: resolvedSubcommand,
+      },
+    },
+    printLine,
+  );
+}

--- a/packages/wp-typia/src/node-fallback/templates.ts
+++ b/packages/wp-typia/src/node-fallback/templates.ts
@@ -64,7 +64,7 @@ export async function dispatchNodeFallbackTemplates({
     typeof mergedFlags.id === 'string'
       ? mergedFlags.id
       : (positionals[2] as string | undefined);
-  const resolvedSubcommand = templateId ? 'inspect' : (subcommand ?? 'list');
+  const resolvedSubcommand = subcommand ?? (templateId ? 'inspect' : 'list');
   if (resolvedSubcommand !== 'list' && resolvedSubcommand !== 'inspect') {
     throw createCliCommandError({
       code: CLI_DIAGNOSTIC_CODES.INVALID_COMMAND,

--- a/packages/wp-typia/src/node-fallback/version.ts
+++ b/packages/wp-typia/src/node-fallback/version.ts
@@ -1,0 +1,29 @@
+import packageJson from '../../package.json';
+import type { PrintLine } from '../print-line';
+
+export function renderNodeFallbackVersion(
+  printLine: PrintLine,
+  options: {
+    format?: string;
+  } = {},
+) {
+  if (options.format === 'json') {
+    printLine(
+      JSON.stringify(
+        {
+          ok: true,
+          data: {
+            type: 'version',
+            name: packageJson.name,
+            version: packageJson.version,
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  printLine(`wp-typia ${packageJson.version}`);
+}

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -1064,6 +1064,12 @@ process.exit(0);
       code: 'invalid-command',
       command: 'templates',
     });
+    await expect(
+      runNodeCli(['templates', 'unknown', 'basic', '--format', 'json']),
+    ).rejects.toMatchObject({
+      code: 'invalid-command',
+      command: 'templates',
+    });
   });
 
   test('formats migrate failures with a shared non-interactive diagnostic block', () => {

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -97,6 +97,10 @@ const nodeFallbackHelpSource = fs.readFileSync(
   path.join(packageRoot, 'src', 'node-fallback', 'help.ts'),
   'utf8',
 );
+const nodeFallbackErrorsSource = fs.readFileSync(
+  path.join(packageRoot, 'src', 'node-fallback', 'errors.ts'),
+  'utf8',
+);
 const cliSource = fs.readFileSync(
   path.join(packageRoot, 'src', 'cli.ts'),
   'utf8',
@@ -241,7 +245,8 @@ describe('wp-typia package', () => {
     expect(migrateCommandSource).not.toMatch(
       /typeof\s+Bun\s*!==\s*["']undefined["']/,
     );
-    expect(nodeCliSource).toContain('process.exitCode = 1');
+    expect(nodeFallbackErrorsSource).toContain('process.exitCode = 1');
+    expect(nodeCliSource).toContain('handleNodeFallbackEntrypointError');
     expect(nodeCliSource).not.toMatch(/process\.exit\s*\(\s*1\s*\)/);
     expect(cliSource).toContain('process.exitCode = 1');
     expect(cliSource).not.toMatch(/process\.exit\s*\(\s*1\s*\)/);

--- a/packages/wp-typia/tests/node-cli-core.test.ts
+++ b/packages/wp-typia/tests/node-cli-core.test.ts
@@ -242,6 +242,22 @@ describe('Node fallback CLI core routing', () => {
       path.join(packageRoot, 'src', 'node-fallback', 'help.ts'),
       'utf8',
     );
+    const versionSource = fs.readFileSync(
+      path.join(packageRoot, 'src', 'node-fallback', 'version.ts'),
+      'utf8',
+    );
+    const templatesSource = fs.readFileSync(
+      path.join(packageRoot, 'src', 'node-fallback', 'templates.ts'),
+      'utf8',
+    );
+    const doctorSource = fs.readFileSync(
+      path.join(packageRoot, 'src', 'node-fallback', 'doctor.ts'),
+      'utf8',
+    );
+    const errorsSource = fs.readFileSync(
+      path.join(packageRoot, 'src', 'node-fallback', 'errors.ts'),
+      'utf8',
+    );
     const cliErrorMessagesSource = fs.readFileSync(
       path.join(packageRoot, 'src', 'cli-error-messages.ts'),
       'utf8',
@@ -257,8 +273,19 @@ describe('Node fallback CLI core routing', () => {
     expect(nodeCliSource).toContain(
       "from './node-fallback/dispatchers/create'",
     );
+    expect(nodeCliSource).toContain("from './node-fallback/doctor'");
+    expect(nodeCliSource).toContain("from './node-fallback/errors'");
     expect(nodeCliSource).toContain("from './node-fallback/help'");
+    expect(nodeCliSource).toContain("from './node-fallback/templates'");
+    expect(nodeCliSource).toContain("from './node-fallback/version'");
     expect(nodeCliSource).not.toContain('formatAddHelpText');
+    expect(nodeCliSource).not.toContain('function renderVersion');
+    expect(nodeCliSource).not.toContain('function renderTemplatesJson');
+    expect(nodeCliSource).not.toContain('function renderDoctorJson');
+    expect(nodeCliSource).not.toContain('formatCliDiagnosticError');
+    expect(nodeCliSource).not.toContain('serializeCliDiagnosticError');
+    expect(nodeCliSource).not.toContain('getTemplateById');
+    expect(nodeCliSource).not.toContain('getDoctorChecks');
     expect(addDispatcherSource).toContain(
       'export async function dispatchNodeFallbackAdd',
     );
@@ -288,6 +315,20 @@ describe('Node fallback CLI core routing', () => {
     );
     expect(helpSource).toContain("import { printBlock } from '../print-block'");
     expect(helpSource).not.toContain('export function printBlock');
+    expect(versionSource).toContain('export function renderNodeFallbackVersion');
+    expect(versionSource).toContain("import packageJson from '../../package.json'");
+    expect(templatesSource).toContain(
+      'export async function dispatchNodeFallbackTemplates',
+    );
+    expect(templatesSource).toContain('function renderNodeFallbackTemplatesJson');
+    expect(doctorSource).toContain(
+      'export async function dispatchNodeFallbackDoctor',
+    );
+    expect(doctorSource).toContain('function renderNodeFallbackDoctorJson');
+    expect(errorsSource).toContain(
+      'export async function handleNodeFallbackEntrypointError',
+    );
+    expect(errorsSource).toContain('throwUnsupportedNodeFallbackCommand');
     expect(printBlockSource).toContain(
       'export function printBlock(printLine: PrintLine, lines: string[])',
     );


### PR DESCRIPTION
## Summary
- move Node fallback version rendering into a focused version module
- move templates and doctor JSON dispatch/rendering into node-fallback modules
- move entrypoint error formatting and unsupported-command handling into a fallback error helper
- add structural tests so these paths stay out of node-cli.ts

## Validation
- bun test packages/wp-typia/tests/node-cli-core.test.ts
- bun test packages/wp-typia/tests/cli-package.test.ts
- bun run format:check
- bun run --filter wp-typia build
- bun run lint:repo
- bun run typecheck
- bun run changesets:validate
- git diff --check

Closes #920

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * CLI fallback behaviors were reorganized so commands are delegated to focused modules for simpler, more reliable handling.

* **New Features**
  * Version output supports plain text and JSON modes.
  * Templates command supports list and inspect operations with JSON output.

* **Bug Fixes**
  * Doctor diagnostics now emit structured JSON and properly exit with failure when checks fail.
  * Unsupported or missing commands produce clearer CLI diagnostic messages and consistent exit codes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/940)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->