### PR TITLE
docs(runtime): document temp-root cleanup swallow

### DIFF
--- a/.sampo/changesets/921-temp-root-cleanup-doc.md
+++ b/.sampo/changesets/921-temp-root-cleanup-doc.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Document why process-exit temp-root cleanup intentionally ignores removal failures.

--- a/packages/wp-typia-project-tools/src/runtime/temp-roots.ts
+++ b/packages/wp-typia-project-tools/src/runtime/temp-roots.ts
@@ -34,7 +34,10 @@ function cleanupTrackedTempRootsSync(): void {
 		trackedTempRoots.delete(tempRoot);
 		try {
 			fs.rmSync(tempRoot, { force: true, recursive: true });
-		} catch {}
+		} catch {
+			// Process-exit cleanup is best-effort: shutdown-time rm failures
+			// such as EPERM are intentionally ignored rather than made fatal.
+		}
 	}
 }
 

--- a/packages/wp-typia-project-tools/tests/temp-roots.test.ts
+++ b/packages/wp-typia-project-tools/tests/temp-roots.test.ts
@@ -65,4 +65,14 @@ describe("@wp-typia/project-tools temp root management", () => {
 		expect(fs.existsSync(freshRoot)).toBe(true);
 		expect(fs.existsSync(unrelatedRoot)).toBe(true);
 	});
+
+	test("documents why process-exit cleanup ignores rm failures", async () => {
+		const source = await fs.promises.readFile(
+			new URL("../src/runtime/temp-roots.ts", import.meta.url),
+			"utf8",
+		);
+
+		expect(source).toContain("Process-exit cleanup is best-effort");
+		expect(source).toContain("such as EPERM are intentionally ignored");
+	});
 });


### PR DESCRIPTION
## Summary
- document why process-exit temp-root cleanup intentionally ignores shutdown-time rm failures
- add a focused regression test that keeps the cleanup rationale visible
- add a Sampo changeset for @wp-typia/project-tools

## Validation
- bun test packages/wp-typia-project-tools/tests/temp-roots.test.ts
- bun run changesets:validate
- bun run lint:repo
- bun run typecheck
- bun run --filter @wp-typia/project-tools build
- bun run format:check
- bun run maintenance-automation:validate
- bun run formatting-policy:validate
- bun run manifest-policy:validate && bun run typescript-strictness:validate && bun run runtime-coupling:validate && bun run typescript-runtime:validate && bun run publish:validate
- git diff --check

Closes #921

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation clarifying that temporary root cleanup intentionally ignores failures that occur during process shutdown.

* **Tests**
  * Added test coverage to verify cleanup failure documentation and behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/941)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->