### PR TITLE
[codex] feat(doctor): add workspace-only exit policy

### DIFF
--- a/.sampo/changesets/925-doctor-workspace-only.md
+++ b/.sampo/changesets/925-doctor-workspace-only.md
@@ -1,0 +1,6 @@
+---
+npm/wp-typia: patch
+npm/@wp-typia/project-tools: patch
+---
+
+Add `wp-typia doctor --workspace-only` with JSON exit-policy summaries so CI can treat environment/runtime failures as advisory while preserving strict doctor behavior by default.

--- a/packages/wp-typia-project-tools/src/runtime/cli-core.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-core.ts
@@ -30,7 +30,18 @@
  * `getTemplateSelectOptions`, `listTemplates`, and `isBuiltInTemplateId` for
  * template inspection flows.
  */
-export { getDoctorChecks, runDoctor, type DoctorCheck } from "./cli-doctor.js";
+export {
+	createDoctorRunSummary,
+	getDoctorChecks,
+	getDoctorExitFailureChecks,
+	getDoctorExitFailureDetailLines,
+	runDoctor,
+	type DoctorCheck,
+	type DoctorCheckScope,
+	type DoctorExitPolicy,
+	type DoctorFailureSummary,
+	type DoctorRunSummary,
+} from "./cli-doctor.js";
 export {
 	createCliCommandError,
 	createCliDiagnosticCodeError,

--- a/packages/wp-typia-project-tools/src/runtime/cli-diagnostics.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-diagnostics.ts
@@ -519,15 +519,25 @@ export function getFailingDoctorChecks<TCheck extends DoctorCheckLike>(
 /**
  * Format the final doctor summary row.
  */
-export function formatDoctorSummaryLine(checks: readonly DoctorCheckLike[]): string {
+export function formatDoctorSummaryLine(
+	checks: readonly DoctorCheckLike[],
+	options: { exitFailureChecks?: readonly DoctorCheckLike[] } = {},
+): string {
 	const failedChecks = getFailingDoctorChecks(checks);
+	const exitFailureChecks = options.exitFailureChecks ?? failedChecks;
+	const advisoryFailureCount = failedChecks.length - exitFailureChecks.length;
 	const warningCount = checks.filter((check) => check.status === "warn").length;
 	const summaryStatus =
-		failedChecks.length > 0 ? "FAIL" : warningCount > 0 ? "WARN" : "PASS";
+		exitFailureChecks.length > 0
+			? "FAIL"
+			: advisoryFailureCount > 0 || warningCount > 0
+				? "WARN"
+				: "PASS";
 	return formatWrappedPrefixedLine(
 		`${summaryStatus} wp-typia doctor summary: `,
 		[
 			`${checks.length - failedChecks.length - warningCount}/${checks.length} checks passed`,
+			advisoryFailureCount > 0 ? `${advisoryFailureCount} advisory failure(s)` : null,
 			warningCount > 0 ? `${warningCount} warning(s)` : null,
 		]
 			.filter((detail): detail is string => detail !== null)

--- a/packages/wp-typia-project-tools/src/runtime/cli-doctor.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-doctor.ts
@@ -177,12 +177,19 @@ export function createDoctorRunSummary(
 }
 
 /**
- * Run doctor checks, render each line, and fail when any check does not pass.
+ * Run doctor checks, render each line, and fail when one or more failed checks
+ * contribute to the exit code under the active exit policy.
+ *
+ * The default `strict` policy treats every failed row as exit-contributing.
+ * The `workspace-only` policy only fails on workspace-scoped rows so
+ * environment/runtime failures remain advisory for CI gates that only care
+ * about generated workspace artifacts.
  *
  * @param cwd Working directory to validate.
- * @param options Optional renderer override for each emitted check row.
+ * @param options Optional renderer overrides and exit-policy selection.
+ * @param options.exitPolicy Policy deciding which failed checks contribute to the process exit code.
  * @returns The completed list of doctor checks.
- * @throws {Error} When one or more checks fail.
+ * @throws {Error} When one or more failed checks contribute to the exit code under the active policy.
  */
 export async function runDoctor(
 	cwd: string,

--- a/packages/wp-typia-project-tools/src/runtime/cli-doctor.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-doctor.ts
@@ -3,10 +3,15 @@ import {
 	createCliCommandError,
 	formatDoctorCheckLine,
 	formatDoctorSummaryLine,
-	getDoctorFailureDetailLines,
 } from "./cli-diagnostics.js";
 import { getEnvironmentDoctorChecks } from "./cli-doctor-environment.js";
 import { getWorkspaceDoctorChecks } from "./cli-doctor-workspace.js";
+
+/** Scope bucket used by doctor exit policies and JSON summaries. */
+export type DoctorCheckScope = "environment" | "workspace";
+
+/** Policy used to decide which failed checks should fail the process. */
+export type DoctorExitPolicy = "strict" | "workspace-only";
 
 /**
  * One doctor check rendered by the CLI diagnostics flow.
@@ -18,13 +23,83 @@ export interface DoctorCheck {
 	detail: string;
 	/** Short label for the dependency, directory, or template check. */
 	label: string;
+	/** Scope bucket used by machine-readable summaries and exit-code policies. */
+	scope?: DoctorCheckScope;
 	/** Final pass/fail/warn status for this diagnostic row. */
 	status: "pass" | "fail" | "warn";
 }
 
+/** One failed row classified against the active doctor exit policy. */
+export interface DoctorFailureSummary {
+	code?: string;
+	label: string;
+	scope: DoctorCheckScope | "unknown";
+	severity: "advisory" | "error";
+}
+
+/** Stable JSON summary for `wp-typia doctor --format json`. */
+export interface DoctorRunSummary {
+	advisoryFailureCount: number;
+	advisoryFailures: DoctorFailureSummary[];
+	exitCode: 0 | 1;
+	exitFailureCount: number;
+	exitFailures: DoctorFailureSummary[];
+	exitPolicy: DoctorExitPolicy;
+	failed: number;
+	passed: number;
+	total: number;
+	warnings: number;
+}
+
 interface RunDoctorOptions {
+	exitPolicy?: DoctorExitPolicy;
 	renderLine?: (check: DoctorCheck) => void;
 	renderSummaryLine?: (summaryLine: string) => void;
+}
+
+interface DoctorSummaryOptions {
+	exitPolicy?: DoctorExitPolicy;
+}
+
+const DEFAULT_DOCTOR_EXIT_POLICY: DoctorExitPolicy = "strict";
+
+function annotateDoctorChecks(
+	checks: DoctorCheck[],
+	scope: DoctorCheckScope,
+): DoctorCheck[] {
+	return checks.map((check) => ({
+		...check,
+		scope: check.scope ?? scope,
+	}));
+}
+
+function resolveDoctorExitPolicy(options: DoctorSummaryOptions): DoctorExitPolicy {
+	return options.exitPolicy ?? DEFAULT_DOCTOR_EXIT_POLICY;
+}
+
+function doesCheckContributeToExit(
+	check: DoctorCheck,
+	exitPolicy: DoctorExitPolicy,
+): boolean {
+	if (check.status !== "fail") {
+		return false;
+	}
+	if (exitPolicy === "strict") {
+		return true;
+	}
+	return check.scope === "workspace";
+}
+
+function toFailureSummary(
+	check: DoctorCheck,
+	severity: DoctorFailureSummary["severity"],
+): DoctorFailureSummary {
+	return {
+		...(check.code ? { code: check.code } : {}),
+		label: check.label,
+		scope: check.scope ?? "unknown",
+		severity,
+	};
 }
 
 /**
@@ -40,9 +115,65 @@ interface RunDoctorOptions {
  */
 export async function getDoctorChecks(cwd: string): Promise<DoctorCheck[]> {
 	return [
-		...(await getEnvironmentDoctorChecks(cwd)),
-		...(await getWorkspaceDoctorChecks(cwd)),
+		...annotateDoctorChecks(await getEnvironmentDoctorChecks(cwd), "environment"),
+		...annotateDoctorChecks(await getWorkspaceDoctorChecks(cwd), "workspace"),
 	];
+}
+
+/**
+ * Return failed rows that contribute to the process exit code for one policy.
+ */
+export function getDoctorExitFailureChecks(
+	checks: readonly DoctorCheck[],
+	options: DoctorSummaryOptions = {},
+): DoctorCheck[] {
+	const exitPolicy = resolveDoctorExitPolicy(options);
+	return checks.filter((check) => doesCheckContributeToExit(check, exitPolicy));
+}
+
+/**
+ * Format only exit-contributing doctor failures for structured diagnostics.
+ */
+export function getDoctorExitFailureDetailLines(
+	checks: readonly DoctorCheck[],
+	options: DoctorSummaryOptions = {},
+): string[] {
+	return getDoctorExitFailureChecks(checks, options).map(
+		(check) => `${check.label}: ${check.detail}`,
+	);
+}
+
+/**
+ * Build the stable JSON summary for one doctor run.
+ */
+export function createDoctorRunSummary(
+	checks: readonly DoctorCheck[],
+	options: DoctorSummaryOptions = {},
+): DoctorRunSummary {
+	const exitPolicy = resolveDoctorExitPolicy(options);
+	const failedChecks = checks.filter((check) => check.status === "fail");
+	const exitFailureChecks = failedChecks.filter((check) =>
+		doesCheckContributeToExit(check, exitPolicy),
+	);
+	const advisoryFailureChecks = failedChecks.filter(
+		(check) => !doesCheckContributeToExit(check, exitPolicy),
+	);
+	const warnings = checks.filter((check) => check.status === "warn").length;
+
+	return {
+		advisoryFailureCount: advisoryFailureChecks.length,
+		advisoryFailures: advisoryFailureChecks.map((check) =>
+			toFailureSummary(check, "advisory"),
+		),
+		exitCode: exitFailureChecks.length > 0 ? 1 : 0,
+		exitFailureCount: exitFailureChecks.length,
+		exitFailures: exitFailureChecks.map((check) => toFailureSummary(check, "error")),
+		exitPolicy,
+		failed: failedChecks.length,
+		passed: checks.length - failedChecks.length - warnings,
+		total: checks.length,
+		warnings,
+	};
 }
 
 /**
@@ -57,6 +188,7 @@ export async function runDoctor(
 	cwd: string,
 	options: RunDoctorOptions = {},
 ): Promise<DoctorCheck[]> {
+	const exitPolicy = resolveDoctorExitPolicy(options);
 	const renderLine =
 		options.renderLine ?? ((check: DoctorCheck) => console.log(formatDoctorCheckLine(check)));
 	const renderSummaryLine =
@@ -68,9 +200,10 @@ export async function runDoctor(
 		renderLine(check);
 	}
 
-	renderSummaryLine(formatDoctorSummaryLine(checks));
+	const exitFailureChecks = getDoctorExitFailureChecks(checks, { exitPolicy });
+	renderSummaryLine(formatDoctorSummaryLine(checks, { exitFailureChecks }));
 
-	const failureDetailLines = getDoctorFailureDetailLines(checks);
+	const failureDetailLines = getDoctorExitFailureDetailLines(checks, { exitPolicy });
 	if (failureDetailLines.length > 0) {
 		throw createCliCommandError({
 			code: CLI_DIAGNOSTIC_CODES.DOCTOR_CHECK_FAILED,

--- a/packages/wp-typia-project-tools/src/runtime/index.ts
+++ b/packages/wp-typia-project-tools/src/runtime/index.ts
@@ -174,6 +174,7 @@ export {
 } from "./temp-roots.js";
 export {
 	createReadlinePrompt,
+	createDoctorRunSummary,
 	createCliCommandError,
 	createCliDiagnosticCodeError,
 	CliDiagnosticError,
@@ -187,6 +188,8 @@ export {
 	formatTemplateFeatures,
 	formatTemplateSummary,
 	getDoctorChecks,
+	getDoctorExitFailureChecks,
+	getDoctorExitFailureDetailLines,
 	getDoctorFailureDetailLines,
 	getFailingDoctorChecks,
 	getNextSteps,
@@ -216,6 +219,10 @@ export type {
 	CliDiagnosticCodeError,
 	CliDiagnosticMessage,
 	DoctorCheck,
+	DoctorCheckScope,
+	DoctorExitPolicy,
+	DoctorFailureSummary,
+	DoctorRunSummary,
 	EditorPluginSlotId,
 	HookedBlockPositionId,
 	ReadlinePrompt,

--- a/packages/wp-typia-project-tools/tests/cli-entry.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-entry.test.ts
@@ -1245,12 +1245,15 @@ test("node entry exposes fallback help and rejects the removed migrations alias"
   expect(helpOutput).toContain(
     "Inspect or sync schema-driven MCP metadata."
   );
-  expect(doctorHelpOutput).toContain("Usage: wp-typia doctor [--format json]");
+  expect(doctorHelpOutput).toContain(
+    "Usage: wp-typia doctor [--format json] [--workspace-only]"
+  );
   expect(doctorHelpOutput).toContain("Supported flags:");
   expect(doctorHelpOutput).toContain("--format");
+  expect(doctorHelpOutput).toContain("--workspace-only");
   expect(doctorHelpOutput).toContain("machine-readable doctor check output");
   expect(doctorHelpAliasOutput).toContain(
-    "Usage: wp-typia doctor [--format json]"
+    "Usage: wp-typia doctor [--format json] [--workspace-only]"
   );
   expect(errorMessage).toContain(
     "`wp-typia migrations` was removed in favor of `wp-typia migrate`."
@@ -1286,9 +1289,12 @@ test("bun entry exposes fallback help and rejects the removed migrations alias",
   expect(helpOutput).toContain(
     "Inspect or sync schema-driven MCP metadata."
   );
-  expect(doctorHelpOutput).toContain("Usage: wp-typia doctor [--format json]");
+  expect(doctorHelpOutput).toContain(
+    "Usage: wp-typia doctor [--format json] [--workspace-only]"
+  );
   expect(doctorHelpOutput).toContain("Supported flags:");
   expect(doctorHelpOutput).toContain("--format");
+  expect(doctorHelpOutput).toContain("--workspace-only");
   expect(doctorHelpOutput).toContain("machine-readable doctor check output");
   expect(errorMessage).toContain(
     "`wp-typia migrations` was removed in favor of `wp-typia migrate`."

--- a/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
@@ -3,7 +3,11 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { cleanupScaffoldTempRoot, createScaffoldTempRoot, entryPath, getCommandErrorMessage, linkWorkspaceNodeModules, parseJsonObjectFromOutput, runCli, scaffoldOfficialWorkspace, stripPhpFunction, workspaceTemplatePackageManifest } from "./helpers/scaffold-test-harness.js";
 import { scaffoldProject } from "../src/runtime/index.js";
-import { getDoctorChecks } from "../src/runtime/cli-core.js";
+import {
+  createDoctorRunSummary,
+  getDoctorChecks,
+  getDoctorExitFailureDetailLines,
+} from "../src/runtime/cli-core.js";
 import {
   getWorkspaceBlockSelectOptions,
   getWorkspaceBlockSelectOptionsAsync,
@@ -47,6 +51,50 @@ test("doctor reports environment-only scope outside official workspace roots", a
   expect(
     checks.some((check) => check.label === "Workspace package metadata")
   ).toBe(false);
+});
+
+test("doctor workspace-only policy treats environment failures as advisory", () => {
+  const checks = [
+    {
+      detail: "Not available",
+      label: "Bun",
+      scope: "environment" as const,
+      status: "fail" as const,
+    },
+    {
+      detail: "Workspace metadata is current",
+      label: "Workspace package metadata",
+      scope: "workspace" as const,
+      status: "pass" as const,
+    },
+  ];
+
+  const strictSummary = createDoctorRunSummary(checks);
+  expect(strictSummary.exitPolicy).toBe("strict");
+  expect(strictSummary.exitCode).toBe(1);
+  expect(strictSummary.exitFailureCount).toBe(1);
+  expect(strictSummary.advisoryFailureCount).toBe(0);
+  expect(getDoctorExitFailureDetailLines(checks)).toEqual([
+    "Bun: Not available",
+  ]);
+
+  const workspaceOnlySummary = createDoctorRunSummary(checks, {
+    exitPolicy: "workspace-only",
+  });
+  expect(workspaceOnlySummary.exitPolicy).toBe("workspace-only");
+  expect(workspaceOnlySummary.exitCode).toBe(0);
+  expect(workspaceOnlySummary.exitFailureCount).toBe(0);
+  expect(workspaceOnlySummary.advisoryFailureCount).toBe(1);
+  expect(workspaceOnlySummary.advisoryFailures).toEqual([
+    {
+      label: "Bun",
+      scope: "environment",
+      severity: "advisory",
+    },
+  ]);
+  expect(
+    getDoctorExitFailureDetailLines(checks, { exitPolicy: "workspace-only" })
+  ).toEqual([]);
 });
 
 test("doctor reports invalid nearby workspace metadata before workspace checks", async () => {

--- a/packages/wp-typia/src/command-options/doctor.ts
+++ b/packages/wp-typia/src/command-options/doctor.ts
@@ -9,4 +9,10 @@ export const DOCTOR_OPTION_METADATA = {
       'Use `json` for machine-readable doctor check output or `text` for human-readable output.',
     type: 'string',
   },
+  'workspace-only': {
+    argumentKind: 'flag',
+    description:
+      'Fail only on workspace-scoped doctor checks; environment/runtime failures remain advisory in JSON summaries.',
+    type: 'boolean',
+  },
 } as const satisfies CommandOptionMetadataMap;

--- a/packages/wp-typia/src/commands/doctor.ts
+++ b/packages/wp-typia/src/commands/doctor.ts
@@ -1,5 +1,6 @@
 import { defineCommand } from "@bunli/core";
 import { CLI_DIAGNOSTIC_CODES } from "@wp-typia/project-tools/cli-diagnostics";
+import type { DoctorExitPolicy } from "@wp-typia/project-tools/cli-doctor";
 import {
 	emitCliDiagnosticFailure,
 	prefersStructuredCliOutput,
@@ -15,8 +16,9 @@ export const doctorCommand = defineCommand({
 	description: "Run repository and project diagnostics.",
 	handler: async (args) => {
 		const prefersStructuredOutput = prefersStructuredCliOutput(args);
-		const doctorArgs = args as typeof args & { "workspace-only"?: boolean };
-		const doctorExitPolicy = doctorArgs["workspace-only"] ? "workspace-only" : "strict";
+		const doctorExitPolicy: DoctorExitPolicy = args.flags["workspace-only"]
+			? "workspace-only"
+			: "strict";
 		if (prefersStructuredOutput) {
 			const {
 				createDoctorRunSummary,

--- a/packages/wp-typia/src/commands/doctor.ts
+++ b/packages/wp-typia/src/commands/doctor.ts
@@ -15,28 +15,35 @@ export const doctorCommand = defineCommand({
 	description: "Run repository and project diagnostics.",
 	handler: async (args) => {
 		const prefersStructuredOutput = prefersStructuredCliOutput(args);
+		const doctorArgs = args as typeof args & { "workspace-only"?: boolean };
+		const doctorExitPolicy = doctorArgs["workspace-only"] ? "workspace-only" : "strict";
 		if (prefersStructuredOutput) {
-			const [{ getDoctorChecks }, { getDoctorFailureDetailLines }] =
-				await Promise.all([
-					import("@wp-typia/project-tools/cli-doctor"),
-					import("@wp-typia/project-tools/cli-diagnostics"),
-				]);
+			const {
+				createDoctorRunSummary,
+				getDoctorChecks,
+				getDoctorExitFailureDetailLines,
+			} = await import("@wp-typia/project-tools/cli-doctor");
 			const checks = await getDoctorChecks(args.cwd);
-			if (checks.some((check) => check.status === "fail")) {
+			const summary = createDoctorRunSummary(checks, {
+				exitPolicy: doctorExitPolicy,
+			});
+			if (summary.exitCode === 1) {
 				emitCliDiagnosticFailure(args, {
 					code: CLI_DIAGNOSTIC_CODES.DOCTOR_CHECK_FAILED,
 					command: "doctor",
-					detailLines: getDoctorFailureDetailLines(checks),
-					extraOutput: { checks },
+					detailLines: getDoctorExitFailureDetailLines(checks, {
+						exitPolicy: doctorExitPolicy,
+					}),
+					extraOutput: { checks, summary },
 					summary: "One or more doctor checks failed.",
 				});
 				return;
 			}
-			args.output({ checks });
+			args.output({ checks, summary });
 			return;
 		}
 		try {
-			await executeDoctorCommand(args.cwd);
+			await executeDoctorCommand(args.cwd, { exitPolicy: doctorExitPolicy });
 		} catch (error) {
 			emitCliDiagnosticFailure(args, {
 				command: "doctor",

--- a/packages/wp-typia/src/node-fallback/doctor.ts
+++ b/packages/wp-typia/src/node-fallback/doctor.ts
@@ -2,11 +2,10 @@ import {
   CLI_DIAGNOSTIC_CODES,
   createCliCommandError,
 } from '@wp-typia/project-tools/cli-diagnostics';
+import type { DoctorExitPolicy } from '@wp-typia/project-tools/cli-doctor';
 import { executeDoctorCommand } from '../runtime-bridge';
 import type { PrintLine } from '../print-line';
 import type { NodeFallbackDispatchContext } from './types';
-
-type DoctorExitPolicy = 'strict' | 'workspace-only';
 
 async function renderNodeFallbackDoctorJson(
   cwd: string,

--- a/packages/wp-typia/src/node-fallback/doctor.ts
+++ b/packages/wp-typia/src/node-fallback/doctor.ts
@@ -6,30 +6,35 @@ import { executeDoctorCommand } from '../runtime-bridge';
 import type { PrintLine } from '../print-line';
 import type { NodeFallbackDispatchContext } from './types';
 
+type DoctorExitPolicy = 'strict' | 'workspace-only';
+
 async function renderNodeFallbackDoctorJson(
   cwd: string,
+  exitPolicy: DoctorExitPolicy,
   printLine: PrintLine,
 ): Promise<void> {
-  const [{ getDoctorChecks }, { getDoctorFailureDetailLines }] =
-    await Promise.all([
-      import('@wp-typia/project-tools/cli-doctor'),
-      import('@wp-typia/project-tools/cli-diagnostics'),
-    ]);
+  const {
+    createDoctorRunSummary,
+    getDoctorChecks,
+    getDoctorExitFailureDetailLines,
+  } = await import('@wp-typia/project-tools/cli-doctor');
   const checks = await getDoctorChecks(cwd);
+  const summary = createDoctorRunSummary(checks, { exitPolicy });
   printLine(
     JSON.stringify(
       {
         checks,
+        summary,
       },
       null,
       2,
     ),
   );
-  if (checks.some((check) => check.status === 'fail')) {
+  if (summary.exitCode === 1) {
     throw createCliCommandError({
       code: CLI_DIAGNOSTIC_CODES.DOCTOR_CHECK_FAILED,
       command: 'doctor',
-      detailLines: getDoctorFailureDetailLines(checks),
+      detailLines: getDoctorExitFailureDetailLines(checks, { exitPolicy }),
       summary: 'One or more doctor checks failed.',
     });
   }
@@ -40,9 +45,10 @@ export async function dispatchNodeFallbackDoctor({
   mergedFlags,
   printLine,
 }: NodeFallbackDispatchContext): Promise<void> {
+  const exitPolicy = mergedFlags['workspace-only'] ? 'workspace-only' : 'strict';
   if (mergedFlags.format === 'json') {
-    await renderNodeFallbackDoctorJson(cwd, printLine);
+    await renderNodeFallbackDoctorJson(cwd, exitPolicy, printLine);
     return;
   }
-  await executeDoctorCommand(cwd);
+  await executeDoctorCommand(cwd, { exitPolicy });
 }

--- a/packages/wp-typia/src/node-fallback/help.ts
+++ b/packages/wp-typia/src/node-fallback/help.ts
@@ -93,9 +93,9 @@ const NODE_FALLBACK_COMMAND_HELP_CONFIG = {
   },
   doctor: {
     bodyLines: [
-      'Runs read-only environment readiness checks. Official wp-typia workspace roots also get inventory, source-tree drift, iframe/API v3 compatibility, and shared convention checks.',
+      'Runs read-only environment readiness checks. Official wp-typia workspace roots also get inventory, source-tree drift, iframe/API v3 compatibility, and shared convention checks. Use --workspace-only for CI gates that should fail only on workspace-scoped checks while keeping environment failures advisory.',
     ],
-    heading: 'Usage: wp-typia doctor [--format json]',
+    heading: 'Usage: wp-typia doctor [--format json] [--workspace-only]',
     optionMetadata: DOCTOR_OPTION_METADATA,
   },
   init: {

--- a/packages/wp-typia/src/runtime-bridge-doctor.ts
+++ b/packages/wp-typia/src/runtime-bridge-doctor.ts
@@ -2,10 +2,17 @@ import { wrapCliCommandError } from './runtime-bridge-shared';
 
 const loadCliDoctorRuntime = () => import('@wp-typia/project-tools/cli-doctor');
 
-export async function executeDoctorCommand(cwd: string): Promise<void> {
+type ExecuteDoctorCommandOptions = {
+  exitPolicy?: 'strict' | 'workspace-only';
+};
+
+export async function executeDoctorCommand(
+  cwd: string,
+  options: ExecuteDoctorCommandOptions = {},
+): Promise<void> {
   try {
     const { runDoctor } = await loadCliDoctorRuntime();
-    await runDoctor(cwd);
+    await runDoctor(cwd, { exitPolicy: options.exitPolicy });
   } catch (error) {
     throw await wrapCliCommandError('doctor', error);
   }

--- a/packages/wp-typia/src/runtime-bridge-doctor.ts
+++ b/packages/wp-typia/src/runtime-bridge-doctor.ts
@@ -1,9 +1,10 @@
+import type { DoctorExitPolicy } from '@wp-typia/project-tools/cli-doctor';
 import { wrapCliCommandError } from './runtime-bridge-shared';
 
 const loadCliDoctorRuntime = () => import('@wp-typia/project-tools/cli-doctor');
 
 type ExecuteDoctorCommandOptions = {
-  exitPolicy?: 'strict' | 'workspace-only';
+  exitPolicy?: DoctorExitPolicy;
 };
 
 export async function executeDoctorCommand(

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -867,6 +867,7 @@ process.exit(0);
     expect(doctorCommandSource).toContain(
       'buildCommandOptions(DOCTOR_OPTION_METADATA)',
     );
+    expect(doctorCommandSource).toContain('args.flags["workspace-only"]');
     expect(migrateCommandSource).toContain(
       'buildCommandOptions(MIGRATE_OPTION_METADATA)',
     );

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -1130,6 +1130,68 @@ process.exit(0);
     }
   });
 
+  test('keeps strict doctor JSON failures while offering workspace-only advisory exits', () => {
+    const fixtureRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'wp-typia-doctor-workspace-only-'),
+    );
+
+    type DoctorPayload = {
+      checks: Array<{
+        label: string;
+        scope?: 'environment' | 'workspace';
+        status: 'fail' | 'pass' | 'warn';
+      }>;
+      summary: {
+        advisoryFailureCount: number;
+        exitCode: 0 | 1;
+        exitFailureCount: number;
+        exitPolicy: 'strict' | 'workspace-only';
+      };
+    };
+
+    try {
+      const strictResult = runCapturedCommand(
+        process.execPath,
+        [entryPath, 'doctor', '--format', 'json'],
+        {
+          cwd: fixtureRoot,
+          env: withoutLocalBunEnv(),
+        },
+      );
+      const strictPayload = parseJsonObjectFromOutput<DoctorPayload>(
+        strictResult.stdout,
+      );
+
+      expect(strictResult.status).toBe(1);
+      expect(strictPayload.summary.exitPolicy).toBe('strict');
+      expect(strictPayload.summary.exitCode).toBe(1);
+      expect(strictPayload.summary.exitFailureCount).toBeGreaterThan(0);
+      expect(
+        strictPayload.checks.find((check) => check.label === 'Bun')?.scope,
+      ).toBe('environment');
+
+      const workspaceOnlyResult = runCapturedCommand(
+        process.execPath,
+        [entryPath, 'doctor', '--format', 'json', '--workspace-only'],
+        {
+          cwd: fixtureRoot,
+          env: withoutLocalBunEnv(),
+        },
+      );
+      const workspaceOnlyPayload = parseJsonObjectFromOutput<DoctorPayload>(
+        workspaceOnlyResult.stdout,
+      );
+
+      expect(workspaceOnlyResult.status).toBe(0);
+      expect(workspaceOnlyPayload.summary.exitPolicy).toBe('workspace-only');
+      expect(workspaceOnlyPayload.summary.exitCode).toBe(0);
+      expect(workspaceOnlyPayload.summary.exitFailureCount).toBe(0);
+      expect(workspaceOnlyPayload.summary.advisoryFailureCount).toBeGreaterThan(0);
+    } finally {
+      fs.rmSync(fixtureRoot, { force: true, recursive: true });
+    }
+  });
+
   test('prints an explicit environment-only doctor scope outside workspace roots', () => {
     const fixtureRoot = fs.mkdtempSync(
       path.join(os.tmpdir(), 'wp-typia-doctor-scope-'),

--- a/packages/wp-typia/tests/command-option-metadata.test.ts
+++ b/packages/wp-typia/tests/command-option-metadata.test.ts
@@ -283,7 +283,7 @@ describe('command option metadata helpers', () => {
 
   test('parses doctor structured output flags from shared metadata', () => {
     const parsed = parseCommandArgvWithMetadata(
-      ['doctor', '--format', 'json'],
+      ['doctor', '--format', 'json', '--workspace-only'],
       {
         extraBooleanOptionNames: ['help', 'version'],
         parser: buildCommandOptionParser(
@@ -295,6 +295,7 @@ describe('command option metadata helpers', () => {
 
     expect(parsed.flags).toEqual({
       format: 'json',
+      'workspace-only': true,
     });
     expect(parsed.positionals).toEqual(['doctor']);
   });


### PR DESCRIPTION
## Summary
- Add a strict-by-default doctor exit-policy model plus a `--workspace-only` mode that treats environment/runtime failures as advisory.
- Include scoped doctor checks and stable JSON summaries that list exit-contributing failures separately from advisory failures.
- Wire the policy through Bunli and Node fallback doctor paths, shared option metadata, help text, and coverage.

## Validation
- bun test packages/wp-typia-project-tools/tests/workspace-doctor.test.ts packages/wp-typia-project-tools/tests/cli-entry.test.ts
- bun test packages/wp-typia/tests/command-option-metadata.test.ts packages/wp-typia/tests/cli-package.test.ts -t "doctor"
- bun run typecheck
- bun run lint:repo
- bun run format:check
- bun run changesets:validate
- git diff --check
- bun run --filter @wp-typia/project-tools build
- bun run --filter wp-typia build
- bun run maintenance-automation:validate
- bun run formatting-policy:validate
- bun run manifest-policy:validate
- bun run typescript-strictness:validate
- bun run runtime-coupling:validate
- bun run typescript-runtime:validate
- bun run publish:validate

Closes #925

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--workspace-only` flag to `doctor` to treat environment/runtime failures as advisory while keeping workspace failures fatal.
  * Doctor now emits machine-readable JSON run summaries that include the selected exit-policy and advisory vs exit-failure details.

* **Documentation**
  * Updated doctor help/usage text to document `--workspace-only` behavior.

* **Tests**
  * Updated and added tests covering `--workspace-only`, JSON summaries, and exit-policy behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/944)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->