### PR TITLE
feat(rest): package runtime REST schemas

### DIFF
--- a/.sampo/changesets/927-rest-schema-package.md
+++ b/.sampo/changesets/927-rest-schema-package.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/create-workspace-template: patch
+npm/@wp-typia/project-tools: patch
+---
+
+Package generated REST JSON schemas into `inc/rest-schemas` for workspace release zips and add release-check scripts that fail when packaged runtime schemas are missing or stale.

--- a/README.md
+++ b/README.md
@@ -185,6 +185,11 @@ Existing workspaces can adopt the same policy without regenerating: add a
 add `wp-typia:sync`, `wp-typia:doctor`, `wp-typia:doctor:workspace`, and
 `wp-typia:add` scripts to `package.json`.
 
+REST-heavy workspace releases should also run `sync-rest:package` before
+building a zip and `sync-rest:package:check` in release CI. Those scripts copy
+generated REST schemas into `inc/rest-schemas`, so runtime validation does not
+depend on shipping TypeScript source directories.
+
 ## Start here
 
 - Want the smallest possible starting point? Start with `basic`.

--- a/packages/create-workspace-template/README.md
+++ b/packages/create-workspace-template/README.md
@@ -32,6 +32,8 @@ expose package scripts for the common CLI entrypoints:
 ```json
 {
   "scripts": {
+    "sync-rest:package": "tsx scripts/sync-rest-contracts.ts --package",
+    "sync-rest:package:check": "tsx scripts/sync-rest-contracts.ts --package --check",
     "wp-typia:sync": "wp-typia sync",
     "wp-typia:doctor": "wp-typia doctor",
     "wp-typia:doctor:workspace": "wp-typia doctor --workspace-only",
@@ -45,6 +47,11 @@ expose package scripts for the common CLI entrypoints:
 
 Use the script form from generated workspaces so the executable CLI package is
 clearly separated from support packages such as `@wp-typia/project-tools`.
+
+Workspaces that ship REST resources can run `sync-rest:package` before release
+builds to copy generated runtime schemas into `inc/rest-schemas`. Add
+`sync-rest:package:check` to release CI so stale or missing packaged schemas are
+caught before a zip is built without TypeScript source files.
 
 | Package manager | Doctor                     | Sync check                         | Add a block                                               |
 | --------------- | -------------------------- | ---------------------------------- | --------------------------------------------------------- |

--- a/packages/create-workspace-template/README.md.mustache
+++ b/packages/create-workspace-template/README.md.mustache
@@ -42,11 +42,16 @@ binary package:
 bun run wp-typia:doctor
 bun run wp-typia:doctor:workspace
 bun run wp-typia:sync --check
+bun run sync-rest:package:check
 bun run wp-typia:add block counter-card --template basic
 ```
 
 Use `wp-typia:doctor:workspace` in CI when optional local runtimes are advisory
 but workspace checks must still fail the job.
+
+Run `sync-rest:package` before building release zips when REST resources are
+registered. It copies generated runtime schemas into `inc/rest-schemas` and
+`sync-rest:package:check` fails CI if packaged schemas are missing or stale.
 
 ## Development
 

--- a/packages/create-workspace-template/package.json.mustache
+++ b/packages/create-workspace-template/package.json.mustache
@@ -9,6 +9,8 @@
     "sync": "tsx scripts/sync-project.ts",
     "sync-types": "tsx scripts/sync-types-to-block-json.ts",
     "sync-rest": "tsx scripts/sync-rest-contracts.ts",
+    "sync-rest:package": "tsx scripts/sync-rest-contracts.ts --package",
+    "sync-rest:package:check": "tsx scripts/sync-rest-contracts.ts --package --check",
     "wp-typia:sync": "wp-typia sync",
     "wp-typia:doctor": "wp-typia doctor",
     "wp-typia:doctor:workspace": "wp-typia doctor --workspace-only",

--- a/packages/create-workspace-template/scripts/block-config.ts.mustache
+++ b/packages/create-workspace-template/scripts/block-config.ts.mustache
@@ -114,6 +114,11 @@ export interface WorkspaceAdminViewConfig {
 	source?: string;
 }
 
+export interface WorkspaceRestSchemaPackageConfig {
+	manifestFile?: string;
+	outputDir: string;
+}
+
 export const BLOCKS: WorkspaceBlockConfig[] = [
 	// wp-typia add block entries
 ];
@@ -157,3 +162,8 @@ export const EDITOR_PLUGINS: WorkspaceEditorPluginConfig[] = [
 export const ADMIN_VIEWS: WorkspaceAdminViewConfig[] = [
 	// wp-typia add admin-view entries
 ];
+
+export const REST_SCHEMA_PACKAGE: WorkspaceRestSchemaPackageConfig = {
+	manifestFile: 'inc/rest-schemas/manifest.json',
+	outputDir: 'inc/rest-schemas',
+};

--- a/packages/create-workspace-template/scripts/sync-rest-contracts.ts.mustache
+++ b/packages/create-workspace-template/scripts/sync-rest-contracts.ts.mustache
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+import { promises as fsp } from 'node:fs';
 import path from 'node:path';
 
 import {
@@ -8,6 +9,7 @@ import {
 	syncTypeSchemas,
 } from '@wp-typia/block-runtime/metadata-core';
 
+import * as workspaceConfig from './block-config';
 import {
 	BLOCKS,
 	CONTRACTS,
@@ -19,9 +21,25 @@ import {
 	type WorkspaceRestResourceConfig,
 } from './block-config';
 
+type WorkspaceRestSchemaPackageConfig = {
+	manifestFile?: string;
+	outputDir: string;
+};
+
+const DEFAULT_REST_SCHEMA_PACKAGE: WorkspaceRestSchemaPackageConfig = {
+	manifestFile: 'inc/rest-schemas/manifest.json',
+	outputDir: 'inc/rest-schemas',
+};
+const workspaceConfigWithPackage = workspaceConfig as {
+	REST_SCHEMA_PACKAGE?: WorkspaceRestSchemaPackageConfig;
+};
+const REST_SCHEMA_PACKAGE =
+	workspaceConfigWithPackage.REST_SCHEMA_PACKAGE ?? DEFAULT_REST_SCHEMA_PACKAGE;
+
 function parseCliOptions( argv: string[] ) {
 	const options = {
 		check: false,
+		packageSchemas: false,
 	};
 
 	for ( const argument of argv ) {
@@ -30,10 +48,79 @@ function parseCliOptions( argv: string[] ) {
 			continue;
 		}
 
+		if ( argument === '--package' ) {
+			options.packageSchemas = true;
+			continue;
+		}
+
 		throw new Error( `Unknown sync-rest flag: ${ argument }` );
 	}
 
 	return options;
+}
+
+type RuntimeRestSchemaPackageEntry = {
+	id: string;
+	kind: 'block' | 'rest-resource';
+	owner: string;
+	path: string;
+	schema: string;
+	source: string;
+};
+
+type RuntimeRestSchemaPackageManifest = {
+	generatedBy: 'wp-typia sync-rest --package';
+	outputDir: string;
+	schemaVersion: 1;
+	schemas: RuntimeRestSchemaPackageEntry[];
+};
+
+function getNodeErrorCode( error: unknown ) {
+	return typeof error === 'object' &&
+		error !== null &&
+		'code' in error &&
+		typeof ( error as { code?: unknown } ).code === 'string'
+		? ( error as { code: string } ).code
+		: undefined;
+}
+
+function normalizeProjectPath( filePath: string, label: string ) {
+	if ( path.isAbsolute( filePath ) ) {
+		throw new Error( `${ label } must be project-relative: ${ filePath }` );
+	}
+
+	const normalized = path.normalize( filePath );
+	if ( normalized === '..' || normalized.startsWith( `..${ path.sep }` ) ) {
+		throw new Error( `${ label } cannot point outside the project: ${ filePath }` );
+	}
+
+	return normalized.split( path.sep ).join( '/' );
+}
+
+function resolveRestSchemaPackageConfig() {
+	const outputDir = normalizeProjectPath(
+		REST_SCHEMA_PACKAGE.outputDir,
+		'REST_SCHEMA_PACKAGE.outputDir'
+	);
+	const manifestFile = normalizeProjectPath(
+		REST_SCHEMA_PACKAGE.manifestFile ?? path.join( outputDir, 'manifest.json' ),
+		'REST_SCHEMA_PACKAGE.manifestFile'
+	);
+
+	if (
+		outputDir !== '.' &&
+		manifestFile !== outputDir &&
+		! manifestFile.startsWith( `${ outputDir }/` )
+	) {
+		throw new Error(
+			`REST_SCHEMA_PACKAGE.manifestFile must stay inside REST_SCHEMA_PACKAGE.outputDir (${ outputDir }): ${ manifestFile }`
+		);
+	}
+
+	return {
+		manifestFile,
+		outputDir,
+	};
 }
 
 function isRestEnabledBlock(
@@ -96,6 +183,299 @@ function isWorkspacePostMetaContract(
 		typeof postMeta.sourceTypeName === 'string' &&
 		typeof postMeta.typesFile === 'string'
 	);
+}
+
+function getBlockRestSchemaEntries(
+	block: WorkspaceBlockConfig & {
+		restManifest: NonNullable< WorkspaceBlockConfig[ 'restManifest' ] >;
+	},
+	outputDir: string
+): RuntimeRestSchemaPackageEntry[] {
+	return Object.keys( block.restManifest.contracts ).map( ( baseName ) => ( {
+		id: `block:${ block.slug }:${ baseName }`,
+		kind: 'block',
+		owner: block.slug,
+		path: normalizeProjectPath(
+			path.join(
+				outputDir,
+				'blocks',
+				block.slug,
+				`${ baseName }.schema.json`
+			),
+			'REST schema package path'
+		),
+		schema: baseName,
+		source: normalizeProjectPath(
+			path.join(
+				'src',
+				'blocks',
+				block.slug,
+				'api-schemas',
+				`${ baseName }.schema.json`
+			),
+			'REST schema source path'
+		),
+	} ) );
+}
+
+function getRestResourceSchemaEntries(
+	resource: WorkspaceRestResourceConfig & {
+		restManifest: NonNullable< WorkspaceRestResourceConfig[ 'restManifest' ] >;
+		typesFile: string;
+	},
+	outputDir: string
+): RuntimeRestSchemaPackageEntry[] {
+	return Object.keys( resource.restManifest.contracts ).map( ( baseName ) => ( {
+		id: `rest:${ resource.slug }:${ baseName }`,
+		kind: 'rest-resource',
+		owner: resource.slug,
+		path: normalizeProjectPath(
+			path.join(
+				outputDir,
+				'rest',
+				resource.slug,
+				`${ baseName }.schema.json`
+			),
+			'REST schema package path'
+		),
+		schema: baseName,
+		source: normalizeProjectPath(
+			path.join(
+				path.dirname( resource.typesFile ),
+				'api-schemas',
+				`${ baseName }.schema.json`
+			),
+			'REST schema source path'
+		),
+	} ) );
+}
+
+function buildRuntimeRestSchemaPackageManifest(
+	restBlocks: Array<
+		WorkspaceBlockConfig & {
+			restManifest: NonNullable< WorkspaceBlockConfig[ 'restManifest' ] >;
+		}
+	>,
+	restResources: Array<
+		WorkspaceRestResourceConfig & {
+			restManifest: NonNullable< WorkspaceRestResourceConfig[ 'restManifest' ] >;
+			typesFile: string;
+		}
+	>
+): RuntimeRestSchemaPackageManifest {
+	const { outputDir } = resolveRestSchemaPackageConfig();
+	const schemas = [
+		...restBlocks.flatMap( ( block ) =>
+			getBlockRestSchemaEntries( block, outputDir )
+		),
+		...restResources.flatMap( ( resource ) =>
+			getRestResourceSchemaEntries( resource, outputDir )
+		),
+	].sort(
+		( left, right ) =>
+			left.path.localeCompare( right.path ) || left.id.localeCompare( right.id )
+	);
+	const seenPaths = new Set< string >();
+	const seenIds = new Set< string >();
+
+	for ( const schema of schemas ) {
+		if ( seenIds.has( schema.id ) ) {
+			throw new Error( `Duplicate runtime REST schema package id: ${ schema.id }` );
+		}
+
+		if ( seenPaths.has( schema.path ) ) {
+			throw new Error(
+				`Duplicate runtime REST schema package path: ${ schema.path }`
+			);
+		}
+
+		seenIds.add( schema.id );
+		seenPaths.add( schema.path );
+	}
+
+	return {
+		generatedBy: 'wp-typia sync-rest --package',
+		outputDir,
+		schemaVersion: 1,
+		schemas,
+	};
+}
+
+async function readUtf8IfExists( filePath: string ) {
+	try {
+		return await fsp.readFile( filePath, 'utf8' );
+	} catch ( error ) {
+		if ( getNodeErrorCode( error ) === 'ENOENT' ) {
+			return undefined;
+		}
+
+		throw error;
+	}
+}
+
+async function writeUtf8IfChanged( filePath: string, content: string ) {
+	const existing = await readUtf8IfExists( filePath );
+	if ( existing === content ) {
+		return;
+	}
+
+	await fsp.mkdir( path.dirname( filePath ), { recursive: true } );
+	await fsp.writeFile( filePath, content, 'utf8' );
+}
+
+async function unlinkIfExists( filePath: string ) {
+	try {
+		await fsp.unlink( filePath );
+	} catch ( error ) {
+		if ( getNodeErrorCode( error ) === 'ENOENT' ) {
+			return;
+		}
+
+		throw error;
+	}
+}
+
+async function collectPackagedSchemaFiles( outputDir: string ) {
+	const schemaFiles: string[] = [];
+
+	async function walk( relativeDir: string ) {
+		const currentDir =
+			relativeDir.length > 0 ? path.join( outputDir, relativeDir ) : outputDir;
+		let directoryEntries: import( 'node:fs' ).Dirent[];
+
+		try {
+			directoryEntries = await fsp.readdir( currentDir, {
+				withFileTypes: true,
+			} );
+		} catch ( error ) {
+			if ( getNodeErrorCode( error ) === 'ENOENT' ) {
+				return;
+			}
+
+			throw error;
+		}
+
+		for ( const directoryEntry of directoryEntries ) {
+			const relativePath = path.join( relativeDir, directoryEntry.name );
+
+			if ( directoryEntry.isDirectory() ) {
+				await walk( relativePath );
+				continue;
+			}
+
+			if (
+				directoryEntry.isFile() &&
+				directoryEntry.name.endsWith( '.schema.json' )
+			) {
+				schemaFiles.push(
+					normalizeProjectPath(
+						path.join( outputDir, relativePath ),
+						'REST schema package file'
+					)
+				);
+			}
+		}
+	}
+
+	await walk( '' );
+	return schemaFiles.sort();
+}
+
+async function syncRuntimeRestSchemaPackage(
+	restBlocks: Array<
+		WorkspaceBlockConfig & {
+			restManifest: NonNullable< WorkspaceBlockConfig[ 'restManifest' ] >;
+		}
+	>,
+	restResources: Array<
+		WorkspaceRestResourceConfig & {
+			restManifest: NonNullable< WorkspaceRestResourceConfig[ 'restManifest' ] >;
+			typesFile: string;
+		}
+	>,
+	options: { check: boolean }
+) {
+	const { manifestFile, outputDir } = resolveRestSchemaPackageConfig();
+	const manifest = buildRuntimeRestSchemaPackageManifest(
+		restBlocks,
+		restResources
+	);
+	const manifestContent = `${ JSON.stringify( manifest, null, 2 ) }\n`;
+	const expectedPackagePaths = new Set(
+		manifest.schemas.map( ( schema ) => schema.path )
+	);
+	const packageFailures: string[] = [];
+
+	for ( const schema of manifest.schemas ) {
+		const sourceContent = await readUtf8IfExists( schema.source );
+
+		if ( sourceContent === undefined ) {
+			if ( ! options.check ) {
+				throw new Error(
+					`Runtime REST schema source is missing: ${ schema.source }\nRun \`sync-rest\` before \`sync-rest --package\` to generate source schemas.`
+				);
+			}
+
+			packageFailures.push( `${ schema.source } (source missing)` );
+			continue;
+		}
+
+		if ( options.check ) {
+			const packagedContent = await readUtf8IfExists( schema.path );
+
+			if ( packagedContent === undefined ) {
+				packageFailures.push( `${ schema.path } (missing)` );
+				continue;
+			}
+
+			if ( packagedContent !== sourceContent ) {
+				packageFailures.push( `${ schema.path } (stale)` );
+			}
+
+			continue;
+		}
+
+		await writeUtf8IfChanged( schema.path, sourceContent );
+	}
+
+	const existingPackagedSchemas = await collectPackagedSchemaFiles( outputDir );
+	for ( const schemaPath of existingPackagedSchemas ) {
+		if ( expectedPackagePaths.has( schemaPath ) ) {
+			continue;
+		}
+
+		if ( options.check ) {
+			packageFailures.push( `${ schemaPath } (unexpected)` );
+			continue;
+		}
+
+		await unlinkIfExists( schemaPath );
+	}
+
+	if ( options.check ) {
+		const existingManifestContent = await readUtf8IfExists( manifestFile );
+
+		if ( existingManifestContent === undefined ) {
+			packageFailures.push( `${ manifestFile } (missing)` );
+		} else if ( existingManifestContent !== manifestContent ) {
+			packageFailures.push( `${ manifestFile } (stale)` );
+		}
+
+		if ( packageFailures.length > 0 ) {
+			throw new Error(
+				`Runtime REST schema package is missing or stale:\n${ packageFailures
+					.map( ( failure ) => `- ${ failure }` )
+					.join(
+						'\n'
+					) }\nRun \`sync-rest --package\` to refresh packaged REST schemas before building a release zip.`
+			);
+		}
+
+		return manifest.schemas.length;
+	}
+
+	await writeUtf8IfChanged( manifestFile, manifestContent );
+	return manifest.schemas.length;
 }
 
 async function assertTypeArtifactsCurrent( block: WorkspaceBlockConfig ) {
@@ -278,6 +658,22 @@ async function main() {
 			{
 				check: options.check,
 			}
+		);
+	}
+
+	if ( options.packageSchemas ) {
+		const packagedSchemaCount = await syncRuntimeRestSchemaPackage(
+			restBlocks,
+			restResources,
+			{
+				check: options.check,
+			}
+		);
+
+		console.log(
+			options.check
+				? `✅ Runtime REST schema package is already up to date (${ packagedSchemaCount } schemas).`
+				: `✅ Runtime REST schema package generated (${ packagedSchemaCount } schemas).`
 		);
 	}
 

--- a/packages/create-workspace-template/scripts/sync-rest-contracts.ts.mustache
+++ b/packages/create-workspace-template/scripts/sync-rest-contracts.ts.mustache
@@ -107,11 +107,13 @@ function resolveRestSchemaPackageConfig() {
 		'REST_SCHEMA_PACKAGE.manifestFile'
 	);
 
-	if (
-		outputDir !== '.' &&
-		manifestFile !== outputDir &&
-		! manifestFile.startsWith( `${ outputDir }/` )
-	) {
+	if ( outputDir === '.' ) {
+		throw new Error(
+			'REST_SCHEMA_PACKAGE.outputDir must not be the project root; use a dedicated subdirectory such as "inc/rest-schemas".'
+		);
+	}
+
+	if ( manifestFile === outputDir || ! manifestFile.startsWith( `${ outputDir }/` ) ) {
 		throw new Error(
 			`REST_SCHEMA_PACKAGE.manifestFile must stay inside REST_SCHEMA_PACKAGE.outputDir (${ outputDir }): ${ manifestFile }`
 		);
@@ -121,6 +123,33 @@ function resolveRestSchemaPackageConfig() {
 		manifestFile,
 		outputDir,
 	};
+}
+
+function assertSafeSchemaBaseName( baseName: string, owner: string ) {
+	if (
+		! /^[A-Za-z0-9][A-Za-z0-9._-]*$/u.test( baseName ) ||
+		baseName === '.' ||
+		baseName === '..'
+	) {
+		throw new Error(
+			`${ owner }: REST schema contract key must be a file basename containing only letters, numbers, dots, underscores, or hyphens: ${ baseName }`
+		);
+	}
+}
+
+function getPackagePath( outputDir: string, owner: string, ...segments: string[] ) {
+	const packagePath = normalizeProjectPath(
+		path.join( outputDir, ...segments ),
+		'REST schema package path'
+	);
+
+	if ( ! packagePath.startsWith( `${ outputDir }/` ) ) {
+		throw new Error(
+			`${ owner }: REST schema package path must stay inside ${ outputDir }: ${ packagePath }`
+		);
+	}
+
+	return packagePath;
 }
 
 function isRestEnabledBlock(
@@ -191,31 +220,34 @@ function getBlockRestSchemaEntries(
 	},
 	outputDir: string
 ): RuntimeRestSchemaPackageEntry[] {
-	return Object.keys( block.restManifest.contracts ).map( ( baseName ) => ( {
-		id: `block:${ block.slug }:${ baseName }`,
-		kind: 'block',
-		owner: block.slug,
-		path: normalizeProjectPath(
-			path.join(
+	return Object.keys( block.restManifest.contracts ).map( ( baseName ) => {
+		const owner = `Block ${ block.slug }`;
+		assertSafeSchemaBaseName( baseName, owner );
+
+		return {
+			id: `block:${ block.slug }:${ baseName }`,
+			kind: 'block',
+			owner: block.slug,
+			path: getPackagePath(
 				outputDir,
+				owner,
 				'blocks',
 				block.slug,
 				`${ baseName }.schema.json`
 			),
-			'REST schema package path'
-		),
-		schema: baseName,
-		source: normalizeProjectPath(
-			path.join(
-				'src',
-				'blocks',
-				block.slug,
-				'api-schemas',
-				`${ baseName }.schema.json`
+			schema: baseName,
+			source: normalizeProjectPath(
+				path.join(
+					'src',
+					'blocks',
+					block.slug,
+					'api-schemas',
+					`${ baseName }.schema.json`
+				),
+				'REST schema source path'
 			),
-			'REST schema source path'
-		),
-	} ) );
+		};
+	} );
 }
 
 function getRestResourceSchemaEntries(
@@ -225,29 +257,32 @@ function getRestResourceSchemaEntries(
 	},
 	outputDir: string
 ): RuntimeRestSchemaPackageEntry[] {
-	return Object.keys( resource.restManifest.contracts ).map( ( baseName ) => ( {
-		id: `rest:${ resource.slug }:${ baseName }`,
-		kind: 'rest-resource',
-		owner: resource.slug,
-		path: normalizeProjectPath(
-			path.join(
+	return Object.keys( resource.restManifest.contracts ).map( ( baseName ) => {
+		const owner = `REST resource ${ resource.slug }`;
+		assertSafeSchemaBaseName( baseName, owner );
+
+		return {
+			id: `rest:${ resource.slug }:${ baseName }`,
+			kind: 'rest-resource',
+			owner: resource.slug,
+			path: getPackagePath(
 				outputDir,
+				owner,
 				'rest',
 				resource.slug,
 				`${ baseName }.schema.json`
 			),
-			'REST schema package path'
-		),
-		schema: baseName,
-		source: normalizeProjectPath(
-			path.join(
-				path.dirname( resource.typesFile ),
-				'api-schemas',
-				`${ baseName }.schema.json`
+			schema: baseName,
+			source: normalizeProjectPath(
+				path.join(
+					path.dirname( resource.typesFile ),
+					'api-schemas',
+					`${ baseName }.schema.json`
+				),
+				'REST schema source path'
 			),
-			'REST schema source path'
-		),
-	} ) );
+		};
+	} );
 }
 
 function buildRuntimeRestSchemaPackageManifest(
@@ -456,7 +491,9 @@ async function syncRuntimeRestSchemaPackage(
 		const existingManifestContent = await readUtf8IfExists( manifestFile );
 
 		if ( existingManifestContent === undefined ) {
-			packageFailures.push( `${ manifestFile } (missing)` );
+			if ( manifest.schemas.length > 0 ) {
+				packageFailures.push( `${ manifestFile } (missing)` );
+			}
 		} else if ( existingManifestContent !== manifestContent ) {
 			packageFailures.push( `${ manifestFile } (stale)` );
 		}
@@ -519,6 +556,22 @@ async function main() {
 		postMetaContracts.length === 0 &&
 		restResources.length === 0
 	) {
+		if ( options.packageSchemas ) {
+			const packagedSchemaCount = await syncRuntimeRestSchemaPackage(
+				restBlocks,
+				restResources,
+				{
+					check: options.check,
+				}
+			);
+
+			console.log(
+				options.check
+					? `✅ Runtime REST schema package is already up to date (${ packagedSchemaCount } schemas).`
+					: `✅ Runtime REST schema package generated (${ packagedSchemaCount } schemas).`
+			);
+		}
+
 		console.log(
 			options.check
 				? 'ℹ️ No REST-enabled workspace blocks, standalone contracts, post meta contracts, or plugin-level REST resources are registered yet. `sync-rest --check` is already clean.'

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest-php-templates.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest-php-templates.ts
@@ -309,13 +309,23 @@ if ( ! function_exists( '${saveItemsFunctionName}' ) ) {
 if ( ! function_exists( '${loadSchemaFunctionName}' ) ) {
 \tfunction ${loadSchemaFunctionName}( $schema_name ) {
 \t\t$project_root = dirname( __DIR__, 2 );
-\t\t$schema_path  = $project_root . '/src/rest/${restResourceSlug}/api-schemas/' . $schema_name . '.schema.json';
-\t\tif ( ! file_exists( $schema_path ) ) {
-\t\t\treturn null;
+\t\t$schema_paths = array(
+\t\t\t$project_root . '/inc/rest-schemas/rest/${restResourceSlug}/' . $schema_name . '.schema.json',
+\t\t\t$project_root . '/src/rest/${restResourceSlug}/api-schemas/' . $schema_name . '.schema.json',
+\t\t);
+
+\t\tforeach ( $schema_paths as $schema_path ) {
+\t\t\tif ( ! file_exists( $schema_path ) ) {
+\t\t\t\tcontinue;
+\t\t\t}
+
+\t\t\t$decoded = json_decode( file_get_contents( $schema_path ), true );
+\t\t\tif ( is_array( $decoded ) ) {
+\t\t\t\treturn $decoded;
+\t\t\t}
 \t\t}
 
-\t\t$decoded = json_decode( file_get_contents( $schema_path ), true );
-\t\treturn is_array( $decoded ) ? $decoded : null;
+\t\treturn null;
 \t}
 }
 

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest-php-templates.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest-php-templates.ts
@@ -315,11 +315,16 @@ if ( ! function_exists( '${loadSchemaFunctionName}' ) ) {
 \t\t);
 
 \t\tforeach ( $schema_paths as $schema_path ) {
-\t\t\tif ( ! file_exists( $schema_path ) ) {
+\t\t\tif ( ! is_file( $schema_path ) || ! is_readable( $schema_path ) ) {
 \t\t\t\tcontinue;
 \t\t\t}
 
-\t\t\t$decoded = json_decode( file_get_contents( $schema_path ), true );
+\t\t\t$schema_json = file_get_contents( $schema_path );
+\t\t\tif ( false === $schema_json ) {
+\t\t\t\tcontinue;
+\t\t\t}
+
+\t\t\t$decoded = json_decode( $schema_json, true );
 \t\t\tif ( is_array( $decoded ) ) {
 \t\t\t\treturn $decoded;
 \t\t\t}

--- a/packages/wp-typia-project-tools/tests/template-source.test.ts
+++ b/packages/wp-typia-project-tools/tests/template-source.test.ts
@@ -1994,7 +1994,15 @@ test("official workspace template scaffolds through the local npm template resol
   );
   expect(blockConfigSource).toContain("// wp-typia add contract entries");
   expect(blockConfigSource).toContain("// wp-typia add post-meta entries");
+  expect(blockConfigSource).toContain("REST_SCHEMA_PACKAGE");
+  expect(blockConfigSource).toContain("outputDir: 'inc/rest-schemas'");
   expect(packageJson.scripts.sync).toBe("tsx scripts/sync-project.ts");
+  expect(packageJson.scripts["sync-rest:package"]).toBe(
+    "tsx scripts/sync-rest-contracts.ts --package"
+  );
+  expect(packageJson.scripts["sync-rest:package:check"]).toBe(
+    "tsx scripts/sync-rest-contracts.ts --package --check"
+  );
   expect(packageJson.scripts["wp-typia:sync"]).toBe("wp-typia sync");
   expect(packageJson.scripts["wp-typia:doctor"]).toBe("wp-typia doctor");
   expect(packageJson.scripts["wp-typia:doctor:workspace"]).toBe(
@@ -2017,6 +2025,7 @@ test("official workspace template scaffolds through the local npm template resol
   );
   expect(readmeSource).toContain("npm run wp-typia:doctor");
   expect(readmeSource).toContain("npm run wp-typia:sync -- --check");
+  expect(readmeSource).toContain("npm run sync-rest:package:check");
   expect(readmeSource).toContain(
     "npm run wp-typia:add -- block counter-card --template basic"
   );

--- a/packages/wp-typia-project-tools/tests/workspace-add.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-add.test.ts
@@ -4358,6 +4358,7 @@ test("canonical CLI can add a plugin-level REST resource to an official workspac
   expect(phpSource).toContain("register_rest_route");
   expect(phpSource).toContain("'demo-space/v1'");
   expect(phpSource).toContain("current_user_can( 'edit_posts' )");
+  expect(phpSource).toContain("inc/rest-schemas/rest/snapshots");
   expect(
     fs.existsSync(path.join(targetDir, "src", "rest", "snapshots", "api-client.ts"))
   ).toBe(true);
@@ -4376,6 +4377,54 @@ test("canonical CLI can add a plugin-level REST resource to an official workspac
       )
     )
   ).toBe(true);
+
+  runCli("npm", ["run", "sync-rest:package"], { cwd: targetDir });
+
+  const packagedListQuerySchemaPath = path.join(
+    targetDir,
+    "inc",
+    "rest-schemas",
+    "rest",
+    "snapshots",
+    "list-query.schema.json"
+  );
+  const packageManifestPath = path.join(
+    targetDir,
+    "inc",
+    "rest-schemas",
+    "manifest.json"
+  );
+  expect(fs.existsSync(packagedListQuerySchemaPath)).toBe(true);
+  expect(fs.existsSync(packageManifestPath)).toBe(true);
+
+  const packageManifest = JSON.parse(
+    fs.readFileSync(packageManifestPath, "utf8")
+  ) as {
+    outputDir: string;
+    schemas: Array<{ id: string; path: string; source: string }>;
+  };
+  expect(packageManifest.outputDir).toBe("inc/rest-schemas");
+  expect(packageManifest.schemas).toContainEqual(
+    expect.objectContaining({
+      id: "rest:snapshots:list-query",
+      path: "inc/rest-schemas/rest/snapshots/list-query.schema.json",
+      source: "src/rest/snapshots/api-schemas/list-query.schema.json",
+    })
+  );
+
+  runCli("npm", ["run", "sync-rest:package:check"], { cwd: targetDir });
+  fs.writeFileSync(packagedListQuerySchemaPath, "{}\n", "utf8");
+  const stalePackageError = getCommandErrorMessage(() =>
+    runCli("npm", ["run", "sync-rest:package:check"], { cwd: targetDir })
+  );
+  expect(stalePackageError).toContain(
+    "Runtime REST schema package is missing or stale"
+  );
+  expect(stalePackageError).toContain(
+    "inc/rest-schemas/rest/snapshots/list-query.schema.json (stale)"
+  );
+  runCli("npm", ["run", "sync-rest:package"], { cwd: targetDir });
+  runCli("npm", ["run", "sync-rest:package:check"], { cwd: targetDir });
 
   const doctorOutput = runCli("node", [entryPath, "doctor", "--format", "json"], {
     cwd: targetDir,

--- a/packages/wp-typia-project-tools/tests/workspace-add.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-add.test.ts
@@ -4359,6 +4359,7 @@ test("canonical CLI can add a plugin-level REST resource to an official workspac
   expect(phpSource).toContain("'demo-space/v1'");
   expect(phpSource).toContain("current_user_can( 'edit_posts' )");
   expect(phpSource).toContain("inc/rest-schemas/rest/snapshots");
+  expect(phpSource).toContain("$schema_json = file_get_contents( $schema_path );");
   expect(
     fs.existsSync(path.join(targetDir, "src", "rest", "snapshots", "api-client.ts"))
   ).toBe(true);
@@ -4449,6 +4450,55 @@ test("canonical CLI can add a plugin-level REST resource to an official workspac
 
   runCli("npm", ["run", "sync-rest", "--", "--check"], { cwd: targetDir });
   typecheckGeneratedProject(targetDir);
+}, 30_000);
+
+test("sync-rest package check flags stale packaged schemas after REST resources are removed", async () => {
+  const targetDir = path.join(tempRoot, "demo-workspace-empty-rest-schema-package");
+
+  await scaffoldProject({
+    projectDir: targetDir,
+    templateId: workspaceTemplatePackageManifest.name,
+    packageManager: "npm",
+    noInstall: true,
+    answers: {
+      author: "Test Runner",
+      description: "Demo workspace empty rest schema package",
+      namespace: "demo-space",
+      phpPrefix: "demo_space",
+      slug: "demo-workspace-empty-rest-schema-package",
+      textDomain: "demo-space",
+      title: "Demo Workspace Empty Rest Schema Package",
+    },
+  });
+
+  linkWorkspaceNodeModules(targetDir);
+
+  runCli("npm", ["run", "sync-rest:package:check"], { cwd: targetDir });
+
+  const staleSchemaPath = path.join(
+    targetDir,
+    "inc",
+    "rest-schemas",
+    "rest",
+    "snapshots",
+    "old.schema.json"
+  );
+  fs.mkdirSync(path.dirname(staleSchemaPath), { recursive: true });
+  fs.writeFileSync(staleSchemaPath, "{}\n", "utf8");
+
+  const stalePackageError = getCommandErrorMessage(() =>
+    runCli("npm", ["run", "sync-rest:package:check"], { cwd: targetDir })
+  );
+  expect(stalePackageError).toContain(
+    "Runtime REST schema package is missing or stale"
+  );
+  expect(stalePackageError).toContain(
+    "inc/rest-schemas/rest/snapshots/old.schema.json (unexpected)"
+  );
+
+  runCli("npm", ["run", "sync-rest:package"], { cwd: targetDir });
+  expect(fs.existsSync(staleSchemaPath)).toBe(false);
+  runCli("npm", ["run", "sync-rest:package:check"], { cwd: targetDir });
 }, 30_000);
 
 test("canonical CLI can add a generated REST resource with custom route and controller hooks", async () => {


### PR DESCRIPTION
## Summary
- Add `sync-rest --package` plus workspace scripts to copy generated REST JSON schemas into `inc/rest-schemas` with a deterministic manifest.
- Make `sync-rest --package --check` fail on missing, stale, or unexpected packaged schema artifacts before release zips are built.
- Teach generated plugin-level REST PHP to prefer packaged runtime schemas and fall back to source schemas for local development.

## Validation
- bun test packages/wp-typia-project-tools/tests/template-source.test.ts -t "official workspace template scaffolds"
- bun test packages/wp-typia-project-tools/tests/workspace-add.test.ts -t "canonical CLI can add a plugin-level REST resource"
- bun test packages/wp-typia-project-tools/tests/cli-add-workspace-ai.test.ts -t "canonical CLI can add a server-only AI feature"
- bun test packages/wp-typia-project-tools/tests/workspace-add.test.ts -t "legacy sync-rest"
- bun test packages/wp-typia-project-tools/tests/workspace-add.test.ts -t "contract-first"
- bun run --filter @wp-typia/project-tools test:workspace
- bun run typecheck
- bun run lint:repo
- bun run format:check
- bun run changesets:validate
- git diff --check

Closes #927

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `sync-rest:package` and `sync-rest:package:check` scripts to package and verify REST JSON schemas into inc/rest-schemas; CI checks will now fail for missing/stale packaged schemas.
  * Runtime now looks for packaged REST schemas in the release package so runtime validation no longer requires TypeScript source dirs.

* **Documentation**
  * Updated READMEs and templates with packaging and CI guidance for REST-heavy workspace releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/946)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->