### PR TITLE
feat(rest): share workspace REST schema helpers

### DIFF
--- a/.sampo/changesets/928-rest-schema-php-helpers.md
+++ b/.sampo/changesets/928-rest-schema-php-helpers.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/create-workspace-template: patch
+npm/@wp-typia/project-tools: patch
+---
+
+Add shared workspace PHP helpers for loading, WordPress-sanitizing, and validating generated REST schemas from packaged or source schema files.

--- a/README.md
+++ b/README.md
@@ -190,6 +190,14 @@ building a zip and `sync-rest:package:check` in release CI. Those scripts copy
 generated REST schemas into `inc/rest-schemas`, so runtime validation does not
 depend on shipping TypeScript source directories.
 
+Generated workspaces include `inc/rest-schema.php`, which exposes
+plugin-prefixed helpers such as
+`<phpPrefix>_get_wordpress_rest_schema( 'settings-response', array( 'resource' => 'settings' ) )`
+and `<phpPrefix>_validate_and_sanitize_rest_payload(...)`. Custom PHP REST
+resources can call those helpers to load packaged or source schemas, strip
+fields WordPress REST does not need, and receive `WP_Error` responses for
+missing or malformed schema files.
+
 ## Start here
 
 - Want the smallest possible starting point? Start with `basic`.

--- a/packages/create-workspace-template/README.md
+++ b/packages/create-workspace-template/README.md
@@ -53,6 +53,13 @@ builds to copy generated runtime schemas into `inc/rest-schemas`. Add
 `sync-rest:package:check` to release CI so stale or missing packaged schemas are
 caught before a zip is built without TypeScript source files.
 
+The generated `inc/rest-schema.php` helper centralizes schema loading and
+WordPress REST sanitization. Generated REST resources use it automatically, and
+custom PHP resources can call
+`<phpPrefix>_get_wordpress_rest_schema( 'settings-response', array( 'resource' => 'settings' ) )`
+or `<phpPrefix>_validate_and_sanitize_rest_payload(...)` to reuse the same
+packaged/source lookup and `WP_Error` handling.
+
 | Package manager | Doctor                     | Sync check                         | Add a block                                               |
 | --------------- | -------------------------- | ---------------------------------- | --------------------------------------------------------- |
 | npm             | `npm run wp-typia:doctor`  | `npm run wp-typia:sync -- --check` | `npm run wp-typia:add -- block my-block --template basic` |

--- a/packages/create-workspace-template/README.md.mustache
+++ b/packages/create-workspace-template/README.md.mustache
@@ -53,6 +53,13 @@ Run `sync-rest:package` before building release zips when REST resources are
 registered. It copies generated runtime schemas into `inc/rest-schemas` and
 `sync-rest:package:check` fails CI if packaged schemas are missing or stale.
 
+The generated `inc/rest-schema.php` helper centralizes schema loading and
+WordPress REST sanitization. Generated REST resources use it automatically, and
+custom PHP resources can call
+`{{phpPrefix}}_get_wordpress_rest_schema( 'settings-response', array( 'resource' => 'settings' ) )`
+or `{{phpPrefix}}_validate_and_sanitize_rest_payload(...)` to reuse the same
+packaged/source lookup and `WP_Error` handling.
+
 ## Development
 
 ```bash

--- a/packages/create-workspace-template/inc/rest-schema.php.mustache
+++ b/packages/create-workspace-template/inc/rest-schema.php.mustache
@@ -1,0 +1,184 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	return;
+}
+
+if ( ! function_exists( '{{phpPrefix}}_is_valid_rest_schema_key' ) ) {
+	function {{phpPrefix}}_is_valid_rest_schema_key( $value ) {
+		return is_string( $value ) && 1 === preg_match( '/\A[A-Za-z0-9_-]+\z/', $value );
+	}
+}
+
+if ( ! function_exists( '{{phpPrefix}}_is_valid_rest_resource_slug' ) ) {
+	function {{phpPrefix}}_is_valid_rest_resource_slug( $value ) {
+		return is_string( $value ) && 1 === preg_match( '/\A[a-z0-9]+(?:-[a-z0-9]+)*\z/', $value );
+	}
+}
+
+if ( ! function_exists( '{{phpPrefix}}_resolve_rest_schema_paths' ) ) {
+	function {{phpPrefix}}_resolve_rest_schema_paths( $schema_name, $options = array() ) {
+		if ( ! {{phpPrefix}}_is_valid_rest_schema_key( $schema_name ) ) {
+			return new WP_Error(
+				'invalid_rest_schema_name',
+				'Invalid REST schema name.',
+				array( 'status' => 500 )
+			);
+		}
+
+		$options      = is_array( $options ) ? $options : array();
+		$project_root = dirname( __DIR__ );
+		$paths        = array();
+
+		if ( isset( $options['resource'] ) && '' !== $options['resource'] ) {
+			if ( ! {{phpPrefix}}_is_valid_rest_resource_slug( $options['resource'] ) ) {
+				return new WP_Error(
+					'invalid_rest_schema_resource',
+					'Invalid REST schema resource slug.',
+					array( 'status' => 500 )
+				);
+			}
+
+			$resource_slug = $options['resource'];
+			$paths[]       = __DIR__ . '/rest-schemas/rest/' . $resource_slug . '/' . $schema_name . '.schema.json';
+			$paths[]       = $project_root . '/src/rest/' . $resource_slug . '/api-schemas/' . $schema_name . '.schema.json';
+		}
+
+		if ( isset( $options['paths'] ) && is_array( $options['paths'] ) ) {
+			foreach ( $options['paths'] as $schema_path ) {
+				if ( is_string( $schema_path ) && '' !== $schema_path && ! in_array( $schema_path, $paths, true ) ) {
+					$paths[] = $schema_path;
+				}
+			}
+		}
+
+		return $paths;
+	}
+}
+
+if ( ! function_exists( '{{phpPrefix}}_load_rest_schema' ) ) {
+	function {{phpPrefix}}_load_rest_schema( $schema_name, $options = array() ) {
+		$schema_paths = {{phpPrefix}}_resolve_rest_schema_paths( $schema_name, $options );
+		if ( is_wp_error( $schema_paths ) ) {
+			return $schema_paths;
+		}
+
+		foreach ( $schema_paths as $schema_path ) {
+			if ( ! is_file( $schema_path ) ) {
+				continue;
+			}
+
+			if ( ! is_readable( $schema_path ) ) {
+				return new WP_Error(
+					'unreadable_rest_schema',
+					'Generated REST schema is not readable.',
+					array(
+						'path'   => $schema_path,
+						'status' => 500,
+					)
+				);
+			}
+
+			$schema_json = file_get_contents( $schema_path );
+			if ( false === $schema_json ) {
+				return new WP_Error(
+					'rest_schema_read_failed',
+					'Generated REST schema could not be read.',
+					array(
+						'path'   => $schema_path,
+						'status' => 500,
+					)
+				);
+			}
+
+			$decoded = json_decode( $schema_json, true );
+			if ( ! is_array( $decoded ) ) {
+				return new WP_Error(
+					'malformed_rest_schema',
+					'Generated REST schema contains malformed JSON.',
+					array(
+						'json_error' => json_last_error_msg(),
+						'path'       => $schema_path,
+						'status'     => 500,
+					)
+				);
+			}
+
+			return $decoded;
+		}
+
+		return new WP_Error(
+			'missing_rest_schema',
+			'Generated REST schema could not be found.',
+			array(
+				'paths'  => $schema_paths,
+				'schema' => $schema_name,
+				'status' => 500,
+			)
+		);
+	}
+}
+
+if ( ! function_exists( '{{phpPrefix}}_prepare_rest_schema_for_wordpress' ) ) {
+	function {{phpPrefix}}_prepare_rest_schema_for_wordpress( $schema ) {
+		if ( ! is_array( $schema ) ) {
+			return $schema;
+		}
+
+		unset( $schema['$schema'], $schema['title'] );
+
+		foreach ( array( 'properties', 'patternProperties', 'definitions', '$defs' ) as $schema_map_key ) {
+			if ( ! isset( $schema[ $schema_map_key ] ) || ! is_array( $schema[ $schema_map_key ] ) ) {
+				continue;
+			}
+
+			foreach ( $schema[ $schema_map_key ] as $key => $property_schema ) {
+				$schema[ $schema_map_key ][ $key ] = {{phpPrefix}}_prepare_rest_schema_for_wordpress( $property_schema );
+			}
+		}
+
+		foreach ( array( 'items', 'additionalProperties', 'contains', 'propertyNames', 'not', 'if', 'then', 'else' ) as $nested_schema_key ) {
+			if ( isset( $schema[ $nested_schema_key ] ) && is_array( $schema[ $nested_schema_key ] ) ) {
+				$schema[ $nested_schema_key ] = {{phpPrefix}}_prepare_rest_schema_for_wordpress( $schema[ $nested_schema_key ] );
+			}
+		}
+
+		foreach ( array( 'allOf', 'anyOf', 'oneOf' ) as $schema_list_key ) {
+			if ( ! isset( $schema[ $schema_list_key ] ) || ! is_array( $schema[ $schema_list_key ] ) ) {
+				continue;
+			}
+
+			foreach ( $schema[ $schema_list_key ] as $index => $variant_schema ) {
+				$schema[ $schema_list_key ][ $index ] = {{phpPrefix}}_prepare_rest_schema_for_wordpress( $variant_schema );
+			}
+		}
+
+		return $schema;
+	}
+}
+
+if ( ! function_exists( '{{phpPrefix}}_get_wordpress_rest_schema' ) ) {
+	function {{phpPrefix}}_get_wordpress_rest_schema( $schema_name, $options = array() ) {
+		$schema = {{phpPrefix}}_load_rest_schema( $schema_name, $options );
+		if ( is_wp_error( $schema ) ) {
+			return $schema;
+		}
+
+		return {{phpPrefix}}_prepare_rest_schema_for_wordpress( $schema );
+	}
+}
+
+if ( ! function_exists( '{{phpPrefix}}_validate_and_sanitize_rest_payload' ) ) {
+	function {{phpPrefix}}_validate_and_sanitize_rest_payload( $value, $schema_name, $param_name, $options = array() ) {
+		$rest_schema = {{phpPrefix}}_get_wordpress_rest_schema( $schema_name, $options );
+		if ( is_wp_error( $rest_schema ) ) {
+			return $rest_schema;
+		}
+
+		$validation = rest_validate_value_from_schema( $value, $rest_schema, $param_name );
+		if ( is_wp_error( $validation ) ) {
+			return $validation;
+		}
+
+		return rest_sanitize_value_from_schema( $value, $rest_schema, $param_name );
+	}
+}

--- a/packages/create-workspace-template/package.json
+++ b/packages/create-workspace-template/package.json
@@ -8,6 +8,7 @@
     "package.json.mustache",
     "tsconfig.json.mustache",
     "webpack.config.js.mustache",
+    "inc/",
     "scripts/",
     "src/",
     "languages/",

--- a/packages/create-workspace-template/{{slugKebabCase}}.php.mustache
+++ b/packages/create-workspace-template/{{slugKebabCase}}.php.mustache
@@ -17,6 +17,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+function {{phpPrefix}}_load_rest_schema_helpers() {
+	$helper_path = __DIR__ . '/inc/rest-schema.php';
+	if ( is_readable( $helper_path ) ) {
+		require_once $helper_path;
+	}
+}
+
+{{phpPrefix}}_load_rest_schema_helpers();
+
 foreach ( glob( __DIR__ . '/src/blocks/*/server.php' ) ?: array() as $server_module ) {
 	require_once $server_module;
 }

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest-anchors.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest-anchors.ts
@@ -12,6 +12,46 @@ import { hasPhpFunctionDefinition } from "./php-utils.js";
 import type { WorkspaceProject } from "./workspace-project.js";
 
 const REST_RESOURCE_SERVER_GLOB = "/inc/rest/*.php";
+const REST_SCHEMA_HELPER_PATH = "/inc/rest-schema.php";
+
+export async function ensureRestSchemaHelperBootstrapAnchors(
+	workspace: WorkspaceProject,
+): Promise<void> {
+	const bootstrapPath = getWorkspaceBootstrapPath(workspace);
+
+	await patchFile(bootstrapPath, (source) => {
+		let nextSource = source;
+		const loadFunctionName = `${workspace.workspace.phpPrefix}_load_rest_schema_helpers`;
+		const loadCall = `${loadFunctionName}();`;
+		const helperFunction = `
+
+function ${loadFunctionName}() {
+\t$helper_path = __DIR__ . '${REST_SCHEMA_HELPER_PATH}';
+\tif ( is_readable( $helper_path ) ) {
+\t\trequire_once $helper_path;
+\t}
+}
+
+${loadCall}
+`;
+
+		if (!hasPhpFunctionDefinition(nextSource, loadFunctionName)) {
+			nextSource = insertPhpSnippetBeforeWorkspaceAnchors(nextSource, helperFunction);
+		} else if (!nextSource.includes(REST_SCHEMA_HELPER_PATH)) {
+			throw new Error(
+				[
+					`Unable to patch ${path.basename(bootstrapPath)} in ensureRestSchemaHelperBootstrapAnchors.`,
+					`The existing ${loadFunctionName}() definition does not include ${REST_SCHEMA_HELPER_PATH}.`,
+					"Restore the generated bootstrap shape or load inc/rest-schema.php manually before retrying.",
+				].join(" "),
+			);
+		} else if (!nextSource.includes(loadCall)) {
+			nextSource = appendPhpSnippetBeforeClosingTag(nextSource, loadCall);
+		}
+
+		return nextSource;
+	});
+}
 
 export async function ensureRestResourceBootstrapAnchors(
 	workspace: WorkspaceProject,

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest-anchors.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest-anchors.ts
@@ -14,6 +14,13 @@ import type { WorkspaceProject } from "./workspace-project.js";
 const REST_RESOURCE_SERVER_GLOB = "/inc/rest/*.php";
 const REST_SCHEMA_HELPER_PATH = "/inc/rest-schema.php";
 
+/**
+ * Ensure the workspace bootstrap loads the shared REST schema helper file.
+ *
+ * @param workspace Resolved workspace project metadata and PHP prefix.
+ * @returns A promise that resolves after the bootstrap is patched.
+ * @throws When an existing loader does not reference `inc/rest-schema.php`.
+ */
 export async function ensureRestSchemaHelperBootstrapAnchors(
 	workspace: WorkspaceProject,
 ): Promise<void> {

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest-generated.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest-generated.ts
@@ -14,9 +14,13 @@ import {
 } from "./cli-add-shared.js";
 import {
 	ensureRestResourceBootstrapAnchors,
+	ensureRestSchemaHelperBootstrapAnchors,
 	ensureRestResourceSyncScriptAnchors,
 } from "./cli-add-workspace-rest-anchors.js";
-import { buildRestResourcePhpSource } from "./cli-add-workspace-rest-php-templates.js";
+import {
+	buildRestResourcePhpSource,
+	buildWorkspaceRestSchemaHelperPhpSource,
+} from "./cli-add-workspace-rest-php-templates.js";
 import {
 	buildRestResourceApiSource,
 	buildRestResourceConfigEntry,
@@ -28,9 +32,52 @@ import {
 	type GeneratedRestResourceScaffoldOptions,
 	type RunAddRestResourceCommandResult,
 } from "./cli-add-workspace-rest-types.js";
+import { hasPhpFunctionDefinition } from "./php-utils.js";
 import { syncRestResourceArtifacts } from "./rest-resource-artifacts.js";
 import { toPascalCase, toTitleCase } from "./string-case.js";
 import { appendWorkspaceInventoryEntries } from "./workspace-inventory.js";
+
+async function ensureWorkspaceRestSchemaHelperFile(
+	helperFilePath: string,
+	phpPrefix: string,
+): Promise<void> {
+	let currentSource: string | null = null;
+	try {
+		currentSource = await fsp.readFile(helperFilePath, "utf8");
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+			throw error;
+		}
+	}
+
+	if (currentSource === null) {
+		await fsp.mkdir(path.dirname(helperFilePath), { recursive: true });
+		await fsp.writeFile(
+			helperFilePath,
+			buildWorkspaceRestSchemaHelperPhpSource(phpPrefix),
+			"utf8",
+		);
+		return;
+	}
+
+	const requiredFunctions = [
+		`${phpPrefix}_load_rest_schema`,
+		`${phpPrefix}_prepare_rest_schema_for_wordpress`,
+		`${phpPrefix}_get_wordpress_rest_schema`,
+		`${phpPrefix}_validate_and_sanitize_rest_payload`,
+	];
+	const missingFunctions = requiredFunctions.filter(
+		(functionName) => !hasPhpFunctionDefinition(currentSource, functionName),
+	);
+	if (missingFunctions.length > 0) {
+		throw new Error(
+			[
+				`Existing ${path.relative(process.cwd(), helperFilePath)} is missing generated REST schema helper functions: ${missingFunctions.join(", ")}.`,
+				"Restore the generated inc/rest-schema.php helper or add these functions manually before retrying.",
+			].join(" "),
+		);
+	}
+}
 
 /**
  * Scaffold generated TypeScript, PHP, schema, and inventory files for a
@@ -81,20 +128,27 @@ export async function scaffoldGeneratedRestResource({
 	}
 	const bootstrapPath = getWorkspaceBootstrapPath(workspace);
 	const dataFilePath = path.join(restResourceDir, "data.ts");
+	const restSchemaHelperPath = path.join(workspace.projectDir, "inc", "rest-schema.php");
 	const phpFilePath = path.join(workspace.projectDir, "inc", "rest", `${restResourceSlug}.php`);
 	const mutationSnapshot: WorkspaceMutationSnapshot = {
 		fileSources: await snapshotWorkspaceFiles([
 			blockConfigPath,
 			bootstrapPath,
+			restSchemaHelperPath,
 			syncRestScriptPath,
 		]),
 		snapshotDirs: [],
-		targetPaths: [restResourceDir, phpFilePath],
+		targetPaths: [restResourceDir, restSchemaHelperPath, phpFilePath],
 	};
 
 	try {
 		await fsp.mkdir(restResourceDir, { recursive: true });
 		await fsp.mkdir(path.dirname(phpFilePath), { recursive: true });
+		await ensureWorkspaceRestSchemaHelperFile(
+			restSchemaHelperPath,
+			workspace.workspace.phpPrefix,
+		);
+		await ensureRestSchemaHelperBootstrapAnchors(workspace);
 		await ensureRestResourceBootstrapAnchors(workspace);
 		await ensureRestResourceSyncScriptAnchors(workspace);
 		await fsp.writeFile(

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest-php-templates.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest-php-templates.ts
@@ -186,8 +186,6 @@ export function buildRestResourcePhpSource(
 	const restResourcePhpId = restResourceSlug.replace(/-/g, "_");
 	const canWriteFunctionName = `${phpPrefix}_${restResourcePhpId}_can_manage_rest_resource`;
 	const getItemsFunctionName = `${phpPrefix}_${restResourcePhpId}_get_rest_resource_items`;
-	const loadSchemaFunctionName = `${phpPrefix}_${restResourcePhpId}_load_rest_resource_schema`;
-	const normalizeSchemaFunctionName = `${phpPrefix}_${restResourcePhpId}_sanitize_rest_resource_schema`;
 	const validatePayloadFunctionName = `${phpPrefix}_${restResourcePhpId}_validate_rest_resource_payload`;
 	const normalizeItemFunctionName = `${phpPrefix}_${restResourcePhpId}_normalize_rest_resource_item`;
 	const saveItemsFunctionName = `${phpPrefix}_${restResourcePhpId}_save_rest_resource_items`;
@@ -306,70 +304,22 @@ if ( ! function_exists( '${saveItemsFunctionName}' ) ) {
 \t}
 }
 
-if ( ! function_exists( '${loadSchemaFunctionName}' ) ) {
-\tfunction ${loadSchemaFunctionName}( $schema_name ) {
-\t\t$project_root = dirname( __DIR__, 2 );
-\t\t$schema_paths = array(
-\t\t\t$project_root . '/inc/rest-schemas/rest/${restResourceSlug}/' . $schema_name . '.schema.json',
-\t\t\t$project_root . '/src/rest/${restResourceSlug}/api-schemas/' . $schema_name . '.schema.json',
-\t\t);
-
-\t\tforeach ( $schema_paths as $schema_path ) {
-\t\t\tif ( ! is_file( $schema_path ) || ! is_readable( $schema_path ) ) {
-\t\t\t\tcontinue;
-\t\t\t}
-
-\t\t\t$schema_json = file_get_contents( $schema_path );
-\t\t\tif ( false === $schema_json ) {
-\t\t\t\tcontinue;
-\t\t\t}
-
-\t\t\t$decoded = json_decode( $schema_json, true );
-\t\t\tif ( is_array( $decoded ) ) {
-\t\t\t\treturn $decoded;
-\t\t\t}
-\t\t}
-
-\t\treturn null;
-\t}
-}
-
-if ( ! function_exists( '${normalizeSchemaFunctionName}' ) ) {
-\tfunction ${normalizeSchemaFunctionName}( $schema ) {
-\t\tif ( ! is_array( $schema ) ) {
-\t\t\treturn $schema;
-\t\t}
-
-\t\tunset( $schema['$schema'], $schema['title'] );
-
-\t\tif ( isset( $schema['properties'] ) && is_array( $schema['properties'] ) ) {
-\t\t\tforeach ( $schema['properties'] as $key => $property_schema ) {
-\t\t\t\t$schema['properties'][ $key ] = ${normalizeSchemaFunctionName}( $property_schema );
-\t\t\t}
-\t\t}
-
-\t\tif ( isset( $schema['items'] ) && is_array( $schema['items'] ) ) {
-\t\t\t$schema['items'] = ${normalizeSchemaFunctionName}( $schema['items'] );
-\t\t}
-
-\t\treturn $schema;
-\t}
-}
-
 if ( ! function_exists( '${validatePayloadFunctionName}' ) ) {
 \tfunction ${validatePayloadFunctionName}( $value, $schema_name, $param_name ) {
-\t\t$schema = ${loadSchemaFunctionName}( $schema_name );
-\t\tif ( ! is_array( $schema ) ) {
-\t\t\treturn new WP_Error( 'missing_schema', 'Missing REST schema.', array( 'status' => 500 ) );
+\t\tif ( ! function_exists( '${phpPrefix}_validate_and_sanitize_rest_payload' ) ) {
+\t\t\treturn new WP_Error(
+\t\t\t\t'missing_rest_schema_helper',
+\t\t\t\t'Missing REST schema helper. Ensure inc/rest-schema.php is loaded before REST resources.',
+\t\t\t\tarray( 'status' => 500 )
+\t\t\t);
 \t\t}
 
-\t\t$rest_schema = ${normalizeSchemaFunctionName}( $schema );
-\t\t$validation  = rest_validate_value_from_schema( $value, $rest_schema, $param_name );
-\t\tif ( is_wp_error( $validation ) ) {
-\t\t\treturn $validation;
-\t\t}
-
-\t\treturn rest_sanitize_value_from_schema( $value, $rest_schema, $param_name );
+\t\treturn ${phpPrefix}_validate_and_sanitize_rest_payload(
+\t\t\t$value,
+\t\t\t$schema_name,
+\t\t\t$param_name,
+\t\t\tarray( 'resource' => ${quotePhpString(restResourceSlug)} )
+\t\t);
 \t}
 }
 
@@ -583,5 +533,199 @@ ${routeRegistrations}
 }
 
 add_action( 'rest_api_init', '${registerRoutesFunctionName}' );
+`;
+}
+
+/**
+ * Build the shared PHP helper loaded by workspace bootstraps for generated REST schemas.
+ *
+ * @param phpPrefix Plugin-scoped PHP function prefix.
+ * @returns PHP source for `inc/rest-schema.php`.
+ */
+export function buildWorkspaceRestSchemaHelperPhpSource(phpPrefix: string): string {
+	return `<?php
+if ( ! defined( 'ABSPATH' ) ) {
+\treturn;
+}
+
+if ( ! function_exists( '${phpPrefix}_is_valid_rest_schema_key' ) ) {
+\tfunction ${phpPrefix}_is_valid_rest_schema_key( $value ) {
+\t\treturn is_string( $value ) && 1 === preg_match( '/\\A[A-Za-z0-9_-]+\\z/', $value );
+\t}
+}
+
+if ( ! function_exists( '${phpPrefix}_is_valid_rest_resource_slug' ) ) {
+\tfunction ${phpPrefix}_is_valid_rest_resource_slug( $value ) {
+\t\treturn is_string( $value ) && 1 === preg_match( '/\\A[a-z0-9]+(?:-[a-z0-9]+)*\\z/', $value );
+\t}
+}
+
+if ( ! function_exists( '${phpPrefix}_resolve_rest_schema_paths' ) ) {
+\tfunction ${phpPrefix}_resolve_rest_schema_paths( $schema_name, $options = array() ) {
+\t\tif ( ! ${phpPrefix}_is_valid_rest_schema_key( $schema_name ) ) {
+\t\t\treturn new WP_Error(
+\t\t\t\t'invalid_rest_schema_name',
+\t\t\t\t'Invalid REST schema name.',
+\t\t\t\tarray( 'status' => 500 )
+\t\t\t);
+\t\t}
+
+\t\t$options      = is_array( $options ) ? $options : array();
+\t\t$project_root = dirname( __DIR__ );
+\t\t$paths        = array();
+
+\t\tif ( isset( $options['resource'] ) && '' !== $options['resource'] ) {
+\t\t\tif ( ! ${phpPrefix}_is_valid_rest_resource_slug( $options['resource'] ) ) {
+\t\t\t\treturn new WP_Error(
+\t\t\t\t\t'invalid_rest_schema_resource',
+\t\t\t\t\t'Invalid REST schema resource slug.',
+\t\t\t\t\tarray( 'status' => 500 )
+\t\t\t\t);
+\t\t\t}
+
+\t\t\t$resource_slug = $options['resource'];
+\t\t\t$paths[]       = __DIR__ . '/rest-schemas/rest/' . $resource_slug . '/' . $schema_name . '.schema.json';
+\t\t\t$paths[]       = $project_root . '/src/rest/' . $resource_slug . '/api-schemas/' . $schema_name . '.schema.json';
+\t\t}
+
+\t\tif ( isset( $options['paths'] ) && is_array( $options['paths'] ) ) {
+\t\t\tforeach ( $options['paths'] as $schema_path ) {
+\t\t\t\tif ( is_string( $schema_path ) && '' !== $schema_path && ! in_array( $schema_path, $paths, true ) ) {
+\t\t\t\t\t$paths[] = $schema_path;
+\t\t\t\t}
+\t\t\t}
+\t\t}
+
+\t\treturn $paths;
+\t}
+}
+
+if ( ! function_exists( '${phpPrefix}_load_rest_schema' ) ) {
+\tfunction ${phpPrefix}_load_rest_schema( $schema_name, $options = array() ) {
+\t\t$schema_paths = ${phpPrefix}_resolve_rest_schema_paths( $schema_name, $options );
+\t\tif ( is_wp_error( $schema_paths ) ) {
+\t\t\treturn $schema_paths;
+\t\t}
+
+\t\tforeach ( $schema_paths as $schema_path ) {
+\t\t\tif ( ! is_file( $schema_path ) ) {
+\t\t\t\tcontinue;
+\t\t\t}
+
+\t\t\tif ( ! is_readable( $schema_path ) ) {
+\t\t\t\treturn new WP_Error(
+\t\t\t\t\t'unreadable_rest_schema',
+\t\t\t\t\t'Generated REST schema is not readable.',
+\t\t\t\t\tarray(
+\t\t\t\t\t\t'path'   => $schema_path,
+\t\t\t\t\t\t'status' => 500,
+\t\t\t\t\t)
+\t\t\t\t);
+\t\t\t}
+
+\t\t\t$schema_json = file_get_contents( $schema_path );
+\t\t\tif ( false === $schema_json ) {
+\t\t\t\treturn new WP_Error(
+\t\t\t\t\t'rest_schema_read_failed',
+\t\t\t\t\t'Generated REST schema could not be read.',
+\t\t\t\t\tarray(
+\t\t\t\t\t\t'path'   => $schema_path,
+\t\t\t\t\t\t'status' => 500,
+\t\t\t\t\t)
+\t\t\t\t);
+\t\t\t}
+
+\t\t\t$decoded = json_decode( $schema_json, true );
+\t\t\tif ( ! is_array( $decoded ) ) {
+\t\t\t\treturn new WP_Error(
+\t\t\t\t\t'malformed_rest_schema',
+\t\t\t\t\t'Generated REST schema contains malformed JSON.',
+\t\t\t\t\tarray(
+\t\t\t\t\t\t'json_error' => json_last_error_msg(),
+\t\t\t\t\t\t'path'       => $schema_path,
+\t\t\t\t\t\t'status'     => 500,
+\t\t\t\t\t)
+\t\t\t\t);
+\t\t\t}
+
+\t\t\treturn $decoded;
+\t\t}
+
+\t\treturn new WP_Error(
+\t\t\t'missing_rest_schema',
+\t\t\t'Generated REST schema could not be found.',
+\t\t\tarray(
+\t\t\t\t'paths'  => $schema_paths,
+\t\t\t\t'schema' => $schema_name,
+\t\t\t\t'status' => 500,
+\t\t\t)
+\t\t);
+\t}
+}
+
+if ( ! function_exists( '${phpPrefix}_prepare_rest_schema_for_wordpress' ) ) {
+\tfunction ${phpPrefix}_prepare_rest_schema_for_wordpress( $schema ) {
+\t\tif ( ! is_array( $schema ) ) {
+\t\t\treturn $schema;
+\t\t}
+
+\t\tunset( $schema['$schema'], $schema['title'] );
+
+\t\tforeach ( array( 'properties', 'patternProperties', 'definitions', '$defs' ) as $schema_map_key ) {
+\t\t\tif ( ! isset( $schema[ $schema_map_key ] ) || ! is_array( $schema[ $schema_map_key ] ) ) {
+\t\t\t\tcontinue;
+\t\t\t}
+
+\t\t\tforeach ( $schema[ $schema_map_key ] as $key => $property_schema ) {
+\t\t\t\t$schema[ $schema_map_key ][ $key ] = ${phpPrefix}_prepare_rest_schema_for_wordpress( $property_schema );
+\t\t\t}
+\t\t}
+
+\t\tforeach ( array( 'items', 'additionalProperties', 'contains', 'propertyNames', 'not', 'if', 'then', 'else' ) as $nested_schema_key ) {
+\t\t\tif ( isset( $schema[ $nested_schema_key ] ) && is_array( $schema[ $nested_schema_key ] ) ) {
+\t\t\t\t$schema[ $nested_schema_key ] = ${phpPrefix}_prepare_rest_schema_for_wordpress( $schema[ $nested_schema_key ] );
+\t\t\t}
+\t\t}
+
+\t\tforeach ( array( 'allOf', 'anyOf', 'oneOf' ) as $schema_list_key ) {
+\t\t\tif ( ! isset( $schema[ $schema_list_key ] ) || ! is_array( $schema[ $schema_list_key ] ) ) {
+\t\t\t\tcontinue;
+\t\t\t}
+
+\t\t\tforeach ( $schema[ $schema_list_key ] as $index => $variant_schema ) {
+\t\t\t\t$schema[ $schema_list_key ][ $index ] = ${phpPrefix}_prepare_rest_schema_for_wordpress( $variant_schema );
+\t\t\t}
+\t\t}
+
+\t\treturn $schema;
+\t}
+}
+
+if ( ! function_exists( '${phpPrefix}_get_wordpress_rest_schema' ) ) {
+\tfunction ${phpPrefix}_get_wordpress_rest_schema( $schema_name, $options = array() ) {
+\t\t$schema = ${phpPrefix}_load_rest_schema( $schema_name, $options );
+\t\tif ( is_wp_error( $schema ) ) {
+\t\t\treturn $schema;
+\t\t}
+
+\t\treturn ${phpPrefix}_prepare_rest_schema_for_wordpress( $schema );
+\t}
+}
+
+if ( ! function_exists( '${phpPrefix}_validate_and_sanitize_rest_payload' ) ) {
+\tfunction ${phpPrefix}_validate_and_sanitize_rest_payload( $value, $schema_name, $param_name, $options = array() ) {
+\t\t$rest_schema = ${phpPrefix}_get_wordpress_rest_schema( $schema_name, $options );
+\t\tif ( is_wp_error( $rest_schema ) ) {
+\t\t\treturn $rest_schema;
+\t\t}
+
+\t\t$validation = rest_validate_value_from_schema( $value, $rest_schema, $param_name );
+\t\tif ( is_wp_error( $validation ) ) {
+\t\t\treturn $validation;
+\t\t}
+
+\t\treturn rest_sanitize_value_from_schema( $value, $rest_schema, $param_name );
+\t}
+}
 `;
 }

--- a/packages/wp-typia-project-tools/tests/template-source.test.ts
+++ b/packages/wp-typia-project-tools/tests/template-source.test.ts
@@ -1977,6 +1977,10 @@ test("official workspace template scaffolds through the local npm template resol
     path.join(targetDir, "scripts", "block-config.ts"),
     "utf8"
   );
+  const restSchemaHelperSource = fs.readFileSync(
+    path.join(targetDir, "inc", "rest-schema.php"),
+    "utf8"
+  );
 
   expect(result.templateId).toBe(workspaceTemplatePackageManifest.name);
   expect(packageJson.wpTypia).toEqual({
@@ -2026,6 +2030,7 @@ test("official workspace template scaffolds through the local npm template resol
   expect(readmeSource).toContain("npm run wp-typia:doctor");
   expect(readmeSource).toContain("npm run wp-typia:sync -- --check");
   expect(readmeSource).toContain("npm run sync-rest:package:check");
+  expect(readmeSource).toContain("demo_space_get_wordpress_rest_schema");
   expect(readmeSource).toContain(
     "npm run wp-typia:add -- block counter-card --template basic"
   );
@@ -2036,9 +2041,22 @@ test("official workspace template scaffolds through the local npm template resol
     "wp_register_block_types_from_metadata_collection"
   );
   expect(bootstrapSource).toContain("src/bindings/*/server.php");
+  expect(bootstrapSource).toContain("function demo_space_load_rest_schema_helpers()");
+  expect(bootstrapSource).toContain("inc/rest-schema.php");
   expect(bootstrapSource).toContain("enqueue_block_editor_assets");
   expect(bootstrapSource).toContain("register_block_pattern_category");
   expect(bootstrapSource).toContain("/src/patterns/*.php");
+  expect(restSchemaHelperSource).toContain("function demo_space_load_rest_schema");
+  expect(restSchemaHelperSource).toContain(
+    "function demo_space_prepare_rest_schema_for_wordpress"
+  );
+  expect(restSchemaHelperSource).toContain(
+    "function demo_space_get_wordpress_rest_schema"
+  );
+  expect(restSchemaHelperSource).toContain(
+    "function demo_space_validate_and_sanitize_rest_payload"
+  );
+  expect(restSchemaHelperSource).toContain("malformed_rest_schema");
   expect(
     fs.existsSync(path.join(targetDir, "src", "blocks", ".gitkeep"))
   ).toBe(true);

--- a/packages/wp-typia-project-tools/tests/workspace-add.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-add.test.ts
@@ -4310,6 +4310,10 @@ test("canonical CLI can add a plugin-level REST resource to an official workspac
     path.join(targetDir, "demo-workspace-add-rest-resource.php"),
     "utf8"
   );
+  const restSchemaHelperSource = fs.readFileSync(
+    path.join(targetDir, "inc", "rest-schema.php"),
+    "utf8"
+  );
   const typesSource = fs.readFileSync(
     path.join(targetDir, "src", "rest", "snapshots", "api-types.ts"),
     "utf8"
@@ -4344,6 +4348,19 @@ test("canonical CLI can add a plugin-level REST resource to an official workspac
   expect(blockConfigSource).toContain("defineEndpointManifest");
   expect(bootstrapSource).toContain("function demo_space_register_rest_resources()");
   expect(bootstrapSource).toContain("inc/rest/*.php");
+  expect(bootstrapSource).toContain("function demo_space_load_rest_schema_helpers()");
+  expect(bootstrapSource).toContain("inc/rest-schema.php");
+  expect(restSchemaHelperSource).toContain("function demo_space_load_rest_schema");
+  expect(restSchemaHelperSource).toContain(
+    "function demo_space_prepare_rest_schema_for_wordpress"
+  );
+  expect(restSchemaHelperSource).toContain(
+    "function demo_space_get_wordpress_rest_schema"
+  );
+  expect(restSchemaHelperSource).toContain(
+    "function demo_space_validate_and_sanitize_rest_payload"
+  );
+  expect(restSchemaHelperSource).toContain("malformed_rest_schema");
   expect(typesSource).toContain("export interface SnapshotsListQuery");
   expect(typesSource).toContain("export interface SnapshotsDeleteResponse");
   expect(validatorsSource).toContain("apiValidators");
@@ -4358,8 +4375,10 @@ test("canonical CLI can add a plugin-level REST resource to an official workspac
   expect(phpSource).toContain("register_rest_route");
   expect(phpSource).toContain("'demo-space/v1'");
   expect(phpSource).toContain("current_user_can( 'edit_posts' )");
-  expect(phpSource).toContain("inc/rest-schemas/rest/snapshots");
-  expect(phpSource).toContain("$schema_json = file_get_contents( $schema_path );");
+  expect(phpSource).toContain("demo_space_validate_and_sanitize_rest_payload");
+  expect(phpSource).toContain("array( 'resource' => 'snapshots' )");
+  expect(phpSource).not.toContain("demo_space_snapshots_load_rest_resource_schema");
+  expect(phpSource).not.toContain("$schema_json = file_get_contents( $schema_path );");
   expect(
     fs.existsSync(path.join(targetDir, "src", "rest", "snapshots", "api-client.ts"))
   ).toBe(true);
@@ -5304,6 +5323,11 @@ test("rest resource workflow repairs legacy sync-rest scripts before writing wor
 
   linkWorkspaceNodeModules(targetDir);
 
+  const bootstrapPath = path.join(
+    targetDir,
+    "demo-workspace-rest-resource-legacy-sync-rest.php"
+  );
+  const restSchemaHelperPath = path.join(targetDir, "inc", "rest-schema.php");
   const syncRestScriptPath = path.join(
     targetDir,
     "scripts",
@@ -5313,12 +5337,32 @@ test("rest resource workflow repairs legacy sync-rest scripts before writing wor
     fs.readFileSync(syncRestScriptPath, "utf8")
   );
   fs.writeFileSync(syncRestScriptPath, legacySyncRestSource, "utf8");
+  fs.rmSync(restSchemaHelperPath, { force: true });
+  fs.writeFileSync(
+    bootstrapPath,
+    fs
+      .readFileSync(bootstrapPath, "utf8")
+      .replace(
+        /\nfunction demo_space_load_rest_schema_helpers\(\) \{[\s\S]*?\n\}\n\ndemo_space_load_rest_schema_helpers\(\);\n/u,
+        "\n"
+      ),
+    "utf8"
+  );
 
   runCli("node", [entryPath, "add", "rest-resource", "snapshots"], {
     cwd: targetDir,
   });
 
+  const repairedBootstrapSource = fs.readFileSync(bootstrapPath, "utf8");
   const repairedSyncRestSource = fs.readFileSync(syncRestScriptPath, "utf8");
+  const repairedRestSchemaHelperSource = fs.readFileSync(
+    restSchemaHelperPath,
+    "utf8"
+  );
+  expect(repairedBootstrapSource).toContain("inc/rest-schema.php");
+  expect(repairedRestSchemaHelperSource).toContain(
+    "function demo_space_validate_and_sanitize_rest_payload"
+  );
   expect(repairedSyncRestSource).toContain("REST_RESOURCES");
   expect(repairedSyncRestSource).toContain("function isWorkspaceRestResource(");
   expect(repairedSyncRestSource).toContain(


### PR DESCRIPTION
## Summary
- Add generated `inc/rest-schema.php` workspace helpers for loading packaged/source REST schemas, preparing them for WordPress REST, and returning actionable `WP_Error` failures for missing/malformed schema files.
- Wire workspace bootstraps and `wp-typia add rest-resource` so new and legacy workspaces load or backfill the shared helper before generated REST resources run.
- Update generated REST resource PHP to call the shared helper instead of duplicating schema loading/sanitization, plus docs, tests, and a changeset.

## Validation
- bun test packages/wp-typia-project-tools/tests/template-source.test.ts -t "official workspace template scaffolds"
- bun test packages/wp-typia-project-tools/tests/workspace-add.test.ts -t "canonical CLI can add a plugin-level REST resource"
- bun test packages/wp-typia-project-tools/tests/workspace-add.test.ts -t "rest resource workflow repairs legacy sync-rest"
- bun run --filter @wp-typia/project-tools test:workspace
- bun run --filter @wp-typia/project-tools build
- bun run --filter wp-typia build
- bun run typecheck
- bun run lint:repo
- bun run format:check
- bun run changesets:validate
- bun run manifest-policy:validate
- bun run typescript-runtime:validate
- bun run runtime-coupling:validate
- bun run typescript-strictness:validate
- bun run maintenance-automation:validate
- bun run formatting-policy:validate
- bun run publish:validate
- bun scripts/lint-generated-php.ts
- git diff --check

Closes #928

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generated workspaces now include shared PHP REST schema helpers for loading, preparing, validating, and sanitizing REST schemas with consistent error handling; generated resources delegate validation to the shared helper and bootstraps ensure it is loaded.

* **Documentation**
  * READMEs updated with usage examples and notes about the bundled REST schema helpers.

* **Tests**
  * Template and workspace tests updated to validate helper presence and wiring during scaffolding.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/947)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->