### PR TITLE
refactor(rest): share nonce helper source

### DIFF
--- a/.sampo/changesets/952-shared-rest-nonce-source.md
+++ b/.sampo/changesets/952-shared-rest-nonce-source.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Share the generated REST nonce helper source across manual contract and REST resource emitters while preserving scaffolded API output.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest-source-emitters.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest-source-emitters.ts
@@ -17,6 +17,47 @@ function indentMultiline(source: string, prefix: string): string {
 		.join("\n");
 }
 
+const RESOLVE_REST_NONCE_SOURCE = `function resolveRestNonce( fallback?: string ): string | undefined {
+\tif ( typeof fallback === 'string' && fallback.length > 0 ) {
+\t\treturn fallback;
+\t}
+
+\tif ( typeof window === 'undefined' ) {
+\t\treturn undefined;
+\t}
+
+\tconst wpApiSettings = (
+\t\twindow as typeof window & {
+\t\t\twpApiSettings?: { nonce?: string };
+\t\t}
+\t).wpApiSettings;
+
+\treturn typeof wpApiSettings?.nonce === 'string' &&
+\t\twpApiSettings.nonce.length > 0
+\t\t? wpApiSettings.nonce
+\t\t: undefined;
+}`;
+
+function formatResolveRestNonceSource(style: "compact" | "spaced"): string {
+	if (style === "spaced") {
+		return RESOLVE_REST_NONCE_SOURCE;
+	}
+
+	return RESOLVE_REST_NONCE_SOURCE
+		.replace(
+			"function resolveRestNonce( fallback?: string ): string | undefined {",
+			"function resolveRestNonce(fallback?: string): string | undefined {",
+		)
+		.replace(
+			"\tif ( typeof fallback === 'string' && fallback.length > 0 ) {",
+			"\tif (typeof fallback === 'string' && fallback.length > 0) {",
+		)
+		.replace(
+			"\tif ( typeof window === 'undefined' ) {",
+			"\tif (typeof window === 'undefined') {",
+		);
+}
+
 /**
  * Build a generated REST resource config entry for `scripts/block-config.ts`.
  *
@@ -345,26 +386,7 @@ import { ${operationId}Endpoint } from './api-client';
 
 export * from './api-client';
 
-${requestTypeSource}function resolveRestNonce(fallback?: string): string | undefined {
-\tif (typeof fallback === 'string' && fallback.length > 0) {
-\t\treturn fallback;
-\t}
-
-\tif (typeof window === 'undefined') {
-\t\treturn undefined;
-\t}
-
-\tconst wpApiSettings = (
-\t\twindow as typeof window & {
-\t\t\twpApiSettings?: { nonce?: string };
-\t\t}
-\t).wpApiSettings;
-
-\treturn typeof wpApiSettings?.nonce === 'string' &&
-\t\twpApiSettings.nonce.length > 0
-\t\t? wpApiSettings.nonce
-\t\t: undefined;
-}
+${requestTypeSource}${formatResolveRestNonceSource("compact")}
 
 function resolveEndpointRouteOptions(request: ${requestTypeName}) {
 \tconst requestOptions = ${operationId}Endpoint.buildRequestOptions?.(request) ?? {};
@@ -672,28 +694,7 @@ export function deleteResource( request: ${pascalCase}DeleteQuery ) {
 
 	const resolveRestNonceSource =
 		writeMethods.length > 0
-			? `function resolveRestNonce( fallback?: string ): string | undefined {
-\tif ( typeof fallback === 'string' && fallback.length > 0 ) {
-\t\treturn fallback;
-\t}
-
-\tif ( typeof window === 'undefined' ) {
-\t\treturn undefined;
-\t}
-
-\tconst wpApiSettings = (
-\t\twindow as typeof window & {
-\t\t\twpApiSettings?: { nonce?: string };
-\t\t}
-\t).wpApiSettings;
-
-\treturn typeof wpApiSettings?.nonce === 'string' &&
-\t\twpApiSettings.nonce.length > 0
-\t\t? wpApiSettings.nonce
-\t\t: undefined;
-}
-
-`
+			? `${formatResolveRestNonceSource("spaced")}\n\n`
 			: "";
 
 	return `import {

--- a/packages/wp-typia-project-tools/tests/cli-add-workspace-rest-source-emitters.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-add-workspace-rest-source-emitters.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "bun:test";
+
+import {
+	buildManualRestContractApiSource,
+	buildRestResourceApiSource,
+} from "../src/runtime/cli-add-workspace-rest-source-emitters.js";
+
+function countOccurrences(source: string, needle: string): number {
+	return source.split(needle).length - 1;
+}
+
+test("manual REST contract API source keeps the compact nonce helper output stable", () => {
+	const source = buildManualRestContractApiSource({
+		queryTypeName: "DemoQuery",
+		restResourceSlug: "demo-resource",
+	});
+
+	expect(source).toContain(
+		"function resolveRestNonce(fallback?: string): string | undefined {",
+	);
+	expect(source).toContain(
+		"\tif (typeof fallback === 'string' && fallback.length > 0) {",
+	);
+	expect(source).not.toContain(
+		"function resolveRestNonce( fallback?: string ): string | undefined {",
+	);
+	expect(countOccurrences(source, "function resolveRestNonce")).toBe(1);
+});
+
+test("REST resource API source keeps the spaced nonce helper output stable", () => {
+	const source = buildRestResourceApiSource("demo-resource", ["list", "create"]);
+
+	expect(source).toContain(
+		"function resolveRestNonce( fallback?: string ): string | undefined {",
+	);
+	expect(source).toContain(
+		"\tif ( typeof fallback === 'string' && fallback.length > 0 ) {",
+	);
+	expect(source).not.toContain(
+		"function resolveRestNonce(fallback?: string): string | undefined {",
+	);
+	expect(countOccurrences(source, "function resolveRestNonce")).toBe(1);
+});
+
+test("REST resource API source omits the nonce helper for read-only methods", () => {
+	const source = buildRestResourceApiSource("demo-resource", ["list", "read"]);
+
+	expect(source).not.toContain("function resolveRestNonce");
+});


### PR DESCRIPTION
## Summary
- Extract the generated REST nonce helper source into one emitter-level constant
- Preserve the existing compact manual-contract output and spaced REST-resource output
- Add focused emitter tests for both nonce helper variants and read-only omission

Closes #952.

## Validation
- bun test packages/wp-typia-project-tools/tests/cli-add-workspace-rest-source-emitters.test.ts
- bun run typecheck
- bun run lint:repo
- bun run format:check
- bun run changesets:validate
- bun run runtime-coupling:validate
- git diff --check
- bun run --filter @wp-typia/project-tools build