### PR TITLE
refactor(rest): normalize secret preserve flag

### DIFF
--- a/.sampo/changesets/954-normalize-secret-preserve.md
+++ b/.sampo/changesets/954-normalize-secret-preserve.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Normalize manual REST `secretPreserveOnEmpty` CLI values before invoking project-tools runtime APIs.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-types.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-types.ts
@@ -304,7 +304,7 @@ export interface RunAddRestResourceCommandOptions {
 	secretFieldName?: string;
 	secretHasValueFieldName?: string;
 	secretMaskedResponseFieldName?: string;
-	secretPreserveOnEmpty?: boolean | string;
+	secretPreserveOnEmpty?: boolean;
 	secretStateFieldName?: string;
 }
 

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest-manual.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest-manual.ts
@@ -38,26 +38,9 @@ const MANUAL_REST_RESPONSE_FIELD_NAMES = new Set([
 ]);
 
 function resolveManualRestSecretPreserveOnEmpty(
-	value: boolean | string | undefined,
+	value: boolean | undefined,
 ): boolean {
-	if (value === undefined) {
-		return true;
-	}
-	if (typeof value === "boolean") {
-		return value;
-	}
-
-	const normalized = value.trim().toLowerCase();
-	if (["1", "true", "yes"].includes(normalized)) {
-		return true;
-	}
-	if (["0", "false", "no"].includes(normalized)) {
-		return false;
-	}
-
-	throw new Error(
-		"Manual REST contract --secret-preserve-on-empty must be true or false.",
-	);
+	return value ?? true;
 }
 
 function resolveManualRestSecretStateFieldCandidate(options: {

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest-types.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest-types.ts
@@ -64,8 +64,8 @@ export interface RunAddRestResourceCommandResult {
  * @property secretMaskedResponseFieldName Optional alias for
  * `secretStateFieldName`.
  * @property secretFieldName Optional write-only request secret field.
- * @property secretPreserveOnEmpty Optional true/false string or boolean for
- * blank-secret preservation. Defaults to true when `secretFieldName` is set.
+ * @property secretPreserveOnEmpty Optional normalized boolean for blank-secret
+ * preservation. Defaults to true when `secretFieldName` is set.
  * @property workspace Resolved official workspace project.
  */
 export interface ManualRestContractScaffoldOptions {
@@ -84,7 +84,7 @@ export interface ManualRestContractScaffoldOptions {
 	secretFieldName: string | undefined;
 	secretHasValueFieldName: string | undefined;
 	secretMaskedResponseFieldName: string | undefined;
-	secretPreserveOnEmpty: boolean | string | undefined;
+	secretPreserveOnEmpty: boolean | undefined;
 	secretStateFieldName: string | undefined;
 	workspace: WorkspaceProject;
 }

--- a/packages/wp-typia-project-tools/tests/cli-add-rest-secret-preserve-boundaries.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-add-rest-secret-preserve-boundaries.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+
+const runtimeRoot = path.join(import.meta.dir, "..", "src", "runtime");
+
+test("REST secret preserve options cross project-tools APIs as normalized booleans", () => {
+	const addTypesSource = fs.readFileSync(
+		path.join(runtimeRoot, "cli-add-types.ts"),
+		"utf8",
+	);
+	const restManualSource = fs.readFileSync(
+		path.join(runtimeRoot, "cli-add-workspace-rest-manual.ts"),
+		"utf8",
+	);
+	const restTypesSource = fs.readFileSync(
+		path.join(runtimeRoot, "cli-add-workspace-rest-types.ts"),
+		"utf8",
+	);
+
+	expect(addTypesSource).toContain("secretPreserveOnEmpty?: boolean;");
+	expect(addTypesSource).not.toContain(
+		"secretPreserveOnEmpty?: boolean | string;",
+	);
+	expect(restTypesSource).toContain(
+		"secretPreserveOnEmpty: boolean | undefined;",
+	);
+	expect(restTypesSource).not.toContain(
+		"secretPreserveOnEmpty: boolean | string | undefined;",
+	);
+	expect(restManualSource).not.toContain("value.trim().toLowerCase()");
+	expect(restManualSource).not.toContain('["1", "true", "yes"]');
+});

--- a/packages/wp-typia/src/add-kinds/rest-resource.ts
+++ b/packages/wp-typia/src/add-kinds/rest-resource.ts
@@ -1,4 +1,9 @@
 import {
+  CLI_DIAGNOSTIC_CODES,
+  createCliDiagnosticCodeError,
+} from '@wp-typia/project-tools/cli-diagnostics';
+
+import {
   readOptionalDashedOrCamelStringFlag,
   readOptionalStrictStringFlag,
 } from '../cli-string-flags';
@@ -20,6 +25,45 @@ const REST_RESOURCE_MISSING_NAME_MESSAGE = [
   `  ${REST_RESOURCE_GENERATED_USAGE}`,
   `  ${REST_RESOURCE_MANUAL_USAGE}`,
 ].join('\n');
+const SECRET_PRESERVE_ON_EMPTY_TRUE_VALUES = new Set(['1', 'true', 'yes']);
+const SECRET_PRESERVE_ON_EMPTY_FALSE_VALUES = new Set(['0', 'false', 'no']);
+
+function readOptionalSecretPreserveOnEmptyFlag(
+  flags: Record<string, unknown>,
+): boolean | undefined {
+  const value = flags['secret-preserve-on-empty'] ?? flags.secretPreserveOnEmpty;
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value !== 'string') {
+    throw createCliDiagnosticCodeError(
+      CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
+      '`--secret-preserve-on-empty` requires a value.',
+    );
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (normalized.length === 0) {
+    throw createCliDiagnosticCodeError(
+      CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
+      '`--secret-preserve-on-empty` requires a value.',
+    );
+  }
+  if (SECRET_PRESERVE_ON_EMPTY_TRUE_VALUES.has(normalized)) {
+    return true;
+  }
+  if (SECRET_PRESERVE_ON_EMPTY_FALSE_VALUES.has(normalized)) {
+    return false;
+  }
+
+  throw createCliDiagnosticCodeError(
+    CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
+    'Manual REST contract --secret-preserve-on-empty must be true or false.',
+  );
+}
 
 export const restResourceAddKindEntry =
   defineAddKindRegistryEntry<AddRestResourceResult>({
@@ -152,10 +196,8 @@ export const restResourceAddKindEntry =
         'secret-masked-response-field',
         'secretMaskedResponseField',
       );
-      const secretPreserveOnEmpty = readOptionalDashedOrCamelStringFlag(
+      const secretPreserveOnEmpty = readOptionalSecretPreserveOnEmptyFlag(
         context.flags,
-        'secret-preserve-on-empty',
-        'secretPreserveOnEmpty',
       );
       const secretStateFieldName = readOptionalDashedOrCamelStringFlag(
         context.flags,

--- a/packages/wp-typia/tests/add-kind-registry.test.ts
+++ b/packages/wp-typia/tests/add-kind-registry.test.ts
@@ -205,6 +205,97 @@ test('splits rest-resource usage by generated and manual modes', () => {
   ]);
 });
 
+async function captureRestResourceRuntimeOptions(
+  flags: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const capturedOptions: Record<string, unknown>[] = [];
+  const plan = await ADD_KIND_REGISTRY['rest-resource'].prepareExecution({
+    addRuntime: {
+      runAddRestResourceCommand: async (options: Record<string, unknown>) => {
+        capturedOptions.push(options);
+
+        return {
+          auth: 'public',
+          method: 'POST',
+          methods: [],
+          mode: 'manual',
+          namespace: 'demo/v1',
+          pathPattern: '/integration-settings',
+          projectDir: String(options.cwd),
+          queryTypeName: 'IntegrationSettingsQuery',
+          restResourceSlug: String(options.restResourceName),
+          responseTypeName: 'IntegrationSettingsResponse',
+          secretFieldName: String(options.secretFieldName),
+          secretPreserveOnEmpty: options.secretPreserveOnEmpty as
+            | boolean
+            | undefined,
+          secretStateFieldName: 'hasApiToken',
+        };
+      },
+    } as unknown as AddKindExecutionContext['addRuntime'],
+    cwd: '/tmp/wp-typia-rest-resource-test',
+    flags: {
+      manual: true,
+      method: 'POST',
+      'secret-field': 'apiToken',
+      ...flags,
+    },
+    getOrCreatePrompt: async () => {
+      throw new Error('rest-resource add-kind should not prompt in this test');
+    },
+    isInteractiveSession: false,
+    name: 'integration-settings',
+    warnLine: () => {},
+  });
+
+  await plan.execute('/tmp/wp-typia-rest-resource-test');
+
+  return capturedOptions[0] ?? {};
+}
+
+test('normalizes manual REST secret preserve values before runtime execution', async () => {
+  const cases = [
+    {
+      expected: false,
+      flags: { 'secret-preserve-on-empty': 'false' },
+    },
+    {
+      expected: true,
+      flags: { secretPreserveOnEmpty: 'yes' },
+    },
+    {
+      expected: false,
+      flags: { secretPreserveOnEmpty: false },
+    },
+  ];
+
+  for (const testCase of cases) {
+    const options = await captureRestResourceRuntimeOptions(testCase.flags);
+    expect(options.secretPreserveOnEmpty).toBe(testCase.expected);
+  }
+});
+
+test('rejects invalid manual REST secret preserve values during preparation', async () => {
+  await expect(
+    ADD_KIND_REGISTRY['rest-resource'].prepareExecution({
+      addRuntime: {} as AddKindExecutionContext['addRuntime'],
+      cwd: '/tmp/wp-typia-rest-resource-test',
+      flags: {
+        manual: true,
+        'secret-preserve-on-empty': 'sometimes',
+      },
+      getOrCreatePrompt: async () => {
+        throw new Error('rest-resource add-kind should not prompt in this test');
+      },
+      isInteractiveSession: false,
+      name: 'integration-settings',
+      warnLine: () => {},
+    }),
+  ).rejects.toThrow(
+    'Manual REST contract --secret-preserve-on-empty must be true or false.',
+  );
+});
+
 test('keeps shared add-kind ids aligned with registry sort order', () => {
   expect(
     Object.entries(ADD_KIND_REGISTRY)


### PR DESCRIPTION
## Summary
- Normalize manual REST `secretPreserveOnEmpty` in the wp-typia add-kind prepare step
- Keep dashed/camel aliases and existing true/false string behavior, while also accepting boolean inputs
- Narrow project-tools runtime API signatures to `boolean | undefined` and simplify manual REST scaffold defaulting
- Add add-kind and project-tools boundary tests for the normalized API boundary

Closes #954.

## Validation
- bun test packages/wp-typia/tests/add-kind-registry.test.ts
- bun test packages/wp-typia-project-tools/tests/cli-add-rest-secret-preserve-boundaries.test.ts
- bun run typecheck
- bun run lint:repo
- bun run format:check
- bun run changesets:validate
- bun run runtime-coupling:validate
- bun run --filter wp-typia build
- bun run --filter @wp-typia/project-tools build
- bun test packages/wp-typia-project-tools/tests/workspace-add.test.ts -t "secret"
- bun test packages/wp-typia-project-tools/tests/workspace-add.test.ts -t "type-only manual REST contract"
- bun test packages/wp-typia-project-tools/tests/workspace-add.test.ts -t "typed admin settings screen"
- bun run --filter wp-typia test

Note: one targeted workspace-add attempt was started before parallel package builds completed and failed on missing dist files; the same test passed after the builds completed.