### PR TITLE
consistency(doctor): align default printers

### DIFF
--- a/.sampo/changesets/955-doctor-line-printer.md
+++ b/.sampo/changesets/955-doctor-line-printer.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Align default doctor output rendering with the shared line-printer convention.

--- a/packages/wp-typia-project-tools/src/runtime/cli-doctor.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-doctor.ts
@@ -61,7 +61,21 @@ interface DoctorSummaryOptions {
 	exitPolicy?: DoctorExitPolicy;
 }
 
+type DoctorLinePrinter = (line: string) => void;
+
 const DEFAULT_DOCTOR_EXIT_POLICY: DoctorExitPolicy = "strict";
+
+const defaultDoctorLinePrinter: DoctorLinePrinter = (line) => {
+	process.stdout.write(`${line}\n`);
+};
+
+function renderDefaultDoctorCheckLine(check: DoctorCheck): void {
+	defaultDoctorLinePrinter(formatDoctorCheckLine(check));
+}
+
+function renderDefaultDoctorSummaryLine(summaryLine: string): void {
+	defaultDoctorLinePrinter(summaryLine);
+}
 
 function annotateDoctorChecks(
 	checks: DoctorCheck[],
@@ -196,11 +210,10 @@ export async function runDoctor(
 	options: RunDoctorOptions = {},
 ): Promise<DoctorCheck[]> {
 	const exitPolicy = resolveDoctorExitPolicy(options);
-	const renderLine =
-		options.renderLine ?? ((check: DoctorCheck) => console.log(formatDoctorCheckLine(check)));
+	const renderLine = options.renderLine ?? renderDefaultDoctorCheckLine;
 	const renderSummaryLine =
 		options.renderSummaryLine ??
-		(options.renderLine ? () => undefined : (summaryLine: string) => console.log(summaryLine));
+		(options.renderLine ? () => undefined : renderDefaultDoctorSummaryLine);
 	const checks = await getDoctorChecks(cwd);
 
 	for (const check of checks) {

--- a/packages/wp-typia-project-tools/src/runtime/cli-doctor.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-doctor.ts
@@ -202,6 +202,8 @@ export function createDoctorRunSummary(
  * @param cwd Working directory to validate.
  * @param options Optional renderer overrides and exit-policy selection.
  * @param options.exitPolicy Policy deciding which failed checks contribute to the process exit code.
+ * @param options.renderLine Optional renderer for each check row. Defaults to the stdout line printer.
+ * @param options.renderSummaryLine Optional renderer for the summary row. Defaults to the stdout line printer unless a custom `renderLine` suppresses implicit summary output.
  * @returns The completed list of doctor checks.
  * @throws {Error} When one or more failed checks contribute to the exit code under the active policy.
  */

--- a/packages/wp-typia-project-tools/tests/cli-doctor-boundaries.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-doctor-boundaries.test.ts
@@ -1,7 +1,9 @@
 import { expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
+import { runDoctor } from "../src/runtime/cli-doctor.js";
 import { resolveWorkspaceBootstrapPath } from "../src/runtime/cli-doctor-workspace-shared.js";
 
 const sourceRoot = resolve(import.meta.dir, "..", "src", "runtime");
@@ -79,7 +81,13 @@ test("cli-doctor keeps environment and workspace checks in dedicated modules", (
 
 	expect(cliDoctorSource).toContain('from "./cli-doctor-environment.js"');
 	expect(cliDoctorSource).toContain('from "./cli-doctor-workspace.js"');
-	expect(cliDoctorSource).toContain("...(await getWorkspaceDoctorChecks(cwd)),");
+	expect(cliDoctorSource).toContain(
+		'...annotateDoctorChecks(await getWorkspaceDoctorChecks(cwd), "workspace"),',
+	);
+	expect(cliDoctorSource).toContain("const defaultDoctorLinePrinter");
+	expect(cliDoctorSource).toContain("process.stdout.write(`${line}\\n`)");
+	expect(cliDoctorSource).not.toContain("console.log(formatDoctorCheckLine");
+	expect(cliDoctorSource).not.toContain("console.log(summaryLine");
 	expect(cliDoctorSource).not.toContain("function readCommandVersion(");
 	expect(cliDoctorSource).not.toContain("function checkWorkspacePackageMetadata(");
 	expect(cliDoctorSource).not.toContain("function checkWorkspaceBindingBootstrap(");
@@ -171,4 +179,35 @@ test("cli-doctor resolves workspace bootstrap paths for scoped and unscoped pack
 	expect(resolveWorkspaceBootstrapPath(projectDir, "demo-plugin")).toBe(
 		join(projectDir, "demo-plugin.php"),
 	);
+});
+
+test("cli-doctor default output writes through the stdout line printer", async () => {
+	const tempDir = mkdtempSync(join(tmpdir(), "wp-typia-doctor-printer-"));
+	const originalLog = console.log;
+	const originalWrite = process.stdout.write;
+	const stdoutChunks: string[] = [];
+
+	console.log = () => {
+		throw new Error("runDoctor should not use console.log as its default printer");
+	};
+	process.stdout.write = ((chunk: unknown, ...args: unknown[]) => {
+		stdoutChunks.push(Buffer.isBuffer(chunk) ? chunk.toString("utf8") : String(chunk));
+		const callback = args.find(
+			(arg): arg is (error?: Error | null) => void => typeof arg === "function",
+		);
+		callback?.();
+		return true;
+	}) as typeof process.stdout.write;
+
+	try {
+		await runDoctor(tempDir, { exitPolicy: "workspace-only" });
+	} finally {
+		process.stdout.write = originalWrite;
+		console.log = originalLog;
+		rmSync(tempDir, { force: true, recursive: true });
+	}
+
+	expect(stdoutChunks.length).toBeGreaterThan(0);
+	expect(stdoutChunks.every((chunk) => chunk.endsWith("\n"))).toBe(true);
+	expect(stdoutChunks.join("")).toContain("wp-typia doctor summary:");
 });


### PR DESCRIPTION
## Summary
- replace doctor default human-readable output renderers with a stdout line-printer helper
- keep caller-provided doctor renderers overrideable
- add boundary/behavior coverage for avoiding console.log defaults

## Verification
- bun test packages/wp-typia-project-tools/tests/cli-doctor-boundaries.test.ts
- bun test packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
- bun run typecheck
- bun run lint:repo
- bun run format:check
- bun run changesets:validate
- bun run runtime-coupling:validate
- bun run --filter @wp-typia/project-tools build

Closes #955

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized the doctor command's output rendering behavior across CLI tooling packages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/971)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->