### PR TITLE
ci: allow workspace smoke CLI helper scripts

### DIFF
--- a/scripts/lib/generated-project-smoke-assertions.mjs
+++ b/scripts/lib/generated-project-smoke-assertions.mjs
@@ -221,9 +221,18 @@ function isLocalProjectToolsRewrite(value) {
 	);
 }
 
+function isOfficialWorkspaceTemplatePackage(packageJson) {
+	return (
+		packageJson.wpTypia?.projectType === "workspace" &&
+		packageJson.wpTypia?.templatePackage === "@wp-typia/create-workspace-template"
+	);
+}
+
 export function assertGeneratedPackageBoundary(projectDir) {
 	const packageJsonPath = path.join(projectDir, "package.json");
 	const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+	const allowWorkspaceCliHelperScripts =
+		isOfficialWorkspaceTemplatePackage(packageJson);
 
 	if (
 		packageJson.dependencies?.["@wp-typia/project-tools"] &&
@@ -254,6 +263,12 @@ export function assertGeneratedPackageBoundary(projectDir) {
 					`Expected generated migration script "${scriptName}" to pin wp-typia`,
 				);
 			}
+			continue;
+		}
+		if (
+			allowWorkspaceCliHelperScripts &&
+			scriptName.startsWith("wp-typia:")
+		) {
 			continue;
 		}
 		if (scriptValue.includes("wp-typia")) {

--- a/tests/unit/generated-project-smoke-reference-lane.test.ts
+++ b/tests/unit/generated-project-smoke-reference-lane.test.ts
@@ -239,6 +239,76 @@ test("generated project smoke assertions accept local project-tools smoke rewrit
 	expect(() => assertGeneratedPackageBoundary(projectDir)).not.toThrow();
 });
 
+test("generated project smoke assertions allow official workspace CLI helper scripts", async () => {
+	const projectDir = fs.mkdtempSync(
+		join(os.tmpdir(), "wp-typia-generated-smoke-workspace-boundary-"),
+	);
+	tempDirs.push(projectDir);
+
+	fs.writeFileSync(
+		join(projectDir, "package.json"),
+		`${JSON.stringify(
+			{
+				name: "demo-smoke-workspace-boundary",
+				private: true,
+				scripts: {
+					"wp-typia:add": "wp-typia add",
+					"wp-typia:doctor": "wp-typia doctor",
+					"wp-typia:sync": "wp-typia sync",
+				},
+				wpTypia: {
+					projectType: "workspace",
+					templatePackage: "@wp-typia/create-workspace-template",
+				},
+			},
+			null,
+			2,
+		)}\n`,
+		"utf8",
+	);
+
+	const { assertGeneratedPackageBoundary } = (await import(
+		new URL("../../scripts/lib/generated-project-smoke-assertions.mjs", import.meta.url).href
+	)) as {
+		assertGeneratedPackageBoundary: (projectDir: string) => void;
+	};
+
+	expect(() => assertGeneratedPackageBoundary(projectDir)).not.toThrow();
+});
+
+test("generated project smoke assertions reject non-workspace wp-typia scripts", async () => {
+	const projectDir = fs.mkdtempSync(
+		join(os.tmpdir(), "wp-typia-generated-smoke-script-boundary-"),
+	);
+	tempDirs.push(projectDir);
+
+	fs.writeFileSync(
+		join(projectDir, "package.json"),
+		`${JSON.stringify(
+			{
+				name: "demo-smoke-script-boundary",
+				private: true,
+				scripts: {
+					"wp-typia:sync": "wp-typia sync",
+				},
+			},
+			null,
+			2,
+		)}\n`,
+		"utf8",
+	);
+
+	const { assertGeneratedPackageBoundary } = (await import(
+		new URL("../../scripts/lib/generated-project-smoke-assertions.mjs", import.meta.url).href
+	)) as {
+		assertGeneratedPackageBoundary: (projectDir: string) => void;
+	};
+
+	expect(() => assertGeneratedPackageBoundary(projectDir)).toThrow(
+		/Expected generated project script "wp-typia:sync" to avoid wp-typia/,
+	);
+});
+
 test("generated project smoke assertions still reject published project-tools dependencies", async () => {
 	const projectDir = fs.mkdtempSync(
 		join(os.tmpdir(), "wp-typia-generated-smoke-boundary-reject-"),


### PR DESCRIPTION
## Summary

- Allow official workspace template smoke projects to keep their intentional `wp-typia:*` package scripts.
- Keep the generated package boundary strict for non-workspace templates.
- Add unit coverage for both allowed workspace helper scripts and rejected non-workspace `wp-typia` scripts.

## Root Cause

The main-only generated project smoke matrix runs official workspace template add-flow scenarios. Those workspaces intentionally expose `wp-typia:*` helper scripts, but `assertGeneratedPackageBoundary()` treated every script containing `wp-typia` as a generated-template leak unless it was a pinned migration script.

## Validation

- `bun test tests/unit/generated-project-smoke-reference-lane.test.ts`
- `bun run typecheck`
- `bun run format:check`
- `git diff --check`
- `bun run lint:repo`
- `node scripts/run-generated-project-smoke.mjs --runtime node --package-manager npm --project-name smoke-workspace-add-editor-plugin-npm --template @wp-typia/create-workspace-template --add-editor-plugin-name document-tools --add-editor-plugin-slot sidebar`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace template packages can now use designated CLI helper scripts without triggering validation errors.

* **Tests**
  * Added test coverage to verify CLI helper script validation for workspace templates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/976)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->