### PR TITLE
feat: add block API compatibility matrix

### DIFF
--- a/.sampo/changesets/962-block-api-compatibility.md
+++ b/.sampo/changesets/962-block-api-compatibility.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/block-types: minor
+npm/wp-typia: minor
+---
+
+Add a shared WordPress block API compatibility matrix for Supports, Variations, and Bindings, plus project config fields for minimum WordPress version and strict compatibility diagnostics.

--- a/.sampo/changesets/962-block-api-compatibility.md
+++ b/.sampo/changesets/962-block-api-compatibility.md
@@ -1,5 +1,6 @@
 ---
 npm/@wp-typia/block-types: minor
+npm/@wp-typia/project-tools: patch
 npm/wp-typia: minor
 ---
 

--- a/apps/docs/src/content/docs/reference/cli.md
+++ b/apps/docs/src/content/docs/reference/cli.md
@@ -46,6 +46,14 @@ For example, this project config:
 
 ```json
 {
+  "wordpress": {
+    "minVersion": "6.7",
+    "testedVersions": ["6.7", "6.8", "6.9"]
+  },
+  "compatibility": {
+    "strict": true,
+    "allowUnknownFutureKeys": false
+  },
   "mcp": {
     "schemaSources": [{ "namespace": "base", "path": "./base.ts" }]
   }
@@ -67,6 +75,13 @@ combined with this later `package.json` override:
 resolves to only the `app` source. To keep both entries, include both in the
 later array. Additive array merging is intentionally out of scope for the
 current config contract.
+
+The `wordpress` and `compatibility` sections describe project-level block API
+intent. `wordpress.minVersion` is the target floor for generated Supports,
+Variations, and Bindings features, while `compatibility.strict` controls whether
+unsupported known features should fail diagnostics or stay as warnings.
+Unknown future keys are guarded unless `compatibility.allowUnknownFutureKeys`
+is explicitly enabled.
 
 ## Machine-readable diagnostics
 

--- a/bun.lock
+++ b/bun.lock
@@ -249,7 +249,7 @@
       "dependencies": {
         "@wp-typia/api-client": "^0.4.5",
         "@wp-typia/block-runtime": "workspace:*",
-        "@wp-typia/block-types": "^0.2.4",
+        "@wp-typia/block-types": "^0.3.0",
         "@wp-typia/rest": "^0.3.11",
         "mustache": "^4.2.0",
         "npm-package-arg": "^13.0.0",

--- a/bun.lock
+++ b/bun.lock
@@ -249,7 +249,7 @@
       "dependencies": {
         "@wp-typia/api-client": "^0.4.5",
         "@wp-typia/block-runtime": "workspace:*",
-        "@wp-typia/block-types": "^0.3.0",
+        "@wp-typia/block-types": "workspace:*",
         "@wp-typia/rest": "^0.3.11",
         "mustache": "^4.2.0",
         "npm-package-arg": "^13.0.0",

--- a/packages/wp-typia-block-types/README.md
+++ b/packages/wp-typia-block-types/README.md
@@ -18,6 +18,7 @@ Shared WordPress block semantic types derived from Gutenberg source and unoffici
 - `@wp-typia/block-types/block-editor/style-attributes`
 - `@wp-typia/block-types/block-editor/typography`
 - `@wp-typia/block-types/blocks`
+- `@wp-typia/block-types/blocks/compatibility`
 - `@wp-typia/block-types/blocks/registration`
 - `@wp-typia/block-types/blocks/supports`
 
@@ -43,6 +44,8 @@ Shared WordPress block semantic types derived from Gutenberg source and unoffici
   migration-facing `BlockInstance`
 - additive stable Core coverage for drop caps, spacing sizes, layout gaps,
   duotone, per-side border widths, and `js` / `locking`
+- a WordPress block API compatibility matrix for Supports, Variations, and
+  Bindings features that codegen and diagnostics can share
 
 ## Registration facade
 
@@ -70,6 +73,34 @@ TypeScript installs surface the requirement explicitly.
 
 Compatibility should track that floor unless the generated project dependency
 matrix changes in the same release.
+
+## WordPress block API compatibility
+
+`@wp-typia/block-types/blocks/compatibility` exposes the shared compatibility
+foundation used by future block Supports, Variations, and Bindings helpers.
+The matrix records documented WordPress version floors, runtime surfaces, derived
+attributes, fallback hints, and source URLs for feature checks.
+
+```ts
+import { createWordPressBlockApiCompatibilityManifest } from '@wp-typia/block-types/blocks/compatibility';
+
+const manifest = createWordPressBlockApiCompatibilityManifest(
+  [
+    { area: 'blockSupports', feature: 'allowedBlocks' },
+    { area: 'blockBindings', feature: 'editorRegistration' },
+  ],
+  {
+    minVersion: '6.7',
+    strict: true,
+    allowUnknownFutureKeys: false,
+  },
+);
+```
+
+Strict mode marks known unsupported features as errors and recommends skipping
+generation. Non-strict mode downgrades them to warnings and recommends guarded
+generation. Unknown future keys are guarded by default, or passed through only
+when `allowUnknownFutureKeys` is enabled.
 
 ## Validation coverage
 

--- a/packages/wp-typia-block-types/package.json
+++ b/packages/wp-typia-block-types/package.json
@@ -56,6 +56,11 @@
       "import": "./dist/blocks/index.js",
       "default": "./dist/blocks/index.js"
     },
+    "./blocks/compatibility": {
+      "types": "./dist/blocks/compatibility.d.ts",
+      "import": "./dist/blocks/compatibility.js",
+      "default": "./dist/blocks/compatibility.js"
+    },
     "./blocks/registration": {
       "types": "./dist/blocks/registration.d.ts",
       "import": "./dist/blocks/registration.js",

--- a/packages/wp-typia-block-types/src/blocks/compatibility.ts
+++ b/packages/wp-typia-block-types/src/blocks/compatibility.ts
@@ -1,0 +1,474 @@
+export type WordPressVersion =
+  | `${number}.${number}`
+  | `${number}.${number}.${number}`;
+
+export type WordPressBlockApiCompatibilityArea =
+  | 'blockSupports'
+  | 'blockVariations'
+  | 'blockBindings';
+
+export type WordPressBlockApiRuntime = 'block-json' | 'editor-js' | 'php';
+
+export type WordPressBlockApiCompatibilityStatus =
+  | 'supported'
+  | 'unsupported'
+  | 'unknown';
+
+export type WordPressBlockApiCompatibilityDiagnosticSeverity =
+  | 'error'
+  | 'warning';
+
+export type WordPressBlockApiCompatibilityAction =
+  | 'generate'
+  | 'guard'
+  | 'skip'
+  | 'pass-through';
+
+export interface WordPressBlockApiCompatibilityEntry {
+  readonly since: WordPressVersion;
+  readonly label: string;
+  readonly runtime: readonly WordPressBlockApiRuntime[];
+  readonly source: keyof typeof WORDPRESS_BLOCK_API_COMPATIBILITY_SOURCES;
+  readonly derivedAttributes?: readonly string[];
+  readonly fallback?: string;
+  readonly notes?: string;
+}
+
+export interface WordPressCompatibilitySettings {
+  readonly minVersion?: WordPressVersion;
+  readonly strict?: boolean;
+  readonly allowUnknownFutureKeys?: boolean;
+}
+
+export interface WordPressBlockApiCompatibilityFeature {
+  readonly area: WordPressBlockApiCompatibilityArea;
+  readonly feature: string;
+}
+
+export interface WordPressBlockApiCompatibilityDiagnostic {
+  readonly area: WordPressBlockApiCompatibilityArea;
+  readonly code:
+    | 'unsupported-wordpress-block-api-feature'
+    | 'unknown-wordpress-block-api-feature';
+  readonly feature: string;
+  readonly message: string;
+  readonly minVersion: WordPressVersion;
+  readonly requiredVersion?: WordPressVersion;
+  readonly severity: WordPressBlockApiCompatibilityDiagnosticSeverity;
+}
+
+export interface WordPressBlockApiCompatibilityEvaluation
+  extends WordPressBlockApiCompatibilityFeature {
+  readonly action: WordPressBlockApiCompatibilityAction;
+  readonly entry?: WordPressBlockApiCompatibilityEntry | undefined;
+  readonly diagnostic?: WordPressBlockApiCompatibilityDiagnostic | undefined;
+  readonly minVersion: WordPressVersion;
+  readonly status: WordPressBlockApiCompatibilityStatus;
+}
+
+export interface WordPressBlockApiCompatibilityManifest {
+  readonly allowUnknownFutureKeys: boolean;
+  readonly diagnostics: readonly WordPressBlockApiCompatibilityDiagnostic[];
+  readonly evaluations: readonly WordPressBlockApiCompatibilityEvaluation[];
+  readonly minVersion: WordPressVersion;
+  readonly strict: boolean;
+  readonly supported: readonly WordPressBlockApiCompatibilityEvaluation[];
+  readonly unknown: readonly WordPressBlockApiCompatibilityEvaluation[];
+  readonly unsupported: readonly WordPressBlockApiCompatibilityEvaluation[];
+}
+
+export const DEFAULT_WORDPRESS_COMPATIBILITY_MIN_VERSION = '6.7' as const;
+
+export const WORDPRESS_VERSION_PATTERN = /^\d+\.\d+(?:\.\d+)?$/u;
+
+export const WORDPRESS_BLOCK_API_COMPATIBILITY_SOURCES = {
+  blockBindingsHandbook:
+    'https://developer.wordpress.org/block-editor/reference-guides/block-api/block-bindings/',
+  blockBindingsReference:
+    'https://developer.wordpress.org/reference/functions/register_block_bindings_source/',
+  blockBindingsSupportedAttributes:
+    'https://developer.wordpress.org/reference/functions/get_block_bindings_supported_attributes/',
+  blockSupportsHandbook:
+    'https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/',
+  blockVariationsDevNote:
+    'https://make.wordpress.org/core/2020/02/27/introduce-block-variations-api/',
+  blockVariationsPhpDevNote:
+    'https://make.wordpress.org/core/2024/02/29/performance-improvements-for-registering-block-variations-with-callbacks/',
+  themeJsonStyleVersions:
+    'https://developer.wordpress.org/block-editor/reference-guides/theme-json-reference/styles-versions/',
+  wordpressBlocksPackage:
+    'https://developer.wordpress.org/block-editor/reference-guides/packages/packages-blocks/',
+} as const;
+
+export const WORDPRESS_BLOCK_API_COMPATIBILITY = {
+  blockBindings: {
+    'metadata.bindings': {
+      derivedAttributes: ['metadata'],
+      label: 'block metadata.bindings',
+      runtime: ['block-json', 'php'],
+      since: '6.5',
+      source: 'blockBindingsHandbook',
+    },
+    editorRegistration: {
+      fallback: 'Keep server-side registration only.',
+      label: 'registerBlockBindingsSource() editor registration',
+      runtime: ['editor-js'],
+      since: '6.7',
+      source: 'wordpressBlocksPackage',
+    },
+    editorSourceLookup: {
+      label: 'getBlockBindingsSource() and getBlockBindingsSources()',
+      runtime: ['editor-js'],
+      since: '6.7',
+      source: 'wordpressBlocksPackage',
+    },
+    serverRegistration: {
+      label: 'register_block_bindings_source()',
+      runtime: ['php'],
+      since: '6.5',
+      source: 'blockBindingsReference',
+    },
+    supportedAttributesFilter: {
+      fallback: 'Keep the core supported-attributes list or guard the filter.',
+      label: 'block_bindings_supported_attributes filters',
+      runtime: ['php'],
+      since: '6.9',
+      source: 'blockBindingsSupportedAttributes',
+    },
+  },
+  blockSupports: {
+    allowedBlocks: {
+      derivedAttributes: ['allowedBlocks'],
+      fallback: 'Pass allowedBlocks directly to useInnerBlocksProps() in custom editor code.',
+      label: 'supports.allowedBlocks',
+      runtime: ['block-json', 'editor-js'],
+      since: '6.9',
+      source: 'blockSupportsHandbook',
+    },
+    background: {
+      derivedAttributes: ['style'],
+      label: 'supports.background',
+      runtime: ['block-json', 'editor-js'],
+      since: '6.5',
+      source: 'blockSupportsHandbook',
+    },
+    'color.button': {
+      derivedAttributes: ['style'],
+      label: 'supports.color.button',
+      runtime: ['block-json', 'editor-js'],
+      since: '6.5',
+      source: 'blockSupportsHandbook',
+    },
+    'color.enableContrastChecker': {
+      label: 'supports.color.enableContrastChecker',
+      runtime: ['block-json', 'editor-js'],
+      since: '6.5',
+      source: 'blockSupportsHandbook',
+    },
+    'color.heading': {
+      derivedAttributes: ['style'],
+      label: 'supports.color.heading',
+      runtime: ['block-json', 'editor-js'],
+      since: '6.5',
+      source: 'blockSupportsHandbook',
+    },
+    dimensions: {
+      derivedAttributes: ['style'],
+      label: 'supports.dimensions',
+      runtime: ['block-json', 'editor-js'],
+      since: '6.2',
+      source: 'blockSupportsHandbook',
+    },
+    'filter.duotone': {
+      derivedAttributes: ['style'],
+      label: 'supports.filter.duotone',
+      runtime: ['block-json', 'editor-js'],
+      since: '5.9',
+      source: 'themeJsonStyleVersions',
+    },
+    position: {
+      derivedAttributes: ['style'],
+      label: 'supports.position',
+      runtime: ['block-json', 'editor-js'],
+      since: '6.2',
+      source: 'blockSupportsHandbook',
+    },
+    renaming: {
+      label: 'supports.renaming',
+      runtime: ['block-json', 'editor-js'],
+      since: '6.5',
+      source: 'blockSupportsHandbook',
+    },
+    shadow: {
+      derivedAttributes: ['style'],
+      label: 'supports.shadow',
+      runtime: ['block-json', 'editor-js'],
+      since: '6.5',
+      source: 'blockSupportsHandbook',
+    },
+    'spacing.blockGap': {
+      derivedAttributes: ['style'],
+      label: 'supports.spacing.blockGap',
+      runtime: ['block-json', 'editor-js'],
+      since: '5.9',
+      source: 'themeJsonStyleVersions',
+    },
+    'spacing.margin': {
+      derivedAttributes: ['style'],
+      label: 'supports.spacing.margin',
+      runtime: ['block-json', 'editor-js'],
+      since: '5.9',
+      source: 'themeJsonStyleVersions',
+    },
+    'spacing.padding': {
+      derivedAttributes: ['style'],
+      label: 'supports.spacing.padding',
+      runtime: ['block-json', 'editor-js'],
+      since: '5.9',
+      source: 'themeJsonStyleVersions',
+    },
+    'typography.fontSize': {
+      derivedAttributes: ['fontSize', 'style'],
+      label: 'supports.typography.fontSize',
+      runtime: ['block-json', 'editor-js'],
+      since: '5.8',
+      source: 'themeJsonStyleVersions',
+    },
+    'typography.letterSpacing': {
+      derivedAttributes: ['style'],
+      label: 'supports.typography.letterSpacing',
+      runtime: ['block-json', 'editor-js'],
+      since: '5.9',
+      source: 'themeJsonStyleVersions',
+    },
+    'typography.lineHeight': {
+      derivedAttributes: ['style'],
+      label: 'supports.typography.lineHeight',
+      runtime: ['block-json', 'editor-js'],
+      since: '5.8',
+      source: 'themeJsonStyleVersions',
+    },
+    'typography.textAlign': {
+      derivedAttributes: ['style'],
+      label: 'supports.typography.textAlign',
+      runtime: ['block-json', 'editor-js'],
+      since: '6.6',
+      source: 'blockSupportsHandbook',
+    },
+    'typography.textDecoration': {
+      derivedAttributes: ['style'],
+      label: 'supports.typography.textDecoration',
+      runtime: ['block-json', 'editor-js'],
+      since: '5.9',
+      source: 'themeJsonStyleVersions',
+    },
+    'typography.textTransform': {
+      derivedAttributes: ['style'],
+      label: 'supports.typography.textTransform',
+      runtime: ['block-json', 'editor-js'],
+      since: '5.9',
+      source: 'themeJsonStyleVersions',
+    },
+    visibility: {
+      fallback: 'Keep the default block options menu behavior.',
+      label: 'supports.visibility',
+      runtime: ['block-json', 'editor-js'],
+      since: '6.9',
+      source: 'blockSupportsHandbook',
+    },
+  },
+  blockVariations: {
+    editorRegistration: {
+      label: 'registerBlockVariation() editor registration',
+      runtime: ['editor-js'],
+      since: '5.4',
+      source: 'blockVariationsDevNote',
+    },
+    phpVariationCallback: {
+      fallback: 'Build static variations or register them in editor JavaScript.',
+      label: 'WP_Block_Type variation_callback',
+      runtime: ['php'],
+      since: '6.5',
+      source: 'blockVariationsPhpDevNote',
+    },
+    phpVariationsFilter: {
+      fallback: 'Use JavaScript registration or guard the PHP filter path.',
+      label: 'get_block_type_variations filter',
+      runtime: ['php'],
+      since: '6.5',
+      source: 'blockVariationsPhpDevNote',
+    },
+    registrationMetadata: {
+      label: 'block registration variations metadata',
+      runtime: ['block-json', 'editor-js'],
+      since: '5.4',
+      source: 'blockVariationsDevNote',
+    },
+  },
+} as const satisfies Record<
+  WordPressBlockApiCompatibilityArea,
+  Record<string, WordPressBlockApiCompatibilityEntry>
+>;
+
+export type WordPressBlockSupportCompatibilityFeature =
+  keyof typeof WORDPRESS_BLOCK_API_COMPATIBILITY.blockSupports;
+
+export type WordPressBlockVariationCompatibilityFeature =
+  keyof typeof WORDPRESS_BLOCK_API_COMPATIBILITY.blockVariations;
+
+export type WordPressBlockBindingCompatibilityFeature =
+  keyof typeof WORDPRESS_BLOCK_API_COMPATIBILITY.blockBindings;
+
+function normalizeCompatibilitySettings(
+  settings: WordPressCompatibilitySettings,
+): Required<WordPressCompatibilitySettings> {
+  return {
+    allowUnknownFutureKeys: settings.allowUnknownFutureKeys ?? false,
+    minVersion: settings.minVersion ?? DEFAULT_WORDPRESS_COMPATIBILITY_MIN_VERSION,
+    strict: settings.strict ?? true,
+  };
+}
+
+export function assertWordPressVersion(
+  value: string,
+): asserts value is WordPressVersion {
+  if (!WORDPRESS_VERSION_PATTERN.test(value)) {
+    throw new Error(
+      `Invalid WordPress version "${value}". Expected dotted numeric version such as "6.7" or "6.7.1".`,
+    );
+  }
+}
+
+export function compareWordPressVersions(left: string, right: string): number {
+  assertWordPressVersion(left);
+  assertWordPressVersion(right);
+
+  const leftParts = left.split('.').map((part) => Number.parseInt(part, 10));
+  const rightParts = right.split('.').map((part) => Number.parseInt(part, 10));
+  const length = Math.max(leftParts.length, rightParts.length);
+
+  for (let index = 0; index < length; index += 1) {
+    const leftValue = leftParts[index] ?? 0;
+    const rightValue = rightParts[index] ?? 0;
+
+    if (leftValue > rightValue) {
+      return 1;
+    }
+    if (leftValue < rightValue) {
+      return -1;
+    }
+  }
+
+  return 0;
+}
+
+export function isWordPressVersionAtLeast(
+  version: string,
+  minimum: string,
+): boolean {
+  return compareWordPressVersions(version, minimum) >= 0;
+}
+
+export function getWordPressBlockApiCompatibilityEntry(
+  area: WordPressBlockApiCompatibilityArea,
+  feature: string,
+): WordPressBlockApiCompatibilityEntry | undefined {
+  return (
+    WORDPRESS_BLOCK_API_COMPATIBILITY[area] as Record<
+      string,
+      WordPressBlockApiCompatibilityEntry | undefined
+    >
+  )[feature];
+}
+
+export function evaluateWordPressBlockApiCompatibility(
+  feature: WordPressBlockApiCompatibilityFeature,
+  settings: WordPressCompatibilitySettings = {},
+): WordPressBlockApiCompatibilityEvaluation {
+  const resolved = normalizeCompatibilitySettings(settings);
+  const entry = getWordPressBlockApiCompatibilityEntry(
+    feature.area,
+    feature.feature,
+  );
+  const severity: WordPressBlockApiCompatibilityDiagnosticSeverity =
+    resolved.strict ? 'error' : 'warning';
+
+  if (!entry) {
+    const diagnostic: WordPressBlockApiCompatibilityDiagnostic | undefined =
+      resolved.allowUnknownFutureKeys
+        ? undefined
+        : {
+            area: feature.area,
+            code: 'unknown-wordpress-block-api-feature',
+            feature: feature.feature,
+            message: `Unknown WordPress block API feature "${feature.area}.${feature.feature}".`,
+            minVersion: resolved.minVersion,
+            severity,
+          };
+
+    return {
+      ...feature,
+      action: resolved.allowUnknownFutureKeys ? 'pass-through' : 'guard',
+      diagnostic,
+      minVersion: resolved.minVersion,
+      status: 'unknown',
+    };
+  }
+
+  if (isWordPressVersionAtLeast(resolved.minVersion, entry.since)) {
+    return {
+      ...feature,
+      action: 'generate',
+      entry,
+      minVersion: resolved.minVersion,
+      status: 'supported',
+    };
+  }
+
+  const diagnostic: WordPressBlockApiCompatibilityDiagnostic = {
+    area: feature.area,
+    code: 'unsupported-wordpress-block-api-feature',
+    feature: feature.feature,
+    message: `${entry.label} requires WordPress ${entry.since}+ but the configured minimum is ${resolved.minVersion}.`,
+    minVersion: resolved.minVersion,
+    requiredVersion: entry.since,
+    severity,
+  };
+
+  return {
+    ...feature,
+    action: resolved.strict ? 'skip' : 'guard',
+    diagnostic,
+    entry,
+    minVersion: resolved.minVersion,
+    status: 'unsupported',
+  };
+}
+
+export function createWordPressBlockApiCompatibilityManifest(
+  features: readonly WordPressBlockApiCompatibilityFeature[],
+  settings: WordPressCompatibilitySettings = {},
+): WordPressBlockApiCompatibilityManifest {
+  const resolved = normalizeCompatibilitySettings(settings);
+  const evaluations = features.map((feature) =>
+    evaluateWordPressBlockApiCompatibility(feature, resolved),
+  );
+  const diagnostics = evaluations.flatMap((evaluation) =>
+    evaluation.diagnostic ? [evaluation.diagnostic] : [],
+  );
+
+  return {
+    allowUnknownFutureKeys: resolved.allowUnknownFutureKeys,
+    diagnostics,
+    evaluations,
+    minVersion: resolved.minVersion,
+    strict: resolved.strict,
+    supported: evaluations.filter(
+      (evaluation) => evaluation.status === 'supported',
+    ),
+    unknown: evaluations.filter((evaluation) => evaluation.status === 'unknown'),
+    unsupported: evaluations.filter(
+      (evaluation) => evaluation.status === 'unsupported',
+    ),
+  };
+}

--- a/packages/wp-typia-block-types/src/blocks/index.ts
+++ b/packages/wp-typia-block-types/src/blocks/index.ts
@@ -1,2 +1,3 @@
+export * from "./compatibility.js";
 export * from "./registration.js";
 export * from "./supports.js";

--- a/packages/wp-typia-block-types/src/blocks/supports.ts
+++ b/packages/wp-typia-block-types/src/blocks/supports.ts
@@ -14,12 +14,15 @@ import type { SpacingAxis, SpacingDimension } from "../block-editor/spacing.js";
 export type BlockSupportFeature =
   | 'align'
   | 'alignWide'
+  | 'allowedBlocks'
   | 'anchor'
   | 'ariaLabel'
+  | 'autoRegister'
   | 'background'
   | 'border'
   | 'className'
   | 'color'
+  | 'contentRole'
   | 'customClassName'
   | 'dimensions'
   | 'filter'
@@ -29,6 +32,7 @@ export type BlockSupportFeature =
   | 'js'
   | 'layout'
   | 'lightbox'
+  | 'listView'
   | 'lock'
   | 'locking'
   | 'multiple'
@@ -37,17 +41,22 @@ export type BlockSupportFeature =
   | 'reusable'
   | 'shadow'
   | 'spacing'
+  | 'splitting'
+  | 'visibility'
   | 'typography';
 
 export const BLOCK_SUPPORT_FEATURES = [
   'align',
   'alignWide',
+  'allowedBlocks',
   'anchor',
   'ariaLabel',
+  'autoRegister',
   'background',
   'border',
   'className',
   'color',
+  'contentRole',
   'customClassName',
   'dimensions',
   'filter',
@@ -57,6 +66,7 @@ export const BLOCK_SUPPORT_FEATURES = [
   'js',
   'layout',
   'lightbox',
+  'listView',
   'lock',
   'locking',
   'multiple',
@@ -65,7 +75,9 @@ export const BLOCK_SUPPORT_FEATURES = [
   'reusable',
   'shadow',
   'spacing',
+  'splitting',
   'typography',
+  'visibility',
 ] as const satisfies readonly BlockSupportFeature[];
 
 export type TypographySupportKey =
@@ -267,12 +279,15 @@ export interface BlockTypographySupport {
 export interface BlockSupports {
   readonly align?: boolean | readonly BlockAlignment[];
   readonly alignWide?: boolean;
+  readonly allowedBlocks?: boolean;
   readonly anchor?: boolean;
   readonly ariaLabel?: boolean;
+  readonly autoRegister?: boolean;
   readonly background?: boolean | BlockBackgroundSupport;
   readonly border?: boolean | BlockBorderSupport;
   readonly className?: boolean;
   readonly color?: boolean | BlockColorSupport;
+  readonly contentRole?: boolean;
   readonly customClassName?: boolean;
   readonly dimensions?: boolean | BlockDimensionsSupport;
   readonly filter?: boolean | BlockFilterSupport;
@@ -282,6 +297,7 @@ export interface BlockSupports {
   readonly js?: boolean;
   readonly layout?: boolean | BlockLayoutSupport;
   readonly lightbox?: boolean | BlockLightboxSupport;
+  readonly listView?: boolean;
   readonly lock?: boolean;
   readonly locking?: boolean;
   readonly multiple?: boolean;
@@ -290,5 +306,7 @@ export interface BlockSupports {
   readonly reusable?: boolean;
   readonly shadow?: boolean | BlockShadowSupport;
   readonly spacing?: boolean | BlockSpacingSupport;
+  readonly splitting?: boolean;
   readonly typography?: boolean | BlockTypographySupport;
+  readonly visibility?: boolean;
 }

--- a/packages/wp-typia-block-types/tests/compatibility.test.ts
+++ b/packages/wp-typia-block-types/tests/compatibility.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+	WORDPRESS_BLOCK_API_COMPATIBILITY,
+	WORDPRESS_BLOCK_API_COMPATIBILITY_SOURCES,
+	assertWordPressVersion,
+	compareWordPressVersions,
+	createWordPressBlockApiCompatibilityManifest,
+	evaluateWordPressBlockApiCompatibility,
+	getWordPressBlockApiCompatibilityEntry,
+	isWordPressVersionAtLeast,
+} from "../src/blocks/compatibility";
+
+describe("WordPress block API compatibility matrix", () => {
+	test("captures the block API feature floors needed by follow-up helpers", () => {
+		expect(WORDPRESS_BLOCK_API_COMPATIBILITY.blockSupports.allowedBlocks).toMatchObject({
+			derivedAttributes: ["allowedBlocks"],
+			since: "6.9",
+			source: "blockSupportsHandbook",
+		});
+		expect(
+			WORDPRESS_BLOCK_API_COMPATIBILITY.blockSupports["typography.textAlign"],
+		).toMatchObject({
+			derivedAttributes: ["style"],
+			since: "6.6",
+			source: "blockSupportsHandbook",
+		});
+		expect(
+			WORDPRESS_BLOCK_API_COMPATIBILITY.blockVariations.editorRegistration,
+		).toMatchObject({
+			runtime: ["editor-js"],
+			since: "5.4",
+			source: "blockVariationsDevNote",
+		});
+		expect(
+			WORDPRESS_BLOCK_API_COMPATIBILITY.blockBindings.serverRegistration,
+		).toMatchObject({
+			runtime: ["php"],
+			since: "6.5",
+			source: "blockBindingsReference",
+		});
+		expect(
+			WORDPRESS_BLOCK_API_COMPATIBILITY.blockBindings.supportedAttributesFilter,
+		).toMatchObject({
+			since: "6.9",
+			source: "blockBindingsSupportedAttributes",
+		});
+		expect(WORDPRESS_BLOCK_API_COMPATIBILITY_SOURCES.blockSupportsHandbook).toContain(
+			"developer.wordpress.org",
+		);
+	});
+
+	test("compares dotted WordPress versions with missing patch parts as zero", () => {
+		expect(compareWordPressVersions("6.7", "6.7.0")).toBe(0);
+		expect(compareWordPressVersions("6.10", "6.9.9")).toBe(1);
+		expect(compareWordPressVersions("6.6.2", "6.7")).toBe(-1);
+		expect(isWordPressVersionAtLeast("6.9", "6.7.1")).toBe(true);
+		expect(() => assertWordPressVersion("6.x")).toThrow(
+			'Invalid WordPress version "6.x"',
+		);
+	});
+
+	test("evaluates strict unsupported features as skip-worthy errors", () => {
+		const evaluation = evaluateWordPressBlockApiCompatibility(
+			{
+				area: "blockSupports",
+				feature: "allowedBlocks",
+			},
+			{
+				minVersion: "6.8",
+				strict: true,
+			},
+		);
+
+		expect(evaluation.status).toBe("unsupported");
+		expect(evaluation.action).toBe("skip");
+		expect(evaluation.diagnostic).toMatchObject({
+			code: "unsupported-wordpress-block-api-feature",
+			feature: "allowedBlocks",
+			minVersion: "6.8",
+			requiredVersion: "6.9",
+			severity: "error",
+		});
+	});
+
+	test("keeps non-strict unsupported features guardable", () => {
+		const evaluation = evaluateWordPressBlockApiCompatibility(
+			{
+				area: "blockBindings",
+				feature: "editorRegistration",
+			},
+			{
+				minVersion: "6.5",
+				strict: false,
+			},
+		);
+
+		expect(evaluation.status).toBe("unsupported");
+		expect(evaluation.action).toBe("guard");
+		expect(evaluation.diagnostic?.severity).toBe("warning");
+		expect(evaluation.entry?.fallback).toContain("server-side registration");
+	});
+
+	test("allows future keys only when explicitly configured", () => {
+		const guarded = evaluateWordPressBlockApiCompatibility(
+			{
+				area: "blockSupports",
+				feature: "futureLayoutMode",
+			},
+			{
+				minVersion: "6.9",
+			},
+		);
+		const passThrough = evaluateWordPressBlockApiCompatibility(
+			{
+				area: "blockSupports",
+				feature: "futureLayoutMode",
+			},
+			{
+				allowUnknownFutureKeys: true,
+				minVersion: "6.9",
+			},
+		);
+
+		expect(guarded.status).toBe("unknown");
+		expect(guarded.action).toBe("guard");
+		expect(guarded.diagnostic?.code).toBe("unknown-wordpress-block-api-feature");
+		expect(passThrough.status).toBe("unknown");
+		expect(passThrough.action).toBe("pass-through");
+		expect(passThrough.diagnostic).toBeUndefined();
+	});
+
+	test("creates manifest-shaped summaries for codegen and diagnostics", () => {
+		const manifest = createWordPressBlockApiCompatibilityManifest(
+			[
+				{
+					area: "blockSupports",
+					feature: "typography.fontSize",
+				},
+				{
+					area: "blockSupports",
+					feature: "visibility",
+				},
+				{
+					area: "blockBindings",
+					feature: "futureEditorFieldList",
+				},
+			],
+			{
+				minVersion: "6.8",
+				strict: false,
+			},
+		);
+
+		expect(manifest.supported.map((feature) => feature.feature)).toEqual([
+			"typography.fontSize",
+		]);
+		expect(manifest.unsupported.map((feature) => feature.feature)).toEqual([
+			"visibility",
+		]);
+		expect(manifest.unknown.map((feature) => feature.feature)).toEqual([
+			"futureEditorFieldList",
+		]);
+		expect(manifest.diagnostics).toHaveLength(2);
+	});
+
+	test("resolves individual matrix entries by area and feature", () => {
+		expect(
+			getWordPressBlockApiCompatibilityEntry(
+				"blockVariations",
+				"phpVariationsFilter",
+			),
+		).toMatchObject({
+			since: "6.5",
+			source: "blockVariationsPhpDevNote",
+		});
+		expect(
+			getWordPressBlockApiCompatibilityEntry("blockVariations", "missing"),
+		).toBeUndefined();
+	});
+});

--- a/packages/wp-typia-block-types/tests/fixtures/public-type-contracts.ts
+++ b/packages/wp-typia-block-types/tests/fixtures/public-type-contracts.ts
@@ -54,6 +54,14 @@ import {
 	type WritingMode,
 } from "@wp-typia/block-types/block-editor/typography";
 import {
+	WORDPRESS_BLOCK_API_COMPATIBILITY,
+	createWordPressBlockApiCompatibilityManifest,
+	type WordPressBlockApiCompatibilityFeature,
+	type WordPressBlockSupportCompatibilityFeature,
+	type WordPressCompatibilitySettings,
+	type WordPressVersion,
+} from "@wp-typia/block-types/blocks/compatibility";
+import {
 	BLOCK_VARIATION_SCOPES,
 	registerScaffoldBlockType,
 	type BlockConfiguration,
@@ -107,6 +115,24 @@ const spacingSupportKeys =
 	SPACING_SUPPORT_KEYS satisfies readonly SpacingSupportKey[];
 const typographySupportKeys =
 	TYPOGRAPHY_SUPPORT_KEYS satisfies readonly TypographySupportKey[];
+const compatibilityMinVersion: WordPressVersion = "6.7";
+const compatibilitySettings: WordPressCompatibilitySettings = {
+	allowUnknownFutureKeys: false,
+	minVersion: compatibilityMinVersion,
+	strict: true,
+};
+const compatibilityFeature: WordPressBlockApiCompatibilityFeature = {
+	area: "blockSupports",
+	feature: "allowedBlocks",
+};
+const supportCompatibilityFeature: WordPressBlockSupportCompatibilityFeature =
+	"typography.textAlign";
+const compatibilityManifest = createWordPressBlockApiCompatibilityManifest(
+	[compatibilityFeature],
+	compatibilitySettings,
+);
+const supportsTextAlignSince =
+	WORDPRESS_BLOCK_API_COMPATIBILITY.blockSupports["typography.textAlign"].since;
 
 declare const configuration: BlockConfiguration<ExampleAttributes>;
 declare const editProps: BlockEditProps<ExampleAttributes>;
@@ -148,6 +174,7 @@ const styleAttributes: BlockStyleAttributes = {
 };
 
 const supports: BlockSupports = {
+	allowedBlocks: true,
 	color: {
 		button: true,
 		gradients: true,
@@ -169,6 +196,7 @@ const supports: BlockSupports = {
 		dropCap: true,
 		textAlign: ["left", "center"],
 	},
+	visibility: true,
 };
 
 void alignments;
@@ -193,6 +221,9 @@ void variationScopes;
 void supportFeatures;
 void spacingSupportKeys;
 void typographySupportKeys;
+void compatibilityManifest;
+void supportCompatibilityFeature;
+void supportsTextAlignSince;
 void registrationResult;
 void content;
 void maybeVariationTitle;

--- a/packages/wp-typia-block-types/tests/package-contracts.test.ts
+++ b/packages/wp-typia-block-types/tests/package-contracts.test.ts
@@ -91,6 +91,11 @@ describe("@wp-typia/block-types export contracts", () => {
 			import: "./dist/blocks/index.js",
 			types: "./dist/blocks/index.d.ts",
 		});
+		expect(packageJson.exports?.["./blocks/compatibility"]).toEqual({
+			default: "./dist/blocks/compatibility.js",
+			import: "./dist/blocks/compatibility.js",
+			types: "./dist/blocks/compatibility.d.ts",
+		});
 		expect(packageJson.exports?.["./blocks/registration"]).toEqual({
 			default: "./dist/blocks/registration.js",
 			import: "./dist/blocks/registration.js",
@@ -124,6 +129,7 @@ describe("@wp-typia/block-types export contracts", () => {
 							"const styleAttributes = await import('@wp-typia/block-types/block-editor/style-attributes');",
 							"const typography = await import('@wp-typia/block-types/block-editor/typography');",
 							"const blocks = await import('@wp-typia/block-types/blocks');",
+							"const compatibility = await import('@wp-typia/block-types/blocks/compatibility');",
 							"const registration = await import('@wp-typia/block-types/blocks/registration');",
 							"const supports = await import('@wp-typia/block-types/blocks/supports');",
 							"const registered = registration.registerScaffoldBlockType('wp-typia/demo', { title: 'Demo' });",
@@ -135,6 +141,7 @@ describe("@wp-typia/block-types export contracts", () => {
 							"  namedColors: color.CSS_NAMED_COLORS,",
 							"  aspectRatios: dimensions.ASPECT_RATIOS,",
 							"  layoutTypes: layout.LAYOUT_TYPES,",
+							"  manifestStatus: compatibility.createWordPressBlockApiCompatibilityManifest([{ area: 'blockSupports', feature: 'visibility' }], { minVersion: '6.8' }).unsupported[0]?.status ?? null,",
 							"  spacingDimensions: spacing.SPACING_DIMENSIONS,",
 							"  textDecorations: typography.TEXT_DECORATIONS,",
 							"  supportsFeatures: supports.BLOCK_SUPPORT_FEATURES,",
@@ -160,6 +167,7 @@ describe("@wp-typia/block-types export contracts", () => {
 				registeredTitle: string | null;
 				rootHasRegister: boolean;
 				rootHasSupports: boolean;
+				manifestStatus: string | null;
 				spacingDimensions: string[];
 				styleAttributeKeys: string[];
 				supportsFeatures: string[];
@@ -181,6 +189,7 @@ describe("@wp-typia/block-types export contracts", () => {
 		]);
 		expect(summary.aspectRatios).toContain("16/9");
 		expect(summary.layoutTypes).toEqual(["flow", "constrained", "flex", "grid"]);
+		expect(summary.manifestStatus).toBe("unsupported");
 		expect(summary.spacingDimensions).toEqual([
 			"top",
 			"right",
@@ -217,5 +226,6 @@ describe("@wp-typia/block-types export contracts", () => {
 		expect(builtBlockEditorIndexJs).toContain('export * from "./style-attributes.js";');
 		expect(builtBlocksIndexJs).toContain('export * from "./registration.js";');
 		expect(builtBlocksIndexJs).toContain('export * from "./supports.js";');
+		expect(builtBlocksIndexJs).toContain('export * from "./compatibility.js";');
 	});
 });

--- a/packages/wp-typia-block-types/tests/type-contracts.test.ts
+++ b/packages/wp-typia-block-types/tests/type-contracts.test.ts
@@ -37,6 +37,7 @@ describe("@wp-typia/block-types type contracts", () => {
 		const fixtureSource = readFileSync(fixtureSourcePath, "utf8");
 
 		expect(fixtureSource).toContain("@wp-typia/block-types/blocks/registration");
+		expect(fixtureSource).toContain("@wp-typia/block-types/blocks/compatibility");
 		expect(fixtureSource).toContain("@wp-typia/block-types/blocks/supports");
 		expect(fixtureSource).toContain(
 			"@wp-typia/block-types/block-editor/style-attributes",

--- a/packages/wp-typia-project-tools/package.json
+++ b/packages/wp-typia-project-tools/package.json
@@ -163,7 +163,7 @@
     "@wp-typia/api-client": "^0.4.5",
     "@wp-typia/block-runtime": "workspace:*",
     "@wp-typia/rest": "^0.3.13",
-    "@wp-typia/block-types": "^0.3.0",
+    "@wp-typia/block-types": "workspace:*",
     "mustache": "^4.2.0",
     "npm-package-arg": "^13.0.0",
     "semver": "^7.7.3",

--- a/packages/wp-typia-project-tools/package.json
+++ b/packages/wp-typia-project-tools/package.json
@@ -163,7 +163,7 @@
     "@wp-typia/api-client": "^0.4.5",
     "@wp-typia/block-runtime": "workspace:*",
     "@wp-typia/rest": "^0.3.13",
-    "@wp-typia/block-types": "^0.2.4",
+    "@wp-typia/block-types": "^0.3.0",
     "mustache": "^4.2.0",
     "npm-package-arg": "^13.0.0",
     "semver": "^7.7.3",

--- a/packages/wp-typia-project-tools/src/runtime/package-versions.ts
+++ b/packages/wp-typia-project-tools/src/runtime/package-versions.ts
@@ -271,6 +271,14 @@ export function getPackageVersions(): PackageVersions {
       'package.json',
     ),
   );
+  const blockTypesManifestLocation = resolvePackageManifestLocation(
+    path.join(
+      PROJECT_TOOLS_PACKAGE_ROOT,
+      '..',
+      'wp-typia-block-types',
+      'package.json',
+    ),
+  );
   const wpTypiaManifestLocation = resolvePackageManifestLocation(
     path.join(PROJECT_TOOLS_PACKAGE_ROOT, '..', 'wp-typia', 'package.json'),
   );
@@ -298,6 +306,7 @@ export function getPackageVersions(): PackageVersions {
     createManifestLocation,
     monorepoManifestLocation,
     blockRuntimeManifestLocation,
+    blockTypesManifestLocation,
     wpTypiaManifestLocation,
     installedProjectToolsManifestLocation,
     installedApiClientManifestLocation,
@@ -324,12 +333,19 @@ export function getPackageVersions(): PackageVersions {
     readPackageManifest(blockRuntimeManifestLocation) ??
     readPackageManifest(installedBlockRuntimeManifestLocation) ??
     {};
+  const blockTypesManifest =
+    readPackageManifest(blockTypesManifestLocation) ??
+    readPackageManifest(installedBlockTypesManifestLocation) ??
+    {};
   const wpTypiaManifest =
     readPackageManifest(wpTypiaManifestLocation) ??
     readPackageManifest(installedWpTypiaManifestLocation) ??
     {};
   const blockRuntimeDependencyVersion = normalizeVersionRange(
     createManifest.dependencies?.['@wp-typia/block-runtime'],
+  );
+  const blockTypesDependencyVersion = normalizeVersionRange(
+    createManifest.dependencies?.['@wp-typia/block-types'],
   );
   const versions = {
     apiClientPackageVersion: normalizeVersionRange(
@@ -340,10 +356,10 @@ export function getPackageVersions(): PackageVersions {
       blockRuntimeDependencyVersion !== DEFAULT_VERSION_RANGE
         ? blockRuntimeDependencyVersion
         : normalizeVersionRange(blockRuntimeManifest.version),
-    blockTypesPackageVersion: normalizeVersionRange(
-      createManifest.dependencies?.['@wp-typia/block-types'] ??
-        readPackageManifest(installedBlockTypesManifestLocation)?.version,
-    ),
+    blockTypesPackageVersion:
+      blockTypesDependencyVersion !== DEFAULT_VERSION_RANGE
+        ? blockTypesDependencyVersion
+        : normalizeVersionRange(blockTypesManifest.version),
     projectToolsPackageVersion: normalizeVersionRange(createManifest.version),
     restPackageVersion: normalizeVersionRange(
       createManifest.dependencies?.['@wp-typia/rest'] ??

--- a/packages/wp-typia-project-tools/tests/helpers/scaffold-test-paths.ts
+++ b/packages/wp-typia-project-tools/tests/helpers/scaffold-test-paths.ts
@@ -103,7 +103,24 @@ if (
 }
 
 export const normalizedBlockRuntimePackageVersion = `^${blockRuntimePackageVersion}`;
-export const blockTypesPackageVersion =
-	createPackageManifest.dependencies["@wp-typia/block-types"];
+export const blockTypesPackageManifest = JSON.parse(
+	fs.readFileSync(
+		path.resolve(packageRoot, "..", "wp-typia-block-types", "package.json"),
+		"utf8",
+	),
+);
+
+export const blockTypesPackageManifestVersion = blockTypesPackageManifest.version;
+
+if (
+	typeof blockTypesPackageManifestVersion !== "string" ||
+	blockTypesPackageManifestVersion.length === 0
+) {
+	throw new Error(
+		'Expected "packages/wp-typia-block-types/package.json" to define a version.',
+	);
+}
+
+export const blockTypesPackageVersion = `^${blockTypesPackageManifestVersion}`;
 export const restPackageVersion =
 	createPackageManifest.dependencies["@wp-typia/rest"];

--- a/packages/wp-typia/README.md
+++ b/packages/wp-typia/README.md
@@ -40,6 +40,7 @@ Configuration files:
 - `--config <path>` is an explicit override loaded after the default sources, relative to the current working directory unless absolute
 - config files use a strict schema: unknown keys are errors rather than warnings or stripped values, so typos fail near the source config file
 - object values are deep-merged, while arrays such as `mcp.schemaSources` replace earlier arrays instead of concatenating
+- projects can declare block API compatibility intent with `wordpress.minVersion`, `wordpress.testedVersions`, `compatibility.strict`, and `compatibility.allowUnknownFutureKeys`; future Supports, Variations, and Bindings helpers use those values for version-aware diagnostics
 
 Compatibility notes:
 

--- a/packages/wp-typia/src/config.ts
+++ b/packages/wp-typia/src/config.ts
@@ -16,10 +16,31 @@ export const WP_TYPIA_CONFIG_SOURCES = [
 ] as const;
 type JsonRecord = Record<string, unknown>;
 
+const wordpressVersionSchema = z
+	.string()
+	.regex(
+		/^\d+\.\d+(?:\.\d+)?$/u,
+		'expected dotted numeric WordPress version such as "6.7" or "6.7.1"',
+	);
+
 const wpTypiaSchemaSourceSchema = z
 	.object({
 		namespace: z.string(),
 		path: z.string(),
+	})
+	.strict();
+
+const wordpressCompatibilityConfigSchema = z
+	.object({
+		minVersion: wordpressVersionSchema.optional(),
+		testedVersions: z.array(wordpressVersionSchema).optional(),
+	})
+	.strict();
+
+const blockApiCompatibilityConfigSchema = z
+	.object({
+		allowUnknownFutureKeys: z.boolean().optional(),
+		strict: z.boolean().optional(),
 	})
 	.strict();
 
@@ -75,13 +96,21 @@ const mcpConfigSchema = z
 export const wpTypiaUserConfigSchema = z
 	.object({
 		add: addConfigSchema.optional(),
+		compatibility: blockApiCompatibilityConfigSchema.optional(),
 		create: createConfigSchema.optional(),
 		mcp: mcpConfigSchema.optional(),
+		wordpress: wordpressCompatibilityConfigSchema.optional(),
 	})
 	.strict();
 
 export type WpTypiaSchemaSource = z.infer<typeof wpTypiaSchemaSourceSchema>;
 export type WpTypiaUserConfig = z.infer<typeof wpTypiaUserConfigSchema>;
+export interface WpTypiaWordPressCompatibilitySettings {
+	allowUnknownFutureKeys?: boolean | undefined;
+	minVersion?: string | undefined;
+	strict?: boolean | undefined;
+	testedVersions?: string[] | undefined;
+}
 
 function formatIssuePath(issuePath: ZodIssue["path"]): string {
 	if (issuePath.length === 0) {
@@ -233,4 +262,15 @@ export function getAddBlockDefaults(
 
 export function getMcpSchemaSources(config: WpTypiaUserConfig): WpTypiaSchemaSource[] {
 	return config.mcp?.schemaSources ?? [];
+}
+
+export function getWordPressCompatibilitySettings(
+	config: WpTypiaUserConfig,
+): WpTypiaWordPressCompatibilitySettings {
+	return {
+		allowUnknownFutureKeys: config.compatibility?.allowUnknownFutureKeys,
+		minVersion: config.wordpress?.minVersion,
+		strict: config.compatibility?.strict,
+		testedVersions: config.wordpress?.testedVersions,
+	};
 }

--- a/packages/wp-typia/tests/config.test.ts
+++ b/packages/wp-typia/tests/config.test.ts
@@ -9,9 +9,11 @@ import {
   loadWpTypiaUserConfigFromSource,
   mergeWpTypiaUserConfig,
   validateWpTypiaUserConfig,
+  type getWordPressCompatibilitySettings,
   type getMcpSchemaSources,
   type WpTypiaSchemaSource,
   type WpTypiaUserConfig,
+  type WpTypiaWordPressCompatibilitySettings,
   type wpTypiaUserConfigSchema,
 } from '../src/config';
 import { extractWpTypiaConfigOverride } from '../src/config-override';
@@ -29,13 +31,21 @@ type UserConfigSchemaCompatibility = ExpectTrue<
 type SchemaSourceReturnCompatibility = ExpectTrue<
   IsEqual<ReturnType<typeof getMcpSchemaSources>, WpTypiaSchemaSource[]>
 >;
+type WordPressCompatibilitySettingsReturnCompatibility = ExpectTrue<
+  IsEqual<
+    ReturnType<typeof getWordPressCompatibilitySettings>,
+    WpTypiaWordPressCompatibilitySettings
+  >
+>;
 
 const configTypeCompatibilityChecks = {
   schemaSources: true,
   userConfig: true,
+  wordpressCompatibility: true,
 } satisfies {
   schemaSources: SchemaSourceReturnCompatibility;
   userConfig: UserConfigSchemaCompatibility;
+  wordpressCompatibility: WordPressCompatibilitySettingsReturnCompatibility;
 };
 
 function writeJson(filePath: string, value: unknown): void {
@@ -48,6 +58,7 @@ describe('wp-typia user config loading', () => {
     expect(configTypeCompatibilityChecks).toEqual({
       schemaSources: true,
       userConfig: true,
+      wordpressCompatibility: true,
     });
   });
 
@@ -57,6 +68,10 @@ describe('wp-typia user config loading', () => {
         namespace: 'base-space',
         template: 'basic',
         yes: true,
+      },
+      wordpress: {
+        minVersion: '6.7',
+        testedVersions: ['6.7', '6.8'],
       },
       mcp: {
         schemaSources: [
@@ -71,6 +86,13 @@ describe('wp-typia user config loading', () => {
       create: {
         'package-manager': 'pnpm',
         template: 'persistence',
+      },
+      compatibility: {
+        allowUnknownFutureKeys: true,
+        strict: false,
+      },
+      wordpress: {
+        testedVersions: ['6.9'],
       },
       mcp: {
         schemaSources: [
@@ -89,6 +111,14 @@ describe('wp-typia user config loading', () => {
       'package-manager': 'pnpm',
       template: 'persistence',
       yes: true,
+    });
+    expect(merged.compatibility).toEqual({
+      allowUnknownFutureKeys: true,
+      strict: false,
+    });
+    expect(merged.wordpress).toEqual({
+      minVersion: '6.7',
+      testedVersions: ['6.9'],
     });
     expect(merged.mcp?.schemaSources).toEqual([
       {
@@ -115,6 +145,14 @@ describe('wp-typia user config loading', () => {
               },
             ],
           },
+          compatibility: {
+            allowUnknownFutureKeys: false,
+            strict: true,
+          },
+          wordpress: {
+            minVersion: '6.5',
+            testedVersions: ['6.5', '6.6', '6.7'],
+          },
         },
         'test config',
       ),
@@ -122,6 +160,10 @@ describe('wp-typia user config loading', () => {
       create: {
         'dry-run': true,
         template: 'basic',
+      },
+      compatibility: {
+        allowUnknownFutureKeys: false,
+        strict: true,
       },
       mcp: {
         schemaSources: [
@@ -131,7 +173,40 @@ describe('wp-typia user config loading', () => {
           },
         ],
       },
+      wordpress: {
+        minVersion: '6.5',
+        testedVersions: ['6.5', '6.6', '6.7'],
+      },
     });
+  });
+
+  test('rejects malformed WordPress compatibility versions', () => {
+    let thrown: unknown;
+    try {
+      validateWpTypiaUserConfig(
+        {
+          wordpress: {
+            minVersion: '6.x',
+            testedVersions: ['6.7', 'trunk'],
+          },
+        },
+        'test config',
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect(thrown).toHaveProperty('code', 'invalid-argument');
+    expect(String((thrown as Error).message)).toContain(
+      'wordpress.minVersion',
+    );
+    expect(String((thrown as Error).message)).toContain(
+      'expected dotted numeric WordPress version',
+    );
+    expect(String((thrown as Error).message)).toContain(
+      'wordpress.testedVersions[1]',
+    );
   });
 
   test('loads explicit config sources relative to the requested working directory', async () => {

--- a/scripts/lib/runtime-package-policy.mjs
+++ b/scripts/lib/runtime-package-policy.mjs
@@ -63,6 +63,11 @@ export const WORKSPACE_PROTOCOL_POLICY_EXCEPTIONS = [
 		dependentName: "@wp-typia/project-tools",
 		rangePolicy: RANGE_POLICY.caret,
 	},
+	{
+		dependencyName: "@wp-typia/block-types",
+		dependentName: "@wp-typia/project-tools",
+		rangePolicy: RANGE_POLICY.caret,
+	},
 ];
 
 export const RUNTIME_PACKAGE_NAMES = [

--- a/tests/type-smoke/block-types-smoke.ts
+++ b/tests/type-smoke/block-types-smoke.ts
@@ -35,6 +35,11 @@ import type {
   RegisterBlockTypeResult,
 } from '@wp-typia/block-types/blocks/registration';
 import { registerScaffoldBlockType } from '@wp-typia/block-types/blocks/registration';
+import {
+  createWordPressBlockApiCompatibilityManifest,
+  type WordPressBlockApiCompatibilityFeature,
+  type WordPressVersion,
+} from '@wp-typia/block-types/blocks/compatibility';
 import type {
   BlockSupports,
   SpacingSize,
@@ -58,8 +63,26 @@ const spacingSize: SpacingSize = {
   slug: 'xl',
 };
 const supportKey: TypographySupportKey = 'dropCap';
+const minWordPressVersion: WordPressVersion = '6.7';
+const compatibilityFeatures: WordPressBlockApiCompatibilityFeature[] = [
+  {
+    area: 'blockSupports',
+    feature: 'typography.textAlign',
+  },
+  {
+    area: 'blockBindings',
+    feature: 'serverRegistration',
+  },
+];
+const compatibilityManifest = createWordPressBlockApiCompatibilityManifest(
+  compatibilityFeatures,
+  {
+    minVersion: minWordPressVersion,
+  },
+);
 const blockSupports: BlockSupports = {
   align: ['wide', 'full'],
+  allowedBlocks: true,
   background: {
     backgroundImage: true,
     backgroundSize: true,
@@ -120,6 +143,7 @@ const blockSupports: BlockSupports = {
     textTransform: true,
     __experimentalSkipSerialization: true,
   },
+  visibility: true,
 };
 const textAlignment: TextAlignment = 'justify';
 const textTransform: TextTransform = 'capitalize';
@@ -243,6 +267,7 @@ void aspectRatio;
 void blockAlignment;
 void blockConfiguration;
 void blockSupports;
+void compatibilityManifest;
 void contentPosition;
 void colorSupportAttrs;
 void deprecatedEntries;

--- a/tests/unit/package-manifest-policy.test.ts
+++ b/tests/unit/package-manifest-policy.test.ts
@@ -92,7 +92,7 @@ function createManifestRepo() {
 		dependencies: {
 			"@wp-typia/api-client": "^0.4.3",
 			"@wp-typia/block-runtime": "workspace:*",
-			"@wp-typia/block-types": "^0.2.1",
+			"@wp-typia/block-types": "workspace:*",
 			"@wp-typia/rest": "^0.3.6",
 		},
 		devDependencies: {

--- a/tests/unit/runtime-package-coupling.test.ts
+++ b/tests/unit/runtime-package-coupling.test.ts
@@ -283,7 +283,7 @@ describe("validate-runtime-package-coupling", () => {
 		expect(result.errors).toEqual([]);
 	});
 
-	test("passes when project-tools uses the sanctioned workspace protocol edge for block-runtime", () => {
+	test("passes when project-tools uses sanctioned workspace protocol edges", () => {
 		const repoRoot = createRuntimeRepo();
 		const packageJsonPath = path.join(
 			repoRoot,
@@ -293,6 +293,7 @@ describe("validate-runtime-package-coupling", () => {
 		);
 		const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
 		packageJson.dependencies["@wp-typia/block-runtime"] = "workspace:*";
+		packageJson.dependencies["@wp-typia/block-types"] = "workspace:*";
 		fs.writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`, "utf8");
 
 		const result = validateRuntimePackageCoupling(repoRoot);


### PR DESCRIPTION
## Summary
- add a shared WordPress block API compatibility matrix for block supports, variations, and bindings
- export compatibility helpers from @wp-typia/block-types, including diagnostics and manifest summaries
- add wp-typia config fields for WordPress minimum/tested versions and strict compatibility behavior
- document the new config and add Sampo changeset coverage

Closes #962

## Validation
- bun run --filter @wp-typia/block-types test
- bun test packages/wp-typia/tests/config.test.ts
- bun run typecheck
- bun run changesets:validate
- bun run format:check
- git diff --check
- bun run lint:repo
- bun run --filter wp-typia test
- bun run docs:build

Note: docs build completed successfully while preserving existing Starlight typedoc @property warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added WordPress block API compatibility matrix to evaluate feature support across WordPress versions
- Introduced new project configuration options: `wordpress.minVersion`, `compatibility.strict`, and `compatibility.allowUnknownFutureKeys` for version-aware diagnostics
- Extended block support features to include `allowedBlocks`, `visibility`, and others

## Documentation
- Updated CLI reference and README documentation with new compatibility configuration guidance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/977)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->