### PR TITLE
[codex] Add typed block supports helper

### DIFF
--- a/.sampo/changesets/963-define-supports.md
+++ b/.sampo/changesets/963-define-supports.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/block-types: minor
+---
+
+Add defineSupports() and SupportAttributes helpers for typed WordPress Block Supports authoring with version-aware compatibility diagnostics.

--- a/packages/wp-typia-block-types/README.md
+++ b/packages/wp-typia-block-types/README.md
@@ -119,34 +119,72 @@ breakage in scaffold or runtime packages.
 
 ## WordPress style support helpers
 
-The package now exposes two complementary surfaces:
+The package now exposes three complementary surfaces:
 
-- `@wp-typia/block-types/blocks/supports` for typed `block.json` `supports`
+- `@wp-typia/block-types/blocks/supports` for typed `block.json` `supports`,
+  the `defineSupports()` helper, and `SupportAttributes<typeof supports>`
 - `@wp-typia/block-types/block-editor/style-attributes` for the attribute and `style` shapes WordPress injects when those supports are enabled
+- `@wp-typia/block-types/blocks/compatibility` for version-aware diagnostics
+  when a support key requires a newer WordPress floor
 
 Example:
 
 ```ts
-import type { BlockStyleSupportAttributes } from '@wp-typia/block-types/block-editor/style-attributes';
-import type { BlockSupports } from '@wp-typia/block-types/blocks/supports';
+import {
+  defineSupports,
+  type SupportAttributes,
+} from '@wp-typia/block-types/blocks/supports';
 
-const supports: BlockSupports = {
-  color: { text: true, background: true, gradients: true, enableAlpha: true },
+const supports = defineSupports({
+  minWordPress: '6.6',
+  color: { text: true, background: true },
   spacing: {
     padding: true,
-    units: ['px', 'rem'],
-    spacingSizes: [{ name: 'Large', slug: 'large', size: '2rem' }],
+    margin: true,
+    blockGap: true,
   },
-  typography: { fontSize: true, dropCap: true },
-  js: true,
-  locking: true,
+  typography: {
+    fontSize: true,
+    lineHeight: true,
+    letterSpacing: true,
+    textAlign: ['left', 'center'],
+  },
+  layout: {
+    default: {
+      type: 'constrained',
+    },
+  },
+  anchor: true,
+  html: false,
+});
+
+type OwnAttributes = {
+  content: string;
+  density: 'compact' | 'balanced' | 'airy';
 };
 
-type MyBlockStyleAttrs = Pick<
-  BlockStyleSupportAttributes,
-  'backgroundColor' | 'fontSize' | 'style' | 'textColor'
->;
+type BlockAttributes = OwnAttributes & SupportAttributes<typeof supports>;
 ```
+
+`defineSupports()` returns a plain object that can be written directly to
+`block.json.supports`; inline helper controls such as `minWordPress`, `strict`,
+and `allowUnknownFutureKeys` are stripped from the returned metadata. The helper
+stores its compatibility manifest on a non-enumerable symbol so generated JSON
+stays clean while tests and codegen can still inspect diagnostics through
+`getDefinedSupportsCompatibilityManifest()`.
+
+Strict mode is enabled by default. Known support keys that require a newer
+WordPress version throw, while `strict: false` reports warnings through
+`onDiagnostic` and keeps the metadata pass-through. Unknown future top-level
+support keys are rejected unless `allowUnknownFutureKeys` is enabled.
+
+`SupportAttributes<typeof supports>` is intentionally conservative where
+Gutenberg behavior is broad. Enabling color, spacing, typography, border,
+dimensions, background, filter duotone, position, or shadow includes the shared
+`style` attribute shape. Typography also exposes slug attributes such as
+`fontSize` and `fontFamily` when typography support is enabled; the compatibility
+matrix tracks version-gated typography keys like `textAlign` separately from
+longstanding keys such as `dropCap`.
 
 Stable Core coverage now also includes support/style helpers for layout
 `rowGap` / `columnGap`, color `duotone`, per-side border widths, and other

--- a/packages/wp-typia-block-types/src/blocks/compatibility.ts
+++ b/packages/wp-typia-block-types/src/blocks/compatibility.ts
@@ -172,6 +172,12 @@ export const WORDPRESS_BLOCK_API_COMPATIBILITY = {
       since: '6.5',
       source: 'blockSupportsHandbook',
     },
+    contentRole: {
+      label: 'supports.contentRole',
+      runtime: ['block-json', 'editor-js'],
+      since: '6.9',
+      source: 'blockSupportsHandbook',
+    },
     dimensions: {
       derivedAttributes: ['style'],
       label: 'supports.dimensions',
@@ -185,6 +191,12 @@ export const WORDPRESS_BLOCK_API_COMPATIBILITY = {
       runtime: ['block-json', 'editor-js'],
       since: '5.9',
       source: 'themeJsonStyleVersions',
+    },
+    listView: {
+      label: 'supports.listView',
+      runtime: ['block-json', 'editor-js'],
+      since: '7.0',
+      source: 'blockSupportsHandbook',
     },
     position: {
       derivedAttributes: ['style'],

--- a/packages/wp-typia-block-types/src/blocks/supports.ts
+++ b/packages/wp-typia-block-types/src/blocks/supports.ts
@@ -475,7 +475,9 @@ const TYPOGRAPHY_COMPATIBILITY_SUPPORT_KEYS = [
 const TOP_LEVEL_COMPATIBILITY_SUPPORT_KEYS = [
   "allowedBlocks",
   "background",
+  "contentRole",
   "dimensions",
+  "listView",
   "position",
   "renaming",
   "shadow",

--- a/packages/wp-typia-block-types/src/blocks/supports.ts
+++ b/packages/wp-typia-block-types/src/blocks/supports.ts
@@ -4,8 +4,24 @@ import type {
   JustifyContent,
   TextAlignment,
 } from "../block-editor/alignment.js";
+import type {
+  BlockBorderSupportAttributes,
+  BlockColorSupportAttributes,
+  BlockDimensionsSupportAttributes,
+  BlockSpacingSupportAttributes,
+  BlockStyleAttributes,
+  BlockTypographySupportAttributes,
+} from "../block-editor/style-attributes.js";
 import type { FlexWrap, LayoutType, Orientation } from "../block-editor/layout.js";
 import type { SpacingAxis, SpacingDimension } from "../block-editor/spacing.js";
+import {
+  createWordPressBlockApiCompatibilityManifest,
+  type WordPressBlockApiCompatibilityDiagnostic,
+  type WordPressBlockApiCompatibilityFeature,
+  type WordPressBlockApiCompatibilityManifest,
+  type WordPressCompatibilitySettings,
+  type WordPressVersion,
+} from "./compatibility.js";
 
 /**
  * Derived from Gutenberg block support keys and commonly used block.json
@@ -309,4 +325,384 @@ export interface BlockSupports {
   readonly splitting?: boolean;
   readonly typography?: boolean | BlockTypographySupport;
   readonly visibility?: boolean;
+}
+
+export type BlockSupportsInput = BlockSupports & Readonly<Record<string, unknown>>;
+
+export interface BlockAlignSupportAttributes {
+  readonly align?: BlockAlignment;
+}
+
+export interface BlockAllowedBlocksSupportAttributes {
+  readonly allowedBlocks?: readonly string[];
+}
+
+export interface BlockLayoutSupportAttributes {
+  readonly layout?: BlockLayoutDefault;
+}
+
+export interface BlockStyleAttributeSupportAttributes {
+  readonly style?: BlockStyleAttributes;
+}
+
+type SupportTruthy<TValue> = [TValue] extends [false | null | undefined]
+  ? false
+  : true;
+
+type HasSupport<TSupports, TKey extends PropertyKey> = TKey extends keyof TSupports
+  ? SupportTruthy<TSupports[TKey]>
+  : false;
+
+type HasNestedSupport<
+  TSupports,
+  TSection extends keyof BlockSupports,
+  TKey extends PropertyKey,
+> = TSection extends keyof TSupports
+  ? TSupports[TSection] extends true
+    ? true
+    : TSupports[TSection] extends Readonly<Record<TKey, infer TValue>>
+      ? SupportTruthy<TValue>
+      : false
+  : false;
+
+type IfSupport<TCondition, TAttributes> = TCondition extends true
+  ? TAttributes
+  : {};
+
+export interface DefineSupportsInlineOptions {
+  readonly allowUnknownFutureKeys?: boolean;
+  readonly minVersion?: WordPressVersion;
+  readonly minWordPress?: WordPressVersion;
+  readonly onDiagnostic?: (diagnostic: WordPressBlockApiCompatibilityDiagnostic) => void;
+  readonly strict?: boolean;
+}
+
+export interface DefineSupportsOptions extends WordPressCompatibilitySettings {
+  readonly minWordPress?: WordPressVersion;
+  readonly onDiagnostic?: (diagnostic: WordPressBlockApiCompatibilityDiagnostic) => void;
+}
+
+export type StripDefineSupportsOptions<TSupports> = Omit<
+  TSupports,
+  keyof DefineSupportsInlineOptions
+>;
+
+export const DEFINED_BLOCK_SUPPORTS_METADATA: unique symbol = Symbol.for(
+  "@wp-typia/block-types/defined-supports",
+) as never;
+
+export type DefinedBlockSupportsMetadataKey =
+  typeof DEFINED_BLOCK_SUPPORTS_METADATA;
+
+export interface DefinedBlockSupportsMetadata {
+  readonly diagnostics: readonly WordPressBlockApiCompatibilityDiagnostic[];
+  readonly manifest: WordPressBlockApiCompatibilityManifest;
+}
+
+export type DefinedBlockSupports<TSupports extends BlockSupportsInput = BlockSupportsInput> =
+  Readonly<StripDefineSupportsOptions<TSupports>> & {
+    readonly [DEFINED_BLOCK_SUPPORTS_METADATA]?: DefinedBlockSupportsMetadata;
+  };
+
+export type SupportAttributes<TSupports> =
+  TSupports extends DefinedBlockSupports<infer TDefinedSupports>
+    ? SupportAttributesFromBlockSupports<
+        StripDefineSupportsOptions<TDefinedSupports>
+      >
+    : TSupports extends BlockSupportsInput
+      ? SupportAttributesFromBlockSupports<StripDefineSupportsOptions<TSupports>>
+      : {};
+
+export type SupportAttributesFromBlockSupports<TSupports> =
+  IfSupport<
+    HasSupport<TSupports, "align"> | HasSupport<TSupports, "alignWide">,
+    BlockAlignSupportAttributes
+  > &
+    IfSupport<
+      HasSupport<TSupports, "allowedBlocks">,
+      BlockAllowedBlocksSupportAttributes
+    > &
+    IfSupport<HasSupport<TSupports, "layout">, BlockLayoutSupportAttributes> &
+    IfSupport<HasSupport<TSupports, "color">, BlockColorSupportAttributes> &
+    IfSupport<
+      HasSupport<TSupports, "typography">,
+      BlockTypographySupportAttributes
+    > &
+    IfSupport<HasSupport<TSupports, "spacing">, BlockSpacingSupportAttributes> &
+    IfSupport<
+      HasSupport<TSupports, "dimensions">,
+      BlockDimensionsSupportAttributes
+    > &
+    IfSupport<HasSupport<TSupports, "border">, BlockBorderSupportAttributes> &
+    IfSupport<
+      HasSupport<TSupports, "background">,
+      BlockStyleAttributeSupportAttributes
+    > &
+    IfSupport<
+      HasNestedSupport<TSupports, "filter", "duotone">,
+      BlockStyleAttributeSupportAttributes
+    > &
+    IfSupport<
+      HasSupport<TSupports, "position">,
+      BlockStyleAttributeSupportAttributes
+    > &
+    IfSupport<
+      HasSupport<TSupports, "shadow">,
+      BlockStyleAttributeSupportAttributes
+    >;
+
+const KNOWN_BLOCK_SUPPORT_FEATURES = new Set<string>(BLOCK_SUPPORT_FEATURES);
+const DEFINE_SUPPORTS_INLINE_OPTION_KEYS = new Set<string>([
+  "allowUnknownFutureKeys",
+  "minVersion",
+  "minWordPress",
+  "onDiagnostic",
+  "strict",
+]);
+const COLOR_COMPATIBILITY_SUPPORT_KEYS = [
+  "button",
+  "enableContrastChecker",
+  "heading",
+] as const;
+const TYPOGRAPHY_COMPATIBILITY_SUPPORT_KEYS = [
+  "fontSize",
+  "letterSpacing",
+  "lineHeight",
+  "textAlign",
+  "textDecoration",
+  "textTransform",
+] as const satisfies readonly TypographySupportKey[];
+const TOP_LEVEL_COMPATIBILITY_SUPPORT_KEYS = [
+  "allowedBlocks",
+  "background",
+  "dimensions",
+  "position",
+  "renaming",
+  "shadow",
+  "visibility",
+] as const satisfies readonly BlockSupportFeature[];
+
+function isSupportObject(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isEnabledSupportValue(value: unknown): boolean {
+  return value !== false && value !== null && value !== undefined;
+}
+
+function hasEnabledNestedSupport(
+  section: unknown,
+  key: string,
+): boolean {
+  if (section === true) {
+    return true;
+  }
+
+  return isSupportObject(section) && isEnabledSupportValue(section[key]);
+}
+
+function addCompatibilityFeature(
+  features: WordPressBlockApiCompatibilityFeature[],
+  seen: Set<string>,
+  feature: string,
+): void {
+  const id = `blockSupports.${feature}`;
+
+  if (seen.has(id)) {
+    return;
+  }
+
+  seen.add(id);
+  features.push({
+    area: "blockSupports",
+    feature,
+  });
+}
+
+export function collectBlockSupportsCompatibilityFeatures(
+  supports: BlockSupportsInput,
+): readonly WordPressBlockApiCompatibilityFeature[] {
+  const features: WordPressBlockApiCompatibilityFeature[] = [];
+  const seen = new Set<string>();
+
+  for (const key of TOP_LEVEL_COMPATIBILITY_SUPPORT_KEYS) {
+    if (isEnabledSupportValue(supports[key])) {
+      addCompatibilityFeature(features, seen, key);
+    }
+  }
+
+  const spacing = supports.spacing;
+  for (const key of SPACING_SUPPORT_KEYS) {
+    if (hasEnabledNestedSupport(spacing, key)) {
+      addCompatibilityFeature(features, seen, `spacing.${key}`);
+    }
+  }
+
+  const typography = supports.typography;
+  for (const key of TYPOGRAPHY_COMPATIBILITY_SUPPORT_KEYS) {
+    if (hasEnabledNestedSupport(typography, key)) {
+      addCompatibilityFeature(features, seen, `typography.${key}`);
+    }
+  }
+
+  const color = supports.color;
+  if (isSupportObject(color)) {
+    for (const key of COLOR_COMPATIBILITY_SUPPORT_KEYS) {
+      if (isEnabledSupportValue(color[key])) {
+        addCompatibilityFeature(features, seen, `color.${key}`);
+      }
+    }
+  }
+
+  if (hasEnabledNestedSupport(supports.filter, "duotone")) {
+    addCompatibilityFeature(features, seen, "filter.duotone");
+  }
+
+  for (const key of Object.keys(supports)) {
+    if (
+      !KNOWN_BLOCK_SUPPORT_FEATURES.has(key) &&
+      !DEFINE_SUPPORTS_INLINE_OPTION_KEYS.has(key)
+    ) {
+      addCompatibilityFeature(features, seen, key);
+    }
+  }
+
+  return features;
+}
+
+function splitDefineSupportsInput<TSupports extends BlockSupportsInput>(
+  supports: TSupports & DefineSupportsInlineOptions,
+): {
+  inlineOptions: DefineSupportsInlineOptions;
+  supports: StripDefineSupportsOptions<TSupports> & BlockSupportsInput;
+} {
+  const normalizedSupports: Record<string, unknown> = {};
+  const inlineOptions: DefineSupportsInlineOptions = {};
+
+  for (const [key, value] of Object.entries(supports)) {
+    if (DEFINE_SUPPORTS_INLINE_OPTION_KEYS.has(key)) {
+      Object.assign(inlineOptions, { [key]: value });
+      continue;
+    }
+
+    normalizedSupports[key] = value;
+  }
+
+  return {
+    inlineOptions,
+    supports: normalizedSupports as StripDefineSupportsOptions<TSupports> &
+      BlockSupportsInput,
+  };
+}
+
+function resolveDefineSupportsSettings(
+  inlineOptions: DefineSupportsInlineOptions,
+  options: DefineSupportsOptions,
+): WordPressCompatibilitySettings {
+  const settings: WordPressCompatibilitySettings = {};
+  const allowUnknownFutureKeys =
+    options.allowUnknownFutureKeys ?? inlineOptions.allowUnknownFutureKeys;
+  const minVersion =
+    options.minVersion ??
+    options.minWordPress ??
+    inlineOptions.minVersion ??
+    inlineOptions.minWordPress;
+  const strict = options.strict ?? inlineOptions.strict;
+
+  if (allowUnknownFutureKeys !== undefined) {
+    Object.assign(settings, { allowUnknownFutureKeys });
+  }
+  if (minVersion !== undefined) {
+    Object.assign(settings, { minVersion });
+  }
+  if (strict !== undefined) {
+    Object.assign(settings, { strict });
+  }
+
+  return settings;
+}
+
+export function createBlockSupportsCompatibilityManifest(
+  supports: BlockSupportsInput,
+  settings: DefineSupportsOptions = {},
+): WordPressBlockApiCompatibilityManifest {
+  const compatibilitySettings = resolveDefineSupportsSettings({}, settings);
+
+  return createWordPressBlockApiCompatibilityManifest(
+    collectBlockSupportsCompatibilityFeatures(supports),
+    compatibilitySettings,
+  );
+}
+
+function handleDefineSupportsDiagnostics(
+  diagnostics: readonly WordPressBlockApiCompatibilityDiagnostic[],
+  onDiagnostic: DefineSupportsOptions["onDiagnostic"],
+): void {
+  const errors = diagnostics.filter(
+    (diagnostic) => diagnostic.severity === "error",
+  );
+
+  if (errors.length > 0) {
+    throw new Error(
+      [
+        "WordPress block supports compatibility check failed:",
+        ...errors.map((diagnostic) => `- ${diagnostic.message}`),
+      ].join("\n"),
+    );
+  }
+
+  for (const diagnostic of diagnostics) {
+    if (onDiagnostic) {
+      onDiagnostic(diagnostic);
+      continue;
+    }
+
+    console.warn(`[wp-typia] ${diagnostic.message}`);
+  }
+}
+
+export function getDefinedSupportsCompatibilityManifest(
+  supports: unknown,
+): WordPressBlockApiCompatibilityManifest | undefined {
+  return isSupportObject(supports)
+    ? (
+        supports as {
+          readonly [DEFINED_BLOCK_SUPPORTS_METADATA]?:
+            | DefinedBlockSupportsMetadata
+            | undefined;
+        }
+      )[DEFINED_BLOCK_SUPPORTS_METADATA]?.manifest
+    : undefined;
+}
+
+export function defineSupports<
+  const TSupports extends BlockSupportsInput & DefineSupportsInlineOptions,
+>(
+  supports: TSupports,
+  options: DefineSupportsOptions = {},
+): DefinedBlockSupports<TSupports> {
+  const { inlineOptions, supports: normalizedSupports } =
+    splitDefineSupportsInput(supports);
+  const settings = resolveDefineSupportsSettings(inlineOptions, options);
+  const manifest = createBlockSupportsCompatibilityManifest(
+    normalizedSupports,
+    settings,
+  );
+
+  handleDefineSupportsDiagnostics(
+    manifest.diagnostics,
+    options.onDiagnostic ?? inlineOptions.onDiagnostic,
+  );
+
+  Object.defineProperty(normalizedSupports, DEFINED_BLOCK_SUPPORTS_METADATA, {
+    configurable: false,
+    enumerable: false,
+    value: {
+      diagnostics: manifest.diagnostics,
+      manifest,
+    } satisfies DefinedBlockSupportsMetadata,
+    writable: false,
+  });
+
+  return normalizedSupports as DefinedBlockSupports<TSupports>;
 }

--- a/packages/wp-typia-block-types/src/blocks/supports.ts
+++ b/packages/wp-typia-block-types/src/blocks/supports.ts
@@ -561,7 +561,8 @@ export function collectBlockSupportsCompatibilityFeatures(
   for (const key of Object.keys(supports)) {
     if (
       !KNOWN_BLOCK_SUPPORT_FEATURES.has(key) &&
-      !DEFINE_SUPPORTS_INLINE_OPTION_KEYS.has(key)
+      !DEFINE_SUPPORTS_INLINE_OPTION_KEYS.has(key) &&
+      isEnabledSupportValue(supports[key])
     ) {
       addCompatibilityFeature(features, seen, key);
     }

--- a/packages/wp-typia-block-types/src/blocks/supports.ts
+++ b/packages/wp-typia-block-types/src/blocks/supports.ts
@@ -494,10 +494,6 @@ function hasEnabledNestedSupport(
   section: unknown,
   key: string,
 ): boolean {
-  if (section === true) {
-    return true;
-  }
-
   return isSupportObject(section) && isEnabledSupportValue(section[key]);
 }
 

--- a/packages/wp-typia-block-types/src/blocks/supports.ts
+++ b/packages/wp-typia-block-types/src/blocks/supports.ts
@@ -415,7 +415,7 @@ export type SupportAttributes<TSupports> =
 
 export type SupportAttributesFromBlockSupports<TSupports> =
   IfSupport<
-    HasSupport<TSupports, "align"> | HasSupport<TSupports, "alignWide">,
+    HasSupport<TSupports, "align">,
     BlockAlignSupportAttributes
   > &
     IfSupport<
@@ -490,6 +490,18 @@ function isEnabledSupportValue(value: unknown): boolean {
   return value !== false && value !== null && value !== undefined;
 }
 
+function isEnabledTopLevelSupportValue(value: unknown): boolean {
+  if (!isSupportObject(value)) {
+    return isEnabledSupportValue(value);
+  }
+
+  return Object.entries(value).some(
+    ([key, nestedValue]) =>
+      !key.startsWith("__experimental") &&
+      isEnabledSupportValue(nestedValue),
+  );
+}
+
 function hasEnabledNestedSupport(
   section: unknown,
   key: string,
@@ -522,7 +534,7 @@ export function collectBlockSupportsCompatibilityFeatures(
   const seen = new Set<string>();
 
   for (const key of TOP_LEVEL_COMPATIBILITY_SUPPORT_KEYS) {
-    if (isEnabledSupportValue(supports[key])) {
+    if (isEnabledTopLevelSupportValue(supports[key])) {
       addCompatibilityFeature(features, seen, key);
     }
   }
@@ -558,7 +570,7 @@ export function collectBlockSupportsCompatibilityFeatures(
     if (
       !KNOWN_BLOCK_SUPPORT_FEATURES.has(key) &&
       !DEFINE_SUPPORTS_INLINE_OPTION_KEYS.has(key) &&
-      isEnabledSupportValue(supports[key])
+      isEnabledTopLevelSupportValue(supports[key])
     ) {
       addCompatibilityFeature(features, seen, key);
     }

--- a/packages/wp-typia-block-types/tests/compatibility.test.ts
+++ b/packages/wp-typia-block-types/tests/compatibility.test.ts
@@ -18,6 +18,14 @@ describe("WordPress block API compatibility matrix", () => {
 			since: "6.9",
 			source: "blockSupportsHandbook",
 		});
+		expect(WORDPRESS_BLOCK_API_COMPATIBILITY.blockSupports.contentRole).toMatchObject({
+			since: "6.9",
+			source: "blockSupportsHandbook",
+		});
+		expect(WORDPRESS_BLOCK_API_COMPATIBILITY.blockSupports.listView).toMatchObject({
+			since: "7.0",
+			source: "blockSupportsHandbook",
+		});
 		expect(
 			WORDPRESS_BLOCK_API_COMPATIBILITY.blockSupports["typography.textAlign"],
 		).toMatchObject({

--- a/packages/wp-typia-block-types/tests/fixtures/public-type-contracts.ts
+++ b/packages/wp-typia-block-types/tests/fixtures/public-type-contracts.ts
@@ -158,6 +158,22 @@ const proseSupports = defineSupports({
 });
 const proseSupportManifest =
 	getDefinedSupportsCompatibilityManifest(proseSupports);
+const alignSupports = defineSupports({
+	align: ["wide", "full"],
+});
+type AlignSupportAttributes = SupportAttributes<typeof alignSupports>;
+const alignSupportHasAlign: "align" extends keyof AlignSupportAttributes
+	? true
+	: never = true;
+const alignWideOnlySupports = defineSupports({
+	alignWide: true,
+});
+type AlignWideOnlySupportAttributes = SupportAttributes<
+	typeof alignWideOnlySupports
+>;
+const alignWideDoesNotExposeAlign: "align" extends keyof AlignWideOnlySupportAttributes
+	? never
+	: true = true;
 
 type ExampleAttributes = SupportAttributes<typeof proseSupports> & {
 	content: string;
@@ -279,6 +295,10 @@ void supportCompatibilityFeature;
 void supportsTextAlignSince;
 void proseSupports;
 void proseSupportManifest;
+void alignSupports;
+void alignSupportHasAlign;
+void alignWideOnlySupports;
+void alignWideDoesNotExposeAlign;
 void registrationResult;
 void content;
 void maybeVariationTitle;

--- a/packages/wp-typia-block-types/tests/fixtures/public-type-contracts.ts
+++ b/packages/wp-typia-block-types/tests/fixtures/public-type-contracts.ts
@@ -41,7 +41,6 @@ import {
 import type {
 	BlockStyleAttributes,
 	BlockStyleColorValue,
-	BlockStyleSupportAttributes,
 } from "@wp-typia/block-types/block-editor/style-attributes";
 import {
 	FONT_STYLES,
@@ -74,15 +73,14 @@ import {
 	BLOCK_SUPPORT_FEATURES,
 	SPACING_SUPPORT_KEYS,
 	TYPOGRAPHY_SUPPORT_KEYS,
+	defineSupports,
+	getDefinedSupportsCompatibilityManifest,
 	type BlockSupportFeature,
 	type BlockSupports,
 	type SpacingSupportKey,
+	type SupportAttributes,
 	type TypographySupportKey,
 } from "@wp-typia/block-types/blocks/supports";
-
-type ExampleAttributes = BlockStyleSupportAttributes & {
-	content: string;
-};
 
 const alignments = BLOCK_ALIGNMENTS satisfies readonly BlockAlignment[];
 const contentPositions =
@@ -133,6 +131,37 @@ const compatibilityManifest = createWordPressBlockApiCompatibilityManifest(
 );
 const supportsTextAlignSince =
 	WORDPRESS_BLOCK_API_COMPATIBILITY.blockSupports["typography.textAlign"].since;
+const proseSupports = defineSupports({
+	minWordPress: "6.6",
+	anchor: true,
+	color: {
+		background: true,
+		text: true,
+	},
+	html: false,
+	layout: {
+		default: {
+			type: "constrained",
+		},
+	},
+	spacing: {
+		blockGap: true,
+		margin: true,
+		padding: true,
+	},
+	typography: {
+		fontSize: true,
+		letterSpacing: true,
+		lineHeight: true,
+		textAlign: ["left", "center"],
+	},
+});
+const proseSupportManifest =
+	getDefinedSupportsCompatibilityManifest(proseSupports);
+
+type ExampleAttributes = SupportAttributes<typeof proseSupports> & {
+	content: string;
+};
 
 declare const configuration: BlockConfiguration<ExampleAttributes>;
 declare const editProps: BlockEditProps<ExampleAttributes>;
@@ -171,6 +200,30 @@ const styleAttributes: BlockStyleAttributes = {
 		textAlign: "center",
 		textDecoration: "underline",
 	},
+};
+const derivedSupportAttributes: SupportAttributes<typeof proseSupports> = {
+	backgroundColor: "primary",
+	fontSize: "large",
+	layout: {
+		type: "constrained",
+	},
+	style: {
+		color: {
+			text: "var:preset|color|primary",
+		},
+		spacing: {
+			margin: "1rem",
+			padding: {
+				top: "1rem",
+			},
+		},
+		typography: {
+			letterSpacing: "0.02em",
+			lineHeight: 1.5,
+			textAlign: "center",
+		},
+	},
+	textColor: "foreground",
 };
 
 const supports: BlockSupports = {
@@ -224,10 +277,13 @@ void typographySupportKeys;
 void compatibilityManifest;
 void supportCompatibilityFeature;
 void supportsTextAlignSince;
+void proseSupports;
+void proseSupportManifest;
 void registrationResult;
 void content;
 void maybeVariationTitle;
 void styleAttributes;
+void derivedSupportAttributes;
 void supports;
 void duotonePalette;
 void validMinHeightValue;

--- a/packages/wp-typia-block-types/tests/package-contracts.test.ts
+++ b/packages/wp-typia-block-types/tests/package-contracts.test.ts
@@ -133,7 +133,11 @@ describe("@wp-typia/block-types export contracts", () => {
 							"const registration = await import('@wp-typia/block-types/blocks/registration');",
 							"const supports = await import('@wp-typia/block-types/blocks/supports');",
 							"const registered = registration.registerScaffoldBlockType('wp-typia/demo', { title: 'Demo' });",
+							"const definedSupports = supports.defineSupports({ minWordPress: '6.6', spacing: { padding: true }, typography: { fontSize: true } });",
+							"const supportsManifest = supports.getDefinedSupportsCompatibilityManifest(definedSupports);",
 							"console.log(JSON.stringify({",
+							"  definedSupportsPadding: definedSupports.spacing.padding,",
+							"  definedSupportsManifestFeatures: supportsManifest.supported.map((feature) => feature.feature),",
 							"  rootHasRegister: typeof root.registerScaffoldBlockType === 'function',",
 							"  rootHasSupports: Array.isArray(root.BLOCK_SUPPORT_FEATURES),",
 							"  blockEditorHasSpacing: Array.isArray(blockEditor.SPACING_DIMENSIONS),",
@@ -161,6 +165,8 @@ describe("@wp-typia/block-types export contracts", () => {
 				alignments: string[];
 				aspectRatios: string[];
 				blockEditorHasSpacing: boolean;
+				definedSupportsManifestFeatures: string[];
+				definedSupportsPadding: boolean;
 				layoutTypes: string[];
 				namedColors: string[];
 				registeredName: string | null;
@@ -178,6 +184,11 @@ describe("@wp-typia/block-types export contracts", () => {
 
 		expect(summary.rootHasRegister).toBe(true);
 		expect(summary.rootHasSupports).toBe(true);
+		expect(summary.definedSupportsPadding).toBe(true);
+		expect(summary.definedSupportsManifestFeatures).toEqual([
+			"spacing.padding",
+			"typography.fontSize",
+		]);
 		expect(summary.blockEditorHasSpacing).toBe(true);
 		expect(summary.alignments).toEqual(["left", "center", "right", "wide", "full"]);
 		expect(summary.namedColors).toEqual([

--- a/packages/wp-typia-block-types/tests/supports.test.ts
+++ b/packages/wp-typia-block-types/tests/supports.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import type { WordPressBlockApiCompatibilityDiagnostic } from "../src/blocks/compatibility";
 import {
 	collectBlockSupportsCompatibilityFeatures,
+	createBlockSupportsCompatibilityManifest,
 	defineSupports,
 	getDefinedSupportsCompatibilityManifest,
 } from "../src/blocks/supports";
@@ -86,7 +87,11 @@ describe("defineSupports", () => {
 			filter: {
 				duotone: true,
 			},
-			spacing: true,
+			spacing: {
+				blockGap: true,
+				margin: true,
+				padding: true,
+			},
 			typography: {
 				dropCap: true,
 				fontSize: true,
@@ -102,6 +107,21 @@ describe("defineSupports", () => {
 			"color.button",
 			"filter.duotone",
 		]);
+	});
+
+	test("does not expand boolean parent supports into version-gated nested keys", () => {
+		const manifest = createBlockSupportsCompatibilityManifest(
+			{
+				spacing: true,
+				typography: true,
+			},
+			{
+				minWordPress: "6.5",
+			},
+		);
+
+		expect(manifest.diagnostics).toEqual([]);
+		expect(manifest.evaluations).toEqual([]);
 	});
 
 	test("throws in strict mode when supports require a newer WordPress floor", () => {

--- a/packages/wp-typia-block-types/tests/supports.test.ts
+++ b/packages/wp-typia-block-types/tests/supports.test.ts
@@ -166,6 +166,27 @@ describe("defineSupports", () => {
 		).toThrow("supports.allowedBlocks requires WordPress 6.9+");
 	});
 
+	test("checks version gates for newer top-level supports", () => {
+		const features = collectBlockSupportsCompatibilityFeatures({
+			contentRole: true,
+			listView: true,
+		}).map((feature) => feature.feature);
+
+		expect(features).toEqual(["contentRole", "listView"]);
+		expect(() =>
+			defineSupports({
+				minWordPress: "6.8",
+				contentRole: true,
+			}),
+		).toThrow("supports.contentRole requires WordPress 6.9+");
+		expect(() =>
+			defineSupports({
+				minWordPress: "6.9",
+				listView: true,
+			}),
+		).toThrow("supports.listView requires WordPress 7.0+");
+	});
+
 	test("reports non-strict compatibility warnings without dropping metadata", () => {
 		const diagnostics: WordPressBlockApiCompatibilityDiagnostic[] = [];
 		const supports = defineSupports({

--- a/packages/wp-typia-block-types/tests/supports.test.ts
+++ b/packages/wp-typia-block-types/tests/supports.test.ts
@@ -124,6 +124,39 @@ describe("defineSupports", () => {
 		expect(manifest.evaluations).toEqual([]);
 	});
 
+	test("skips disabled object supports during compatibility checks", () => {
+		const disabledFeatures = collectBlockSupportsCompatibilityFeatures({
+			background: {
+				backgroundImage: false,
+				backgroundSize: false,
+			},
+			dimensions: {
+				aspectRatio: false,
+				height: false,
+				minHeight: false,
+				width: false,
+			},
+			position: {
+				fixed: false,
+				sticky: false,
+			},
+		}).map((feature) => feature.feature);
+		const enabledFeatures = collectBlockSupportsCompatibilityFeatures({
+			background: {
+				backgroundImage: true,
+			},
+			dimensions: {
+				aspectRatio: true,
+			},
+			position: {
+				sticky: true,
+			},
+		}).map((feature) => feature.feature);
+
+		expect(disabledFeatures).toEqual([]);
+		expect(enabledFeatures).toEqual(["background", "dimensions", "position"]);
+	});
+
 	test("throws in strict mode when supports require a newer WordPress floor", () => {
 		expect(() =>
 			defineSupports({

--- a/packages/wp-typia-block-types/tests/supports.test.ts
+++ b/packages/wp-typia-block-types/tests/supports.test.ts
@@ -169,4 +169,22 @@ describe("defineSupports", () => {
 			}),
 		).toThrow('Unknown WordPress block API feature "blockSupports.futureLayoutMode"');
 	});
+
+	test("ignores disabled unknown future keys when collecting diagnostics", () => {
+		const diagnostics: WordPressBlockApiCompatibilityDiagnostic[] = [];
+		const supports = defineSupports({
+			minWordPress: "6.9",
+			futureLayoutMode: false,
+			onDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+			strict: false,
+		});
+		const manifest = getDefinedSupportsCompatibilityManifest(supports);
+
+		expect(supports).toEqual({
+			futureLayoutMode: false,
+		});
+		expect(manifest?.unknown).toEqual([]);
+		expect(manifest?.diagnostics).toEqual([]);
+		expect(diagnostics).toEqual([]);
+	});
 });

--- a/packages/wp-typia-block-types/tests/supports.test.ts
+++ b/packages/wp-typia-block-types/tests/supports.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, test } from "bun:test";
+
+import type { WordPressBlockApiCompatibilityDiagnostic } from "../src/blocks/compatibility";
+import {
+	collectBlockSupportsCompatibilityFeatures,
+	defineSupports,
+	getDefinedSupportsCompatibilityManifest,
+} from "../src/blocks/supports";
+
+describe("defineSupports", () => {
+	test("returns block.json-ready supports metadata and stores diagnostics out of band", () => {
+		const supports = defineSupports({
+			minWordPress: "6.6",
+			anchor: true,
+			color: {
+				background: true,
+				text: true,
+			},
+			html: false,
+			layout: {
+				default: {
+					type: "constrained",
+				},
+			},
+			spacing: {
+				blockGap: true,
+				margin: true,
+				padding: true,
+			},
+			typography: {
+				fontSize: true,
+				letterSpacing: true,
+				lineHeight: true,
+				textAlign: ["left", "center"],
+			},
+		});
+
+		expect(supports).toEqual({
+			anchor: true,
+			color: {
+				background: true,
+				text: true,
+			},
+			html: false,
+			layout: {
+				default: {
+					type: "constrained",
+				},
+			},
+			spacing: {
+				blockGap: true,
+				margin: true,
+				padding: true,
+			},
+			typography: {
+				fontSize: true,
+				letterSpacing: true,
+				lineHeight: true,
+				textAlign: ["left", "center"],
+			},
+		});
+		expect(Object.keys(supports)).not.toContain("minWordPress");
+		expect(JSON.parse(JSON.stringify(supports))).toEqual(supports);
+
+		const manifest = getDefinedSupportsCompatibilityManifest(supports);
+
+		expect(manifest?.diagnostics).toEqual([]);
+		expect(manifest?.supported.map((feature) => feature.feature)).toEqual([
+			"spacing.blockGap",
+			"spacing.margin",
+			"spacing.padding",
+			"typography.fontSize",
+			"typography.letterSpacing",
+			"typography.lineHeight",
+			"typography.textAlign",
+		]);
+	});
+
+	test("collects only version-gated support keys from nested supports", () => {
+		const features = collectBlockSupportsCompatibilityFeatures({
+			color: {
+				button: true,
+				heading: false,
+				text: true,
+			},
+			filter: {
+				duotone: true,
+			},
+			spacing: true,
+			typography: {
+				dropCap: true,
+				fontSize: true,
+				textDecoration: false,
+			},
+		}).map((feature) => feature.feature);
+
+		expect(features).toEqual([
+			"spacing.blockGap",
+			"spacing.margin",
+			"spacing.padding",
+			"typography.fontSize",
+			"color.button",
+			"filter.duotone",
+		]);
+	});
+
+	test("throws in strict mode when supports require a newer WordPress floor", () => {
+		expect(() =>
+			defineSupports({
+				minWordPress: "6.8",
+				allowedBlocks: true,
+			}),
+		).toThrow("supports.allowedBlocks requires WordPress 6.9+");
+	});
+
+	test("reports non-strict compatibility warnings without dropping metadata", () => {
+		const diagnostics: WordPressBlockApiCompatibilityDiagnostic[] = [];
+		const supports = defineSupports({
+			minWordPress: "6.8",
+			allowedBlocks: true,
+			onDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+			strict: false,
+		});
+
+		expect(supports).toEqual({
+			allowedBlocks: true,
+		});
+		expect(diagnostics).toHaveLength(1);
+		expect(diagnostics[0]).toMatchObject({
+			code: "unsupported-wordpress-block-api-feature",
+			feature: "allowedBlocks",
+			requiredVersion: "6.9",
+			severity: "warning",
+		});
+	});
+
+	test("passes through unknown future keys only when explicitly allowed", () => {
+		const supports = defineSupports({
+			minWordPress: "6.9",
+			allowUnknownFutureKeys: true,
+			futureLayoutMode: {
+				enabled: true,
+			},
+			spacing: {
+				padding: true,
+			},
+		});
+		const manifest = getDefinedSupportsCompatibilityManifest(supports);
+
+		expect(supports).toEqual({
+			futureLayoutMode: {
+				enabled: true,
+			},
+			spacing: {
+				padding: true,
+			},
+		});
+		expect(manifest?.diagnostics).toEqual([]);
+		expect(manifest?.unknown).toMatchObject([
+			{
+				action: "pass-through",
+				feature: "futureLayoutMode",
+			},
+		]);
+		expect(() =>
+			defineSupports({
+				minWordPress: "6.9",
+				futureLayoutMode: true,
+			}),
+		).toThrow('Unknown WordPress block API feature "blockSupports.futureLayoutMode"');
+	});
+});

--- a/packages/wp-typia-block-types/tests/type-contracts.test.ts
+++ b/packages/wp-typia-block-types/tests/type-contracts.test.ts
@@ -43,6 +43,8 @@ describe("@wp-typia/block-types type contracts", () => {
 			"@wp-typia/block-types/block-editor/style-attributes",
 		);
 		expect(fixtureSource).toContain("@ts-expect-error");
+		expect(fixtureSource).toContain("defineSupports");
+		expect(fixtureSource).toContain("SupportAttributes<typeof proseSupports>");
 		expect(fixtureSource).toContain("registerScaffoldBlockType");
 	});
 });

--- a/packages/wp-typia-project-tools/tests/workspace-add.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-add.test.ts
@@ -1437,7 +1437,7 @@ test("canonical CLI can dry-run hooked-block metadata updates without rewriting 
       "utf8"
     )
   ).toBe(originalBlockJsonSource);
-});
+}, 20_000);
 
 test(
   "duplicate add block failures preserve existing workspace blocks",

--- a/tests/type-smoke/block-types-smoke.ts
+++ b/tests/type-smoke/block-types-smoke.ts
@@ -40,9 +40,14 @@ import {
   type WordPressBlockApiCompatibilityFeature,
   type WordPressVersion,
 } from '@wp-typia/block-types/blocks/compatibility';
+import {
+  defineSupports,
+  getDefinedSupportsCompatibilityManifest,
+} from '@wp-typia/block-types/blocks/supports';
 import type {
   BlockSupports,
   SpacingSize,
+  SupportAttributes,
   TypographySupportKey,
 } from '@wp-typia/block-types/blocks/supports';
 
@@ -144,6 +149,57 @@ const blockSupports: BlockSupports = {
     __experimentalSkipSerialization: true,
   },
   visibility: true,
+};
+const typedSupports = defineSupports({
+  minWordPress: '6.6',
+  anchor: true,
+  color: {
+    background: true,
+    text: true,
+  },
+  html: false,
+  layout: {
+    default: {
+      type: 'constrained',
+    },
+  },
+  spacing: {
+    blockGap: true,
+    margin: true,
+    padding: true,
+  },
+  typography: {
+    fontSize: true,
+    letterSpacing: true,
+    lineHeight: true,
+    textAlign: ['left', 'center'],
+  },
+});
+const typedSupportManifest = getDefinedSupportsCompatibilityManifest(typedSupports);
+const derivedSupportAttrs: SupportAttributes<typeof typedSupports> = {
+  backgroundColor: 'primary',
+  fontSize: 'large',
+  layout: {
+    type: 'constrained',
+  },
+  style: {
+    color: {
+      text: 'var(--wp--preset--color--primary)',
+    },
+    spacing: {
+      blockGap: '1rem',
+      margin: '1rem',
+      padding: {
+        top: '1rem',
+      },
+    },
+    typography: {
+      letterSpacing: '0.02em',
+      lineHeight: 1.5,
+      textAlign: 'center',
+    },
+  },
+  textColor: 'foreground',
 };
 const textAlignment: TextAlignment = 'justify';
 const textTransform: TextTransform = 'capitalize';
@@ -286,6 +342,9 @@ void spacingDimension;
 void spacingSize;
 void styleBag;
 void supportStyleAttributes;
+void typedSupports;
+void typedSupportManifest;
+void derivedSupportAttrs;
 void supportKey;
 void textAlignment;
 void textColor;


### PR DESCRIPTION
## Summary

- add `defineSupports()` for typed WordPress Block Supports metadata with inline compatibility controls stripped from generated JSON
- add `SupportAttributes<typeof supports>` plus compatibility feature collection and manifest inspection helpers
- document the recommended own-attributes-plus-support-attributes pattern and typography compatibility notes
- add runtime, package export, and consumer type fixture coverage

Closes #963

## Validation

- `bun run --filter @wp-typia/block-types test`
- `bun run typecheck`
- `bun run lint:repo`
- `bun run changesets:validate`
- `bun run format:check`
- `bun run test:unit`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added defineSupports() and SupportAttributes utilities to author typed Block Supports with integrated version-aware compatibility manifests and diagnostics.

* **Documentation**
  * README updated to document new helpers, usage examples, and compatibility/diagnostics behavior.

* **Tests**
  * Added and extended tests to cover support-definition logic, compatibility manifest generation, diagnostics, and type-contract expectations.

* **Bug Fixes**
  * Fixed a test timeout registration issue so subsequent tests run reliably.

* **Chores**
  * Released a minor package bump and release notes for the new support helpers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/978)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->