### PR TITLE
feat(block-variations): add typed defineVariation helpers

### DIFF
--- a/.sampo/changesets/964-define-variations.md
+++ b/.sampo/changesets/964-define-variations.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/block-types: minor
+---
+
+Add typed defineVariation() and defineVariations() helpers with validation diagnostics and static JavaScript registration source generation.

--- a/packages/wp-typia-block-types/README.md
+++ b/packages/wp-typia-block-types/README.md
@@ -21,6 +21,7 @@ Shared WordPress block semantic types derived from Gutenberg source and unoffici
 - `@wp-typia/block-types/blocks/compatibility`
 - `@wp-typia/block-types/blocks/registration`
 - `@wp-typia/block-types/blocks/supports`
+- `@wp-typia/block-types/blocks/variations`
 
 ## Current policy
 
@@ -46,6 +47,8 @@ Shared WordPress block semantic types derived from Gutenberg source and unoffici
   duotone, per-side border widths, and `js` / `locking`
 - a WordPress block API compatibility matrix for Supports, Variations, and
   Bindings features that codegen and diagnostics can share
+- typed Block Variations authoring helpers with static JavaScript registration
+  source generation
 
 ## Registration facade
 
@@ -194,6 +197,94 @@ recently stabilized support keys.
 for blocks that compute style output on the server. This follows Gutenberg's
 current experimental surface and should not be treated as a long-term
 stability guarantee.
+
+## WordPress block variation helpers
+
+`@wp-typia/block-types/blocks/variations` provides a type-first layer over the
+native Block Variations API. `defineVariation()` returns a plain variation
+metadata object suitable for `registerBlockVariation(...)`; the target block name
+and compatibility manifest are stored on a non-enumerable symbol so generated
+registration code can still recover the block target.
+
+```ts
+import {
+  createStaticBlockVariationRegistrationSource,
+  defineVariation,
+  defineVariations,
+} from '@wp-typia/block-types/blocks/variations';
+
+type HeadingVariationAttributes = {
+  className?: string;
+  level?: number;
+};
+
+const paragraphVariation = defineVariation('core/paragraph', {
+  name: 'example-balanced-paragraph',
+  title: 'Balanced Paragraph',
+  attributes: {
+    className: 'is-style-example-balanced',
+  },
+  scope: ['inserter', 'transform'],
+  isActive: ['className'],
+});
+
+const headingVariation = defineVariation<HeadingVariationAttributes>(
+  'core/heading',
+  {
+    name: 'example-balanced-heading',
+    title: 'Balanced Heading',
+    attributes: {
+      className: 'is-style-example-heading',
+      level: 2,
+    },
+    scope: ['inserter', 'transform'],
+    isActive: ['className', 'level'],
+  },
+);
+
+const variations = defineVariations([
+  paragraphVariation,
+  headingVariation,
+] as const);
+
+const registrationSource =
+  createStaticBlockVariationRegistrationSource(variations);
+```
+
+Custom block variations use the same helper. Pass the custom block name and a
+local attribute type when the variation should be checked against project-owned
+metadata:
+
+```ts
+type TestimonialAttributes = {
+  className?: string;
+  layout?: 'quote' | 'card';
+};
+
+export const featuredTestimonialVariation =
+  defineVariation<TestimonialAttributes>('acme/testimonial', {
+    name: 'acme-featured-testimonial',
+    title: 'Featured Testimonial',
+    attributes: {
+      className: 'is-style-acme-featured',
+      layout: 'card',
+    },
+    isActive: ['className', 'layout'],
+  });
+```
+
+`defineVariation()` warns when active-state detection is missing or points at an
+attribute not present in the variation metadata. Use `allowMissingIsActive: true`
+for intentionally passive/default-style variations. `defineVariations()` detects
+duplicate variation names and shared active discriminators for the same target
+block.
+
+Static code generation currently targets editor-side
+`registerBlockVariation(...)` calls. Function-based `isActive` callbacks are
+accepted by the type helper, but static source generation rejects them because
+they cannot be represented safely as JSON-backed registration metadata. PHP or
+dynamic variation registration remains scoped to a future helper built on the
+existing `blockVariations.phpVariationCallback` compatibility entry.
 
 ## Typia pipeline notes
 

--- a/packages/wp-typia-block-types/README.md
+++ b/packages/wp-typia-block-types/README.md
@@ -206,6 +206,12 @@ metadata object suitable for `registerBlockVariation(...)`; the target block nam
 and compatibility manifest are stored on a non-enumerable symbol so generated
 registration code can still recover the block target.
 
+Static registration source generation serializes JSON-compatible variation
+metadata. Function-based `isActive` callbacks are accepted by the type helper,
+but `createStaticBlockVariationRegistrationSource()` rejects them; use a dynamic
+registration path aligned with the `blockVariations.phpVariationCallback`
+compatibility entry when callbacks must stay executable.
+
 ```ts
 import {
   createStaticBlockVariationRegistrationSource,

--- a/packages/wp-typia-block-types/package.json
+++ b/packages/wp-typia-block-types/package.json
@@ -71,6 +71,11 @@
       "import": "./dist/blocks/supports.js",
       "default": "./dist/blocks/supports.js"
     },
+    "./blocks/variations": {
+      "types": "./dist/blocks/variations.d.ts",
+      "import": "./dist/blocks/variations.js",
+      "default": "./dist/blocks/variations.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/wp-typia-block-types/src/blocks/index.ts
+++ b/packages/wp-typia-block-types/src/blocks/index.ts
@@ -1,3 +1,4 @@
 export * from "./compatibility.js";
 export * from "./registration.js";
 export * from "./supports.js";
+export * from "./variations.js";

--- a/packages/wp-typia-block-types/src/blocks/variations.ts
+++ b/packages/wp-typia-block-types/src/blocks/variations.ts
@@ -512,14 +512,16 @@ export function defineVariations<
 ): DefinedBlockVariations<TVariations> {
   const entries = createBlockVariationRegistrationPlan(variations);
   const strict = options.strict ?? true;
+  const variationDiagnostics = entries.flatMap(
+    (entry) => getDefinedVariationMetadata(entry.variation)?.diagnostics ?? [],
+  );
+  const collectionDiagnostics = createCollectionDiagnostics(entries, strict);
   const diagnostics = [
-    ...entries.flatMap(
-      (entry) => getDefinedVariationMetadata(entry.variation)?.diagnostics ?? [],
-    ),
-    ...createCollectionDiagnostics(entries, strict),
+    ...variationDiagnostics,
+    ...collectionDiagnostics,
   ];
 
-  handleVariationDiagnostics(diagnostics, options.onDiagnostic);
+  handleVariationDiagnostics(collectionDiagnostics, options.onDiagnostic);
 
   const normalizedVariations = [...variations] as unknown as DefinedBlockVariations<
     TVariations

--- a/packages/wp-typia-block-types/src/blocks/variations.ts
+++ b/packages/wp-typia-block-types/src/blocks/variations.ts
@@ -1,0 +1,618 @@
+import type {
+  BlockAttributes,
+  BlockVariation,
+  BlockVariationScope,
+} from "./registration.js";
+import {
+  createWordPressBlockApiCompatibilityManifest,
+  type WordPressBlockApiCompatibilityDiagnostic,
+  type WordPressBlockApiCompatibilityFeature,
+  type WordPressBlockApiCompatibilityManifest,
+  type WordPressCompatibilitySettings,
+  type WordPressVersion,
+} from "./compatibility.js";
+
+export type BlockVariationAttributeMap<
+  TAttributes extends BlockAttributes = BlockAttributes,
+> = Partial<TAttributes> & BlockAttributes;
+
+export type BlockVariationInnerBlockTemplate = readonly [
+  name: string,
+  attributes?: Readonly<BlockAttributes>,
+  innerBlocks?: readonly BlockVariationInnerBlockTemplate[],
+];
+
+export type BlockVariationInnerBlocks =
+  readonly BlockVariationInnerBlockTemplate[];
+
+export type BlockVariationIsActive<
+  TAttributes extends BlockAttributes = BlockAttributes,
+> =
+  | readonly Extract<keyof TAttributes, string>[]
+  | ((
+      blockAttributes: Readonly<BlockVariationAttributeMap<TAttributes>>,
+      variationAttributes: Readonly<BlockVariationAttributeMap<TAttributes>>,
+    ) => boolean);
+
+export interface BlockVariationDefinition<
+  TAttributes extends BlockAttributes = BlockAttributes,
+> extends Omit<
+    BlockVariation<BlockVariationAttributeMap<TAttributes>>,
+    "attributes" | "example" | "innerBlocks" | "isActive" | "scope"
+  > {
+  readonly attributes?: BlockVariationAttributeMap<TAttributes>;
+  readonly example?:
+    | BlockVariation<BlockVariationAttributeMap<TAttributes>>["example"]
+    | {
+        readonly attributes: BlockVariationAttributeMap<TAttributes>;
+        readonly innerBlocks?: BlockVariationInnerBlocks;
+      };
+  readonly innerBlocks?: BlockVariationInnerBlocks;
+  readonly isActive?: BlockVariationIsActive<TAttributes>;
+  readonly scope?: readonly BlockVariationScope[];
+}
+
+export interface DefineVariationInlineOptions {
+  readonly allowMissingIsActive?: boolean;
+  readonly minVersion?: WordPressVersion;
+  readonly minWordPress?: WordPressVersion;
+  readonly onDiagnostic?: (diagnostic: BlockVariationDiagnostic) => void;
+  readonly requireIsActive?: boolean;
+  readonly strict?: boolean;
+}
+
+export interface DefineVariationOptions extends WordPressCompatibilitySettings {
+  readonly allowMissingIsActive?: boolean;
+  readonly minWordPress?: WordPressVersion;
+  readonly onDiagnostic?: (diagnostic: BlockVariationDiagnostic) => void;
+  readonly requireIsActive?: boolean;
+}
+
+export type StripDefineVariationOptions<TVariation> = Omit<
+  TVariation,
+  keyof DefineVariationInlineOptions
+>;
+
+export const DEFINED_BLOCK_VARIATION_METADATA: unique symbol = Symbol.for(
+  "@wp-typia/block-types/defined-variation",
+) as never;
+
+export const DEFINED_BLOCK_VARIATIONS_METADATA: unique symbol = Symbol.for(
+  "@wp-typia/block-types/defined-variations",
+) as never;
+
+export type DefinedBlockVariationMetadataKey =
+  typeof DEFINED_BLOCK_VARIATION_METADATA;
+
+export type DefinedBlockVariationsMetadataKey =
+  typeof DEFINED_BLOCK_VARIATIONS_METADATA;
+
+export interface DefinedBlockVariationMetadata {
+  readonly blockName: string;
+  readonly diagnostics: readonly BlockVariationDiagnostic[];
+  readonly manifest: WordPressBlockApiCompatibilityManifest;
+}
+
+export interface DefinedBlockVariationsMetadata {
+  readonly diagnostics: readonly BlockVariationDiagnostic[];
+  readonly entries: readonly BlockVariationRegistrationEntry[];
+}
+
+export type DefinedBlockVariation<
+  TBlockName extends string = string,
+  TAttributes extends BlockAttributes = BlockAttributes,
+  TVariation extends BlockVariationDefinition<TAttributes> = BlockVariationDefinition<TAttributes>,
+> = Readonly<StripDefineVariationOptions<TVariation>> & {
+  readonly [DEFINED_BLOCK_VARIATION_METADATA]?: DefinedBlockVariationMetadata;
+  readonly __wpTypiaVariationAttributes?: TAttributes;
+  readonly __wpTypiaVariationTarget?: TBlockName;
+};
+
+export type DefinedBlockVariations<
+  TVariations extends readonly DefinedBlockVariation[] = readonly DefinedBlockVariation[],
+> = Readonly<TVariations> & {
+  readonly [DEFINED_BLOCK_VARIATIONS_METADATA]?: DefinedBlockVariationsMetadata;
+};
+
+export type BlockVariationDiagnosticCode =
+  | "duplicate-active-marker"
+  | "duplicate-variation-name"
+  | "missing-is-active"
+  | "missing-stable-marker"
+  | "unknown-is-active-attribute";
+
+export interface BlockVariationAuthoringDiagnostic {
+  readonly attribute?: string | undefined;
+  readonly blockName: string;
+  readonly code: BlockVariationDiagnosticCode;
+  readonly message: string;
+  readonly severity: "error" | "warning";
+  readonly variationName: string;
+}
+
+export type BlockVariationDiagnostic =
+  | BlockVariationAuthoringDiagnostic
+  | WordPressBlockApiCompatibilityDiagnostic;
+
+export interface BlockVariationRegistrationEntry {
+  readonly blockName: string;
+  readonly variation: Readonly<BlockVariationDefinition>;
+}
+
+export interface CreateBlockVariationRegistrationSourceOptions {
+  readonly functionName?: string;
+  readonly importSource?: string;
+}
+
+const DEFINE_VARIATION_INLINE_OPTION_KEYS = new Set<string>([
+  "allowMissingIsActive",
+  "minVersion",
+  "minWordPress",
+  "onDiagnostic",
+  "requireIsActive",
+  "strict",
+]);
+
+const STABLE_VARIATION_MARKER_ATTRIBUTES = [
+  "className",
+  "namespace",
+  "wpTypiaVariation",
+] as const;
+
+function isObjectRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function splitDefineVariationInput<
+  TAttributes extends BlockAttributes,
+  TVariation extends BlockVariationDefinition<TAttributes> &
+    DefineVariationInlineOptions,
+>(variation: TVariation): {
+  inlineOptions: DefineVariationInlineOptions;
+  variation: StripDefineVariationOptions<TVariation> &
+    BlockVariationDefinition<TAttributes>;
+} {
+  const inlineOptions: DefineVariationInlineOptions = {};
+  const normalizedVariation: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(variation)) {
+    if (DEFINE_VARIATION_INLINE_OPTION_KEYS.has(key)) {
+      Object.assign(inlineOptions, { [key]: value });
+      continue;
+    }
+
+    normalizedVariation[key] = value;
+  }
+
+  return {
+    inlineOptions,
+    variation: normalizedVariation as StripDefineVariationOptions<TVariation> &
+      BlockVariationDefinition<TAttributes>,
+  };
+}
+
+function resolveDefineVariationSettings(
+  inlineOptions: DefineVariationInlineOptions,
+  options: DefineVariationOptions,
+): {
+  compatibility: WordPressCompatibilitySettings;
+  diagnostics: {
+    allowMissingIsActive: boolean;
+    requireIsActive: boolean;
+    strict: boolean;
+  };
+  onDiagnostic: DefineVariationOptions["onDiagnostic"];
+} {
+  const compatibility: WordPressCompatibilitySettings = {};
+  const allowUnknownFutureKeys = options.allowUnknownFutureKeys;
+  const minVersion =
+    options.minVersion ??
+    options.minWordPress ??
+    inlineOptions.minVersion ??
+    inlineOptions.minWordPress;
+  const strict = options.strict ?? inlineOptions.strict ?? true;
+
+  if (allowUnknownFutureKeys !== undefined) {
+    Object.assign(compatibility, { allowUnknownFutureKeys });
+  }
+  if (minVersion !== undefined) {
+    Object.assign(compatibility, { minVersion });
+  }
+  Object.assign(compatibility, { strict });
+
+  return {
+    compatibility,
+    diagnostics: {
+      allowMissingIsActive:
+        options.allowMissingIsActive ?? inlineOptions.allowMissingIsActive ?? false,
+      requireIsActive:
+        options.requireIsActive ?? inlineOptions.requireIsActive ?? true,
+      strict,
+    },
+    onDiagnostic: options.onDiagnostic ?? inlineOptions.onDiagnostic,
+  };
+}
+
+function getDiagnosticSeverity(strict: boolean): "error" | "warning" {
+  return strict ? "error" : "warning";
+}
+
+export function collectBlockVariationCompatibilityFeatures(): readonly WordPressBlockApiCompatibilityFeature[] {
+  return [
+    {
+      area: "blockVariations",
+      feature: "editorRegistration",
+    },
+  ];
+}
+
+export function createBlockVariationCompatibilityManifest(
+  settings: DefineVariationOptions = {},
+): WordPressBlockApiCompatibilityManifest {
+  const resolved = resolveDefineVariationSettings({}, settings);
+
+  return createWordPressBlockApiCompatibilityManifest(
+    collectBlockVariationCompatibilityFeatures(),
+    resolved.compatibility,
+  );
+}
+
+function hasStableMarkerAttribute<TAttributes extends BlockAttributes>(
+  attributes: BlockVariationDefinition<TAttributes>["attributes"],
+): boolean {
+  if (!isObjectRecord(attributes)) {
+    return false;
+  }
+
+  return STABLE_VARIATION_MARKER_ATTRIBUTES.some((key) => key in attributes);
+}
+
+function createVariationDiagnostics<TAttributes extends BlockAttributes>(
+  blockName: string,
+  variation: BlockVariationDefinition<TAttributes>,
+  options: ReturnType<typeof resolveDefineVariationSettings>["diagnostics"],
+): readonly BlockVariationAuthoringDiagnostic[] {
+  const diagnostics: BlockVariationAuthoringDiagnostic[] = [];
+  const variationName = variation.name;
+  const attributes = variation.attributes;
+  const isActive = variation.isActive;
+
+  if (
+    options.requireIsActive &&
+    !options.allowMissingIsActive &&
+    !variation.isDefault &&
+    isActive === undefined
+  ) {
+    diagnostics.push({
+      blockName,
+      code: "missing-is-active",
+      message: `Block variation "${variationName}" for "${blockName}" does not declare isActive; add an active discriminator or set allowMissingIsActive.`,
+      severity: "warning",
+      variationName,
+    });
+  }
+
+  if (
+    options.requireIsActive &&
+    !options.allowMissingIsActive &&
+    !variation.isDefault &&
+    isActive === undefined &&
+    !hasStableMarkerAttribute(attributes)
+  ) {
+    diagnostics.push({
+      blockName,
+      code: "missing-stable-marker",
+      message: `Block variation "${variationName}" for "${blockName}" has no stable marker attribute such as className, namespace, or wpTypiaVariation.`,
+      severity: "warning",
+      variationName,
+    });
+  }
+
+  if (Array.isArray(isActive)) {
+    for (const attribute of isActive) {
+      if (!isObjectRecord(attributes) || !(attribute in attributes)) {
+        diagnostics.push({
+          attribute,
+          blockName,
+          code: "unknown-is-active-attribute",
+          message: `Block variation "${variationName}" for "${blockName}" uses isActive attribute "${attribute}" that is not present in its attributes.`,
+          severity: "warning",
+          variationName,
+        });
+      }
+    }
+  }
+
+  return diagnostics;
+}
+
+function handleVariationDiagnostics(
+  diagnostics: readonly BlockVariationDiagnostic[],
+  onDiagnostic: DefineVariationOptions["onDiagnostic"],
+): void {
+  const errors = diagnostics.filter(
+    (diagnostic) => diagnostic.severity === "error",
+  );
+
+  if (errors.length > 0) {
+    throw new Error(
+      [
+        "WordPress block variation check failed:",
+        ...errors.map((diagnostic) => `- ${diagnostic.message}`),
+      ].join("\n"),
+    );
+  }
+
+  for (const diagnostic of diagnostics) {
+    if (onDiagnostic) {
+      onDiagnostic(diagnostic);
+      continue;
+    }
+
+    console.warn(`[wp-typia] ${diagnostic.message}`);
+  }
+}
+
+export function getDefinedVariationMetadata(
+  variation: unknown,
+): DefinedBlockVariationMetadata | undefined {
+  return isObjectRecord(variation)
+    ? (
+        variation as {
+          readonly [DEFINED_BLOCK_VARIATION_METADATA]?:
+            | DefinedBlockVariationMetadata
+            | undefined;
+        }
+      )[DEFINED_BLOCK_VARIATION_METADATA]
+    : undefined;
+}
+
+export function getDefinedVariationBlockName(
+  variation: unknown,
+): string | undefined {
+  return getDefinedVariationMetadata(variation)?.blockName;
+}
+
+export function getDefinedVariationCompatibilityManifest(
+  variation: unknown,
+): WordPressBlockApiCompatibilityManifest | undefined {
+  return getDefinedVariationMetadata(variation)?.manifest;
+}
+
+export function getDefinedVariationsMetadata(
+  variations: unknown,
+): DefinedBlockVariationsMetadata | undefined {
+  return Array.isArray(variations)
+    ? (
+        variations as {
+          readonly [DEFINED_BLOCK_VARIATIONS_METADATA]?:
+            | DefinedBlockVariationsMetadata
+            | undefined;
+        }
+      )[DEFINED_BLOCK_VARIATIONS_METADATA]
+    : undefined;
+}
+
+export function defineVariation<
+  TAttributes extends BlockAttributes = BlockAttributes,
+  const TBlockName extends string = string,
+  const TVariation extends BlockVariationDefinition<TAttributes> &
+    DefineVariationInlineOptions = BlockVariationDefinition<TAttributes> &
+    DefineVariationInlineOptions,
+>(
+  blockName: TBlockName,
+  variation: TVariation,
+	options: DefineVariationOptions = {},
+): DefinedBlockVariation<TBlockName, TAttributes, TVariation> {
+	const { inlineOptions, variation: normalizedVariation } =
+		splitDefineVariationInput<TAttributes, TVariation>(variation);
+  const resolved = resolveDefineVariationSettings(inlineOptions, options);
+  const manifest = createWordPressBlockApiCompatibilityManifest(
+    collectBlockVariationCompatibilityFeatures(),
+    resolved.compatibility,
+  );
+  const diagnostics = [
+    ...manifest.diagnostics,
+    ...createVariationDiagnostics(
+      blockName,
+      normalizedVariation,
+      resolved.diagnostics,
+    ),
+  ];
+
+  handleVariationDiagnostics(diagnostics, resolved.onDiagnostic);
+
+  Object.defineProperty(normalizedVariation, DEFINED_BLOCK_VARIATION_METADATA, {
+    configurable: false,
+    enumerable: false,
+    value: {
+      blockName,
+      diagnostics,
+      manifest,
+    } satisfies DefinedBlockVariationMetadata,
+    writable: false,
+  });
+
+  return normalizedVariation as DefinedBlockVariation<
+    TBlockName,
+    TAttributes,
+    TVariation
+  >;
+}
+
+function createCollectionDiagnostics(
+  entries: readonly BlockVariationRegistrationEntry[],
+  strict: boolean,
+): readonly BlockVariationAuthoringDiagnostic[] {
+  const diagnostics: BlockVariationAuthoringDiagnostic[] = [];
+  const seenNames = new Map<string, BlockVariationRegistrationEntry>();
+  const seenActiveMarkers = new Map<string, BlockVariationRegistrationEntry>();
+
+  for (const entry of entries) {
+    const nameKey = `${entry.blockName}:${entry.variation.name}`;
+    const activeMarker = Array.isArray(entry.variation.isActive)
+      ? entry.variation.isActive.join("|")
+      : undefined;
+
+    if (seenNames.has(nameKey)) {
+      diagnostics.push({
+        blockName: entry.blockName,
+        code: "duplicate-variation-name",
+        message: `Duplicate block variation name "${entry.variation.name}" for "${entry.blockName}".`,
+        severity: getDiagnosticSeverity(strict),
+        variationName: entry.variation.name,
+      });
+    }
+    seenNames.set(nameKey, entry);
+
+    if (activeMarker && activeMarker.length > 0) {
+      const markerKey = `${entry.blockName}:${activeMarker}`;
+      const existing = seenActiveMarkers.get(markerKey);
+
+      if (existing) {
+        diagnostics.push({
+          blockName: entry.blockName,
+          code: "duplicate-active-marker",
+          message: `Block variations "${existing.variation.name}" and "${entry.variation.name}" for "${entry.blockName}" share the same isActive discriminator "${activeMarker}".`,
+          severity: "warning",
+          variationName: entry.variation.name,
+        });
+      }
+      seenActiveMarkers.set(markerKey, entry);
+    }
+  }
+
+  return diagnostics;
+}
+
+export function createBlockVariationRegistrationPlan(
+  variations: readonly DefinedBlockVariation[],
+): readonly BlockVariationRegistrationEntry[] {
+  return variations.map((variation) => {
+    const metadata = getDefinedVariationMetadata(variation);
+
+    if (!metadata) {
+      throw new Error(
+        `Block variation "${variation.name}" was not created by defineVariation().`,
+      );
+    }
+
+    return {
+      blockName: metadata.blockName,
+      variation,
+    };
+  });
+}
+
+export function defineVariations<
+  const TVariations extends readonly DefinedBlockVariation[],
+>(
+  variations: TVariations,
+  options: DefineVariationOptions = {},
+): DefinedBlockVariations<TVariations> {
+  const entries = createBlockVariationRegistrationPlan(variations);
+  const strict = options.strict ?? true;
+  const diagnostics = [
+    ...entries.flatMap(
+      (entry) => getDefinedVariationMetadata(entry.variation)?.diagnostics ?? [],
+    ),
+    ...createCollectionDiagnostics(entries, strict),
+  ];
+
+  handleVariationDiagnostics(diagnostics, options.onDiagnostic);
+
+  const normalizedVariations = [...variations] as unknown as DefinedBlockVariations<
+    TVariations
+  >;
+
+  Object.defineProperty(
+    normalizedVariations,
+    DEFINED_BLOCK_VARIATIONS_METADATA,
+    {
+      configurable: false,
+      enumerable: false,
+      value: {
+        diagnostics,
+        entries,
+      } satisfies DefinedBlockVariationsMetadata,
+      writable: false,
+    },
+  );
+
+  return normalizedVariations;
+}
+
+function normalizeStaticRegistrationValue(value: unknown, path: string): unknown {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (
+    value === null ||
+    typeof value === "boolean" ||
+    typeof value === "number" ||
+    typeof value === "string"
+  ) {
+    return value;
+  }
+  if (typeof value === "function") {
+    throw new Error(
+      `Cannot generate static variation registration code for function value at ${path}.`,
+    );
+  }
+  if (typeof value === "bigint" || typeof value === "symbol") {
+    throw new Error(
+      `Cannot generate static variation registration code for ${typeof value} value at ${path}.`,
+    );
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry, index) =>
+      normalizeStaticRegistrationValue(entry, `${path}[${index}]`),
+    );
+  }
+  if (isObjectRecord(value)) {
+    const normalized: Record<string, unknown> = {};
+
+    for (const [key, nestedValue] of Object.entries(value)) {
+      const nextValue = normalizeStaticRegistrationValue(
+        nestedValue,
+        `${path}.${key}`,
+      );
+
+      if (nextValue !== undefined) {
+        normalized[key] = nextValue;
+      }
+    }
+
+    return normalized;
+  }
+
+  throw new Error(
+    `Cannot generate static variation registration code for unsupported value at ${path}.`,
+  );
+}
+
+export function createStaticBlockVariationRegistrationSource(
+  variations: readonly DefinedBlockVariation[],
+  options: CreateBlockVariationRegistrationSourceOptions = {},
+): string {
+  const importSource = options.importSource ?? "@wordpress/blocks";
+  const functionName = options.functionName ?? "registerWpTypiaBlockVariations";
+  const entries = createBlockVariationRegistrationPlan(variations).map(
+    (entry, index) =>
+      normalizeStaticRegistrationValue(entry, `variations[${index}]`),
+  );
+  const serializedEntries = JSON.stringify(entries, null, 2);
+
+  return [
+    `import { registerBlockVariation } from ${JSON.stringify(importSource)};`,
+    "",
+    `const variations = ${serializedEntries};`,
+    "",
+    `export function ${functionName}() {`,
+    "  for (const { blockName, variation } of variations) {",
+    "    registerBlockVariation(blockName, variation);",
+    "  }",
+    "}",
+    "",
+  ].join("\n");
+}

--- a/packages/wp-typia-block-types/tests/fixtures/public-type-contracts.ts
+++ b/packages/wp-typia-block-types/tests/fixtures/public-type-contracts.ts
@@ -81,6 +81,13 @@ import {
 	type SupportAttributes,
 	type TypographySupportKey,
 } from "@wp-typia/block-types/blocks/supports";
+import {
+	createStaticBlockVariationRegistrationSource,
+	defineVariation,
+	defineVariations,
+	getDefinedVariationsMetadata,
+	type BlockVariationRegistrationEntry,
+} from "@wp-typia/block-types/blocks/variations";
 
 const alignments = BLOCK_ALIGNMENTS satisfies readonly BlockAlignment[];
 const contentPositions =
@@ -178,6 +185,67 @@ const alignWideDoesNotExposeAlign: "align" extends keyof AlignWideOnlySupportAtt
 type ExampleAttributes = SupportAttributes<typeof proseSupports> & {
 	content: string;
 };
+
+type ParagraphVariationAttributes = {
+	className?: string;
+	content?: string;
+};
+type HeadingVariationAttributes = {
+	className?: string;
+	level?: number;
+};
+
+const paragraphVariation = defineVariation<ParagraphVariationAttributes>(
+	"core/paragraph",
+	{
+		attributes: {
+			className: "is-style-balanced",
+		},
+		isActive: ["className"],
+		name: "example-balanced-paragraph",
+		scope: ["inserter", "transform"],
+		title: "Balanced Paragraph",
+	},
+);
+const headingVariation = defineVariation<HeadingVariationAttributes>(
+	"core/heading",
+	{
+		attributes: {
+			className: "is-style-balanced-heading",
+			level: 2,
+		},
+		isActive: ["className", "level"],
+		name: "example-balanced-heading",
+		scope: ["inserter", "transform"],
+		title: "Balanced Heading",
+	},
+);
+const proseGroupVariation = defineVariation("core/group", {
+	attributes: {
+		className: "is-style-prose-group",
+	},
+	innerBlocks: [
+		["core/heading", { level: 2, placeholder: "Title" }],
+		["core/paragraph", { placeholder: "Write..." }],
+	],
+	isActive: ["className"],
+	name: "example-prose-group",
+	scope: ["inserter"],
+	title: "Prose Group",
+});
+const blockVariations = defineVariations([
+	paragraphVariation,
+	headingVariation,
+	proseGroupVariation,
+] as const);
+const variationEntries = getDefinedVariationsMetadata(blockVariations)?.entries;
+const variationRegistrationEntry: BlockVariationRegistrationEntry =
+	variationEntries?.[0] ?? {
+		blockName: "core/paragraph",
+		variation: paragraphVariation,
+	};
+const variationRegistrationSource =
+	createStaticBlockVariationRegistrationSource(blockVariations);
 
 declare const configuration: BlockConfiguration<ExampleAttributes>;
 declare const editProps: BlockEditProps<ExampleAttributes>;
@@ -299,6 +367,13 @@ void alignSupports;
 void alignSupportHasAlign;
 void alignWideOnlySupports;
 void alignWideDoesNotExposeAlign;
+void paragraphVariation;
+void headingVariation;
+void proseGroupVariation;
+void blockVariations;
+void variationEntries;
+void variationRegistrationEntry;
+void variationRegistrationSource;
 void registrationResult;
 void content;
 void maybeVariationTitle;
@@ -320,7 +395,21 @@ const invalidVariationScope: BlockVariationScope = "toolbar";
 // @ts-expect-error Typography textAlign should only accept text alignment values.
 const invalidTextAlignments = ["wide"] satisfies readonly TextAlignment[];
 
+const invalidVariationActiveAttribute = defineVariation<HeadingVariationAttributes>(
+	"core/heading",
+	{
+		attributes: {
+			level: 2,
+		},
+		// @ts-expect-error Variation isActive should reference typed variation attributes.
+		isActive: ["missing"],
+		name: "invalid-heading-variation",
+		title: "Invalid Heading Variation",
+	},
+);
+
 void invalidBlockAlignment;
 void invalidNamedColor;
 void invalidVariationScope;
 void invalidTextAlignments;
+void invalidVariationActiveAttribute;

--- a/packages/wp-typia-block-types/tests/package-contracts.test.ts
+++ b/packages/wp-typia-block-types/tests/package-contracts.test.ts
@@ -37,6 +37,10 @@ function writeMockWordPressBlocks(projectRoot: string) {
 			"export function registerBlockType(name, settings) {",
 			"  return { name, settings, source: '@wordpress/blocks' };",
 			"}",
+			"export function registerBlockVariation(blockName, variation) {",
+			"  globalThis.__wpTypiaRegisteredVariations ??= [];",
+			"  globalThis.__wpTypiaRegisteredVariations.push({ blockName, variation });",
+			"}",
 			"",
 		].join("\n"),
 		"utf8",
@@ -106,6 +110,11 @@ describe("@wp-typia/block-types export contracts", () => {
 			import: "./dist/blocks/supports.js",
 			types: "./dist/blocks/supports.d.ts",
 		});
+		expect(packageJson.exports?.["./blocks/variations"]).toEqual({
+			default: "./dist/blocks/variations.js",
+			import: "./dist/blocks/variations.js",
+			types: "./dist/blocks/variations.d.ts",
+		});
 	});
 
 	test("published self imports resolve through the package entrypoints with the expected runtime values", () => {
@@ -132,12 +141,19 @@ describe("@wp-typia/block-types export contracts", () => {
 							"const compatibility = await import('@wp-typia/block-types/blocks/compatibility');",
 							"const registration = await import('@wp-typia/block-types/blocks/registration');",
 							"const supports = await import('@wp-typia/block-types/blocks/supports');",
+							"const variations = await import('@wp-typia/block-types/blocks/variations');",
 							"const registered = registration.registerScaffoldBlockType('wp-typia/demo', { title: 'Demo' });",
 							"const definedSupports = supports.defineSupports({ minWordPress: '6.6', spacing: { padding: true }, typography: { fontSize: true } });",
 							"const supportsManifest = supports.getDefinedSupportsCompatibilityManifest(definedSupports);",
+							"const paragraphVariation = variations.defineVariation('core/paragraph', { allowMissingIsActive: true, name: 'demo-paragraph', title: 'Demo Paragraph', attributes: { className: 'is-style-demo' } });",
+							"const variationManifest = variations.getDefinedVariationCompatibilityManifest(paragraphVariation);",
+							"const variationSource = variations.createStaticBlockVariationRegistrationSource([paragraphVariation]);",
 							"console.log(JSON.stringify({",
 							"  definedSupportsPadding: definedSupports.spacing.padding,",
 							"  definedSupportsManifestFeatures: supportsManifest.supported.map((feature) => feature.feature),",
+							"  definedVariationBlockName: variations.getDefinedVariationBlockName(paragraphVariation),",
+							"  definedVariationManifestFeatures: variationManifest.supported.map((feature) => feature.feature),",
+							"  rootHasVariations: typeof root.defineVariation === 'function',",
 							"  rootHasRegister: typeof root.registerScaffoldBlockType === 'function',",
 							"  rootHasSupports: Array.isArray(root.BLOCK_SUPPORT_FEATURES),",
 							"  blockEditorHasSpacing: Array.isArray(blockEditor.SPACING_DIMENSIONS),",
@@ -149,6 +165,7 @@ describe("@wp-typia/block-types export contracts", () => {
 							"  spacingDimensions: spacing.SPACING_DIMENSIONS,",
 							"  textDecorations: typography.TEXT_DECORATIONS,",
 							"  supportsFeatures: supports.BLOCK_SUPPORT_FEATURES,",
+							"  variationSourceHasRegistration: variationSource.includes('registerBlockVariation(blockName, variation);'),",
 							"  variationScopes: registration.BLOCK_VARIATION_SCOPES,",
 							"  registeredName: registered?.name ?? null,",
 							"  registeredTitle: registered?.settings?.title ?? null,",
@@ -165,6 +182,8 @@ describe("@wp-typia/block-types export contracts", () => {
 				alignments: string[];
 				aspectRatios: string[];
 				blockEditorHasSpacing: boolean;
+				definedVariationBlockName: string | undefined;
+				definedVariationManifestFeatures: string[];
 				definedSupportsManifestFeatures: string[];
 				definedSupportsPadding: boolean;
 				layoutTypes: string[];
@@ -173,21 +192,28 @@ describe("@wp-typia/block-types export contracts", () => {
 				registeredTitle: string | null;
 				rootHasRegister: boolean;
 				rootHasSupports: boolean;
+				rootHasVariations: boolean;
 				manifestStatus: string | null;
 				spacingDimensions: string[];
 				styleAttributeKeys: string[];
 				supportsFeatures: string[];
 				textDecorations: string[];
+				variationSourceHasRegistration: boolean;
 				variationScopes: string[];
 			},
 		);
 
 		expect(summary.rootHasRegister).toBe(true);
 		expect(summary.rootHasSupports).toBe(true);
+		expect(summary.rootHasVariations).toBe(true);
 		expect(summary.definedSupportsPadding).toBe(true);
 		expect(summary.definedSupportsManifestFeatures).toEqual([
 			"spacing.padding",
 			"typography.fontSize",
+		]);
+		expect(summary.definedVariationBlockName).toBe("core/paragraph");
+		expect(summary.definedVariationManifestFeatures).toEqual([
+			"editorRegistration",
 		]);
 		expect(summary.blockEditorHasSpacing).toBe(true);
 		expect(summary.alignments).toEqual(["left", "center", "right", "wide", "full"]);
@@ -211,6 +237,7 @@ describe("@wp-typia/block-types export contracts", () => {
 		]);
 		expect(summary.textDecorations).toEqual(["none", "underline", "line-through"]);
 		expect(summary.supportsFeatures).toContain("interactivity");
+		expect(summary.variationSourceHasRegistration).toBe(true);
 		expect(summary.variationScopes).toEqual(["block", "inserter", "transform"]);
 		expect(summary.registeredName).toBe("wp-typia/demo");
 		expect(summary.registeredTitle).toBe("Demo");
@@ -238,5 +265,6 @@ describe("@wp-typia/block-types export contracts", () => {
 		expect(builtBlocksIndexJs).toContain('export * from "./registration.js";');
 		expect(builtBlocksIndexJs).toContain('export * from "./supports.js";');
 		expect(builtBlocksIndexJs).toContain('export * from "./compatibility.js";');
+		expect(builtBlocksIndexJs).toContain('export * from "./variations.js";');
 	});
 });

--- a/packages/wp-typia-block-types/tests/type-contracts.test.ts
+++ b/packages/wp-typia-block-types/tests/type-contracts.test.ts
@@ -39,12 +39,15 @@ describe("@wp-typia/block-types type contracts", () => {
 		expect(fixtureSource).toContain("@wp-typia/block-types/blocks/registration");
 		expect(fixtureSource).toContain("@wp-typia/block-types/blocks/compatibility");
 		expect(fixtureSource).toContain("@wp-typia/block-types/blocks/supports");
+		expect(fixtureSource).toContain("@wp-typia/block-types/blocks/variations");
 		expect(fixtureSource).toContain(
 			"@wp-typia/block-types/block-editor/style-attributes",
 		);
 		expect(fixtureSource).toContain("@ts-expect-error");
 		expect(fixtureSource).toContain("defineSupports");
 		expect(fixtureSource).toContain("SupportAttributes<typeof proseSupports>");
+		expect(fixtureSource).toContain("defineVariation");
+		expect(fixtureSource).toContain("defineVariations");
 		expect(fixtureSource).toContain("registerScaffoldBlockType");
 	});
 });

--- a/packages/wp-typia-block-types/tests/variations.test.ts
+++ b/packages/wp-typia-block-types/tests/variations.test.ts
@@ -290,6 +290,41 @@ describe("defineVariations", () => {
 		]);
 	});
 
+	test("stores per-variation diagnostics without re-emitting them from collections", () => {
+		const variationDiagnostics: BlockVariationDiagnostic[] = [];
+		const collectionDiagnostics: BlockVariationDiagnostic[] = [];
+		const variation = defineVariation<ParagraphAttributes>(
+			"core/paragraph",
+			{
+				attributes: {
+					className: "is-style-passive",
+				},
+				name: "example-passive-paragraph",
+				title: "Passive Paragraph",
+			},
+			{
+				onDiagnostic: (diagnostic) => variationDiagnostics.push(diagnostic),
+			},
+		);
+		const variations = defineVariations([variation] as const, {
+			onDiagnostic: (diagnostic) => collectionDiagnostics.push(diagnostic),
+		});
+
+		expect(variationDiagnostics).toMatchObject([
+			{
+				code: "missing-is-active",
+				variationName: "example-passive-paragraph",
+			},
+		]);
+		expect(collectionDiagnostics).toEqual([]);
+		expect(getDefinedVariationsMetadata(variations)?.diagnostics).toMatchObject([
+			{
+				code: "missing-is-active",
+				variationName: "example-passive-paragraph",
+			},
+		]);
+	});
+
 	test("rejects function-based isActive when generating static registration source", () => {
 		const variation = defineVariation<ParagraphAttributes>("core/paragraph", {
 			attributes: {

--- a/packages/wp-typia-block-types/tests/variations.test.ts
+++ b/packages/wp-typia-block-types/tests/variations.test.ts
@@ -1,0 +1,307 @@
+import { describe, expect, test } from "bun:test";
+
+import type { BlockVariationDiagnostic } from "../src/blocks/variations";
+import {
+	createStaticBlockVariationRegistrationSource,
+	defineVariation,
+	defineVariations,
+	getDefinedVariationBlockName,
+	getDefinedVariationCompatibilityManifest,
+	getDefinedVariationMetadata,
+	getDefinedVariationsMetadata,
+} from "../src/blocks/variations";
+
+interface ParagraphAttributes {
+	className?: string;
+	content?: string;
+}
+
+interface HeadingAttributes {
+	className?: string;
+	level?: number;
+}
+
+interface TestimonialAttributes {
+	className?: string;
+	layout?: "card" | "quote";
+}
+
+describe("defineVariation", () => {
+	test("returns registration-ready metadata and stores target details out of band", () => {
+		const variation = defineVariation<ParagraphAttributes>("core/paragraph", {
+			attributes: {
+				className: "is-style-balanced",
+			},
+			description: "An opinionated paragraph style.",
+			isActive: ["className"],
+			name: "example-balanced-paragraph",
+			scope: ["inserter", "transform"],
+			title: "Balanced Paragraph",
+		});
+		const manifest = getDefinedVariationCompatibilityManifest(variation);
+
+		expect(variation).toEqual({
+			attributes: {
+				className: "is-style-balanced",
+			},
+			description: "An opinionated paragraph style.",
+			isActive: ["className"],
+			name: "example-balanced-paragraph",
+			scope: ["inserter", "transform"],
+			title: "Balanced Paragraph",
+		});
+		expect(JSON.parse(JSON.stringify(variation))).toEqual(variation);
+		expect(getDefinedVariationBlockName(variation)).toBe("core/paragraph");
+		expect(getDefinedVariationMetadata(variation)?.diagnostics).toEqual([]);
+		expect(manifest?.supported.map((feature) => feature.feature)).toEqual([
+			"editorRegistration",
+		]);
+	});
+
+	test("reports missing active detection unless explicitly disabled", () => {
+		const diagnostics: BlockVariationDiagnostic[] = [];
+		const variation = defineVariation<ParagraphAttributes>("core/paragraph", {
+			allowMissingIsActive: true,
+			attributes: {
+				className: "is-style-quiet",
+			},
+			name: "example-quiet-paragraph",
+			title: "Quiet Paragraph",
+		});
+
+		defineVariation<ParagraphAttributes>(
+			"core/paragraph",
+			{
+				attributes: {
+					className: "is-style-editorial",
+				},
+				name: "example-editorial-paragraph",
+				title: "Editorial Paragraph",
+			},
+			{
+				onDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+			},
+		);
+
+		expect(getDefinedVariationMetadata(variation)?.diagnostics).toEqual([]);
+		expect(diagnostics).toMatchObject([
+			{
+				code: "missing-is-active",
+				severity: "warning",
+				variationName: "example-editorial-paragraph",
+			},
+		]);
+	});
+
+	test("warns when isActive references attributes not declared by the variation", () => {
+		const diagnostics: BlockVariationDiagnostic[] = [];
+
+		defineVariation<HeadingAttributes>(
+			"core/heading",
+			{
+				attributes: {
+					className: "is-style-balanced-heading",
+				},
+				isActive: ["level"],
+				name: "example-balanced-heading",
+				title: "Balanced Heading",
+			},
+			{
+				onDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+			},
+		);
+
+		expect(diagnostics).toMatchObject([
+			{
+				attribute: "level",
+				code: "unknown-is-active-attribute",
+				severity: "warning",
+			},
+		]);
+	});
+
+	test("throws in strict mode when editor registration is below the WordPress floor", () => {
+		expect(() =>
+			defineVariation<ParagraphAttributes>("core/paragraph", {
+				attributes: {
+					className: "is-style-legacy",
+				},
+				isActive: ["className"],
+				minWordPress: "5.3",
+				name: "example-legacy-paragraph",
+				title: "Legacy Paragraph",
+			}),
+		).toThrow("registerBlockVariation() editor registration requires WordPress 5.4+");
+	});
+});
+
+describe("defineVariations", () => {
+	test("collects multiple core block variations and generates static registration code", () => {
+		const paragraphVariation = defineVariation<ParagraphAttributes>("core/paragraph", {
+			attributes: {
+				className: "is-style-balanced",
+			},
+			isActive: ["className"],
+			name: "example-balanced-paragraph",
+			scope: ["inserter", "transform"],
+			title: "Balanced Paragraph",
+		});
+		const headingVariation = defineVariation<HeadingAttributes>("core/heading", {
+			attributes: {
+				className: "is-style-balanced-heading",
+				level: 2,
+			},
+			isActive: ["className", "level"],
+			name: "example-balanced-heading",
+			scope: ["inserter", "transform"],
+			title: "Balanced Heading",
+		});
+		const groupVariation = defineVariation("core/group", {
+			attributes: {
+				className: "is-style-prose-group",
+			},
+			innerBlocks: [
+				["core/heading", { level: 2, placeholder: "Title" }],
+				["core/paragraph", { placeholder: "Write..." }],
+			],
+			isActive: ["className"],
+			name: "example-prose-group",
+			scope: ["inserter", "transform"],
+			title: "Prose Group",
+		});
+		const queryVariation = defineVariation("core/query", {
+			attributes: {
+				namespace: "example/books-query",
+				query: {
+					postType: "book",
+				},
+			},
+			innerBlocks: [
+				["core/post-template", {}, [["core/post-title"], ["core/post-excerpt"]]],
+			],
+			isActive: ["namespace"],
+			name: "example-books-query",
+			scope: ["inserter"],
+			title: "Books Query",
+		});
+		const testimonialVariation = defineVariation<TestimonialAttributes>(
+			"acme/testimonial",
+			{
+				attributes: {
+					className: "is-style-featured-testimonial",
+					layout: "card",
+				},
+				isActive: ["className", "layout"],
+				name: "acme-featured-testimonial",
+				scope: ["inserter"],
+				title: "Featured Testimonial",
+			},
+		);
+		const variations = defineVariations([
+			paragraphVariation,
+			headingVariation,
+			groupVariation,
+			queryVariation,
+			testimonialVariation,
+		] as const);
+		const source = createStaticBlockVariationRegistrationSource(variations);
+
+		expect(getDefinedVariationsMetadata(variations)?.entries).toMatchObject([
+			{
+				blockName: "core/paragraph",
+				variation: {
+					name: "example-balanced-paragraph",
+				},
+			},
+			{
+				blockName: "core/heading",
+				variation: {
+					name: "example-balanced-heading",
+				},
+			},
+			{
+				blockName: "core/group",
+				variation: {
+					name: "example-prose-group",
+				},
+			},
+			{
+				blockName: "core/query",
+				variation: {
+					name: "example-books-query",
+				},
+			},
+			{
+				blockName: "acme/testimonial",
+				variation: {
+					name: "acme-featured-testimonial",
+				},
+			},
+		]);
+		expect(source).toContain(
+			'import { registerBlockVariation } from "@wordpress/blocks";',
+		);
+		expect(source).toContain('"blockName": "core/query"');
+		expect(source).toContain('"blockName": "acme/testimonial"');
+		expect(source).toContain('"name": "example-books-query"');
+		expect(source).toContain("registerBlockVariation(blockName, variation);");
+	});
+
+	test("detects duplicate variation names and active discriminators", () => {
+		const first = defineVariation<ParagraphAttributes>("core/paragraph", {
+			attributes: {
+				className: "is-style-first",
+			},
+			isActive: ["className"],
+			name: "example-duplicate",
+			title: "First",
+		});
+		const duplicateName = defineVariation<ParagraphAttributes>("core/paragraph", {
+			attributes: {
+				className: "is-style-second",
+			},
+			isActive: ["className"],
+			name: "example-duplicate",
+			title: "Second",
+		});
+		const duplicateMarker = defineVariation<ParagraphAttributes>("core/paragraph", {
+			attributes: {
+				className: "is-style-third",
+			},
+			isActive: ["className"],
+			name: "example-third",
+			title: "Third",
+		});
+		const diagnostics: BlockVariationDiagnostic[] = [];
+
+		expect(() => defineVariations([first, duplicateName] as const)).toThrow(
+			'Duplicate block variation name "example-duplicate"',
+		);
+		defineVariations([first, duplicateMarker] as const, {
+			onDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+		});
+
+		expect(diagnostics).toMatchObject([
+			{
+				code: "duplicate-active-marker",
+				severity: "warning",
+				variationName: "example-third",
+			},
+		]);
+	});
+
+	test("rejects function-based isActive when generating static registration source", () => {
+		const variation = defineVariation<ParagraphAttributes>("core/paragraph", {
+			attributes: {
+				className: "is-style-dynamic",
+			},
+			isActive: (attributes) => attributes.className === "is-style-dynamic",
+			name: "example-dynamic-paragraph",
+			title: "Dynamic Paragraph",
+		});
+
+		expect(() => createStaticBlockVariationRegistrationSource([variation])).toThrow(
+			"function value",
+		);
+	});
+});

--- a/tests/type-smoke/block-types-smoke.ts
+++ b/tests/type-smoke/block-types-smoke.ts
@@ -50,6 +50,16 @@ import type {
   SupportAttributes,
   TypographySupportKey,
 } from '@wp-typia/block-types/blocks/supports';
+import {
+  createStaticBlockVariationRegistrationSource,
+  defineVariation,
+  defineVariations,
+  getDefinedVariationsMetadata,
+} from '@wp-typia/block-types/blocks/variations';
+import type {
+  BlockVariationDiagnostic,
+  BlockVariationRegistrationEntry,
+} from '@wp-typia/block-types/blocks/variations';
 
 const aspectRatio: AspectRatio = '16/9';
 const blockAlignment: BlockAlignment = 'wide';
@@ -276,6 +286,43 @@ const variation = {
   scope: ['inserter'],
   title: 'Smoke Variation',
 } satisfies BlockVariation<DemoRegistrationAttributes>;
+const typedParagraphVariation = defineVariation<DemoRegistrationAttributes>(
+  'core/paragraph',
+  {
+    attributes: {
+      content: 'Typed paragraph',
+      isVisible: true,
+    },
+    isActive: ['isVisible'],
+    name: 'typed-paragraph',
+    scope: ['inserter', 'transform'],
+    title: 'Typed Paragraph',
+  },
+);
+const typedGroupVariation = defineVariation('core/group', {
+  attributes: {
+    className: 'is-style-smoke-group',
+  },
+  innerBlocks: [
+    ['core/heading', { level: 2, placeholder: 'Title' }],
+    ['core/paragraph', { placeholder: 'Write...' }],
+  ],
+  isActive: ['className'],
+  name: 'typed-group',
+  scope: ['inserter'],
+  title: 'Typed Group',
+});
+const typedVariations = defineVariations([
+  typedParagraphVariation,
+  typedGroupVariation,
+] as const);
+const typedVariationEntries = getDefinedVariationsMetadata(typedVariations)
+  ?.entries;
+const typedVariationEntry: BlockVariationRegistrationEntry | undefined =
+  typedVariationEntries?.[0];
+const typedVariationSource =
+  createStaticBlockVariationRegistrationSource(typedVariations);
+const variationDiagnostic: BlockVariationDiagnostic | undefined = undefined;
 const parsedBlock: BlockInstance<DemoRegistrationAttributes> = {
   attributes: { content: 'hello', isVisible: true },
   clientId: 'demo-client-id',
@@ -350,4 +397,11 @@ void textAlignment;
 void textColor;
 void textTransform;
 void variation;
+void typedParagraphVariation;
+void typedGroupVariation;
+void typedVariations;
+void typedVariationEntries;
+void typedVariationEntry;
+void typedVariationSource;
+void variationDiagnostic;
 void blockVerticalAlignment;


### PR DESCRIPTION
## Summary

- Add typed defineVariation() / defineVariations() helpers for WordPress block variations.
- Add validation diagnostics, compatibility metadata, and static JS registration source generation.
- Publish the new @wp-typia/block-types/blocks/variations subpath with docs, type contracts, smoke coverage, and a Sampo changeset.

Closes #964.

## Verification

- bun run --filter @wp-typia/block-types test
- bun run typecheck
- bun run lint:repo
- bun run changesets:validate
- bun run format:check
- git diff --check
- bun run test:unit
- bun run test:cli
- bun run manifest-policy:validate
- bun run typescript-strictness:validate
- bun run runtime-coupling:validate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added typed block variation helpers: `defineVariation()` and `defineVariations()` in new `@wp-typia/block-types/blocks/variations` export
- Includes validation diagnostics for variation configuration
- Supports static JavaScript registration source generation for block variations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/979)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->