### PR TITLE
feat(block-bindings): add defineBindingSource helper

### DIFF
--- a/.sampo/changesets/965-define-binding-source.md
+++ b/.sampo/changesets/965-define-binding-source.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/block-types: minor
+---
+
+Add typed defineBindingSource() helpers with Block Bindings metadata types, version-gated diagnostics, and PHP/editor registration source generation.

--- a/packages/wp-typia-block-types/README.md
+++ b/packages/wp-typia-block-types/README.md
@@ -18,6 +18,7 @@ Shared WordPress block semantic types derived from Gutenberg source and unoffici
 - `@wp-typia/block-types/block-editor/style-attributes`
 - `@wp-typia/block-types/block-editor/typography`
 - `@wp-typia/block-types/blocks`
+- `@wp-typia/block-types/blocks/bindings`
 - `@wp-typia/block-types/blocks/compatibility`
 - `@wp-typia/block-types/blocks/registration`
 - `@wp-typia/block-types/blocks/supports`
@@ -49,6 +50,8 @@ Shared WordPress block semantic types derived from Gutenberg source and unoffici
   Bindings features that codegen and diagnostics can share
 - typed Block Variations authoring helpers with static JavaScript registration
   source generation
+- typed Block Bindings source helpers with PHP/editor source generation and
+  `metadata.bindings` type helpers
 
 ## Registration facade
 
@@ -291,6 +294,85 @@ accepted by the type helper, but static source generation rejects them because
 they cannot be represented safely as JSON-backed registration metadata. PHP or
 dynamic variation registration remains scoped to a future helper built on the
 existing `blockVariations.phpVariationCallback` compatibility entry.
+
+## WordPress block binding helpers
+
+`@wp-typia/block-types/blocks/bindings` provides a type-first layer for the
+Block Bindings API. `defineBindingSource()` returns a plain source metadata
+object, while compatibility diagnostics and codegen metadata are stored on a
+non-enumerable symbol.
+
+The helper tracks the documented WordPress floors for server registration
+(`6.5`), editor registration (`6.7`), and editor field lists/custom bindable
+attribute filters (`6.9`). Strict mode throws for unsupported combinations;
+`strict: false` reports diagnostics and omits unsupported editor-only output.
+
+```ts
+import {
+  createEditorBindingSourceRegistrationSource,
+  createPhpBindingSourceRegistrationSource,
+  defineBindableAttributes,
+  defineBindingSource,
+  defineBlockMetadataBindings,
+  type Binding,
+} from '@wp-typia/block-types/blocks/bindings';
+
+type ProfileCardAttributes = {
+  imageUrl?: string;
+};
+
+const profileSource = defineBindingSource({
+  name: 'example/profile-data',
+  label: 'Profile Data',
+  getValueCallback: 'example_get_profile_binding_value',
+  usesContext: ['postId'],
+  minWordPress: {
+    server: '6.5',
+    editor: '6.7',
+    fieldsList: '6.9',
+    supportedAttributesFilter: '6.9',
+  },
+  args: {
+    field: 'image_url' as 'display_name' | 'image_url',
+  },
+  fields: [
+    {
+      name: 'display_name',
+      label: 'Display name',
+      args: { field: 'display_name' },
+      type: 'string',
+    },
+    {
+      name: 'image_url',
+      label: 'Image URL',
+      args: { field: 'image_url' },
+      type: 'string',
+    },
+  ],
+  bindableAttributes: [
+    defineBindableAttributes<ProfileCardAttributes>('example/profile-card', [
+      'imageUrl',
+    ] as const),
+  ],
+});
+
+const metadata = defineBlockMetadataBindings({
+  imageUrl: {
+    source: profileSource.name,
+    args: { field: 'image_url' },
+  } satisfies Binding<typeof profileSource, { field: 'image_url' }>,
+});
+
+const phpSource = createPhpBindingSourceRegistrationSource(profileSource);
+const editorSource = createEditorBindingSourceRegistrationSource(profileSource);
+```
+
+The generated PHP registers `register_block_bindings_source()` on `init` and,
+when custom bindable attributes are declared, adds the
+`block_bindings_supported_attributes_{$block_type}` filter behind a WordPress
+6.9-compatible guard. The generated editor source registers
+`registerBlockBindingsSource()` and emits `getFieldsList()` only when the
+source compatibility manifest marks field lists as supported.
 
 ## Typia pipeline notes
 

--- a/packages/wp-typia-block-types/package.json
+++ b/packages/wp-typia-block-types/package.json
@@ -56,6 +56,11 @@
       "import": "./dist/blocks/index.js",
       "default": "./dist/blocks/index.js"
     },
+    "./blocks/bindings": {
+      "types": "./dist/blocks/bindings.d.ts",
+      "import": "./dist/blocks/bindings.js",
+      "default": "./dist/blocks/bindings.js"
+    },
     "./blocks/compatibility": {
       "types": "./dist/blocks/compatibility.d.ts",
       "import": "./dist/blocks/compatibility.js",

--- a/packages/wp-typia-block-types/src/blocks/bindings.ts
+++ b/packages/wp-typia-block-types/src/blocks/bindings.ts
@@ -1,0 +1,1118 @@
+import type { BlockAttributes } from "./registration.js";
+import {
+  DEFAULT_WORDPRESS_COMPATIBILITY_MIN_VERSION,
+  evaluateWordPressBlockApiCompatibility,
+  type WordPressBlockApiCompatibilityDiagnostic,
+  type WordPressBlockApiCompatibilityEvaluation,
+  type WordPressBlockApiCompatibilityFeature,
+  type WordPressBlockApiCompatibilityManifest,
+  type WordPressCompatibilitySettings,
+  type WordPressVersion,
+} from "./compatibility.js";
+
+export type BindingSourceName = `${string}/${string}`;
+
+export type BindingSourceArgs = Readonly<Record<string, unknown>>;
+
+export type BindingFieldType =
+  | "array"
+  | "boolean"
+  | "integer"
+  | "number"
+  | "object"
+  | "string";
+
+export interface BindingSourceField<
+  TArgs extends BindingSourceArgs = BindingSourceArgs,
+> {
+  readonly args?: TArgs;
+  readonly label: string;
+  readonly name: string;
+  readonly type?: BindingFieldType;
+}
+
+export type BlockBindingAttributeName<
+  TAttributes extends BlockAttributes = BlockAttributes,
+> = Extract<Exclude<keyof TAttributes, "metadata">, string>;
+
+export interface BindingSourceBindableAttributes<
+  TAttributes extends BlockAttributes = BlockAttributes,
+  TBlockName extends string = string,
+  TAttributesList extends readonly BlockBindingAttributeName<TAttributes>[] = readonly BlockBindingAttributeName<TAttributes>[],
+> {
+  readonly attributes: TAttributesList;
+  readonly blockName: TBlockName;
+}
+
+export interface BindingSourceDefinition<
+  TName extends string = string,
+  TArgs extends BindingSourceArgs = BindingSourceArgs,
+  TFields extends readonly BindingSourceField[] = readonly BindingSourceField[],
+> {
+  readonly args?: TArgs;
+  readonly bindableAttributes?: readonly BindingSourceBindableAttributes[];
+  readonly fields?: TFields;
+  readonly getValueCallback?: string;
+  readonly label?: string;
+  readonly name: TName;
+  readonly usesContext?: readonly string[];
+}
+
+export interface BindingSourceVersionGates {
+  readonly editor?: WordPressVersion;
+  readonly fieldsList?: WordPressVersion;
+  readonly server?: WordPressVersion;
+  readonly supportedAttributesFilter?: WordPressVersion;
+}
+
+export interface DefineBindingSourceInlineOptions {
+  readonly allowUnknownFutureKeys?: boolean;
+  readonly editor?: boolean;
+  readonly fieldsList?: boolean;
+  readonly minVersion?: WordPressVersion;
+  readonly minWordPress?: WordPressVersion | BindingSourceVersionGates;
+  readonly minWordPressEditor?: WordPressVersion;
+  readonly minWordPressFieldsList?: WordPressVersion;
+  readonly minWordPressServer?: WordPressVersion;
+  readonly minWordPressSupportedAttributesFilter?: WordPressVersion;
+  readonly onDiagnostic?: (diagnostic: BindingSourceDiagnostic) => void;
+  readonly server?: boolean;
+  readonly strict?: boolean;
+  readonly supportedAttributesFilter?: boolean;
+}
+
+export interface DefineBindingSourceOptions extends WordPressCompatibilitySettings {
+  readonly editor?: boolean;
+  readonly fieldsList?: boolean;
+  readonly minWordPress?: WordPressVersion | BindingSourceVersionGates;
+  readonly minWordPressEditor?: WordPressVersion;
+  readonly minWordPressFieldsList?: WordPressVersion;
+  readonly minWordPressServer?: WordPressVersion;
+  readonly minWordPressSupportedAttributesFilter?: WordPressVersion;
+  readonly onDiagnostic?: (diagnostic: BindingSourceDiagnostic) => void;
+  readonly server?: boolean;
+  readonly supportedAttributesFilter?: boolean;
+}
+
+export type StripDefineBindingSourceOptions<TSource> = Omit<
+  TSource,
+  keyof DefineBindingSourceInlineOptions
+>;
+
+export const DEFINED_BLOCK_BINDING_SOURCE_METADATA: unique symbol = Symbol.for(
+  "@wp-typia/block-types/defined-binding-source",
+) as never;
+
+export type DefinedBlockBindingSourceMetadataKey =
+  typeof DEFINED_BLOCK_BINDING_SOURCE_METADATA;
+
+export interface DefinedBlockBindingSourceMetadata {
+  readonly diagnostics: readonly BindingSourceDiagnostic[];
+  readonly features: readonly WordPressBlockApiCompatibilityFeature[];
+  readonly manifest: WordPressBlockApiCompatibilityManifest;
+}
+
+export type DefinedBindingSource<
+  TName extends string = string,
+  TArgs extends BindingSourceArgs = BindingSourceArgs,
+  TFields extends readonly BindingSourceField[] = readonly BindingSourceField[],
+  TSource extends BindingSourceDefinition = BindingSourceDefinition,
+> = Readonly<StripDefineBindingSourceOptions<TSource>> & {
+  readonly [DEFINED_BLOCK_BINDING_SOURCE_METADATA]?:
+    | DefinedBlockBindingSourceMetadata
+    | undefined;
+  readonly __wpTypiaBindingSourceArgs?: TArgs;
+  readonly __wpTypiaBindingSourceFields?: TFields;
+  readonly name: TName;
+};
+
+export interface BlockBinding<
+  TSourceName extends string = string,
+  TArgs extends BindingSourceArgs = BindingSourceArgs,
+> {
+  readonly args?: TArgs;
+  readonly source: TSourceName;
+}
+
+type BindingSourceInferredArgs<TSource> = TSource extends {
+  readonly __wpTypiaBindingSourceArgs?: infer TArgs extends BindingSourceArgs;
+}
+  ? TArgs
+  : BindingSourceArgs;
+
+export type Binding<
+  TSource extends DefinedBindingSource | string,
+  TArgs extends BindingSourceArgs = BindingSourceInferredArgs<TSource>,
+> = TSource extends DefinedBindingSource<infer TName, infer TSourceArgs>
+  ? TArgs extends TSourceArgs
+    ? BlockBinding<TName, TArgs>
+    : never
+  : TSource extends string
+    ? BlockBinding<TSource, TArgs>
+    : never;
+
+export type BlockBindingMap<
+  TAttributes extends BlockAttributes = BlockAttributes,
+> = Readonly<
+  Partial<Record<BlockBindingAttributeName<TAttributes>, BlockBinding>>
+>;
+
+export interface BlockMetadataBindings<
+  TBindings extends Readonly<
+    Record<string, BlockBinding | undefined>
+  > = Readonly<Record<string, BlockBinding>>,
+> {
+  readonly bindings?: TBindings;
+}
+
+export type TypedBlockMetadataBindings<
+  TAttributes extends BlockAttributes,
+  TBindings extends BlockBindingMap<TAttributes> = BlockBindingMap<TAttributes>,
+> = BlockMetadataBindings<TBindings>;
+
+export type BindingSourceDiagnosticCode =
+  | "duplicate-bindable-attribute"
+  | "duplicate-field-name"
+  | "fields-list-requires-editor"
+  | "invalid-bindable-attribute"
+  | "invalid-block-name"
+  | "invalid-field-name"
+  | "invalid-source-name"
+  | "missing-php-callback";
+
+export interface BindingSourceAuthoringDiagnostic {
+  readonly attribute?: string | undefined;
+  readonly blockName?: string | undefined;
+  readonly code: BindingSourceDiagnosticCode;
+  readonly fieldName?: string | undefined;
+  readonly message: string;
+  readonly severity: "error" | "warning";
+  readonly sourceName: string;
+}
+
+export type BindingSourceDiagnostic =
+  | BindingSourceAuthoringDiagnostic
+  | WordPressBlockApiCompatibilityDiagnostic;
+
+export interface BindingSourceRegistrationEntry {
+  readonly metadata: DefinedBlockBindingSourceMetadata;
+  readonly source: DefinedBindingSource;
+}
+
+export interface CreatePhpBindingSourceRegistrationSourceOptions {
+  readonly functionName?: string;
+  readonly hook?: string;
+  readonly includeOpeningTag?: boolean;
+  readonly textDomain?: string;
+}
+
+export interface CreateEditorBindingSourceRegistrationSourceOptions {
+  readonly functionName?: string;
+  readonly importSource?: string;
+}
+
+const DEFINE_BINDING_SOURCE_INLINE_OPTION_KEYS = new Set<string>([
+  "allowUnknownFutureKeys",
+  "editor",
+  "fieldsList",
+  "minVersion",
+  "minWordPress",
+  "minWordPressEditor",
+  "minWordPressFieldsList",
+  "minWordPressServer",
+  "minWordPressSupportedAttributesFilter",
+  "onDiagnostic",
+  "server",
+  "strict",
+  "supportedAttributesFilter",
+]);
+
+const SOURCE_NAME_PATTERN = /^[a-z0-9-]+\/[a-z0-9-]+$/u;
+const FIELD_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_-]*$/u;
+
+function isObjectRecord(
+  value: unknown,
+): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isBindingSourceVersionGates(
+  value: WordPressVersion | BindingSourceVersionGates | undefined,
+): value is BindingSourceVersionGates {
+  return isObjectRecord(value);
+}
+
+function splitDefineBindingSourceInput<
+  TSource extends BindingSourceDefinition & DefineBindingSourceInlineOptions,
+>(source: TSource): {
+  inlineOptions: DefineBindingSourceInlineOptions;
+  source: StripDefineBindingSourceOptions<TSource> & BindingSourceDefinition;
+} {
+  const inlineOptions: DefineBindingSourceInlineOptions = {};
+  const normalizedSource: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(source)) {
+    if (DEFINE_BINDING_SOURCE_INLINE_OPTION_KEYS.has(key)) {
+      Object.assign(inlineOptions, { [key]: value });
+      continue;
+    }
+
+    normalizedSource[key] = value;
+  }
+
+  return {
+    inlineOptions,
+    source: normalizedSource as StripDefineBindingSourceOptions<TSource> &
+      BindingSourceDefinition,
+  };
+}
+
+function resolveMinWordPress(
+  inlineOptions: DefineBindingSourceInlineOptions,
+  options: DefineBindingSourceOptions,
+): {
+  compatibility: WordPressCompatibilitySettings;
+  gates: BindingSourceVersionGates;
+} {
+  const optionMinWordPress = options.minWordPress;
+  const inlineMinWordPress = inlineOptions.minWordPress;
+  const optionGates = isBindingSourceVersionGates(optionMinWordPress)
+    ? optionMinWordPress
+    : {};
+  const inlineGates = isBindingSourceVersionGates(inlineMinWordPress)
+    ? inlineMinWordPress
+    : {};
+  const minVersion =
+    options.minVersion ??
+    (typeof optionMinWordPress === "string" ? optionMinWordPress : undefined) ??
+    inlineOptions.minVersion ??
+    (typeof inlineMinWordPress === "string" ? inlineMinWordPress : undefined);
+  const compatibility: WordPressCompatibilitySettings = {
+    strict: options.strict ?? inlineOptions.strict ?? true,
+  };
+
+  if (options.allowUnknownFutureKeys ?? inlineOptions.allowUnknownFutureKeys) {
+    Object.assign(compatibility, {
+      allowUnknownFutureKeys:
+        options.allowUnknownFutureKeys ?? inlineOptions.allowUnknownFutureKeys,
+    });
+  }
+  if (minVersion !== undefined) {
+    Object.assign(compatibility, { minVersion });
+  }
+
+  const gates: BindingSourceVersionGates = {};
+  const editor =
+    options.minWordPressEditor ??
+    optionGates.editor ??
+    inlineOptions.minWordPressEditor ??
+    inlineGates.editor;
+  const fieldsList =
+    options.minWordPressFieldsList ??
+    optionGates.fieldsList ??
+    inlineOptions.minWordPressFieldsList ??
+    inlineGates.fieldsList;
+  const server =
+    options.minWordPressServer ??
+    optionGates.server ??
+    inlineOptions.minWordPressServer ??
+    inlineGates.server;
+  const supportedAttributesFilter =
+    options.minWordPressSupportedAttributesFilter ??
+    optionGates.supportedAttributesFilter ??
+    inlineOptions.minWordPressSupportedAttributesFilter ??
+    inlineGates.supportedAttributesFilter;
+
+  if (editor !== undefined) {
+    Object.assign(gates, { editor });
+  }
+  if (fieldsList !== undefined) {
+    Object.assign(gates, { fieldsList });
+  }
+  if (server !== undefined) {
+    Object.assign(gates, { server });
+  }
+  if (supportedAttributesFilter !== undefined) {
+    Object.assign(gates, { supportedAttributesFilter });
+  }
+
+  return {
+    compatibility,
+    gates,
+  };
+}
+
+function resolveDefineBindingSourceSettings(
+  inlineOptions: DefineBindingSourceInlineOptions,
+  options: DefineBindingSourceOptions,
+  source: BindingSourceDefinition,
+): {
+  compatibility: WordPressCompatibilitySettings;
+  features: {
+    editor: boolean;
+    fieldsList: boolean;
+    metadata: boolean;
+    server: boolean;
+    supportedAttributesFilter: boolean;
+  };
+  gates: BindingSourceVersionGates;
+  onDiagnostic: DefineBindingSourceOptions["onDiagnostic"];
+  strict: boolean;
+} {
+  const { compatibility, gates } = resolveMinWordPress(inlineOptions, options);
+  const strict = compatibility.strict ?? true;
+  const hasFields = (source.fields?.length ?? 0) > 0;
+  const hasBindableAttributes = (source.bindableAttributes?.length ?? 0) > 0;
+
+  return {
+    compatibility,
+    features: {
+      editor: options.editor ?? inlineOptions.editor ?? true,
+      fieldsList: options.fieldsList ?? inlineOptions.fieldsList ?? hasFields,
+      metadata: true,
+      server: options.server ?? inlineOptions.server ?? true,
+      supportedAttributesFilter:
+        options.supportedAttributesFilter ??
+        inlineOptions.supportedAttributesFilter ??
+        hasBindableAttributes,
+    },
+    gates,
+    onDiagnostic: options.onDiagnostic ?? inlineOptions.onDiagnostic,
+    strict,
+  };
+}
+
+function getDiagnosticSeverity(strict: boolean): "error" | "warning" {
+  return strict ? "error" : "warning";
+}
+
+function getFeatureMinVersion(
+  feature: WordPressBlockApiCompatibilityFeature,
+  fallback: WordPressVersion,
+  gates: BindingSourceVersionGates,
+): WordPressVersion {
+  if (feature.area !== "blockBindings") {
+    return fallback;
+  }
+
+  switch (feature.feature) {
+    case "metadata.bindings":
+    case "serverRegistration":
+      return gates.server ?? fallback;
+    case "editorFieldsList":
+      return gates.fieldsList ?? fallback;
+    case "editorRegistration":
+    case "editorSourceLookup":
+      return gates.editor ?? fallback;
+    case "supportedAttributesFilter":
+      return gates.supportedAttributesFilter ?? gates.fieldsList ?? fallback;
+    default:
+      return fallback;
+  }
+}
+
+function createBindingCompatibilityManifest(
+  features: readonly WordPressBlockApiCompatibilityFeature[],
+  settings: WordPressCompatibilitySettings,
+  gates: BindingSourceVersionGates,
+): WordPressBlockApiCompatibilityManifest {
+  const fallback =
+    settings.minVersion ?? DEFAULT_WORDPRESS_COMPATIBILITY_MIN_VERSION;
+  const strict = settings.strict ?? true;
+  const allowUnknownFutureKeys = settings.allowUnknownFutureKeys ?? false;
+  const evaluations = features.map((feature) =>
+    evaluateWordPressBlockApiCompatibility(feature, {
+      allowUnknownFutureKeys,
+      minVersion: getFeatureMinVersion(feature, fallback, gates),
+      strict,
+    }),
+  );
+  const diagnostics = evaluations.flatMap((evaluation) =>
+    evaluation.diagnostic ? [evaluation.diagnostic] : [],
+  );
+
+  return {
+    allowUnknownFutureKeys,
+    diagnostics,
+    evaluations,
+    minVersion: fallback,
+    strict,
+    supported: evaluations.filter(
+      (evaluation) => evaluation.status === "supported",
+    ),
+    unknown: evaluations.filter((evaluation) => evaluation.status === "unknown"),
+    unsupported: evaluations.filter(
+      (evaluation) => evaluation.status === "unsupported",
+    ),
+  };
+}
+
+export function collectBindingSourceCompatibilityFeatures(
+  settings: {
+    readonly editor?: boolean;
+    readonly fieldsList?: boolean;
+    readonly metadata?: boolean;
+    readonly server?: boolean;
+    readonly supportedAttributesFilter?: boolean;
+  } = {},
+): readonly WordPressBlockApiCompatibilityFeature[] {
+  const features: WordPressBlockApiCompatibilityFeature[] = [];
+
+  if (settings.metadata ?? true) {
+    features.push({
+      area: "blockBindings",
+      feature: "metadata.bindings",
+    });
+  }
+  if (settings.server ?? true) {
+    features.push({
+      area: "blockBindings",
+      feature: "serverRegistration",
+    });
+  }
+  if (settings.editor ?? true) {
+    features.push({
+      area: "blockBindings",
+      feature: "editorRegistration",
+    });
+  }
+  if (settings.fieldsList ?? false) {
+    features.push({
+      area: "blockBindings",
+      feature: "editorFieldsList",
+    });
+  }
+  if (settings.supportedAttributesFilter ?? false) {
+    features.push({
+      area: "blockBindings",
+      feature: "supportedAttributesFilter",
+    });
+  }
+
+  return features;
+}
+
+export function createBindingSourceCompatibilityManifest(
+  settings: DefineBindingSourceOptions = {},
+): WordPressBlockApiCompatibilityManifest {
+  const resolved = resolveDefineBindingSourceSettings({}, settings, {
+    name: "wp-typia/binding-source",
+  });
+
+  return createBindingCompatibilityManifest(
+    collectBindingSourceCompatibilityFeatures(resolved.features),
+    resolved.compatibility,
+    resolved.gates,
+  );
+}
+
+function createBindingSourceDiagnostics(
+  source: BindingSourceDefinition,
+  options: {
+    readonly editor: boolean;
+    readonly fieldsList: boolean;
+    readonly server: boolean;
+    readonly strict: boolean;
+  },
+): readonly BindingSourceAuthoringDiagnostic[] {
+  const diagnostics: BindingSourceAuthoringDiagnostic[] = [];
+  const severity = getDiagnosticSeverity(options.strict);
+
+  if (!SOURCE_NAME_PATTERN.test(source.name)) {
+    diagnostics.push({
+      code: "invalid-source-name",
+      message: `Block binding source "${source.name}" must be lowercase and namespaced, such as "acme/profile-data".`,
+      severity,
+      sourceName: source.name,
+    });
+  }
+
+  if (options.server && !source.getValueCallback) {
+    diagnostics.push({
+      code: "missing-php-callback",
+      message: `Block binding source "${source.name}" needs getValueCallback when server registration is enabled.`,
+      severity,
+      sourceName: source.name,
+    });
+  }
+
+  if (options.fieldsList && !options.editor) {
+    diagnostics.push({
+      code: "fields-list-requires-editor",
+      message: `Block binding source "${source.name}" enables getFieldsList() without editor registration.`,
+      severity,
+      sourceName: source.name,
+    });
+  }
+
+  const seenFields = new Set<string>();
+  for (const field of source.fields ?? []) {
+    if (!FIELD_NAME_PATTERN.test(field.name)) {
+      diagnostics.push({
+        code: "invalid-field-name",
+        fieldName: field.name,
+        message: `Block binding source "${source.name}" field "${field.name}" must be a stable identifier.`,
+        severity,
+        sourceName: source.name,
+      });
+    }
+    if (seenFields.has(field.name)) {
+      diagnostics.push({
+        code: "duplicate-field-name",
+        fieldName: field.name,
+        message: `Block binding source "${source.name}" declares duplicate field "${field.name}".`,
+        severity,
+        sourceName: source.name,
+      });
+    }
+    seenFields.add(field.name);
+  }
+
+  for (const target of source.bindableAttributes ?? []) {
+    if (!SOURCE_NAME_PATTERN.test(target.blockName)) {
+      diagnostics.push({
+        blockName: target.blockName,
+        code: "invalid-block-name",
+        message: `Bindable attributes target "${target.blockName}" must be a lowercase namespaced block name.`,
+        severity,
+        sourceName: source.name,
+      });
+    }
+
+    const seenAttributes = new Set<string>();
+    for (const attribute of target.attributes) {
+      if (!FIELD_NAME_PATTERN.test(attribute)) {
+        diagnostics.push({
+          attribute,
+          blockName: target.blockName,
+          code: "invalid-bindable-attribute",
+          message: `Bindable attribute "${attribute}" for "${target.blockName}" must be a stable identifier.`,
+          severity,
+          sourceName: source.name,
+        });
+      }
+      if (seenAttributes.has(attribute)) {
+        diagnostics.push({
+          attribute,
+          blockName: target.blockName,
+          code: "duplicate-bindable-attribute",
+          message: `Bindable attribute "${attribute}" for "${target.blockName}" is declared more than once.`,
+          severity,
+          sourceName: source.name,
+        });
+      }
+      seenAttributes.add(attribute);
+    }
+  }
+
+  return diagnostics;
+}
+
+function handleBindingSourceDiagnostics(
+  diagnostics: readonly BindingSourceDiagnostic[],
+  onDiagnostic: DefineBindingSourceOptions["onDiagnostic"],
+): void {
+  const errors = diagnostics.filter(
+    (diagnostic) => diagnostic.severity === "error",
+  );
+
+  if (errors.length > 0) {
+    throw new Error(
+      [
+        "WordPress block binding source check failed:",
+        ...errors.map((diagnostic) => `- ${diagnostic.message}`),
+      ].join("\n"),
+    );
+  }
+
+  for (const diagnostic of diagnostics) {
+    if (onDiagnostic) {
+      onDiagnostic(diagnostic);
+      continue;
+    }
+
+    console.warn(`[wp-typia] ${diagnostic.message}`);
+  }
+}
+
+export function getDefinedBindingSourceMetadata(
+  source: unknown,
+): DefinedBlockBindingSourceMetadata | undefined {
+  return isObjectRecord(source)
+    ? (
+        source as {
+          readonly [DEFINED_BLOCK_BINDING_SOURCE_METADATA]?:
+            | DefinedBlockBindingSourceMetadata
+            | undefined;
+        }
+      )[DEFINED_BLOCK_BINDING_SOURCE_METADATA]
+    : undefined;
+}
+
+export function getDefinedBindingSourceCompatibilityManifest(
+  source: unknown,
+): WordPressBlockApiCompatibilityManifest | undefined {
+  return getDefinedBindingSourceMetadata(source)?.manifest;
+}
+
+export function defineBindingSource<
+  const TSource extends BindingSourceDefinition &
+    DefineBindingSourceInlineOptions,
+>(
+  source: TSource,
+  options: DefineBindingSourceOptions = {},
+): DefinedBindingSource<
+  Extract<TSource["name"], string>,
+  TSource extends { readonly args: infer TArgs extends BindingSourceArgs }
+    ? TArgs
+    : BindingSourceArgs,
+  TSource extends { readonly fields: infer TFields extends readonly BindingSourceField[] }
+    ? TFields
+    : readonly BindingSourceField[],
+  TSource
+> {
+  const { inlineOptions, source: normalizedSource } =
+    splitDefineBindingSourceInput(source);
+  const resolved = resolveDefineBindingSourceSettings(
+    inlineOptions,
+    options,
+    normalizedSource,
+  );
+  const features = collectBindingSourceCompatibilityFeatures(resolved.features);
+  const manifest = createBindingCompatibilityManifest(
+    features,
+    resolved.compatibility,
+    resolved.gates,
+  );
+  const diagnostics = [
+    ...manifest.diagnostics,
+    ...createBindingSourceDiagnostics(normalizedSource, {
+      editor: resolved.features.editor,
+      fieldsList: resolved.features.fieldsList,
+      server: resolved.features.server,
+      strict: resolved.strict,
+    }),
+  ];
+
+  handleBindingSourceDiagnostics(diagnostics, resolved.onDiagnostic);
+
+  Object.defineProperty(
+    normalizedSource,
+    DEFINED_BLOCK_BINDING_SOURCE_METADATA,
+    {
+      configurable: false,
+      enumerable: false,
+      value: {
+        diagnostics,
+        features,
+        manifest,
+      } satisfies DefinedBlockBindingSourceMetadata,
+      writable: false,
+    },
+  );
+
+  return normalizedSource as DefinedBindingSource<
+    Extract<TSource["name"], string>,
+    TSource extends { readonly args: infer TArgs extends BindingSourceArgs }
+      ? TArgs
+      : BindingSourceArgs,
+    TSource extends { readonly fields: infer TFields extends readonly BindingSourceField[] }
+      ? TFields
+      : readonly BindingSourceField[],
+    TSource
+  >;
+}
+
+export function defineBindableAttributes<
+  TAttributes extends BlockAttributes = BlockAttributes,
+  const TBlockName extends string = string,
+  const TAttributesList extends readonly BlockBindingAttributeName<TAttributes>[] = readonly BlockBindingAttributeName<TAttributes>[],
+>(
+  blockName: TBlockName,
+  attributes: TAttributesList,
+): BindingSourceBindableAttributes<TAttributes, TBlockName, TAttributesList> {
+  return {
+    attributes,
+    blockName,
+  };
+}
+
+export function defineBlockMetadataBindings<
+  const TBindings extends Readonly<Record<string, BlockBinding | undefined>>,
+>(bindings: TBindings): BlockMetadataBindings<TBindings> {
+  return { bindings };
+}
+
+export function defineTypedBlockMetadataBindings<
+  TAttributes extends BlockAttributes,
+  const TBindings extends BlockBindingMap<TAttributes> = BlockBindingMap<TAttributes>,
+>(bindings: TBindings): TypedBlockMetadataBindings<TAttributes, TBindings> {
+  return { bindings };
+}
+
+export function createBindingSourceRegistrationPlan(
+  sources: readonly DefinedBindingSource[],
+): readonly BindingSourceRegistrationEntry[] {
+  return sources.map((source) => {
+    const metadata = getDefinedBindingSourceMetadata(source);
+
+    if (!metadata) {
+      throw new Error(
+        `Block binding source "${source.name}" was not created by defineBindingSource().`,
+      );
+    }
+
+    return {
+      metadata,
+      source,
+    };
+  });
+}
+
+function normalizeStaticRegistrationValue(value: unknown, path: string): unknown {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (
+    value === null ||
+    typeof value === "boolean" ||
+    typeof value === "number" ||
+    typeof value === "string"
+  ) {
+    return value;
+  }
+  if (typeof value === "function") {
+    throw new Error(
+      `Cannot generate static binding source registration code for function value at ${path}.`,
+    );
+  }
+  if (typeof value === "bigint" || typeof value === "symbol") {
+    throw new Error(
+      `Cannot generate static binding source registration code for ${typeof value} value at ${path}.`,
+    );
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry, index) =>
+      normalizeStaticRegistrationValue(entry, `${path}[${index}]`),
+    );
+  }
+  if (isObjectRecord(value)) {
+    const normalized: Record<string, unknown> = {};
+
+    for (const [key, nestedValue] of Object.entries(value)) {
+      const nextValue = normalizeStaticRegistrationValue(
+        nestedValue,
+        `${path}.${key}`,
+      );
+
+      if (nextValue !== undefined) {
+        normalized[key] = nextValue;
+      }
+    }
+
+    return normalized;
+  }
+
+  throw new Error(
+    `Cannot generate static binding source registration code for unsupported value at ${path}.`,
+  );
+}
+
+function getBindingEvaluation(
+  metadata: DefinedBlockBindingSourceMetadata,
+  feature: string,
+): WordPressBlockApiCompatibilityEvaluation | undefined {
+  return metadata.manifest.evaluations.find(
+    (evaluation) =>
+      evaluation.area === "blockBindings" && evaluation.feature === feature,
+  );
+}
+
+function shouldGenerateFeature(
+  metadata: DefinedBlockBindingSourceMetadata,
+  feature: string,
+): boolean {
+  const evaluation = getBindingEvaluation(metadata, feature);
+
+  return evaluation?.action === "generate";
+}
+
+function asSourceList(
+  sources: DefinedBindingSource | readonly DefinedBindingSource[],
+): readonly DefinedBindingSource[] {
+  if (Array.isArray(sources)) {
+    return sources;
+  }
+
+  return [sources as DefinedBindingSource];
+}
+
+function escapePhpSingleQuotedString(value: string): string {
+  return value.replace(/\\/gu, "\\\\").replace(/'/gu, "\\'");
+}
+
+function phpString(value: string): string {
+  return `'${escapePhpSingleQuotedString(value)}'`;
+}
+
+function phpStringArray(values: readonly string[]): string {
+  return values.length === 0
+    ? "array()"
+    : `array( ${values.map((value) => phpString(value)).join(", ")} )`;
+}
+
+function sanitizePhpIdentifier(value: string): string {
+  const sanitized = value.replace(/[^A-Za-z0-9_]/gu, "_").replace(/_+/gu, "_");
+
+  return /^[A-Za-z_]/u.test(sanitized) ? sanitized : `wp_typia_${sanitized}`;
+}
+
+function createPhpSourceProperties(
+  source: DefinedBindingSource,
+  options: CreatePhpBindingSourceRegistrationSourceOptions,
+): string[] {
+  const properties: string[] = [];
+
+  if (source.label) {
+    const label = options.textDomain
+      ? `__( ${phpString(source.label)}, ${phpString(options.textDomain)} )`
+      : phpString(source.label);
+    properties.push(`'label' => ${label}`);
+  }
+  if (source.usesContext && source.usesContext.length > 0) {
+    properties.push(`'uses_context' => ${phpStringArray(source.usesContext)}`);
+  }
+  if (source.getValueCallback) {
+    properties.push(
+      `'get_value_callback' => ${phpString(source.getValueCallback)}`,
+    );
+  }
+
+  return properties;
+}
+
+function createPhpBindableAttributeFilterSource(
+  entries: readonly BindingSourceRegistrationEntry[],
+  functionName: string,
+): string[] {
+  const lines: string[] = [];
+  const targets = entries.flatMap((entry) =>
+    (entry.source.bindableAttributes ?? []).map((target, index) => ({
+      index,
+      metadata: entry.metadata,
+      sourceName: entry.source.name,
+      target,
+    })),
+  );
+
+  if (targets.length === 0) {
+    return lines;
+  }
+
+  lines.push("");
+  lines.push("if ( function_exists( 'get_block_bindings_supported_attributes' ) ) {");
+  for (const target of targets) {
+    if (!shouldGenerateFeature(target.metadata, "supportedAttributesFilter")) {
+      lines.push(
+        `\t// block_bindings_supported_attributes requires WordPress 6.9+ for ${target.target.blockName}.`,
+      );
+      continue;
+    }
+
+    const callbackName = sanitizePhpIdentifier(
+      `${functionName}_${target.sourceName}_${target.target.blockName}_${target.index}_supported_attributes`,
+    );
+    lines.push(
+      `\tadd_filter( ${phpString(
+        `block_bindings_supported_attributes_${target.target.blockName}`,
+      )}, ${phpString(callbackName)} );`,
+    );
+    lines.push(`\tfunction ${callbackName}( $supported_attributes ) {`);
+    lines.push(
+      `\t\treturn array_values( array_unique( array_merge( $supported_attributes, ${phpStringArray(
+        target.target.attributes,
+      )} ) ) );`,
+    );
+    lines.push("\t}");
+  }
+  lines.push("}");
+
+  return lines;
+}
+
+export function createPhpBindingSourceRegistrationSource(
+  sources: DefinedBindingSource | readonly DefinedBindingSource[],
+  options: CreatePhpBindingSourceRegistrationSourceOptions = {},
+): string {
+  const functionName =
+    options.functionName ?? "wp_typia_register_block_binding_sources";
+  const hook = options.hook ?? "init";
+  const entries = createBindingSourceRegistrationPlan(asSourceList(sources));
+  const lines: string[] = [];
+
+  if (options.includeOpeningTag ?? false) {
+    lines.push("<?php");
+    lines.push("");
+  }
+
+  lines.push(`function ${functionName}() {`);
+  lines.push("\tif ( ! function_exists( 'register_block_bindings_source' ) ) {");
+  lines.push("\t\treturn;");
+  lines.push("\t}");
+  lines.push("");
+
+  for (const entry of entries) {
+    if (!shouldGenerateFeature(entry.metadata, "serverRegistration")) {
+      lines.push(
+        `\t// register_block_bindings_source() requires WordPress 6.5+ for ${entry.source.name}.`,
+      );
+      continue;
+    }
+
+    const properties = createPhpSourceProperties(entry.source, options);
+    lines.push(`\tregister_block_bindings_source( ${phpString(entry.source.name)}, array(`);
+    for (const property of properties) {
+      lines.push(`\t\t${property},`);
+    }
+    lines.push("\t) );");
+  }
+
+  lines.push("}");
+  lines.push(`add_action( ${phpString(hook)}, ${phpString(functionName)} );`);
+  lines.push(
+    ...createPhpBindableAttributeFilterSource(entries, functionName),
+  );
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+function createEditorRegistrationEntries(
+  entries: readonly BindingSourceRegistrationEntry[],
+): {
+  readonly fields: Readonly<Record<string, readonly BindingSourceField[]>>;
+  readonly sources: readonly unknown[];
+  readonly skipped: readonly string[];
+  readonly skippedFields: readonly string[];
+} {
+  const fields: Record<string, readonly BindingSourceField[]> = {};
+  const skipped: string[] = [];
+  const skippedFields: string[] = [];
+  const sources: unknown[] = [];
+
+  for (const entry of entries) {
+    const editorEvaluation = getBindingEvaluation(
+      entry.metadata,
+      "editorRegistration",
+    );
+
+    if (editorEvaluation === undefined) {
+      continue;
+    }
+    if (editorEvaluation.action !== "generate") {
+      skipped.push(entry.source.name);
+      continue;
+    }
+
+    sources.push(
+      normalizeStaticRegistrationValue(
+        {
+          label: entry.source.label,
+          name: entry.source.name,
+          usesContext: entry.source.usesContext,
+        },
+        `sources.${entry.source.name}`,
+      ),
+    );
+
+    if ((entry.source.fields?.length ?? 0) === 0) {
+      continue;
+    }
+    if (!shouldGenerateFeature(entry.metadata, "editorFieldsList")) {
+      skippedFields.push(entry.source.name);
+      continue;
+    }
+
+    fields[entry.source.name] = normalizeStaticRegistrationValue(
+      entry.source.fields,
+      `fields.${entry.source.name}`,
+    ) as readonly BindingSourceField[];
+  }
+
+  return {
+    fields,
+    skipped,
+    skippedFields,
+    sources,
+  };
+}
+
+export function createEditorBindingSourceRegistrationSource(
+  sources: DefinedBindingSource | readonly DefinedBindingSource[],
+  options: CreateEditorBindingSourceRegistrationSourceOptions = {},
+): string {
+  const importSource = options.importSource ?? "@wordpress/blocks";
+  const functionName = options.functionName ?? "registerWpTypiaBindingSources";
+  const entries = createBindingSourceRegistrationPlan(asSourceList(sources));
+  const registration = createEditorRegistrationEntries(entries);
+  if (registration.sources.length === 0) {
+    return [
+      "// No editor block binding sources were generated.",
+      ...(registration.skipped.length > 0
+        ? [
+            `// Skipped editor registration for ${registration.skipped.join(
+              ", ",
+            )}; registerBlockBindingsSource() requires WordPress 6.7+.`,
+          ]
+        : []),
+      "",
+    ].join("\n");
+  }
+
+  const serializedSources = JSON.stringify(registration.sources, null, 2);
+  const serializedFields = JSON.stringify(registration.fields, null, 2);
+  const hasGeneratedFields = Object.keys(registration.fields).length > 0;
+  const lines = [
+    `import { registerBlockBindingsSource } from ${JSON.stringify(importSource)};`,
+    "",
+    `const sources = ${serializedSources};`,
+    ...(hasGeneratedFields ? [`const fieldsBySource = ${serializedFields};`] : []),
+    "",
+    `export function ${functionName}() {`,
+    "  if (typeof registerBlockBindingsSource !== \"function\") {",
+    "    return;",
+    "  }",
+    "  for (const source of sources) {",
+    ...(hasGeneratedFields
+      ? [
+          "    const fields = fieldsBySource[source.name];",
+          "    registerBlockBindingsSource({",
+          "      ...source,",
+          "      ...(fields ? { getFieldsList: () => fields } : {}),",
+          "    });",
+        ]
+      : ["    registerBlockBindingsSource(source);"]),
+    "  }",
+    "}",
+  ];
+
+  if (registration.skipped.length > 0) {
+    lines.push(
+      "",
+      `// Skipped editor registration for ${registration.skipped.join(
+        ", ",
+      )}; registerBlockBindingsSource() requires WordPress 6.7+.`,
+    );
+  }
+  if (registration.skippedFields.length > 0) {
+    lines.push(
+      "",
+      `// Skipped getFieldsList() for ${registration.skippedFields.join(
+        ", ",
+      )}; getFieldsList() requires WordPress 6.9+.`,
+    );
+  }
+  lines.push("");
+
+  return lines.join("\n");
+}

--- a/packages/wp-typia-block-types/src/blocks/bindings.ts
+++ b/packages/wp-typia-block-types/src/blocks/bindings.ts
@@ -228,7 +228,7 @@ const DEFINE_BINDING_SOURCE_INLINE_OPTION_KEYS = new Set<string>([
 ]);
 
 const SOURCE_NAME_PATTERN =
-  /^[a-z0-9]+(?:-[a-z0-9]+)*\/[a-z0-9]+(?:-[a-z0-9]+)*$/u;
+  /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\/[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/u;
 const FIELD_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_-]*$/u;
 
 function isObjectRecord(
@@ -868,6 +868,17 @@ function sanitizePhpIdentifier(value: string): string {
   return /^[A-Za-z_]/u.test(sanitized) ? sanitized : `wp_typia_${sanitized}`;
 }
 
+function createPhpIdentifierHash(value: string): string {
+  let hash = 0x811c9dc5;
+
+  for (const character of value) {
+    hash ^= character.codePointAt(0) ?? 0;
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+
+  return hash.toString(36);
+}
+
 function createPhpSourceProperties(
   source: DefinedBindingSource,
   options: CreatePhpBindingSourceRegistrationSourceOptions,
@@ -912,7 +923,7 @@ function createPhpBindableAttributeFilterSource(
 
   lines.push("");
   lines.push("if ( function_exists( 'get_block_bindings_supported_attributes' ) ) {");
-  for (const target of targets) {
+  for (const [targetIndex, target] of targets.entries()) {
     if (!shouldGenerateFeature(target.metadata, "supportedAttributesFilter")) {
       lines.push(
         `\t// block_bindings_supported_attributes requires WordPress 6.9+ for ${target.target.blockName}.`,
@@ -920,8 +931,17 @@ function createPhpBindableAttributeFilterSource(
       continue;
     }
 
+    const callbackSeed = [
+      functionName,
+      target.sourceName,
+      target.target.blockName,
+      String(target.index),
+      String(targetIndex),
+    ].join("\0");
     const callbackName = sanitizePhpIdentifier(
-      `${functionName}_${target.sourceName}_${target.target.blockName}_${target.index}_supported_attributes`,
+      `${functionName}_${target.sourceName}_${target.target.blockName}_${target.index}_${targetIndex}_${createPhpIdentifierHash(
+        callbackSeed,
+      )}_supported_attributes`,
     );
     lines.push(
       `\tadd_filter( ${phpString(

--- a/packages/wp-typia-block-types/src/blocks/bindings.ts
+++ b/packages/wp-typia-block-types/src/blocks/bindings.ts
@@ -227,7 +227,8 @@ const DEFINE_BINDING_SOURCE_INLINE_OPTION_KEYS = new Set<string>([
   "supportedAttributesFilter",
 ]);
 
-const SOURCE_NAME_PATTERN = /^[a-z0-9-]+\/[a-z0-9-]+$/u;
+const SOURCE_NAME_PATTERN =
+  /^[a-z0-9]+(?:-[a-z0-9]+)*\/[a-z0-9]+(?:-[a-z0-9]+)*$/u;
 const FIELD_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_-]*$/u;
 
 function isObjectRecord(

--- a/packages/wp-typia-block-types/src/blocks/compatibility.ts
+++ b/packages/wp-typia-block-types/src/blocks/compatibility.ts
@@ -116,6 +116,14 @@ export const WORDPRESS_BLOCK_API_COMPATIBILITY = {
       since: '6.7',
       source: 'wordpressBlocksPackage',
     },
+    editorFieldsList: {
+      fallback:
+        'Register the source without getFieldsList() or keep a custom editor UI.',
+      label: 'registerBlockBindingsSource() getFieldsList()',
+      runtime: ['editor-js'],
+      since: '6.9',
+      source: 'blockBindingsHandbook',
+    },
     editorSourceLookup: {
       label: 'getBlockBindingsSource() and getBlockBindingsSources()',
       runtime: ['editor-js'],

--- a/packages/wp-typia-block-types/src/blocks/index.ts
+++ b/packages/wp-typia-block-types/src/blocks/index.ts
@@ -1,3 +1,4 @@
+export * from "./bindings.js";
 export * from "./compatibility.js";
 export * from "./registration.js";
 export * from "./supports.js";

--- a/packages/wp-typia-block-types/tests/bindings.test.ts
+++ b/packages/wp-typia-block-types/tests/bindings.test.ts
@@ -184,6 +184,13 @@ describe("defineBindingSource", () => {
     ).toThrow("must be lowercase and namespaced");
     expect(() =>
       defineBindingSource({
+        getValueCallback: "example_get_invalid_binding_value",
+        label: "Invalid hyphen",
+        name: "-example/profile-",
+      }),
+    ).toThrow("must be lowercase and namespaced");
+    expect(() =>
+      defineBindingSource({
         label: "Missing callback",
         name: "example/missing-callback",
       }),

--- a/packages/wp-typia-block-types/tests/bindings.test.ts
+++ b/packages/wp-typia-block-types/tests/bindings.test.ts
@@ -191,6 +191,13 @@ describe("defineBindingSource", () => {
     ).toThrow("must be lowercase and namespaced");
     expect(() =>
       defineBindingSource({
+        getValueCallback: "example_get_double_hyphen_binding_value",
+        label: "Double hyphen",
+        name: "example--plugin/profile--data",
+      }),
+    ).not.toThrow();
+    expect(() =>
+      defineBindingSource({
         label: "Missing callback",
         name: "example/missing-callback",
       }),
@@ -300,6 +307,42 @@ describe("binding source registration source generation", () => {
     expect(editorSource).toContain('"name": "example/profile-data"');
     expect(editorSource).toContain('"name": "image_url"');
     expect(editorSource).toContain("getFieldsList: () => fields");
+  });
+
+  test("keeps generated PHP filter callbacks unique after sanitization", () => {
+    const first = defineBindingSource({
+      bindableAttributes: [
+        defineBindableAttributes("example/profile-card", ["imageUrl"] as const),
+      ],
+      getValueCallback: "example_get_first_binding_value",
+      minWordPress: {
+        editor: "6.7",
+        server: "6.5",
+        supportedAttributesFilter: "6.9",
+      },
+      name: "acme-foo/bar",
+    });
+    const second = defineBindingSource({
+      bindableAttributes: [
+        defineBindableAttributes("example/profile-card", ["imageUrl"] as const),
+      ],
+      getValueCallback: "example_get_second_binding_value",
+      minWordPress: {
+        editor: "6.7",
+        server: "6.5",
+        supportedAttributesFilter: "6.9",
+      },
+      name: "acme/foo-bar",
+    });
+    const phpSource = createPhpBindingSourceRegistrationSource([first, second]);
+    const callbackNames = [
+      ...phpSource.matchAll(
+        /function (wp_typia_register_block_binding_sources_[A-Za-z0-9_]+)\(/gu,
+      ),
+    ].map((match) => match[1]);
+
+    expect(callbackNames).toHaveLength(2);
+    expect(new Set(callbackNames).size).toBe(2);
   });
 
   test("exposes a direct compatibility manifest helper", () => {

--- a/packages/wp-typia-block-types/tests/bindings.test.ts
+++ b/packages/wp-typia-block-types/tests/bindings.test.ts
@@ -1,0 +1,315 @@
+import { describe, expect, test } from "bun:test";
+
+import type { BindingSourceDiagnostic } from "../src/blocks/bindings";
+import {
+  createBindingSourceCompatibilityManifest,
+  createEditorBindingSourceRegistrationSource,
+  createPhpBindingSourceRegistrationSource,
+  defineBindableAttributes,
+  defineBindingSource,
+  defineBlockMetadataBindings,
+  getDefinedBindingSourceCompatibilityManifest,
+  getDefinedBindingSourceMetadata,
+  type Binding,
+} from "../src/blocks/bindings";
+
+interface ProfileCardAttributes {
+  displayName?: string;
+  imageUrl?: string;
+  metadata?: unknown;
+}
+
+describe("defineBindingSource", () => {
+  test("returns binding source metadata and stores compatibility details out of band", () => {
+    const bindableAttributes =
+      defineBindableAttributes<ProfileCardAttributes>("example/profile-card", [
+        "imageUrl",
+      ] as const);
+    const source = defineBindingSource({
+      args: {
+        field: "image_url" as "display_name" | "image_url",
+      },
+      bindableAttributes: [bindableAttributes],
+      fields: [
+        {
+          args: {
+            field: "display_name",
+          },
+          label: "Display name",
+          name: "display_name",
+          type: "string",
+        },
+        {
+          args: {
+            field: "image_url",
+          },
+          label: "Image URL",
+          name: "image_url",
+          type: "string",
+        },
+      ],
+      getValueCallback: "example_get_profile_binding_value",
+      label: "Profile Data",
+      minWordPress: {
+        editor: "6.7",
+        fieldsList: "6.9",
+        server: "6.5",
+        supportedAttributesFilter: "6.9",
+      },
+      name: "example/profile-data",
+      usesContext: ["postId", "postType"],
+    });
+    const manifest = getDefinedBindingSourceCompatibilityManifest(source);
+    const bindingMetadata = defineBlockMetadataBindings({
+      imageUrl: {
+        args: {
+          field: "image_url",
+        },
+        source: source.name,
+      } satisfies Binding<typeof source, { field: "image_url" }>,
+    });
+
+    expect(source).toEqual({
+      args: {
+        field: "image_url",
+      },
+      bindableAttributes: [
+        {
+          attributes: ["imageUrl"],
+          blockName: "example/profile-card",
+        },
+      ],
+      fields: [
+        {
+          args: {
+            field: "display_name",
+          },
+          label: "Display name",
+          name: "display_name",
+          type: "string",
+        },
+        {
+          args: {
+            field: "image_url",
+          },
+          label: "Image URL",
+          name: "image_url",
+          type: "string",
+        },
+      ],
+      getValueCallback: "example_get_profile_binding_value",
+      label: "Profile Data",
+      name: "example/profile-data",
+      usesContext: ["postId", "postType"],
+    });
+    expect(JSON.parse(JSON.stringify(source))).toEqual(source);
+    expect(getDefinedBindingSourceMetadata(source)?.diagnostics).toEqual([]);
+    expect(manifest?.supported.map((feature) => feature.feature)).toEqual([
+      "metadata.bindings",
+      "serverRegistration",
+      "editorRegistration",
+      "editorFieldsList",
+      "supportedAttributesFilter",
+    ]);
+    expect(bindingMetadata.bindings?.imageUrl?.source).toBe(
+      "example/profile-data",
+    );
+  });
+
+  test("reports unsupported editor field lists without generating them in fallback mode", () => {
+    const diagnostics: BindingSourceDiagnostic[] = [];
+    const source = defineBindingSource(
+      {
+        fields: [
+          {
+            args: {
+              field: "title",
+            },
+            label: "Title",
+            name: "title",
+            type: "string",
+          },
+        ],
+        getValueCallback: "example_get_post_binding_value",
+        label: "Post Data",
+        minWordPress: "6.7",
+        name: "example/post-data",
+        strict: false,
+      },
+      {
+        onDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+      },
+    );
+    const editorSource = createEditorBindingSourceRegistrationSource(source);
+
+    expect(diagnostics).toMatchObject([
+      {
+        code: "unsupported-wordpress-block-api-feature",
+        feature: "editorFieldsList",
+        requiredVersion: "6.9",
+        severity: "warning",
+      },
+    ]);
+    expect(editorSource).toContain("registerBlockBindingsSource");
+    expect(editorSource).not.toContain("getFieldsList: () => fields");
+    expect(editorSource).toContain("Skipped getFieldsList()");
+  });
+
+  test("supports server-only sources without editor registration output", () => {
+    const source = defineBindingSource({
+      editor: false,
+      getValueCallback: "example_get_server_only_binding_value",
+      label: "Server Only",
+      name: "example/server-only",
+    });
+    const manifest = getDefinedBindingSourceCompatibilityManifest(source);
+    const editorSource = createEditorBindingSourceRegistrationSource(source);
+
+    expect(manifest?.supported.map((feature) => feature.feature)).toEqual([
+      "metadata.bindings",
+      "serverRegistration",
+    ]);
+    expect(editorSource).toContain(
+      "No editor block binding sources were generated.",
+    );
+    expect(editorSource).not.toContain("registerBlockBindingsSource");
+  });
+
+  test("throws in strict mode for invalid sources and missing PHP callbacks", () => {
+    expect(() =>
+      defineBindingSource({
+        label: "Invalid",
+        name: "Example/Profile",
+      }),
+    ).toThrow("must be lowercase and namespaced");
+    expect(() =>
+      defineBindingSource({
+        label: "Missing callback",
+        name: "example/missing-callback",
+      }),
+    ).toThrow("needs getValueCallback");
+  });
+
+  test("reports duplicate fields and bindable attributes through diagnostics", () => {
+    const diagnostics: BindingSourceDiagnostic[] = [];
+
+    defineBindingSource(
+      {
+        bindableAttributes: [
+          defineBindableAttributes("example/profile-card", [
+            "imageUrl",
+            "imageUrl",
+          ] as const),
+        ],
+        fields: [
+          {
+            label: "Title",
+            name: "title",
+          },
+          {
+            label: "Title duplicate",
+            name: "title",
+          },
+        ],
+        getValueCallback: "example_get_profile_binding_value",
+        name: "example/profile-data",
+        strict: false,
+      },
+      {
+        onDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+      },
+    );
+
+    expect(diagnostics).toMatchObject([
+      {
+        code: "unsupported-wordpress-block-api-feature",
+        feature: "editorFieldsList",
+      },
+      {
+        code: "unsupported-wordpress-block-api-feature",
+        feature: "supportedAttributesFilter",
+      },
+      {
+        code: "duplicate-field-name",
+        fieldName: "title",
+      },
+      {
+        attribute: "imageUrl",
+        code: "duplicate-bindable-attribute",
+      },
+    ]);
+  });
+});
+
+describe("binding source registration source generation", () => {
+  test("generates PHP and editor registration sources for supported bindings", () => {
+    const source = defineBindingSource({
+      bindableAttributes: [
+        defineBindableAttributes<ProfileCardAttributes>(
+          "example/profile-card",
+          ["imageUrl"] as const,
+        ),
+      ],
+      fields: [
+        {
+          args: {
+            field: "image_url",
+          },
+          label: "Image URL",
+          name: "image_url",
+          type: "string",
+        },
+      ],
+      getValueCallback: "example_get_profile_binding_value",
+      label: "Profile Data",
+      minWordPress: {
+        editor: "6.7",
+        fieldsList: "6.9",
+        server: "6.5",
+        supportedAttributesFilter: "6.9",
+      },
+      name: "example/profile-data",
+      usesContext: ["postId"],
+    });
+    const phpSource = createPhpBindingSourceRegistrationSource(source, {
+      textDomain: "example",
+    });
+    const editorSource = createEditorBindingSourceRegistrationSource(source);
+
+    expect(phpSource).toContain(
+      "register_block_bindings_source( 'example/profile-data'",
+    );
+    expect(phpSource).toContain("'uses_context' => array( 'postId' )");
+    expect(phpSource).toContain(
+      "'get_value_callback' => 'example_get_profile_binding_value'",
+    );
+    expect(phpSource).toContain(
+      "block_bindings_supported_attributes_example/profile-card",
+    );
+    expect(phpSource).toContain("array( 'imageUrl' )");
+    expect(editorSource).toContain(
+      'import { registerBlockBindingsSource } from "@wordpress/blocks";',
+    );
+    expect(editorSource).toContain('"name": "example/profile-data"');
+    expect(editorSource).toContain('"name": "image_url"');
+    expect(editorSource).toContain("getFieldsList: () => fields");
+  });
+
+  test("exposes a direct compatibility manifest helper", () => {
+    const manifest = createBindingSourceCompatibilityManifest({
+      fieldsList: true,
+      minWordPress: {
+        editor: "6.7",
+        fieldsList: "6.9",
+        server: "6.5",
+      },
+    });
+
+    expect(manifest.supported.map((feature) => feature.feature)).toEqual([
+      "metadata.bindings",
+      "serverRegistration",
+      "editorRegistration",
+      "editorFieldsList",
+    ]);
+  });
+});

--- a/packages/wp-typia-block-types/tests/compatibility.test.ts
+++ b/packages/wp-typia-block-types/tests/compatibility.test.ts
@@ -48,6 +48,13 @@ describe("WordPress block API compatibility matrix", () => {
 			source: "blockBindingsReference",
 		});
 		expect(
+			WORDPRESS_BLOCK_API_COMPATIBILITY.blockBindings.editorFieldsList,
+		).toMatchObject({
+			runtime: ["editor-js"],
+			since: "6.9",
+			source: "blockBindingsHandbook",
+		});
+		expect(
 			WORDPRESS_BLOCK_API_COMPATIBILITY.blockBindings.supportedAttributesFilter,
 		).toMatchObject({
 			since: "6.9",

--- a/packages/wp-typia-block-types/tests/fixtures/public-type-contracts.ts
+++ b/packages/wp-typia-block-types/tests/fixtures/public-type-contracts.ts
@@ -55,11 +55,27 @@ import {
 import {
 	WORDPRESS_BLOCK_API_COMPATIBILITY,
 	createWordPressBlockApiCompatibilityManifest,
+	type WordPressBlockBindingCompatibilityFeature,
 	type WordPressBlockApiCompatibilityFeature,
 	type WordPressBlockSupportCompatibilityFeature,
 	type WordPressCompatibilitySettings,
 	type WordPressVersion,
 } from "@wp-typia/block-types/blocks/compatibility";
+import {
+	createEditorBindingSourceRegistrationSource,
+	createPhpBindingSourceRegistrationSource,
+	defineBindableAttributes,
+	defineBindingSource,
+	defineBlockMetadataBindings,
+	defineTypedBlockMetadataBindings,
+	getDefinedBindingSourceMetadata,
+	getDefinedBindingSourceCompatibilityManifest,
+	type Binding,
+	type BindingSourceField,
+	type BindingSourceRegistrationEntry,
+	type BlockMetadataBindings,
+	type TypedBlockMetadataBindings,
+} from "@wp-typia/block-types/blocks/bindings";
 import {
 	BLOCK_VARIATION_SCOPES,
 	registerScaffoldBlockType,
@@ -132,6 +148,8 @@ const compatibilityFeature: WordPressBlockApiCompatibilityFeature = {
 };
 const supportCompatibilityFeature: WordPressBlockSupportCompatibilityFeature =
 	"typography.textAlign";
+const bindingCompatibilityFeature: WordPressBlockBindingCompatibilityFeature =
+	"editorFieldsList";
 const compatibilityManifest = createWordPressBlockApiCompatibilityManifest(
 	[compatibilityFeature],
 	compatibilitySettings,
@@ -184,6 +202,92 @@ const alignWideDoesNotExposeAlign: "align" extends keyof AlignWideOnlySupportAtt
 
 type ExampleAttributes = SupportAttributes<typeof proseSupports> & {
 	content: string;
+};
+
+type ProfileBindingArgs = {
+	field: "display_name" | "image_url";
+};
+
+type ProfileCardAttributes = {
+	displayName?: string;
+	imageUrl?: string;
+	metadata?: BlockMetadataBindings<{
+		imageUrl: Binding<"example/profile-data", { field: "image_url" }>;
+	}>;
+};
+
+const profileBindableAttributes =
+	defineBindableAttributes<ProfileCardAttributes>("example/profile-card", [
+		"imageUrl",
+	] as const);
+const profileFields = [
+	{
+		args: {
+			field: "display_name",
+		},
+		label: "Display name",
+		name: "display_name",
+		type: "string",
+	},
+	{
+		args: {
+			field: "image_url",
+		},
+		label: "Image URL",
+		name: "image_url",
+		type: "string",
+	},
+] as const satisfies readonly BindingSourceField<ProfileBindingArgs>[];
+const profileDataSource = defineBindingSource({
+	args: {
+		field: "display_name" as ProfileBindingArgs["field"],
+	},
+	bindableAttributes: [profileBindableAttributes],
+	fields: profileFields,
+	getValueCallback: "example_get_profile_binding_value",
+	label: "Profile Data",
+	minWordPress: {
+		editor: "6.7",
+		fieldsList: "6.9",
+		server: "6.5",
+		supportedAttributesFilter: "6.9",
+	},
+	name: "example/profile-data",
+	usesContext: ["postId"],
+});
+const profileSourceManifest =
+	getDefinedBindingSourceCompatibilityManifest(profileDataSource);
+const profileSourceMetadata = getDefinedBindingSourceMetadata(profileDataSource);
+const profileMetadata = defineBlockMetadataBindings({
+	imageUrl: {
+		args: {
+			field: "image_url",
+		},
+		source: profileDataSource.name,
+	} satisfies Binding<typeof profileDataSource, { field: "image_url" }>,
+});
+const typedProfileMetadata =
+	defineTypedBlockMetadataBindings<ProfileCardAttributes>({
+		imageUrl: {
+			args: {
+				field: "display_name",
+			},
+			source: profileDataSource.name,
+		} satisfies Binding<typeof profileDataSource, { field: "display_name" }>,
+	});
+const profileMetadataContract: TypedBlockMetadataBindings<
+	ProfileCardAttributes,
+	{
+		imageUrl: Binding<typeof profileDataSource, { field: "image_url" }>;
+	}
+> = profileMetadata;
+const profilePhpRegistrationSource =
+	createPhpBindingSourceRegistrationSource(profileDataSource);
+const profileEditorRegistrationSource =
+	createEditorBindingSourceRegistrationSource(profileDataSource);
+const profileRegistrationEntry: BindingSourceRegistrationEntry = {
+	metadata: profileSourceMetadata!,
+	source: profileDataSource,
 };
 
 type ParagraphVariationAttributes = {
@@ -360,6 +464,7 @@ void spacingSupportKeys;
 void typographySupportKeys;
 void compatibilityManifest;
 void supportCompatibilityFeature;
+void bindingCompatibilityFeature;
 void supportsTextAlignSince;
 void proseSupports;
 void proseSupportManifest;
@@ -367,6 +472,17 @@ void alignSupports;
 void alignSupportHasAlign;
 void alignWideOnlySupports;
 void alignWideDoesNotExposeAlign;
+void profileBindableAttributes;
+void profileFields;
+void profileDataSource;
+void profileSourceManifest;
+void profileSourceMetadata;
+void profileMetadata;
+void typedProfileMetadata;
+void profileMetadataContract;
+void profilePhpRegistrationSource;
+void profileEditorRegistrationSource;
+void profileRegistrationEntry;
 void paragraphVariation;
 void headingVariation;
 void proseGroupVariation;
@@ -408,8 +524,36 @@ const invalidVariationActiveAttribute = defineVariation<HeadingVariationAttribut
 	},
 );
 
+// @ts-expect-error Binding args must match the source args declared by defineBindingSource().
+const invalidProfileBinding: Binding<typeof profileDataSource, { field: "missing" }> = {
+	args: {
+		field: "missing",
+	},
+	source: profileDataSource.name,
+};
+
+const invalidBindableAttributes =
+	defineBindableAttributes<ProfileCardAttributes>("example/profile-card", [
+		// @ts-expect-error Bindable attributes must reference typed block attributes.
+		"missing",
+	] as const);
+
+const invalidTypedProfileMetadata =
+	defineTypedBlockMetadataBindings<ProfileCardAttributes>({
+		// @ts-expect-error metadata.bindings keys must reference typed block attributes.
+		missing: {
+			args: {
+				field: "image_url",
+			},
+			source: profileDataSource.name,
+		},
+	});
+
 void invalidBlockAlignment;
 void invalidNamedColor;
 void invalidVariationScope;
 void invalidTextAlignments;
 void invalidVariationActiveAttribute;
+void invalidProfileBinding;
+void invalidBindableAttributes;
+void invalidTypedProfileMetadata;

--- a/packages/wp-typia-block-types/tests/package-contracts.test.ts
+++ b/packages/wp-typia-block-types/tests/package-contracts.test.ts
@@ -41,6 +41,10 @@ function writeMockWordPressBlocks(projectRoot: string) {
 			"  globalThis.__wpTypiaRegisteredVariations ??= [];",
 			"  globalThis.__wpTypiaRegisteredVariations.push({ blockName, variation });",
 			"}",
+			"export function registerBlockBindingsSource(source) {",
+			"  globalThis.__wpTypiaRegisteredBindingSources ??= [];",
+			"  globalThis.__wpTypiaRegisteredBindingSources.push(source);",
+			"}",
 			"",
 		].join("\n"),
 		"utf8",
@@ -95,6 +99,11 @@ describe("@wp-typia/block-types export contracts", () => {
 			import: "./dist/blocks/index.js",
 			types: "./dist/blocks/index.d.ts",
 		});
+		expect(packageJson.exports?.["./blocks/bindings"]).toEqual({
+			default: "./dist/blocks/bindings.js",
+			import: "./dist/blocks/bindings.js",
+			types: "./dist/blocks/bindings.d.ts",
+		});
 		expect(packageJson.exports?.["./blocks/compatibility"]).toEqual({
 			default: "./dist/blocks/compatibility.js",
 			import: "./dist/blocks/compatibility.js",
@@ -138,6 +147,7 @@ describe("@wp-typia/block-types export contracts", () => {
 							"const styleAttributes = await import('@wp-typia/block-types/block-editor/style-attributes');",
 							"const typography = await import('@wp-typia/block-types/block-editor/typography');",
 							"const blocks = await import('@wp-typia/block-types/blocks');",
+							"const bindings = await import('@wp-typia/block-types/blocks/bindings');",
 							"const compatibility = await import('@wp-typia/block-types/blocks/compatibility');",
 							"const registration = await import('@wp-typia/block-types/blocks/registration');",
 							"const supports = await import('@wp-typia/block-types/blocks/supports');",
@@ -148,11 +158,21 @@ describe("@wp-typia/block-types export contracts", () => {
 							"const paragraphVariation = variations.defineVariation('core/paragraph', { allowMissingIsActive: true, name: 'demo-paragraph', title: 'Demo Paragraph', attributes: { className: 'is-style-demo' } });",
 							"const variationManifest = variations.getDefinedVariationCompatibilityManifest(paragraphVariation);",
 							"const variationSource = variations.createStaticBlockVariationRegistrationSource([paragraphVariation]);",
+							"const profileSource = bindings.defineBindingSource({ name: 'example/profile-data', label: 'Profile Data', getValueCallback: 'example_get_profile_binding_value', minWordPress: { server: '6.5', editor: '6.7', fieldsList: '6.9', supportedAttributesFilter: '6.9' }, fields: [{ name: 'image_url', label: 'Image URL', args: { field: 'image_url' } }], bindableAttributes: [bindings.defineBindableAttributes('example/profile-card', ['imageUrl'])] });",
+							"const bindingManifest = bindings.getDefinedBindingSourceCompatibilityManifest(profileSource);",
+							"const bindingMetadata = bindings.defineBlockMetadataBindings({ imageUrl: { source: profileSource.name, args: { field: 'image_url' } } });",
+							"const bindingPhpSource = bindings.createPhpBindingSourceRegistrationSource(profileSource);",
+							"const bindingEditorSource = bindings.createEditorBindingSourceRegistrationSource(profileSource);",
 							"console.log(JSON.stringify({",
+							"  bindingEditorSourceHasRegistration: bindingEditorSource.includes('registerBlockBindingsSource({'),",
+							"  bindingManifestFeatures: bindingManifest.supported.map((feature) => feature.feature),",
+							"  bindingMetadataSource: bindingMetadata.bindings.imageUrl.source,",
+							"  bindingPhpSourceHasRegistration: bindingPhpSource.includes(\"register_block_bindings_source( 'example/profile-data'\"),",
 							"  definedSupportsPadding: definedSupports.spacing.padding,",
 							"  definedSupportsManifestFeatures: supportsManifest.supported.map((feature) => feature.feature),",
 							"  definedVariationBlockName: variations.getDefinedVariationBlockName(paragraphVariation),",
 							"  definedVariationManifestFeatures: variationManifest.supported.map((feature) => feature.feature),",
+							"  rootHasBindings: typeof root.defineBindingSource === 'function',",
 							"  rootHasVariations: typeof root.defineVariation === 'function',",
 							"  rootHasRegister: typeof root.registerScaffoldBlockType === 'function',",
 							"  rootHasSupports: Array.isArray(root.BLOCK_SUPPORT_FEATURES),",
@@ -181,6 +201,10 @@ describe("@wp-typia/block-types export contracts", () => {
 			) as {
 				alignments: string[];
 				aspectRatios: string[];
+				bindingEditorSourceHasRegistration: boolean;
+				bindingManifestFeatures: string[];
+				bindingMetadataSource: string;
+				bindingPhpSourceHasRegistration: boolean;
 				blockEditorHasSpacing: boolean;
 				definedVariationBlockName: string | undefined;
 				definedVariationManifestFeatures: string[];
@@ -190,6 +214,7 @@ describe("@wp-typia/block-types export contracts", () => {
 				namedColors: string[];
 				registeredName: string | null;
 				registeredTitle: string | null;
+				rootHasBindings: boolean;
 				rootHasRegister: boolean;
 				rootHasSupports: boolean;
 				rootHasVariations: boolean;
@@ -206,6 +231,17 @@ describe("@wp-typia/block-types export contracts", () => {
 		expect(summary.rootHasRegister).toBe(true);
 		expect(summary.rootHasSupports).toBe(true);
 		expect(summary.rootHasVariations).toBe(true);
+		expect(summary.rootHasBindings).toBe(true);
+		expect(summary.bindingManifestFeatures).toEqual([
+			"metadata.bindings",
+			"serverRegistration",
+			"editorRegistration",
+			"editorFieldsList",
+			"supportedAttributesFilter",
+		]);
+		expect(summary.bindingMetadataSource).toBe("example/profile-data");
+		expect(summary.bindingPhpSourceHasRegistration).toBe(true);
+		expect(summary.bindingEditorSourceHasRegistration).toBe(true);
 		expect(summary.definedSupportsPadding).toBe(true);
 		expect(summary.definedSupportsManifestFeatures).toEqual([
 			"spacing.padding",
@@ -262,6 +298,7 @@ describe("@wp-typia/block-types export contracts", () => {
 		expect(builtIndexDts).toContain('export * from "./blocks/index.js";');
 		expect(builtBlockEditorIndexJs).toContain('export * from "./alignment.js";');
 		expect(builtBlockEditorIndexJs).toContain('export * from "./style-attributes.js";');
+		expect(builtBlocksIndexJs).toContain('export * from "./bindings.js";');
 		expect(builtBlocksIndexJs).toContain('export * from "./registration.js";');
 		expect(builtBlocksIndexJs).toContain('export * from "./supports.js";');
 		expect(builtBlocksIndexJs).toContain('export * from "./compatibility.js";');

--- a/packages/wp-typia-block-types/tests/type-contracts.test.ts
+++ b/packages/wp-typia-block-types/tests/type-contracts.test.ts
@@ -37,6 +37,7 @@ describe("@wp-typia/block-types type contracts", () => {
 		const fixtureSource = readFileSync(fixtureSourcePath, "utf8");
 
 		expect(fixtureSource).toContain("@wp-typia/block-types/blocks/registration");
+		expect(fixtureSource).toContain("@wp-typia/block-types/blocks/bindings");
 		expect(fixtureSource).toContain("@wp-typia/block-types/blocks/compatibility");
 		expect(fixtureSource).toContain("@wp-typia/block-types/blocks/supports");
 		expect(fixtureSource).toContain("@wp-typia/block-types/blocks/variations");
@@ -48,6 +49,8 @@ describe("@wp-typia/block-types type contracts", () => {
 		expect(fixtureSource).toContain("SupportAttributes<typeof proseSupports>");
 		expect(fixtureSource).toContain("defineVariation");
 		expect(fixtureSource).toContain("defineVariations");
+		expect(fixtureSource).toContain("defineBindingSource");
+		expect(fixtureSource).toContain("Binding<typeof profileDataSource");
 		expect(fixtureSource).toContain("registerScaffoldBlockType");
 	});
 });

--- a/tests/type-smoke/block-types-smoke.ts
+++ b/tests/type-smoke/block-types-smoke.ts
@@ -41,6 +41,19 @@ import {
   type WordPressVersion,
 } from '@wp-typia/block-types/blocks/compatibility';
 import {
+  createEditorBindingSourceRegistrationSource,
+  createPhpBindingSourceRegistrationSource,
+  defineBindableAttributes,
+  defineBindingSource,
+  defineTypedBlockMetadataBindings,
+} from '@wp-typia/block-types/blocks/bindings';
+import type {
+  Binding,
+  BindingSourceDiagnostic,
+  BindingSourceRegistrationEntry,
+  TypedBlockMetadataBindings,
+} from '@wp-typia/block-types/blocks/bindings';
+import {
   defineSupports,
   getDefinedSupportsCompatibilityManifest,
 } from '@wp-typia/block-types/blocks/supports';
@@ -271,6 +284,10 @@ interface DemoRegistrationAttributes {
   content?: string;
   isVisible?: boolean;
 }
+interface DemoProfileAttributes {
+  displayName?: string;
+  imageUrl?: string;
+}
 
 const DemoEdit = (_props: BlockEditProps<DemoRegistrationAttributes>) => null;
 const DemoSave = (_props: BlockSaveProps<DemoRegistrationAttributes>) => null;
@@ -323,6 +340,61 @@ const typedVariationEntry: BlockVariationRegistrationEntry | undefined =
 const typedVariationSource =
   createStaticBlockVariationRegistrationSource(typedVariations);
 const variationDiagnostic: BlockVariationDiagnostic | undefined = undefined;
+const profileBindableAttributes =
+  defineBindableAttributes<DemoProfileAttributes>('demo/profile-card', [
+    'imageUrl',
+  ] as const);
+const profileBindingSource = defineBindingSource({
+  args: {
+    field: 'display_name' as 'display_name' | 'image_url',
+  },
+  bindableAttributes: [profileBindableAttributes],
+  fields: [
+    {
+      args: {
+        field: 'display_name',
+      },
+      label: 'Display name',
+      name: 'display_name',
+      type: 'string',
+    },
+    {
+      args: {
+        field: 'image_url',
+      },
+      label: 'Image URL',
+      name: 'image_url',
+      type: 'string',
+    },
+  ],
+  getValueCallback: 'demo_get_profile_binding_value',
+  label: 'Profile Data',
+  minWordPress: {
+    editor: '6.7',
+    fieldsList: '6.9',
+    server: '6.5',
+    supportedAttributesFilter: '6.9',
+  },
+  name: 'demo/profile-data',
+  usesContext: ['postId'],
+});
+const profileBindings = defineTypedBlockMetadataBindings<DemoProfileAttributes>({
+  imageUrl: {
+    args: {
+      field: 'image_url',
+    },
+    source: profileBindingSource.name,
+  } satisfies Binding<typeof profileBindingSource, { field: 'image_url' }>,
+});
+const profileBindingsContract: TypedBlockMetadataBindings<DemoProfileAttributes> =
+  profileBindings;
+const profilePhpSource =
+  createPhpBindingSourceRegistrationSource(profileBindingSource);
+const profileEditorSource =
+  createEditorBindingSourceRegistrationSource(profileBindingSource);
+const profileBindingDiagnostic: BindingSourceDiagnostic | undefined = undefined;
+const profileRegistrationEntry: BindingSourceRegistrationEntry | undefined =
+  undefined;
 const parsedBlock: BlockInstance<DemoRegistrationAttributes> = {
   attributes: { content: 'hello', isVisible: true },
   clientId: 'demo-client-id',
@@ -404,4 +476,12 @@ void typedVariationEntries;
 void typedVariationEntry;
 void typedVariationSource;
 void variationDiagnostic;
+void profileBindableAttributes;
+void profileBindingSource;
+void profileBindings;
+void profileBindingsContract;
+void profilePhpSource;
+void profileEditorSource;
+void profileBindingDiagnostic;
+void profileRegistrationEntry;
 void blockVerticalAlignment;


### PR DESCRIPTION
## Summary
- Add @wp-typia/block-types/blocks/bindings with defineBindingSource(), typed metadata.bindings helpers, bindable-attribute helpers, and PHP/editor registration source generation.
- Extend the Block Bindings compatibility matrix with the WordPress 6.9 getFieldsList() gate and per-surface source diagnostics.
- Cover runtime exports, public type contracts, docs, type smoke, and Sampo changeset for #965.

## Tests
- bun run --filter @wp-typia/block-types test
- bun run typecheck
- bun run format:check
- bun run changesets:validate
- bun run lint:repo

Closes #965

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced typed Block Bindings helper API for defining binding sources with full type safety.
  * Added automatic PHP and editor registration code generation for block bindings.
  * Included version-gated compatibility diagnostics for WordPress block binding features across different versions.
  * Added comprehensive block binding metadata types for typed block attribute bindings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/980)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->