### PR TITLE
feat: add typed block nesting contracts

### DIFF
--- a/.sampo/changesets/984-block-nesting-contracts.md
+++ b/.sampo/changesets/984-block-nesting-contracts.md
@@ -1,0 +1,7 @@
+---
+npm/@wp-typia/block-runtime: minor
+npm/@wp-typia/create-workspace-template: minor
+npm/@wp-typia/project-tools: minor
+---
+
+Add typed block nesting contracts that drive `block.json` `parent`, `ancestor`, and `allowedBlocks` metadata during sync, including unknown-reference diagnostics for generated workspaces.

--- a/README.md
+++ b/README.md
@@ -127,6 +127,13 @@ Use it for:
 
 The `compound` template creates a parent/child block structure with hidden implementation children, and the generated `add-child` workflow can now grow that into visible container children plus nested ancestor chains for richer document-style `InnerBlocks` hierarchies.
 
+Workspace projects can also keep static nesting metadata in one typed contract.
+Edit `BLOCK_NESTING` in `scripts/block-config.ts`, then run
+`wp-typia sync --check` to verify generated `block.json` `parent`,
+`ancestor`, and `allowedBlocks` fields still match the declared relationships.
+Unknown block references fail with actionable diagnostics before artifacts are
+rewritten.
+
 ### 5. Query Loop variations get a first-class scaffold
 
 The `query-loop` template scaffolds an editor-facing `core/query` variation plugin instead of a standalone block, so you can ship a branded inserter entry with stable namespace identity, default query settings, allowed inspector controls, and inline starter `innerBlocks` without rebuilding the full Query Loop setup flow by hand. Because it owns a variation rather than a standalone custom block, it intentionally does not generate `src/types.ts`, `block.json`, or Typia manifests. It also includes connected `src/patterns/*.php` presets so richer editorial layouts can live in pattern files while `src/index.ts` stays focused on variation identity and query defaults, a dedicated `src/query-extension.ts` seam for custom query params and optional editor-side hook registration, and `inc/query-runtime.php` hooks that keep frontend query mapping and editor preview requests aligned for the same variation.

--- a/README.md
+++ b/README.md
@@ -131,8 +131,9 @@ Workspace projects can also keep static nesting metadata in one typed contract.
 Edit `BLOCK_NESTING` in `scripts/block-config.ts`, then run
 `wp-typia sync --check` to verify generated `block.json` `parent`,
 `ancestor`, and `allowedBlocks` fields still match the declared relationships.
-Unknown block references fail with actionable diagnostics before artifacts are
-rewritten.
+Unknown workspace-local block references fail with actionable diagnostics before
+artifacts are rewritten, while external WordPress or plugin blocks like
+`core/group` remain valid relationship targets.
 
 ### 5. Query Loop variations get a first-class scaffold
 

--- a/packages/create-workspace-template/README.md
+++ b/packages/create-workspace-template/README.md
@@ -30,7 +30,8 @@ npm run wp-typia:add -- hooked-block my-block --anchor core/post-content --posit
 Typed block nesting rules live in `BLOCK_NESTING` inside
 `scripts/block-config.ts`. Declare `parent`, `ancestor`, or `allowedBlocks`
 relationships there and `wp-typia sync --check` will validate referenced block
-names and keep the matching `block.json` metadata current.
+names in the workspace namespace while allowing external targets like
+`core/group`, then keep the matching `block.json` metadata current.
 
 ## CLI binary policy
 

--- a/packages/create-workspace-template/README.md
+++ b/packages/create-workspace-template/README.md
@@ -27,6 +27,11 @@ npm run wp-typia:add -- editor-plugin seo-notes --slot document-setting-panel
 npm run wp-typia:add -- hooked-block my-block --anchor core/post-content --position after
 ```
 
+Typed block nesting rules live in `BLOCK_NESTING` inside
+`scripts/block-config.ts`. Declare `parent`, `ancestor`, or `allowedBlocks`
+relationships there and `wp-typia sync --check` will validate referenced block
+names and keep the matching `block.json` metadata current.
+
 ## CLI binary policy
 
 Official workspace projects install `wp-typia` as a local devDependency and

--- a/packages/create-workspace-template/README.md.mustache
+++ b/packages/create-workspace-template/README.md.mustache
@@ -47,7 +47,8 @@ bun run wp-typia:add binding-source integration-state-source --from-post-meta in
 Typed block nesting rules live in `BLOCK_NESTING` inside
 `scripts/block-config.ts`. Declare `parent`, `ancestor`, or `allowedBlocks`
 relationships there and `wp-typia sync --check` will validate referenced block
-names and keep the matching `block.json` metadata current.
+names in the workspace namespace while allowing external targets like
+`core/group`, then keep the matching `block.json` metadata current.
 
 ## CLI Commands
 

--- a/packages/create-workspace-template/README.md.mustache
+++ b/packages/create-workspace-template/README.md.mustache
@@ -44,6 +44,11 @@ bun run wp-typia:add post-meta integration-state --post-type post
 bun run wp-typia:add binding-source integration-state-source --from-post-meta integration-state --meta-path status --block counter-card --attribute headline
 ```
 
+Typed block nesting rules live in `BLOCK_NESTING` inside
+`scripts/block-config.ts`. Declare `parent`, `ancestor`, or `allowedBlocks`
+relationships there and `wp-typia sync --check` will validate referenced block
+names and keep the matching `block.json` metadata current.
+
 ## CLI Commands
 
 This workspace installs the executable `wp-typia` CLI as a local devDependency

--- a/packages/create-workspace-template/scripts/block-config.ts.mustache
+++ b/packages/create-workspace-template/scripts/block-config.ts.mustache
@@ -1,3 +1,5 @@
+import { defineBlockNesting } from '@wp-typia/block-runtime/metadata-core';
+
 export interface WorkspaceBlockConfig {
 	slug: string;
 	attributeTypeName: string;
@@ -8,6 +10,10 @@ export interface WorkspaceBlockConfig {
 		typeof import( '@wp-typia/block-runtime/metadata-core' ).defineEndpointManifest
 	>;
 }
+
+export const BLOCK_NESTING = defineBlockNesting( {
+	// Add parent, ancestor, and allowedBlocks relationships here.
+} );
 
 export interface WorkspaceVariationConfig {
 	block: string;

--- a/packages/create-workspace-template/scripts/sync-types-to-block-json.ts.mustache
+++ b/packages/create-workspace-template/scripts/sync-types-to-block-json.ts.mustache
@@ -28,9 +28,18 @@ function parseCliOptions( argv: string[] ) {
 
 function readWorkspaceBlockName( block: ( typeof BLOCKS )[ number ] ): string {
 	const blockJsonFile = path.join( 'src', 'blocks', block.slug, 'block.json' );
-	const blockJson = JSON.parse( fs.readFileSync( blockJsonFile, 'utf8' ) ) as {
-		name?: unknown;
-	};
+	let blockJson: { name?: unknown };
+	try {
+		blockJson = JSON.parse( fs.readFileSync( blockJsonFile, 'utf8' ) ) as {
+			name?: unknown;
+		};
+	} catch ( error ) {
+		throw new Error(
+			`Failed to read block.json for block "${ block.slug }" at ${ blockJsonFile }: ${
+				error instanceof Error ? error.message : String( error )
+			}`
+		);
+	}
 	if ( typeof blockJson.name !== 'string' || blockJson.name.trim() === '' ) {
 		throw new Error( `${ blockJsonFile } must define a string "name".` );
 	}
@@ -51,12 +60,16 @@ async function main() {
 	}
 
 	const knownBlockNames = BLOCKS.map( readWorkspaceBlockName );
-	validateBlockNestingContract( BLOCK_NESTING, { knownBlockNames } );
+	validateBlockNestingContract( BLOCK_NESTING, {
+		allowExternalBlockNames: true,
+		knownBlockNames,
+	} );
 
 	for ( const block of BLOCKS ) {
 		const baseDir = path.join( 'src', 'blocks', block.slug );
 		const result = await syncBlockMetadata(
 			{
+				allowExternalBlockNames: true,
 				blockJsonFile: path.join( baseDir, 'block.json' ),
 				jsonSchemaFile: path.join( baseDir, 'typia.schema.json' ),
 				knownBlockNames,

--- a/packages/create-workspace-template/scripts/sync-types-to-block-json.ts.mustache
+++ b/packages/create-workspace-template/scripts/sync-types-to-block-json.ts.mustache
@@ -1,9 +1,13 @@
 /* eslint-disable no-console */
+import fs from 'node:fs';
 import path from 'node:path';
 
-import { syncBlockMetadata } from '@wp-typia/block-runtime/metadata-core';
+import {
+	syncBlockMetadata,
+	validateBlockNestingContract,
+} from '@wp-typia/block-runtime/metadata-core';
 
-import { BLOCKS } from './block-config';
+import { BLOCK_NESTING, BLOCKS } from './block-config';
 
 function parseCliOptions( argv: string[] ) {
 	const options = {
@@ -22,6 +26,18 @@ function parseCliOptions( argv: string[] ) {
 	return options;
 }
 
+function readWorkspaceBlockName( block: ( typeof BLOCKS )[ number ] ): string {
+	const blockJsonFile = path.join( 'src', 'blocks', block.slug, 'block.json' );
+	const blockJson = JSON.parse( fs.readFileSync( blockJsonFile, 'utf8' ) ) as {
+		name?: unknown;
+	};
+	if ( typeof blockJson.name !== 'string' || blockJson.name.trim() === '' ) {
+		throw new Error( `${ blockJsonFile } must define a string "name".` );
+	}
+
+	return blockJson.name;
+}
+
 async function main() {
 	const options = parseCliOptions( process.argv.slice( 2 ) );
 
@@ -34,13 +50,18 @@ async function main() {
 		return;
 	}
 
+	const knownBlockNames = BLOCKS.map( readWorkspaceBlockName );
+	validateBlockNestingContract( BLOCK_NESTING, { knownBlockNames } );
+
 	for ( const block of BLOCKS ) {
 		const baseDir = path.join( 'src', 'blocks', block.slug );
 		const result = await syncBlockMetadata(
 			{
 				blockJsonFile: path.join( baseDir, 'block.json' ),
 				jsonSchemaFile: path.join( baseDir, 'typia.schema.json' ),
+				knownBlockNames,
 				manifestFile: path.join( baseDir, 'typia.manifest.json' ),
+				nesting: BLOCK_NESTING,
 				openApiFile: path.join( baseDir, 'typia.openapi.json' ),
 				sourceTypeName: block.attributeTypeName,
 				typesFile: block.typesFile,

--- a/packages/wp-typia-block-runtime/README.md
+++ b/packages/wp-typia-block-runtime/README.md
@@ -9,6 +9,7 @@ This is the supported generated-project package boundary for:
 - manifest-driven inspector helpers
 - validation-aware attribute updates
 - TypeScript-to-metadata sync
+- typed block nesting contracts for `parent`, `ancestor`, and `allowedBlocks`
 - manifest-first REST/OpenAPI/client codegen
 
 It does not include:
@@ -28,7 +29,10 @@ import {
 import { collectPersistentBlockIdentityRepairs } from '@wp-typia/block-runtime/identifiers';
 import { assertResponseMatchesSchema } from '@wp-typia/block-runtime/schema-test';
 import { createNestedAttributeUpdater } from '@wp-typia/block-runtime/validation';
-import { runSyncBlockMetadata } from '@wp-typia/block-runtime/metadata-core';
+import {
+  defineBlockNesting,
+  runSyncBlockMetadata,
+} from '@wp-typia/block-runtime/metadata-core';
 import type { tags } from '@wp-typia/block-runtime/typia-tags';
 ```
 

--- a/packages/wp-typia-block-runtime/src/metadata-core-artifacts.ts
+++ b/packages/wp-typia-block-runtime/src/metadata-core-artifacts.ts
@@ -158,6 +158,12 @@ function resolveSyncBlockMetadataFailureCode(
     return 'recursive-type';
   }
   if (
+    message.startsWith('Invalid block nesting contract:') ||
+    message.includes('before applying block nesting metadata')
+  ) {
+    return 'invalid-block-nesting-contract';
+  }
+  if (
     message.startsWith('Unable to load types file:') ||
     message.startsWith('Unable to find source type "') ||
     message.startsWith('Unable to resolve type reference "') ||

--- a/packages/wp-typia-block-runtime/src/metadata-core-nesting.ts
+++ b/packages/wp-typia-block-runtime/src/metadata-core-nesting.ts
@@ -15,6 +15,7 @@ export interface BlockNestingRule {
 export type BlockNestingContract = Readonly<Record<string, BlockNestingRule>>;
 
 export interface ValidateBlockNestingContractOptions {
+  allowExternalBlockNames?: boolean;
   knownBlockNames?: readonly string[];
 }
 
@@ -24,12 +25,22 @@ interface NormalizedBlockNestingRule {
   parent?: string[];
 }
 
+interface KnownBlockNameValidationContext {
+  allowExternalBlockNames: boolean;
+  knownBlockNames: ReadonlySet<string>;
+  knownBlockNamespaces: ReadonlySet<string>;
+}
+
 function hasOwn(object: object, key: string): boolean {
   return Object.prototype.hasOwnProperty.call(object, key);
 }
 
 function formatKnownBlockNames(knownBlockNames: ReadonlySet<string>): string {
   return [...knownBlockNames].sort().join(', ');
+}
+
+function getBlockNamespace(blockName: string): string {
+  return blockName.slice(0, blockName.indexOf('/'));
 }
 
 function assertBlockName(name: string, context: string): void {
@@ -83,19 +94,53 @@ function normalizeBlockNestingRule(
   return normalized;
 }
 
+function createKnownBlockNameValidationContext(
+  options: ValidateBlockNestingContractOptions,
+): KnownBlockNameValidationContext | null {
+  if (!options.knownBlockNames) {
+    return null;
+  }
+
+  const knownBlockNames = new Set(options.knownBlockNames);
+  return {
+    allowExternalBlockNames: options.allowExternalBlockNames === true,
+    knownBlockNames,
+    knownBlockNamespaces: new Set(
+      [...knownBlockNames].map((blockName) => getBlockNamespace(blockName)),
+    ),
+  };
+}
+
 function validateKnownBlockName(
   issues: string[],
-  knownBlockNames: ReadonlySet<string> | null,
+  knownBlockNameContext: KnownBlockNameValidationContext | null,
   blockName: string,
   context: string,
+  options: {
+    allowExternalBlockName?: boolean;
+  } = {},
 ): void {
-  if (knownBlockNames && !knownBlockNames.has(blockName)) {
-    issues.push(
-      `${context} references unknown block "${blockName}". Expected one of: ${formatKnownBlockNames(
-        knownBlockNames,
-      )}.`,
-    );
+  if (
+    !knownBlockNameContext ||
+    knownBlockNameContext.knownBlockNames.has(blockName)
+  ) {
+    return;
   }
+
+  const isExternalBlockName =
+    options.allowExternalBlockName === true &&
+    knownBlockNameContext.allowExternalBlockNames &&
+    !knownBlockNameContext.knownBlockNamespaces.has(getBlockNamespace(blockName));
+
+  if (isExternalBlockName) {
+    return;
+  }
+
+  issues.push(
+    `${context} references unknown block "${blockName}". Expected one of: ${formatKnownBlockNames(
+      knownBlockNameContext.knownBlockNames,
+    )}.`,
+  );
 }
 
 function normalizeBlockNestingContract(
@@ -125,13 +170,12 @@ export function validateBlockNestingContract(
   options: ValidateBlockNestingContractOptions = {},
 ): void {
   const normalized = normalizeBlockNestingContract(contract);
-  const knownBlockNames = options.knownBlockNames
-    ? new Set(options.knownBlockNames)
-    : null;
+  const knownBlockNameContext =
+    createKnownBlockNameValidationContext(options);
   const issues: string[] = [];
 
   for (const [blockName, rule] of Object.entries(normalized)) {
-    validateKnownBlockName(issues, knownBlockNames, blockName, 'Contract key');
+    validateKnownBlockName(issues, knownBlockNameContext, blockName, 'Contract key');
 
     for (const key of BLOCK_NESTING_RELATION_KEYS) {
       const relatedBlockNames = rule[key];
@@ -142,9 +186,10 @@ export function validateBlockNestingContract(
       for (const relatedBlockName of relatedBlockNames) {
         validateKnownBlockName(
           issues,
-          knownBlockNames,
+          knownBlockNameContext,
           relatedBlockName,
           `${blockName}.${key}`,
+          { allowExternalBlockName: true },
         );
         if (
           relatedBlockName === blockName &&
@@ -152,6 +197,21 @@ export function validateBlockNestingContract(
         ) {
           issues.push(`${blockName}.${key} must not reference itself.`);
         }
+      }
+    }
+  }
+
+  for (const [childBlockName, rule] of Object.entries(normalized)) {
+    for (const parentBlockName of rule.parent ?? []) {
+      const parentRule = normalized[parentBlockName];
+      if (
+        parentRule?.allowedBlocks &&
+        parentRule.allowedBlocks.length > 0 &&
+        !parentRule.allowedBlocks.includes(childBlockName)
+      ) {
+        issues.push(
+          `${childBlockName}.parent includes "${parentBlockName}", but ${parentBlockName}.allowedBlocks does not include "${childBlockName}".`,
+        );
       }
     }
   }
@@ -188,6 +248,8 @@ export function applyBlockNestingMetadata({
   if (!nesting || !hasOwn(nesting, blockName)) {
     return [];
   }
+
+  validateBlockNestingContract(nesting);
 
   const rule = normalizeBlockNestingRule(blockName, nesting[blockName]);
   const appliedKeys: BlockNestingRelationKey[] = [];

--- a/packages/wp-typia-block-runtime/src/metadata-core-nesting.ts
+++ b/packages/wp-typia-block-runtime/src/metadata-core-nesting.ts
@@ -1,0 +1,205 @@
+const BLOCK_NESTING_RELATION_KEYS = [
+  'parent',
+  'ancestor',
+  'allowedBlocks',
+] as const;
+
+type BlockNestingRelationKey = (typeof BLOCK_NESTING_RELATION_KEYS)[number];
+
+export interface BlockNestingRule {
+  ancestor?: readonly string[];
+  allowedBlocks?: readonly string[];
+  parent?: readonly string[];
+}
+
+export type BlockNestingContract = Readonly<Record<string, BlockNestingRule>>;
+
+export interface ValidateBlockNestingContractOptions {
+  knownBlockNames?: readonly string[];
+}
+
+interface NormalizedBlockNestingRule {
+  ancestor?: string[];
+  allowedBlocks?: string[];
+  parent?: string[];
+}
+
+function hasOwn(object: object, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(object, key);
+}
+
+function formatKnownBlockNames(knownBlockNames: ReadonlySet<string>): string {
+  return [...knownBlockNames].sort().join(', ');
+}
+
+function assertBlockName(name: string, context: string): void {
+  if (name.length === 0 || name !== name.trim() || !name.includes('/')) {
+    throw new Error(`${context} must be a non-empty namespaced block name.`);
+  }
+}
+
+function normalizeRelationList(
+  value: unknown,
+  context: string,
+): string[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`${context} must be an array of block names.`);
+  }
+
+  const seen = new Set<string>();
+  return value.map((item, index) => {
+    if (typeof item !== 'string') {
+      throw new Error(`${context}[${index}] must be a block name string.`);
+    }
+    assertBlockName(item, `${context}[${index}]`);
+    if (seen.has(item)) {
+      throw new Error(`${context} must not contain duplicate block "${item}".`);
+    }
+    seen.add(item);
+    return item;
+  });
+}
+
+function normalizeBlockNestingRule(
+  blockName: string,
+  rule: unknown,
+): NormalizedBlockNestingRule {
+  if (rule === null || typeof rule !== 'object' || Array.isArray(rule)) {
+    throw new Error(`Block nesting rule for "${blockName}" must be an object.`);
+  }
+
+  const normalized: NormalizedBlockNestingRule = {};
+  for (const key of BLOCK_NESTING_RELATION_KEYS) {
+    if (!hasOwn(rule, key)) {
+      continue;
+    }
+
+    normalized[key] = normalizeRelationList(
+      (rule as Record<string, unknown>)[key],
+      `Block nesting rule "${blockName}".${key}`,
+    );
+  }
+
+  return normalized;
+}
+
+function validateKnownBlockName(
+  issues: string[],
+  knownBlockNames: ReadonlySet<string> | null,
+  blockName: string,
+  context: string,
+): void {
+  if (knownBlockNames && !knownBlockNames.has(blockName)) {
+    issues.push(
+      `${context} references unknown block "${blockName}". Expected one of: ${formatKnownBlockNames(
+        knownBlockNames,
+      )}.`,
+    );
+  }
+}
+
+function normalizeBlockNestingContract(
+  contract: BlockNestingContract,
+): Record<string, NormalizedBlockNestingRule> {
+  if (contract === null || typeof contract !== 'object' || Array.isArray(contract)) {
+    throw new Error('Block nesting contract must be an object.');
+  }
+
+  return Object.fromEntries(
+    Object.entries(contract).map(([blockName, rule]) => {
+      assertBlockName(blockName, `Block nesting contract key "${blockName}"`);
+      return [blockName, normalizeBlockNestingRule(blockName, rule)];
+    }),
+  );
+}
+
+export function defineBlockNesting<const Contract extends BlockNestingContract>(
+  contract: Contract,
+): Contract {
+  validateBlockNestingContract(contract);
+  return contract;
+}
+
+export function validateBlockNestingContract(
+  contract: BlockNestingContract,
+  options: ValidateBlockNestingContractOptions = {},
+): void {
+  const normalized = normalizeBlockNestingContract(contract);
+  const knownBlockNames = options.knownBlockNames
+    ? new Set(options.knownBlockNames)
+    : null;
+  const issues: string[] = [];
+
+  for (const [blockName, rule] of Object.entries(normalized)) {
+    validateKnownBlockName(issues, knownBlockNames, blockName, 'Contract key');
+
+    for (const key of BLOCK_NESTING_RELATION_KEYS) {
+      const relatedBlockNames = rule[key];
+      if (!relatedBlockNames) {
+        continue;
+      }
+
+      for (const relatedBlockName of relatedBlockNames) {
+        validateKnownBlockName(
+          issues,
+          knownBlockNames,
+          relatedBlockName,
+          `${blockName}.${key}`,
+        );
+        if (
+          relatedBlockName === blockName &&
+          (key === 'parent' || key === 'ancestor')
+        ) {
+          issues.push(`${blockName}.${key} must not reference itself.`);
+        }
+      }
+    }
+  }
+
+  for (const [parentBlockName, rule] of Object.entries(normalized)) {
+    for (const childBlockName of rule.allowedBlocks ?? []) {
+      const childRule = normalized[childBlockName];
+      if (
+        childRule?.parent &&
+        childRule.parent.length > 0 &&
+        !childRule.parent.includes(parentBlockName)
+      ) {
+        issues.push(
+          `${parentBlockName}.allowedBlocks includes "${childBlockName}", but ${childBlockName}.parent does not include "${parentBlockName}".`,
+        );
+      }
+    }
+  }
+
+  if (issues.length > 0) {
+    throw new Error(`Invalid block nesting contract:\n${issues.map((issue) => `- ${issue}`).join('\n')}`);
+  }
+}
+
+export function applyBlockNestingMetadata({
+  blockJson,
+  blockName,
+  nesting,
+}: {
+  blockJson: Record<string, unknown>;
+  blockName: string;
+  nesting?: BlockNestingContract;
+}): BlockNestingRelationKey[] {
+  if (!nesting || !hasOwn(nesting, blockName)) {
+    return [];
+  }
+
+  const rule = normalizeBlockNestingRule(blockName, nesting[blockName]);
+  const appliedKeys: BlockNestingRelationKey[] = [];
+
+  for (const key of BLOCK_NESTING_RELATION_KEYS) {
+    if (hasOwn(rule, key)) {
+      blockJson[key] = rule[key];
+      appliedKeys.push(key);
+    } else {
+      delete blockJson[key];
+    }
+  }
+
+  return appliedKeys;
+}

--- a/packages/wp-typia-block-runtime/src/metadata-core-sync-routines.ts
+++ b/packages/wp-typia-block-runtime/src/metadata-core-sync-routines.ts
@@ -19,6 +19,10 @@ import {
 	resolveSyncBlockMetadataPaths,
 } from './metadata-core-artifacts.js';
 import { normalizeSyncRestOpenApiOptions } from './metadata-core-endpoint-client.js';
+import {
+	applyBlockNestingMetadata,
+	validateBlockNestingContract,
+} from './metadata-core-nesting.js';
 import { renderPhpValidator } from './metadata-php-render.js';
 import { analyzeSourceType, analyzeSourceTypes } from './metadata-parser.js';
 import {
@@ -57,6 +61,21 @@ export async function syncBlockMetadataArtifacts(
 		const blockJson = JSON.parse(
 			fs.readFileSync(blockJsonPath, 'utf8'),
 		) as Record<string, unknown>;
+		if (options.nesting) {
+			validateBlockNestingContract(options.nesting, {
+				knownBlockNames: options.knownBlockNames,
+			});
+			if (typeof blockJson.name !== 'string' || blockJson.name.trim() === '') {
+				throw new Error(
+					`block.json at ${blockJsonPath} must define a string "name" before applying block nesting metadata.`,
+				);
+			}
+			applyBlockNestingMetadata({
+				blockJson,
+				blockName: blockJson.name,
+				nesting: options.nesting,
+			});
+		}
 
 		blockJson.attributes = Object.fromEntries(
 			Object.entries(rootNode.properties).map(([key, node]) => [

--- a/packages/wp-typia-block-runtime/src/metadata-core-sync-routines.ts
+++ b/packages/wp-typia-block-runtime/src/metadata-core-sync-routines.ts
@@ -63,6 +63,7 @@ export async function syncBlockMetadataArtifacts(
 		) as Record<string, unknown>;
 		if (options.nesting) {
 			validateBlockNestingContract(options.nesting, {
+				allowExternalBlockNames: options.allowExternalBlockNames,
 				knownBlockNames: options.knownBlockNames,
 			});
 			if (typeof blockJson.name !== 'string' || blockJson.name.trim() === '') {

--- a/packages/wp-typia-block-runtime/src/metadata-core.ts
+++ b/packages/wp-typia-block-runtime/src/metadata-core.ts
@@ -16,11 +16,23 @@ import {
   syncRestOpenApiArtifacts,
   syncTypeSchemaArtifacts,
 } from './metadata-core-sync-routines.js';
+export {
+  defineBlockNesting,
+  validateBlockNestingContract,
+} from './metadata-core-nesting.js';
+export type {
+  BlockNestingContract,
+  BlockNestingRule,
+  ValidateBlockNestingContractOptions,
+} from './metadata-core-nesting.js';
+import type { BlockNestingContract } from './metadata-core-nesting.js';
 
 export interface SyncBlockMetadataOptions {
   blockJsonFile: string;
   jsonSchemaFile?: string;
+  knownBlockNames?: readonly string[];
   manifestFile?: string;
+  nesting?: BlockNestingContract;
   openApiFile?: string;
   phpValidatorFile?: string;
   projectRoot?: string;
@@ -61,6 +73,8 @@ export type SyncBlockMetadataStatus = 'success' | 'warning' | 'error';
 export type SyncBlockMetadataFailureCode =
   /** Generated artifact files are missing or stale relative to the current sources. */
   | 'stale-generated-artifact'
+  /** A block nesting contract references unknown or contradictory block relationships. */
+  | 'invalid-block-nesting-contract'
   /** A TypeScript node kind is not supported by the metadata parser. */
   | 'unsupported-type-node'
   /** A supported node kind was used in an unsupported pattern or combination. */

--- a/packages/wp-typia-block-runtime/src/metadata-core.ts
+++ b/packages/wp-typia-block-runtime/src/metadata-core.ts
@@ -28,6 +28,7 @@ export type {
 import type { BlockNestingContract } from './metadata-core-nesting.js';
 
 export interface SyncBlockMetadataOptions {
+  allowExternalBlockNames?: boolean;
   blockJsonFile: string;
   jsonSchemaFile?: string;
   knownBlockNames?: readonly string[];

--- a/packages/wp-typia-block-runtime/tests/block-runtime.test.ts
+++ b/packages/wp-typia-block-runtime/tests/block-runtime.test.ts
@@ -65,6 +65,7 @@ describe("@wp-typia/block-runtime", () => {
 		expect(typeof schemaTestModule.assertResponseMatchesSchema).toBe("function");
 		expect(typeof schemaTestModule.createResponseSchemaValidator).toBe("function");
 		expect(Object.keys(migrationTypesModule)).toEqual([]);
+		expect(typeof metadataCoreModule.defineBlockNesting).toBe("function");
 		expect(typeof metadataCoreModule.defineEndpointManifest).toBe("function");
 		expect(typeof metadataCoreModule.runSyncBlockMetadata).toBe("function");
 		expect(typeof metadataCoreModule.syncEndpointClient).toBe("function");

--- a/packages/wp-typia-project-tools/templates/_shared/compound/core/scripts/block-config.ts.mustache
+++ b/packages/wp-typia-project-tools/templates/_shared/compound/core/scripts/block-config.ts.mustache
@@ -1,3 +1,9 @@
+import { defineBlockNesting } from '@wp-typia/block-runtime/metadata-core';
+
+export const BLOCK_NESTING = defineBlockNesting( {
+	// Add parent, ancestor, and allowedBlocks relationships here.
+} );
+
 export const BLOCKS = [
 	{
 		attributeTypeName: '{{pascalCase}}Attributes',

--- a/packages/wp-typia-project-tools/templates/_shared/compound/core/scripts/sync-types-to-block-json.ts.mustache
+++ b/packages/wp-typia-project-tools/templates/_shared/compound/core/scripts/sync-types-to-block-json.ts.mustache
@@ -28,9 +28,18 @@ function parseCliOptions( argv: string[] ) {
 
 function readWorkspaceBlockName( block: ( typeof BLOCKS )[ number ] ): string {
 	const blockJsonFile = path.join( 'src', 'blocks', block.slug, 'block.json' );
-	const blockJson = JSON.parse( fs.readFileSync( blockJsonFile, 'utf8' ) ) as {
-		name?: unknown;
-	};
+	let blockJson: { name?: unknown };
+	try {
+		blockJson = JSON.parse( fs.readFileSync( blockJsonFile, 'utf8' ) ) as {
+			name?: unknown;
+		};
+	} catch ( error ) {
+		throw new Error(
+			`Failed to read block.json for block "${ block.slug }" at ${ blockJsonFile }: ${
+				error instanceof Error ? error.message : String( error )
+			}`
+		);
+	}
 	if ( typeof blockJson.name !== 'string' || blockJson.name.trim() === '' ) {
 		throw new Error( `${ blockJsonFile } must define a string "name".` );
 	}
@@ -41,11 +50,15 @@ function readWorkspaceBlockName( block: ( typeof BLOCKS )[ number ] ): string {
 async function main() {
 	const options = parseCliOptions( process.argv.slice( 2 ) );
 	const knownBlockNames = BLOCKS.map( readWorkspaceBlockName );
-	validateBlockNestingContract( BLOCK_NESTING, { knownBlockNames } );
+	validateBlockNestingContract( BLOCK_NESTING, {
+		allowExternalBlockNames: true,
+		knownBlockNames,
+	} );
 
 	for ( const block of BLOCKS ) {
 		const baseDir = path.join( 'src', 'blocks', block.slug );
 		const result = await syncBlockMetadata( {
+			allowExternalBlockNames: true,
 			blockJsonFile: path.join( baseDir, 'block.json' ),
 			jsonSchemaFile: path.join( baseDir, 'typia.schema.json' ),
 			knownBlockNames,

--- a/packages/wp-typia-project-tools/templates/_shared/compound/core/scripts/sync-types-to-block-json.ts.mustache
+++ b/packages/wp-typia-project-tools/templates/_shared/compound/core/scripts/sync-types-to-block-json.ts.mustache
@@ -1,9 +1,13 @@
 /* eslint-disable no-console */
+import fs from 'node:fs';
 import path from 'node:path';
 
-import { syncBlockMetadata } from '@wp-typia/block-runtime/metadata-core';
+import {
+	syncBlockMetadata,
+	validateBlockNestingContract,
+} from '@wp-typia/block-runtime/metadata-core';
 
-import { BLOCKS } from './block-config';
+import { BLOCK_NESTING, BLOCKS } from './block-config';
 
 function parseCliOptions( argv: string[] ) {
 	const options = {
@@ -22,15 +26,31 @@ function parseCliOptions( argv: string[] ) {
 	return options;
 }
 
+function readWorkspaceBlockName( block: ( typeof BLOCKS )[ number ] ): string {
+	const blockJsonFile = path.join( 'src', 'blocks', block.slug, 'block.json' );
+	const blockJson = JSON.parse( fs.readFileSync( blockJsonFile, 'utf8' ) ) as {
+		name?: unknown;
+	};
+	if ( typeof blockJson.name !== 'string' || blockJson.name.trim() === '' ) {
+		throw new Error( `${ blockJsonFile } must define a string "name".` );
+	}
+
+	return blockJson.name;
+}
+
 async function main() {
 	const options = parseCliOptions( process.argv.slice( 2 ) );
+	const knownBlockNames = BLOCKS.map( readWorkspaceBlockName );
+	validateBlockNestingContract( BLOCK_NESTING, { knownBlockNames } );
 
 	for ( const block of BLOCKS ) {
 		const baseDir = path.join( 'src', 'blocks', block.slug );
 		const result = await syncBlockMetadata( {
 			blockJsonFile: path.join( baseDir, 'block.json' ),
 			jsonSchemaFile: path.join( baseDir, 'typia.schema.json' ),
+			knownBlockNames,
 			manifestFile: path.join( baseDir, 'typia.manifest.json' ),
+			nesting: BLOCK_NESTING,
 			openApiFile: path.join( baseDir, 'typia.openapi.json' ),
 			sourceTypeName: block.attributeTypeName,
 			typesFile: block.typesFile,

--- a/packages/wp-typia-project-tools/templates/_shared/compound/persistence/scripts/block-config.ts.mustache
+++ b/packages/wp-typia-project-tools/templates/_shared/compound/persistence/scripts/block-config.ts.mustache
@@ -1,4 +1,11 @@
-import { defineEndpointManifest } from '@wp-typia/block-runtime/metadata-core';
+import {
+	defineBlockNesting,
+	defineEndpointManifest,
+} from '@wp-typia/block-runtime/metadata-core';
+
+export const BLOCK_NESTING = defineBlockNesting( {
+	// Add parent, ancestor, and allowedBlocks relationships here.
+} );
 
 export const BLOCKS = [
 	{

--- a/packages/wp-typia-project-tools/tests/import-policy.test.ts
+++ b/packages/wp-typia-project-tools/tests/import-policy.test.ts
@@ -61,6 +61,7 @@ describe('@wp-typia/project-tools import policy', () => {
       'function',
     );
     expect(Object.keys(migrationTypesModule)).toEqual([]);
+    expect(typeof metadataCoreModule.defineBlockNesting).toBe('function');
     expect(typeof metadataCoreModule.defineEndpointManifest).toBe('function');
 
     expect('applyTemplateDefaultsFromManifest' in rootModule).toBe(false);

--- a/packages/wp-typia-project-tools/tests/scaffold-compound.test.ts
+++ b/packages/wp-typia-project-tools/tests/scaffold-compound.test.ts
@@ -242,6 +242,8 @@ describe('@wp-typia/project-tools scaffold compound', () => {
       expect(parentBlockJson.allowedBlocks).toEqual([
         'create-block/demo-compound-item',
       ]);
+      expect(blockConfig).toContain('defineBlockNesting');
+      expect(blockConfig).toContain('export const BLOCK_NESTING');
       expect(parentManifest.sourceType).toBe('DemoCompoundAttributes');
       expect(parentManifest.attributes.heading.typia.defaultValue).toBe(
         'Demo Compound',
@@ -842,6 +844,8 @@ describe('@wp-typia/project-tools scaffold compound', () => {
       expect(generatedBlockConfig).toContain(
         'src/blocks/demo-compound-storage/api.openapi.json',
       );
+      expect(generatedBlockConfig).toContain('defineBlockNesting');
+      expect(generatedBlockConfig).toContain('export const BLOCK_NESTING');
       expect(generatedBlockConfig).toContain(
         'restManifest: defineEndpointManifest',
       );

--- a/packages/wp-typia-project-tools/tests/workspace-add.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-add.test.ts
@@ -243,6 +243,7 @@ test("canonical CLI can add a basic block to an official workspace template", as
   expect(blockConfigSource).toContain("export const BLOCK_NESTING");
   expect(blockConfigSource).toContain('slug: "counter-card"');
   expect(syncTypesSource).toContain("validateBlockNestingContract");
+  expect(syncTypesSource).toContain("allowExternalBlockNames: true");
   expect(syncTypesSource).toContain("nesting: BLOCK_NESTING");
   expect(indexSource).toContain("import '../../collection';");
   expect(blockJson.name).toBe("demo-space/counter-card");
@@ -256,7 +257,7 @@ test("canonical CLI can add a basic block to an official workspace template", as
     blockConfigPath,
     blockConfigSource.replace(
       "\t// Add parent, ancestor, and allowedBlocks relationships here.",
-      '\t"demo-space/counter-card": {\n\t\tallowedBlocks: [],\n\t},'
+      '\t"demo-space/counter-card": {\n\t\tallowedBlocks: [ "core/group" ],\n\t},'
     ),
     "utf8"
   );
@@ -267,7 +268,7 @@ test("canonical CLI can add a basic block to an official workspace template", as
       "utf8"
     )
   );
-  expect(blockJsonWithNesting.allowedBlocks).toEqual([]);
+  expect(blockJsonWithNesting.allowedBlocks).toEqual(["core/group"]);
   runGeneratedScript(targetDir, "scripts/sync-types-to-block-json.ts", [
     "--check",
   ]);
@@ -277,7 +278,7 @@ test("canonical CLI can add a basic block to an official workspace template", as
     fs
       .readFileSync(blockConfigPath, "utf8")
       .replace(
-        "\t\tallowedBlocks: [],",
+        '\t\tallowedBlocks: [ "core/group" ],',
         '\t\tallowedBlocks: [ "demo-space/missing-child" ],'
       ),
     "utf8"

--- a/packages/wp-typia-project-tools/tests/workspace-add.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-add.test.ts
@@ -224,6 +224,10 @@ test("canonical CLI can add a basic block to an official workspace template", as
     path.join(targetDir, "scripts", "block-config.ts"),
     "utf8"
   );
+  const syncTypesSource = fs.readFileSync(
+    path.join(targetDir, "scripts", "sync-types-to-block-json.ts"),
+    "utf8"
+  );
   const indexSource = fs.readFileSync(
     path.join(targetDir, "src", "blocks", "counter-card", "index.tsx"),
     "utf8"
@@ -235,13 +239,56 @@ test("canonical CLI can add a basic block to an official workspace template", as
     )
   );
 
+  expect(blockConfigSource).toContain("defineBlockNesting");
+  expect(blockConfigSource).toContain("export const BLOCK_NESTING");
   expect(blockConfigSource).toContain('slug: "counter-card"');
+  expect(syncTypesSource).toContain("validateBlockNestingContract");
+  expect(syncTypesSource).toContain("nesting: BLOCK_NESTING");
   expect(indexSource).toContain("import '../../collection';");
   expect(blockJson.name).toBe("demo-space/counter-card");
   typecheckGeneratedProject(targetDir);
   runGeneratedScript(targetDir, "scripts/sync-types-to-block-json.ts", [
     "--check",
   ]);
+
+  const blockConfigPath = path.join(targetDir, "scripts", "block-config.ts");
+  fs.writeFileSync(
+    blockConfigPath,
+    blockConfigSource.replace(
+      "\t// Add parent, ancestor, and allowedBlocks relationships here.",
+      '\t"demo-space/counter-card": {\n\t\tallowedBlocks: [],\n\t},'
+    ),
+    "utf8"
+  );
+  runGeneratedScript(targetDir, "scripts/sync-types-to-block-json.ts");
+  const blockJsonWithNesting = JSON.parse(
+    fs.readFileSync(
+      path.join(targetDir, "src", "blocks", "counter-card", "block.json"),
+      "utf8"
+    )
+  );
+  expect(blockJsonWithNesting.allowedBlocks).toEqual([]);
+  runGeneratedScript(targetDir, "scripts/sync-types-to-block-json.ts", [
+    "--check",
+  ]);
+
+  fs.writeFileSync(
+    blockConfigPath,
+    fs
+      .readFileSync(blockConfigPath, "utf8")
+      .replace(
+        "\t\tallowedBlocks: [],",
+        '\t\tallowedBlocks: [ "demo-space/missing-child" ],'
+      ),
+    "utf8"
+  );
+  expect(
+    getCommandErrorMessage(() =>
+      runGeneratedScript(targetDir, "scripts/sync-types-to-block-json.ts", [
+        "--check",
+      ])
+    )
+  ).toContain('allowedBlocks references unknown block "demo-space/missing-child"');
 }, 20_000);
 
 test("canonical CLI can add a basic block with an external layer package", async () => {

--- a/tests/unit/metadata-core.test.ts
+++ b/tests/unit/metadata-core.test.ts
@@ -5,11 +5,14 @@ import path from "node:path";
 import { describe, expect, test } from "bun:test";
 
 import {
+  defineBlockNesting,
   defineEndpointManifest,
+  runSyncBlockMetadata,
   syncBlockMetadata,
   syncEndpointClient,
   syncRestOpenApi,
   syncTypeSchemas,
+  validateBlockNestingContract,
   type EndpointManifestDefinition,
   type SyncEndpointClientOptions,
   type SyncRestOpenApiContractsOptions,
@@ -131,6 +134,204 @@ function createTempProject(): { root: string; typesFile: string } {
 }
 
 describe("metadata-core endpoint manifests", () => {
+  test("defineBlockNesting preserves typed nesting contracts", () => {
+    const nesting = defineBlockNesting({
+      "demo/container": {
+        allowedBlocks: ["demo/section"],
+      },
+      "demo/section": {
+        parent: ["demo/container"],
+      },
+    } as const);
+
+    expect(nesting["demo/container"].allowedBlocks).toEqual(["demo/section"]);
+    expect(() =>
+      validateBlockNestingContract(nesting, {
+        knownBlockNames: ["demo/container", "demo/section"],
+      })
+    ).not.toThrow();
+  });
+
+  test("syncBlockMetadata applies typed nesting relationships to block metadata", async () => {
+    const root = fs.mkdtempSync(
+      path.join(os.tmpdir(), "wp-typia-nesting-sync-")
+    );
+    fs.mkdirSync(path.join(root, "src"), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, "block.json"),
+      JSON.stringify(
+        {
+          name: "demo/container",
+          ancestor: ["demo/legacy"],
+          attributes: {},
+          example: { attributes: {} },
+        },
+        null,
+        2
+      ),
+      "utf8"
+    );
+    fs.writeFileSync(
+      path.join(root, "section.json"),
+      JSON.stringify(
+        {
+          name: "demo/section",
+          allowedBlocks: ["demo/legacy-child"],
+          attributes: {},
+          example: { attributes: {} },
+        },
+        null,
+        2
+      ),
+      "utf8"
+    );
+    fs.writeFileSync(
+      path.join(root, "src", "types.ts"),
+      [
+        "export interface ContainerAttributes {",
+        "  title: string;",
+        "}",
+        "",
+      ].join("\n"),
+      "utf8"
+    );
+
+    try {
+      await syncBlockMetadata({
+        blockJsonFile: "block.json",
+        knownBlockNames: ["demo/container", "demo/section"],
+        manifestFile: "typia.manifest.json",
+        nesting: defineBlockNesting({
+          "demo/container": {
+            allowedBlocks: ["demo/section"],
+          },
+          "demo/section": {
+            parent: ["demo/container"],
+          },
+        }),
+        projectRoot: root,
+        sourceTypeName: "ContainerAttributes",
+        typesFile: "src/types.ts",
+      });
+
+      const blockJson = JSON.parse(
+        fs.readFileSync(path.join(root, "block.json"), "utf8")
+      );
+      expect(blockJson.allowedBlocks).toEqual(["demo/section"]);
+      expect(blockJson.ancestor).toBeUndefined();
+      expect(blockJson.attributes.title).toEqual({ type: "string" });
+
+      await syncBlockMetadata({
+        blockJsonFile: "section.json",
+        knownBlockNames: ["demo/root", "demo/container", "demo/section"],
+        manifestFile: "section.manifest.json",
+        nesting: defineBlockNesting({
+          "demo/section": {
+            ancestor: ["demo/root"],
+            parent: ["demo/container"],
+          },
+        }),
+        projectRoot: root,
+        sourceTypeName: "ContainerAttributes",
+        typesFile: "src/types.ts",
+      });
+      const sectionBlockJson = JSON.parse(
+        fs.readFileSync(path.join(root, "section.json"), "utf8")
+      );
+      expect(sectionBlockJson.parent).toEqual(["demo/container"]);
+      expect(sectionBlockJson.ancestor).toEqual(["demo/root"]);
+      expect(sectionBlockJson.allowedBlocks).toBeUndefined();
+
+      fs.writeFileSync(
+        path.join(root, "block.json"),
+        JSON.stringify(
+          {
+            ...blockJson,
+            allowedBlocks: ["demo/other-section"],
+          },
+          null,
+          2
+        ),
+        "utf8"
+      );
+      await expect(
+        syncBlockMetadata(
+          {
+            blockJsonFile: "block.json",
+            knownBlockNames: ["demo/container", "demo/section"],
+            manifestFile: "typia.manifest.json",
+            nesting: defineBlockNesting({
+              "demo/container": {
+                allowedBlocks: ["demo/section"],
+              },
+              "demo/section": {
+                parent: ["demo/container"],
+              },
+            }),
+            projectRoot: root,
+            sourceTypeName: "ContainerAttributes",
+            typesFile: "src/types.ts",
+          },
+          { check: true }
+        )
+      ).rejects.toThrow(path.join(root, "block.json"));
+    } finally {
+      fs.rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test("runSyncBlockMetadata reports unknown nesting references", async () => {
+    const root = fs.mkdtempSync(
+      path.join(os.tmpdir(), "wp-typia-nesting-invalid-")
+    );
+    fs.mkdirSync(path.join(root, "src"), { recursive: true });
+    fs.writeFileSync(
+      path.join(root, "block.json"),
+      JSON.stringify(
+        {
+          name: "demo/container",
+          attributes: {},
+          example: { attributes: {} },
+        },
+        null,
+        2
+      ),
+      "utf8"
+    );
+    fs.writeFileSync(
+      path.join(root, "src", "types.ts"),
+      [
+        "export interface ContainerAttributes {",
+        "  title: string;",
+        "}",
+        "",
+      ].join("\n"),
+      "utf8"
+    );
+
+    try {
+      const report = await runSyncBlockMetadata({
+        blockJsonFile: "block.json",
+        knownBlockNames: ["demo/container"],
+        manifestFile: "typia.manifest.json",
+        nesting: defineBlockNesting({
+          "demo/container": {
+            allowedBlocks: ["demo/missing-section"],
+          },
+        }),
+        projectRoot: root,
+        sourceTypeName: "ContainerAttributes",
+        typesFile: "src/types.ts",
+      });
+
+      expect(report.status).toBe("error");
+      expect(report.failure?.code).toBe("invalid-block-nesting-contract");
+      expect(report.failure?.message).toContain("demo/missing-section");
+    } finally {
+      fs.rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   test("defineEndpointManifest preserves the manifest payload", () => {
     expect(manifest.contracts.query.sourceTypeName).toBe("CounterQuery");
     expect(manifest.endpoints[0]).toMatchObject({

--- a/tests/unit/metadata-core.test.ts
+++ b/tests/unit/metadata-core.test.ts
@@ -152,6 +152,50 @@ describe("metadata-core endpoint manifests", () => {
     ).not.toThrow();
   });
 
+  test("validateBlockNestingContract can allow external relationship names", () => {
+    expect(() =>
+      validateBlockNestingContract(
+        defineBlockNesting({
+          "demo/section": {
+            parent: ["core/group"],
+          },
+        }),
+        {
+          allowExternalBlockNames: true,
+          knownBlockNames: ["demo/section"],
+        }
+      )
+    ).not.toThrow();
+
+    expect(() =>
+      validateBlockNestingContract(
+        defineBlockNesting({
+          "demo/section": {
+            parent: ["demo/missing-parent"],
+          },
+        }),
+        {
+          allowExternalBlockNames: true,
+          knownBlockNames: ["demo/section"],
+        }
+      )
+    ).toThrow('parent references unknown block "demo/missing-parent"');
+
+    expect(() =>
+      validateBlockNestingContract(
+        defineBlockNesting({
+          "core/group": {
+            allowedBlocks: ["demo/section"],
+          },
+        }),
+        {
+          allowExternalBlockNames: true,
+          knownBlockNames: ["demo/section"],
+        }
+      )
+    ).toThrow('Contract key references unknown block "core/group"');
+  });
+
   test("syncBlockMetadata applies typed nesting relationships to block metadata", async () => {
     const root = fs.mkdtempSync(
       path.join(os.tmpdir(), "wp-typia-nesting-sync-")
@@ -198,12 +242,13 @@ describe("metadata-core endpoint manifests", () => {
 
     try {
       await syncBlockMetadata({
+        allowExternalBlockNames: true,
         blockJsonFile: "block.json",
         knownBlockNames: ["demo/container", "demo/section"],
         manifestFile: "typia.manifest.json",
         nesting: defineBlockNesting({
           "demo/container": {
-            allowedBlocks: ["demo/section"],
+            allowedBlocks: ["demo/section", "core/paragraph"],
           },
           "demo/section": {
             parent: ["demo/container"],
@@ -217,7 +262,10 @@ describe("metadata-core endpoint manifests", () => {
       const blockJson = JSON.parse(
         fs.readFileSync(path.join(root, "block.json"), "utf8")
       );
-      expect(blockJson.allowedBlocks).toEqual(["demo/section"]);
+      expect(blockJson.allowedBlocks).toEqual([
+        "demo/section",
+        "core/paragraph",
+      ]);
       expect(blockJson.ancestor).toBeUndefined();
       expect(blockJson.attributes.title).toEqual({ type: "string" });
 


### PR DESCRIPTION
Closes #984

## Summary
- add `defineBlockNesting` and nesting contract validation in `@wp-typia/block-runtime/metadata-core`
- let generated workspace `sync-types` apply declared `parent`, `ancestor`, and `allowedBlocks` metadata to block.json
- add docs, template wiring, changeset, and tests for drift/unknown references

## Tests
- bun test tests/unit/metadata-core.test.ts tests/unit/sync-types-reporting.test.ts
- bun test tests/workspace-add.test.ts -t "basic block to an official workspace"
- bun test tests/scaffold-compound.test.ts
- bun run --filter @wp-typia/block-runtime test
- bun run --filter @wp-typia/project-tools build
- bun run typecheck
- bun run format:check
- bun run changesets:validate
- bun run lint:repo
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced typed block nesting contracts supporting `parent`, `ancestor`, and `allowedBlocks` relationship declarations
  * Added automatic validation of block references with diagnostic messages for unknown or invalid block relationships during workspace synchronization

* **Documentation**
  * Updated README files and templates to document block nesting configuration and validation workflow

* **Tests**
  * Added comprehensive test coverage for block nesting validation and metadata synchronization scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/991)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->