### PR TITLE
feat: validate pattern content against nesting contracts

### DIFF
--- a/.sampo/changesets/986-pattern-nesting-validation.md
+++ b/.sampo/changesets/986-pattern-nesting-validation.md
@@ -1,0 +1,9 @@
+---
+npm/@wp-typia/block-runtime: minor
+npm/@wp-typia/create-workspace-template: minor
+npm/@wp-typia/project-tools: minor
+---
+
+Validate configured pattern files against typed block nesting contracts during
+sync, reporting relationship violations with pattern file and block path
+diagnostics while keeping unknown or unparseable pattern content as warnings.

--- a/README.md
+++ b/README.md
@@ -138,6 +138,12 @@ Default editor templates can live beside those rules in `BLOCK_TEMPLATES` or in
 the optional `template` field on a nesting rule. `wp-typia sync` generates
 `src/inner-blocks-templates.ts`, and `--check` verifies that nested template
 tuples still obey the declared `allowedBlocks`, `parent`, and `ancestor` rules.
+Configured `PATTERNS` files are also parsed during sync so shipped pattern
+content cannot drift from the same nesting contract. Relationship violations
+fail with the pattern file and serialized block path, while unknown or
+unparseable block comments are reported as warnings instead of being rewritten.
+The first validator intentionally reads serialized `<!-- wp:* -->` block
+comment boundaries conservatively and does not execute dynamic PHP content.
 
 ### 5. Query Loop variations get a first-class scaffold
 

--- a/packages/create-workspace-template/README.md
+++ b/packages/create-workspace-template/README.md
@@ -35,6 +35,13 @@ names in the workspace namespace while allowing external targets like
 Declare default editor `InnerBlocks` templates in `BLOCK_TEMPLATES` and
 `wp-typia sync` will generate `src/inner-blocks-templates.ts` with constants you
 can import from edit components.
+Pattern files listed in `PATTERNS` are parsed during the same sync flow so
+`wp-typia sync --check` can catch serialized block content that violates the
+declared `allowedBlocks`, `parent`, or `ancestor` rules. Unknown or unparseable
+pattern blocks are reported as warnings so the first implementation stays
+non-mutating.
+The validator reads serialized `<!-- wp:* -->` block comment boundaries
+conservatively and does not execute dynamic PHP content.
 
 ## CLI binary policy
 

--- a/packages/create-workspace-template/README.md.mustache
+++ b/packages/create-workspace-template/README.md.mustache
@@ -52,6 +52,13 @@ names in the workspace namespace while allowing external targets like
 Declare default editor `InnerBlocks` templates in `BLOCK_TEMPLATES` and
 `wp-typia sync` will generate `src/inner-blocks-templates.ts` with constants you
 can import from edit components.
+Pattern files listed in `PATTERNS` are parsed during the same sync flow so
+`wp-typia sync --check` can catch serialized block content that violates the
+declared `allowedBlocks`, `parent`, or `ancestor` rules. Unknown or unparseable
+pattern blocks are reported as warnings so the first implementation stays
+non-mutating.
+The validator reads serialized `<!-- wp:* -->` block comment boundaries
+conservatively and does not execute dynamic PHP content.
 
 ## CLI Commands
 

--- a/packages/create-workspace-template/scripts/sync-types-to-block-json.ts.mustache
+++ b/packages/create-workspace-template/scripts/sync-types-to-block-json.ts.mustache
@@ -3,13 +3,15 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import {
+	formatBlockPatternContentNestingDiagnostics,
+	validateBlockPatternContentNesting,
 	syncInnerBlocksTemplateModule,
 	syncBlockMetadata,
 	validateBlockNestingContract,
 	validateInnerBlocksTemplates,
 } from '@wp-typia/block-runtime/metadata-core';
 
-import { BLOCK_NESTING, BLOCK_TEMPLATES, BLOCKS } from './block-config';
+import { BLOCK_NESTING, BLOCK_TEMPLATES, BLOCKS, PATTERNS } from './block-config';
 
 function parseCliOptions( argv: string[] ) {
 	const options = {
@@ -49,6 +51,40 @@ function readWorkspaceBlockName( block: ( typeof BLOCKS )[ number ] ): string {
 	return blockJson.name;
 }
 
+function validatePatternContentNesting( knownBlockNames: readonly string[] ) {
+	const diagnostics = PATTERNS.flatMap( ( pattern ) => {
+		const content = fs.readFileSync( pattern.file, 'utf8' );
+		return validateBlockPatternContentNesting( content, {
+			allowExternalBlockNames: true,
+			knownBlockNames,
+			nesting: BLOCK_NESTING,
+			patternFile: pattern.file,
+		} ).diagnostics;
+	} );
+	const warnings = diagnostics.filter(
+		( diagnostic ) => diagnostic.severity === 'warning'
+	);
+	const errors = diagnostics.filter(
+		( diagnostic ) => diagnostic.severity === 'error'
+	);
+
+	if ( warnings.length > 0 ) {
+		console.warn(
+			`⚠️ Pattern nesting validation warnings:\n${ formatBlockPatternContentNestingDiagnostics(
+				warnings
+			) }`
+		);
+	}
+
+	if ( errors.length > 0 ) {
+		throw new Error(
+			`Pattern content violates block nesting contract:\n${ formatBlockPatternContentNestingDiagnostics(
+				errors
+			) }`
+		);
+	}
+}
+
 async function main() {
 	const options = parseCliOptions( process.argv.slice( 2 ) );
 
@@ -62,6 +98,7 @@ async function main() {
 		knownBlockNames,
 		nesting: BLOCK_NESTING,
 	} );
+	validatePatternContentNesting( knownBlockNames );
 	await syncInnerBlocksTemplateModule(
 		{
 			allowExternalBlockNames: true,

--- a/packages/create-workspace-template/scripts/sync-types-to-block-json.ts.mustache
+++ b/packages/create-workspace-template/scripts/sync-types-to-block-json.ts.mustache
@@ -51,9 +51,21 @@ function readWorkspaceBlockName( block: ( typeof BLOCKS )[ number ] ): string {
 	return blockJson.name;
 }
 
+function readPatternFileContent( pattern: ( typeof PATTERNS )[ number ] ): string {
+	try {
+		return fs.readFileSync( pattern.file, 'utf8' );
+	} catch ( error ) {
+		throw new Error(
+			`Failed to read pattern "${ pattern.slug }" at ${ pattern.file }: ${
+				error instanceof Error ? error.message : String( error )
+			}`
+		);
+	}
+}
+
 function validatePatternContentNesting( knownBlockNames: readonly string[] ) {
 	const diagnostics = PATTERNS.flatMap( ( pattern ) => {
-		const content = fs.readFileSync( pattern.file, 'utf8' );
+		const content = readPatternFileContent( pattern );
 		return validateBlockPatternContentNesting( content, {
 			allowExternalBlockNames: true,
 			knownBlockNames,

--- a/packages/wp-typia-block-runtime/README.md
+++ b/packages/wp-typia-block-runtime/README.md
@@ -11,6 +11,7 @@ This is the supported generated-project package boundary for:
 - TypeScript-to-metadata sync
 - typed block nesting contracts for `parent`, `ancestor`, and `allowedBlocks`
 - generated `InnerBlocks` template constants validated against nesting contracts
+- serialized pattern content validation against typed block nesting contracts
 - manifest-first REST/OpenAPI/client codegen
 
 It does not include:

--- a/packages/wp-typia-block-runtime/src/metadata-core-nesting.ts
+++ b/packages/wp-typia-block-runtime/src/metadata-core-nesting.ts
@@ -782,13 +782,32 @@ function parseBlockPatternContent(
         continue;
       }
 
-      const activeBlock = stack[stack.length - 1];
-      if (activeBlock && activeBlock.block.blockName !== comment.blockName) {
+      if (openStackIndex !== stack.length - 1) {
+        for (
+          let unclosedIndex = stack.length - 1;
+          unclosedIndex > openStackIndex;
+          unclosedIndex -= 1
+        ) {
+          const unclosedBlock = stack[unclosedIndex];
+          if (!unclosedBlock) {
+            continue;
+          }
+          addBlockPatternDiagnostic(diagnostics, {
+            blockName: unclosedBlock.block.blockName,
+            blockPath: formatBlockPatternPath(unclosedBlock.pathSegments),
+            code: 'unbalanced-block-pattern-comment',
+            message: `Serialized opening block "${unclosedBlock.block.blockName}" was not closed before "${comment.blockName}" closed.`,
+            patternFile,
+            severity: 'warning',
+          });
+        }
         addBlockPatternDiagnostic(diagnostics, {
           blockName: comment.blockName,
-          blockPath: formatBlockPatternPath(activeBlock.pathSegments),
+          blockPath: formatBlockPatternPath(
+            stack[stack.length - 1]?.pathSegments ?? [],
+          ),
           code: 'unbalanced-block-pattern-comment',
-          message: `Serialized closing block "${comment.blockName}" appeared while "${activeBlock.block.blockName}" was still open.`,
+          message: `Serialized closing block "${comment.blockName}" appeared before all nested blocks were closed.`,
           patternFile,
           severity: 'warning',
         });

--- a/packages/wp-typia-block-runtime/src/metadata-core-nesting.ts
+++ b/packages/wp-typia-block-runtime/src/metadata-core-nesting.ts
@@ -63,7 +63,47 @@ export interface RenderInnerBlocksTemplateModuleOptions {
   exportName?: string;
 }
 
+export type BlockPatternNestingDiagnosticSeverity = 'error' | 'warning';
+
+export type BlockPatternNestingDiagnosticCode =
+  | 'disallowed-child-block'
+  | 'invalid-block-ancestor'
+  | 'invalid-block-parent'
+  | 'invalid-block-pattern-attributes'
+  | 'invalid-block-pattern-comment'
+  | 'unbalanced-block-pattern-comment'
+  | 'unknown-block';
+
+export interface ParsedBlockPatternBlock {
+  attributes: Record<string, unknown>;
+  blockName: string;
+  innerBlocks: ParsedBlockPatternBlock[];
+}
+
+export interface BlockPatternNestingDiagnostic {
+  blockName?: string;
+  blockPath?: string;
+  code: BlockPatternNestingDiagnosticCode;
+  message: string;
+  patternFile?: string;
+  severity: BlockPatternNestingDiagnosticSeverity;
+}
+
+export interface ValidateBlockPatternContentNestingOptions
+  extends ValidateBlockNestingContractOptions {
+  nesting: BlockNestingContract;
+  patternFile?: string;
+}
+
+export interface ValidateBlockPatternContentNestingResult {
+  blocks: ParsedBlockPatternBlock[];
+  diagnostics: BlockPatternNestingDiagnostic[];
+  errors: BlockPatternNestingDiagnostic[];
+  warnings: BlockPatternNestingDiagnostic[];
+}
+
 const TYPESCRIPT_IDENTIFIER_PATTERN = /^[A-Za-z_$][A-Za-z0-9_$]*$/u;
+const WORDPRESS_BLOCK_COMMENT_PATTERN = /<!--([\s\S]*?)-->/gu;
 
 function hasOwn(object: object, key: string): boolean {
   return Object.prototype.hasOwnProperty.call(object, key);
@@ -549,6 +589,453 @@ export function validateInnerBlocksTemplates(
   if (issues.length > 0) {
     throw new Error(`Invalid InnerBlocks template contract:\n${issues.map((issue) => `- ${issue}`).join('\n')}`);
   }
+}
+
+function addBlockPatternDiagnostic(
+  diagnostics: BlockPatternNestingDiagnostic[],
+  diagnostic: BlockPatternNestingDiagnostic,
+): void {
+  diagnostics.push(diagnostic);
+}
+
+function normalizeSerializedBlockName(rawBlockName: string): string | null {
+  const blockName = rawBlockName.includes('/')
+    ? rawBlockName
+    : `core/${rawBlockName}`;
+  try {
+    assertBlockName(blockName, 'Serialized block name');
+  } catch {
+    return null;
+  }
+
+  return blockName;
+}
+
+function parseBlockPatternComment(
+  commentBody: string,
+  diagnostics: BlockPatternNestingDiagnostic[],
+  patternFile?: string,
+):
+  | {
+      attributes: Record<string, unknown>;
+      blockName: string;
+      selfClosing: boolean;
+      type: 'open';
+    }
+  | {
+      blockName: string;
+      type: 'close';
+    }
+  | null {
+  const source = commentBody.trim();
+  if (!source.startsWith('wp:') && !source.startsWith('/wp:')) {
+    return null;
+  }
+
+  if (source.startsWith('/wp:')) {
+    const rawBlockName = source.slice('/wp:'.length).trim().split(/\s+/u)[0];
+    const blockName = rawBlockName
+      ? normalizeSerializedBlockName(rawBlockName)
+      : null;
+    if (!blockName) {
+      addBlockPatternDiagnostic(diagnostics, {
+        code: 'invalid-block-pattern-comment',
+        message: `Unable to parse serialized closing block comment "<!-- ${source} -->".`,
+        patternFile,
+        severity: 'warning',
+      });
+      return null;
+    }
+
+    return {
+      blockName,
+      type: 'close',
+    };
+  }
+
+  const openSource = source.slice('wp:'.length).trim();
+  const whitespaceIndex = openSource.search(/\s/u);
+  let rawBlockName =
+    whitespaceIndex === -1 ? openSource : openSource.slice(0, whitespaceIndex);
+  let remainder =
+    whitespaceIndex === -1 ? '' : openSource.slice(whitespaceIndex).trim();
+  let selfClosing = false;
+
+  if (rawBlockName.endsWith('/')) {
+    rawBlockName = rawBlockName.slice(0, -1);
+    selfClosing = true;
+  }
+
+  if (remainder.endsWith('/')) {
+    remainder = remainder.slice(0, -1).trim();
+    selfClosing = true;
+  }
+
+  const blockName = rawBlockName
+    ? normalizeSerializedBlockName(rawBlockName)
+    : null;
+  if (!blockName) {
+    addBlockPatternDiagnostic(diagnostics, {
+      code: 'invalid-block-pattern-comment',
+      message: `Unable to parse serialized opening block comment "<!-- ${source} -->".`,
+      patternFile,
+      severity: 'warning',
+    });
+    return null;
+  }
+
+  let attributes: Record<string, unknown> = {};
+  if (remainder.length > 0) {
+    try {
+      const parsedAttributes = JSON.parse(remainder) as unknown;
+      if (isRecord(parsedAttributes)) {
+        attributes = parsedAttributes;
+      } else {
+        addBlockPatternDiagnostic(diagnostics, {
+          blockName,
+          code: 'invalid-block-pattern-attributes',
+          message: `Serialized block "${blockName}" attributes must be a JSON object.`,
+          patternFile,
+          severity: 'warning',
+        });
+      }
+    } catch (error) {
+      addBlockPatternDiagnostic(diagnostics, {
+        blockName,
+        code: 'invalid-block-pattern-attributes',
+        message: `Unable to parse serialized block "${blockName}" attributes: ${
+          error instanceof Error ? error.message : String(error)
+        }.`,
+        patternFile,
+        severity: 'warning',
+      });
+    }
+  }
+
+  return {
+    attributes,
+    blockName,
+    selfClosing,
+    type: 'open',
+  };
+}
+
+function formatBlockPatternPath(pathSegments: readonly string[]): string {
+  return pathSegments.join(' > ');
+}
+
+function findOpenBlockStackIndex(
+  stack: readonly {
+    block: ParsedBlockPatternBlock;
+    pathSegments: string[];
+  }[],
+  blockName: string,
+): number {
+  for (let index = stack.length - 1; index > 0; index -= 1) {
+    if (stack[index]?.block.blockName === blockName) {
+      return index;
+    }
+  }
+
+  return -1;
+}
+
+function parseBlockPatternContent(
+  content: string,
+  patternFile?: string,
+): {
+  blocks: ParsedBlockPatternBlock[];
+  diagnostics: BlockPatternNestingDiagnostic[];
+} {
+  const diagnostics: BlockPatternNestingDiagnostic[] = [];
+  const rootBlock: ParsedBlockPatternBlock = {
+    attributes: {},
+    blockName: '__root__',
+    innerBlocks: [],
+  };
+  const stack: {
+    block: ParsedBlockPatternBlock;
+    pathSegments: string[];
+  }[] = [
+    {
+      block: rootBlock,
+      pathSegments: [],
+    },
+  ];
+
+  for (const match of content.matchAll(WORDPRESS_BLOCK_COMMENT_PATTERN)) {
+    const comment = parseBlockPatternComment(match[1] ?? '', diagnostics, patternFile);
+    if (!comment) {
+      continue;
+    }
+
+    if (comment.type === 'close') {
+      const openStackIndex = findOpenBlockStackIndex(stack, comment.blockName);
+      if (openStackIndex === -1) {
+        addBlockPatternDiagnostic(diagnostics, {
+          blockName: comment.blockName,
+          code: 'unbalanced-block-pattern-comment',
+          message: `Serialized closing block "${comment.blockName}" does not match an open block.`,
+          patternFile,
+          severity: 'warning',
+        });
+        continue;
+      }
+
+      const activeBlock = stack[stack.length - 1];
+      if (activeBlock && activeBlock.block.blockName !== comment.blockName) {
+        addBlockPatternDiagnostic(diagnostics, {
+          blockName: comment.blockName,
+          blockPath: formatBlockPatternPath(activeBlock.pathSegments),
+          code: 'unbalanced-block-pattern-comment',
+          message: `Serialized closing block "${comment.blockName}" appeared while "${activeBlock.block.blockName}" was still open.`,
+          patternFile,
+          severity: 'warning',
+        });
+      }
+
+      stack.length = openStackIndex + 1;
+      stack.pop();
+      continue;
+    }
+
+    const parent = stack[stack.length - 1];
+    if (!parent) {
+      continue;
+    }
+
+    const block: ParsedBlockPatternBlock = {
+      attributes: comment.attributes,
+      blockName: comment.blockName,
+      innerBlocks: [],
+    };
+    const blockPathSegments = [
+      ...parent.pathSegments,
+      `${block.blockName}[${parent.block.innerBlocks.length}]`,
+    ];
+    parent.block.innerBlocks.push(block);
+
+    if (!comment.selfClosing) {
+      stack.push({
+        block,
+        pathSegments: blockPathSegments,
+      });
+    }
+  }
+
+  for (let index = stack.length - 1; index > 0; index -= 1) {
+    const openBlock = stack[index];
+    if (!openBlock) {
+      continue;
+    }
+    addBlockPatternDiagnostic(diagnostics, {
+      blockName: openBlock.block.blockName,
+      blockPath: formatBlockPatternPath(openBlock.pathSegments),
+      code: 'unbalanced-block-pattern-comment',
+      message: `Serialized opening block "${openBlock.block.blockName}" was not closed.`,
+      patternFile,
+      severity: 'warning',
+    });
+  }
+
+  return {
+    blocks: rootBlock.innerBlocks,
+    diagnostics,
+  };
+}
+
+function isKnownOrAllowedExternalBlockName(
+  knownBlockNameContext: KnownBlockNameValidationContext | null,
+  blockName: string,
+): boolean {
+  if (!knownBlockNameContext) {
+    return true;
+  }
+
+  if (knownBlockNameContext.knownBlockNames.has(blockName)) {
+    return true;
+  }
+
+  return (
+    knownBlockNameContext.allowExternalBlockNames &&
+    !knownBlockNameContext.knownBlockNamespaces.has(getBlockNamespace(blockName))
+  );
+}
+
+function validateParsedPatternBlocksAgainstNesting(
+  issues: BlockPatternNestingDiagnostic[],
+  blocks: readonly ParsedBlockPatternBlock[],
+  nesting: Record<string, NormalizedBlockNestingRule>,
+  knownBlockNameContext: KnownBlockNameValidationContext | null,
+  patternFile: string | undefined,
+  ancestorBlockNames: readonly string[] = [],
+  pathSegments: readonly string[] = [],
+): void {
+  const parentBlockName = ancestorBlockNames[ancestorBlockNames.length - 1];
+  const parentRule = parentBlockName ? nesting[parentBlockName] : undefined;
+
+  blocks.forEach((block, index) => {
+    const blockPathSegments = [
+      ...pathSegments,
+      `${block.blockName}[${index}]`,
+    ];
+    const blockPath = formatBlockPatternPath(blockPathSegments);
+    const childRule = nesting[block.blockName];
+
+    if (!isKnownOrAllowedExternalBlockName(knownBlockNameContext, block.blockName)) {
+      addBlockPatternDiagnostic(issues, {
+        blockName: block.blockName,
+        blockPath,
+        code: 'unknown-block',
+        message: `Pattern content references unknown block "${block.blockName}". Its own nesting requirements were skipped.`,
+        patternFile,
+        severity: 'warning',
+      });
+    }
+
+    if (
+      parentRule?.allowedBlocks &&
+      parentRule.allowedBlocks.length > 0 &&
+      !parentRule.allowedBlocks.includes(block.blockName)
+    ) {
+      addBlockPatternDiagnostic(issues, {
+        blockName: block.blockName,
+        blockPath,
+        code: 'disallowed-child-block',
+        message: `${parentBlockName}.allowedBlocks does not include "${block.blockName}".`,
+        patternFile,
+        severity: 'error',
+      });
+    }
+
+    if (childRule?.parent && childRule.parent.length > 0) {
+      if (!parentBlockName) {
+        addBlockPatternDiagnostic(issues, {
+          blockName: block.blockName,
+          blockPath,
+          code: 'invalid-block-parent',
+          message: `"${block.blockName}" requires one of these parent blocks: ${childRule.parent.join(', ')}.`,
+          patternFile,
+          severity: 'error',
+        });
+      } else if (!childRule.parent.includes(parentBlockName)) {
+        addBlockPatternDiagnostic(issues, {
+          blockName: block.blockName,
+          blockPath,
+          code: 'invalid-block-parent',
+          message: `"${block.blockName}" requires one of these parent blocks: ${childRule.parent.join(', ')}, but found "${parentBlockName}".`,
+          patternFile,
+          severity: 'error',
+        });
+      }
+    }
+
+    if (
+      childRule?.ancestor &&
+      childRule.ancestor.length > 0 &&
+      !hasRelationshipOverlap(childRule.ancestor, ancestorBlockNames)
+    ) {
+      addBlockPatternDiagnostic(issues, {
+        blockName: block.blockName,
+        blockPath,
+        code: 'invalid-block-ancestor',
+        message: `"${block.blockName}" requires one of these ancestor blocks: ${childRule.ancestor.join(', ')}.`,
+        patternFile,
+        severity: 'error',
+      });
+    }
+
+    validateParsedPatternBlocksAgainstNesting(
+      issues,
+      block.innerBlocks,
+      nesting,
+      knownBlockNameContext,
+      patternFile,
+      [...ancestorBlockNames, block.blockName],
+      blockPathSegments,
+    );
+  });
+}
+
+/**
+ * Parse serialized WordPress block comments in a pattern file and compare the
+ * discovered block tree with a typed block nesting contract.
+ *
+ * Relationship violations are returned as `error` diagnostics. Unknown blocks,
+ * malformed block comments, and unparseable attributes are returned as
+ * `warning` diagnostics so callers can surface them without mutating content.
+ *
+ * @param content PHP or HTML pattern source containing serialized block comments.
+ * @param options Pattern filename, nesting contract, and known block-name policy.
+ * @returns Parsed block tree plus split warning/error diagnostics.
+ */
+export function validateBlockPatternContentNesting(
+  content: string,
+  options: ValidateBlockPatternContentNestingOptions,
+): ValidateBlockPatternContentNestingResult {
+  validateBlockNestingContract(options.nesting, {
+    allowExternalBlockNames: options.allowExternalBlockNames,
+    knownBlockNames: options.knownBlockNames,
+  });
+
+  const nesting = normalizeBlockNestingContract(options.nesting);
+  const knownBlockNameContext = createKnownBlockNameValidationContext(options);
+  const parsed = parseBlockPatternContent(content, options.patternFile);
+  const diagnostics = [...parsed.diagnostics];
+
+  validateParsedPatternBlocksAgainstNesting(
+    diagnostics,
+    parsed.blocks,
+    nesting,
+    knownBlockNameContext,
+    options.patternFile,
+  );
+
+  return {
+    blocks: parsed.blocks,
+    diagnostics,
+    errors: diagnostics.filter((diagnostic) => diagnostic.severity === 'error'),
+    warnings: diagnostics.filter(
+      (diagnostic) => diagnostic.severity === 'warning',
+    ),
+  };
+}
+
+/**
+ * Format one pattern nesting diagnostic with its file and serialized block path.
+ *
+ * @param diagnostic Diagnostic returned by `validateBlockPatternContentNesting`.
+ * @returns Human-readable diagnostic message.
+ */
+export function formatBlockPatternContentNestingDiagnostic(
+  diagnostic: BlockPatternNestingDiagnostic,
+): string {
+  const location = [
+    diagnostic.patternFile,
+    diagnostic.blockPath ? `at ${diagnostic.blockPath}` : undefined,
+  ]
+    .filter(Boolean)
+    .join(' ');
+  const prefix = location.length > 0 ? `${location}: ` : '';
+
+  return `${prefix}${diagnostic.message}`;
+}
+
+/**
+ * Format multiple pattern nesting diagnostics as a bullet list.
+ *
+ * @param diagnostics Diagnostics returned by `validateBlockPatternContentNesting`.
+ * @returns Human-readable bullet list suitable for CLI errors or warnings.
+ */
+export function formatBlockPatternContentNestingDiagnostics(
+  diagnostics: readonly BlockPatternNestingDiagnostic[],
+): string {
+  return diagnostics
+    .map(
+      (diagnostic) =>
+        `- ${formatBlockPatternContentNestingDiagnostic(diagnostic)}`,
+    )
+    .join('\n');
 }
 
 export function renderInnerBlocksTemplateModule(

--- a/packages/wp-typia-block-runtime/src/metadata-core.ts
+++ b/packages/wp-typia-block-runtime/src/metadata-core.ts
@@ -20,19 +20,28 @@ import {
 export {
   defineBlockNesting,
   defineInnerBlocksTemplates,
+  formatBlockPatternContentNestingDiagnostic,
+  formatBlockPatternContentNestingDiagnostics,
   getInnerBlocksTemplatesFromNesting,
   renderInnerBlocksTemplateModule,
+  validateBlockPatternContentNesting,
   validateInnerBlocksTemplates,
   validateBlockNestingContract,
 } from './metadata-core-nesting.js';
 export type {
+  BlockPatternNestingDiagnostic,
+  BlockPatternNestingDiagnosticCode,
+  BlockPatternNestingDiagnosticSeverity,
   BlockInnerBlocksTemplate,
   BlockInnerBlocksTemplateAttributes,
   BlockInnerBlocksTemplateContract,
   BlockInnerBlocksTemplateItem,
   BlockNestingContract,
   BlockNestingRule,
+  ParsedBlockPatternBlock,
   RenderInnerBlocksTemplateModuleOptions,
+  ValidateBlockPatternContentNestingOptions,
+  ValidateBlockPatternContentNestingResult,
   ValidateInnerBlocksTemplatesOptions,
   ValidateBlockNestingContractOptions,
 } from './metadata-core-nesting.js';

--- a/packages/wp-typia-block-runtime/tests/block-runtime.test.ts
+++ b/packages/wp-typia-block-runtime/tests/block-runtime.test.ts
@@ -68,6 +68,12 @@ describe("@wp-typia/block-runtime", () => {
 		expect(typeof metadataCoreModule.defineBlockNesting).toBe("function");
 		expect(typeof metadataCoreModule.defineInnerBlocksTemplates).toBe("function");
 		expect(typeof metadataCoreModule.defineEndpointManifest).toBe("function");
+		expect(typeof metadataCoreModule.validateBlockPatternContentNesting).toBe(
+			"function",
+		);
+		expect(
+			typeof metadataCoreModule.formatBlockPatternContentNestingDiagnostics,
+		).toBe("function");
 		expect(typeof metadataCoreModule.syncInnerBlocksTemplateModule).toBe("function");
 		expect(typeof metadataCoreModule.runSyncBlockMetadata).toBe("function");
 		expect(typeof metadataCoreModule.syncEndpointClient).toBe("function");

--- a/packages/wp-typia-project-tools/templates/_shared/compound/core/scripts/block-config.ts.mustache
+++ b/packages/wp-typia-project-tools/templates/_shared/compound/core/scripts/block-config.ts.mustache
@@ -11,6 +11,11 @@ export const BLOCK_TEMPLATES = defineInnerBlocksTemplates( {
 	// Add default InnerBlocks templates here.
 } );
 
+export interface WorkspacePatternConfig {
+	file: string;
+	slug: string;
+}
+
 export const BLOCKS = [
 	{
 		attributeTypeName: '{{pascalCase}}Attributes',
@@ -24,3 +29,7 @@ export const BLOCKS = [
 	},
 	// add-child: insert new block config entries here
 ] as const;
+
+export const PATTERNS: WorkspacePatternConfig[] = [
+	// wp-typia add pattern entries
+];

--- a/packages/wp-typia-project-tools/templates/_shared/compound/core/scripts/sync-types-to-block-json.ts.mustache
+++ b/packages/wp-typia-project-tools/templates/_shared/compound/core/scripts/sync-types-to-block-json.ts.mustache
@@ -3,13 +3,15 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import {
+	formatBlockPatternContentNestingDiagnostics,
+	validateBlockPatternContentNesting,
 	syncInnerBlocksTemplateModule,
 	syncBlockMetadata,
 	validateBlockNestingContract,
 	validateInnerBlocksTemplates,
 } from '@wp-typia/block-runtime/metadata-core';
 
-import { BLOCK_NESTING, BLOCK_TEMPLATES, BLOCKS } from './block-config';
+import { BLOCK_NESTING, BLOCK_TEMPLATES, BLOCKS, PATTERNS } from './block-config';
 
 function parseCliOptions( argv: string[] ) {
 	const options = {
@@ -49,6 +51,40 @@ function readWorkspaceBlockName( block: ( typeof BLOCKS )[ number ] ): string {
 	return blockJson.name;
 }
 
+function validatePatternContentNesting( knownBlockNames: readonly string[] ) {
+	const diagnostics = PATTERNS.flatMap( ( pattern ) => {
+		const content = fs.readFileSync( pattern.file, 'utf8' );
+		return validateBlockPatternContentNesting( content, {
+			allowExternalBlockNames: true,
+			knownBlockNames,
+			nesting: BLOCK_NESTING,
+			patternFile: pattern.file,
+		} ).diagnostics;
+	} );
+	const warnings = diagnostics.filter(
+		( diagnostic ) => diagnostic.severity === 'warning'
+	);
+	const errors = diagnostics.filter(
+		( diagnostic ) => diagnostic.severity === 'error'
+	);
+
+	if ( warnings.length > 0 ) {
+		console.warn(
+			`⚠️ Pattern nesting validation warnings:\n${ formatBlockPatternContentNestingDiagnostics(
+				warnings
+			) }`
+		);
+	}
+
+	if ( errors.length > 0 ) {
+		throw new Error(
+			`Pattern content violates block nesting contract:\n${ formatBlockPatternContentNestingDiagnostics(
+				errors
+			) }`
+		);
+	}
+}
+
 async function main() {
 	const options = parseCliOptions( process.argv.slice( 2 ) );
 	const knownBlockNames = BLOCKS.map( readWorkspaceBlockName );
@@ -61,6 +97,7 @@ async function main() {
 		knownBlockNames,
 		nesting: BLOCK_NESTING,
 	} );
+	validatePatternContentNesting( knownBlockNames );
 	await syncInnerBlocksTemplateModule(
 		{
 			allowExternalBlockNames: true,

--- a/packages/wp-typia-project-tools/templates/_shared/compound/core/scripts/sync-types-to-block-json.ts.mustache
+++ b/packages/wp-typia-project-tools/templates/_shared/compound/core/scripts/sync-types-to-block-json.ts.mustache
@@ -51,9 +51,21 @@ function readWorkspaceBlockName( block: ( typeof BLOCKS )[ number ] ): string {
 	return blockJson.name;
 }
 
+function readPatternFileContent( pattern: ( typeof PATTERNS )[ number ] ): string {
+	try {
+		return fs.readFileSync( pattern.file, 'utf8' );
+	} catch ( error ) {
+		throw new Error(
+			`Failed to read pattern "${ pattern.slug }" at ${ pattern.file }: ${
+				error instanceof Error ? error.message : String( error )
+			}`
+		);
+	}
+}
+
 function validatePatternContentNesting( knownBlockNames: readonly string[] ) {
 	const diagnostics = PATTERNS.flatMap( ( pattern ) => {
-		const content = fs.readFileSync( pattern.file, 'utf8' );
+		const content = readPatternFileContent( pattern );
 		return validateBlockPatternContentNesting( content, {
 			allowExternalBlockNames: true,
 			knownBlockNames,

--- a/packages/wp-typia-project-tools/templates/_shared/compound/persistence/scripts/block-config.ts.mustache
+++ b/packages/wp-typia-project-tools/templates/_shared/compound/persistence/scripts/block-config.ts.mustache
@@ -12,6 +12,11 @@ export const BLOCK_TEMPLATES = defineInnerBlocksTemplates( {
 	// Add default InnerBlocks templates here.
 } );
 
+export interface WorkspacePatternConfig {
+	file: string;
+	slug: string;
+}
+
 export const BLOCKS = [
 	{
 		apiTypesFile: 'src/blocks/{{slugKebabCase}}/api-types.ts',
@@ -85,3 +90,7 @@ export const BLOCKS = [
 	},
 	// add-child: insert new block config entries here
 ] as const;
+
+export const PATTERNS: WorkspacePatternConfig[] = [
+	// wp-typia add pattern entries
+];

--- a/packages/wp-typia-project-tools/tests/import-policy.test.ts
+++ b/packages/wp-typia-project-tools/tests/import-policy.test.ts
@@ -64,6 +64,12 @@ describe('@wp-typia/project-tools import policy', () => {
     expect(typeof metadataCoreModule.defineBlockNesting).toBe('function');
     expect(typeof metadataCoreModule.defineInnerBlocksTemplates).toBe('function');
     expect(typeof metadataCoreModule.defineEndpointManifest).toBe('function');
+    expect(typeof metadataCoreModule.validateBlockPatternContentNesting).toBe(
+      'function',
+    );
+    expect(
+      typeof metadataCoreModule.formatBlockPatternContentNestingDiagnostics,
+    ).toBe('function');
     expect(typeof metadataCoreModule.syncInnerBlocksTemplateModule).toBe(
       'function',
     );

--- a/packages/wp-typia-project-tools/tests/scaffold-compound.test.ts
+++ b/packages/wp-typia-project-tools/tests/scaffold-compound.test.ts
@@ -246,6 +246,7 @@ describe('@wp-typia/project-tools scaffold compound', () => {
       expect(blockConfig).toContain('defineInnerBlocksTemplates');
       expect(blockConfig).toContain('export const BLOCK_NESTING');
       expect(blockConfig).toContain('export const BLOCK_TEMPLATES');
+      expect(blockConfig).toContain('export const PATTERNS');
       expect(parentManifest.sourceType).toBe('DemoCompoundAttributes');
       expect(parentManifest.attributes.heading.typia.defaultValue).toBe(
         'Demo Compound',
@@ -850,6 +851,7 @@ describe('@wp-typia/project-tools scaffold compound', () => {
       expect(generatedBlockConfig).toContain('defineInnerBlocksTemplates');
       expect(generatedBlockConfig).toContain('export const BLOCK_NESTING');
       expect(generatedBlockConfig).toContain('export const BLOCK_TEMPLATES');
+      expect(generatedBlockConfig).toContain('export const PATTERNS');
       expect(generatedBlockConfig).toContain(
         'restManifest: defineEndpointManifest',
       );

--- a/packages/wp-typia-project-tools/tests/workspace-add.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-add.test.ts
@@ -245,6 +245,8 @@ test("canonical CLI can add a basic block to an official workspace template", as
   expect(blockConfigSource).toContain("export const BLOCK_TEMPLATES");
   expect(blockConfigSource).toContain('slug: "counter-card"');
   expect(syncTypesSource).toContain("syncInnerBlocksTemplateModule");
+  expect(syncTypesSource).toContain("validateBlockPatternContentNesting");
+  expect(syncTypesSource).toContain("PATTERNS");
   expect(syncTypesSource).toContain("validateInnerBlocksTemplates");
   expect(syncTypesSource).toContain("validateBlockNestingContract");
   expect(syncTypesSource).toContain("allowExternalBlockNames: true");
@@ -291,6 +293,44 @@ test("canonical CLI can add a basic block to an official workspace template", as
   runGeneratedScript(targetDir, "scripts/sync-types-to-block-json.ts", [
     "--check",
   ]);
+
+  fs.mkdirSync(path.join(targetDir, "src", "patterns"), { recursive: true });
+  fs.writeFileSync(
+    path.join(targetDir, "src", "patterns", "invalid-nesting.php"),
+    [
+      "<?php",
+      "register_block_pattern(",
+      "\t'demo-space/invalid-nesting',",
+      "\tarray(",
+      "\t\t'title' => 'Invalid nesting',",
+      "\t\t'content' => '<!-- wp:demo-space/counter-card --><!-- wp:paragraph /--><!-- /wp:demo-space/counter-card -->',",
+      "\t)",
+      ");",
+      "",
+    ].join("\n"),
+    "utf8"
+  );
+  fs.writeFileSync(
+    blockConfigPath,
+    fs
+      .readFileSync(blockConfigPath, "utf8")
+      .replace(
+        "\t// wp-typia add pattern entries",
+        '\t{\n\t\tfile: "src/patterns/invalid-nesting.php",\n\t\tslug: "invalid-nesting",\n\t},\n\t// wp-typia add pattern entries'
+      ),
+    "utf8"
+  );
+  const invalidPatternError = getCommandErrorMessage(() =>
+    runGeneratedScript(targetDir, "scripts/sync-types-to-block-json.ts", [
+      "--check",
+    ])
+  );
+  expect(invalidPatternError).toContain(
+    "Pattern content violates block nesting contract"
+  );
+  expect(invalidPatternError).toContain(
+    'demo-space/counter-card.allowedBlocks does not include "core/paragraph"'
+  );
 
   fs.writeFileSync(
     blockConfigPath,

--- a/tests/unit/metadata-core.test.ts
+++ b/tests/unit/metadata-core.test.ts
@@ -8,6 +8,7 @@ import {
   defineBlockNesting,
   defineEndpointManifest,
   defineInnerBlocksTemplates,
+  formatBlockPatternContentNestingDiagnostics,
   getInnerBlocksTemplatesFromNesting,
   renderInnerBlocksTemplateModule,
   runSyncBlockMetadata,
@@ -16,6 +17,7 @@ import {
   syncInnerBlocksTemplateModule,
   syncRestOpenApi,
   syncTypeSchemas,
+  validateBlockPatternContentNesting,
   validateBlockNestingContract,
   validateInnerBlocksTemplates,
   type EndpointManifestDefinition,
@@ -259,6 +261,135 @@ describe("metadata-core endpoint manifests", () => {
       )
     ).toThrow(
       'InnerBlocks template "demo/container"[0] uses "demo/body", but demo/container.allowedBlocks does not include "demo/body".'
+    );
+  });
+
+  test("validateBlockPatternContentNesting accepts serialized patterns that follow nesting rules", () => {
+    const nesting = defineBlockNesting({
+      "demo/container": {
+        allowedBlocks: ["demo/section"],
+      },
+      "demo/section": {
+        allowedBlocks: ["demo/title", "core/paragraph"],
+        parent: ["demo/container"],
+      },
+      "demo/title": {
+        ancestor: ["demo/container"],
+      },
+    });
+    const result = validateBlockPatternContentNesting(
+      [
+        "<!-- wp:demo/container -->",
+        '<div class="wp-block-demo-container">',
+        "<!-- wp:demo/section -->",
+        '<section class="wp-block-demo-section">',
+        '<!-- wp:demo/title {"placeholder":"Title"} /-->',
+        '<!-- wp:paragraph {"placeholder":"Body copy"} /-->',
+        "</section>",
+        "<!-- /wp:demo/section -->",
+        "</div>",
+        "<!-- /wp:demo/container -->",
+      ].join("\n"),
+      {
+        allowExternalBlockNames: true,
+        knownBlockNames: ["demo/container", "demo/section", "demo/title"],
+        nesting,
+        patternFile: "src/patterns/valid.php",
+      }
+    );
+
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toEqual([]);
+    expect(result.blocks[0]?.blockName).toBe("demo/container");
+    expect(result.blocks[0]?.innerBlocks[0]?.innerBlocks[1]?.blockName).toBe(
+      "core/paragraph"
+    );
+  });
+
+  test("validateBlockPatternContentNesting reports invalid block relationships with file and block path", () => {
+    const nesting = defineBlockNesting({
+      "demo/container": {
+        allowedBlocks: ["demo/section"],
+      },
+      "demo/section": {
+        parent: ["demo/container"],
+      },
+      "demo/body": {
+        parent: ["demo/section"],
+      },
+      "demo/eyebrow": {
+        ancestor: ["demo/container"],
+      },
+    });
+    const result = validateBlockPatternContentNesting(
+      [
+        "<!-- wp:demo/container -->",
+        "<!-- wp:demo/body /-->",
+        "<!-- /wp:demo/container -->",
+        "<!-- wp:demo/eyebrow /-->",
+      ].join("\n"),
+      {
+        knownBlockNames: [
+          "demo/container",
+          "demo/section",
+          "demo/body",
+          "demo/eyebrow",
+        ],
+        nesting,
+        patternFile: "src/patterns/invalid.php",
+      }
+    );
+    const formatted = formatBlockPatternContentNestingDiagnostics(result.errors);
+
+    expect(result.warnings).toEqual([]);
+    expect(result.errors.map((diagnostic) => diagnostic.code)).toEqual([
+      "disallowed-child-block",
+      "invalid-block-parent",
+      "invalid-block-ancestor",
+    ]);
+    expect(formatted).toContain("src/patterns/invalid.php");
+    expect(formatted).toContain("demo/container[0] > demo/body[0]");
+    expect(formatted).toContain(
+      'demo/container.allowedBlocks does not include "demo/body"'
+    );
+    expect(formatted).toContain(
+      '"demo/eyebrow" requires one of these ancestor blocks: demo/container'
+    );
+  });
+
+  test("validateBlockPatternContentNesting treats unknown and unparseable pattern content as warnings", () => {
+    const result = validateBlockPatternContentNesting(
+      [
+        '<!-- wp:demo/unknown {"broken":} -->',
+        "<p>Unknown block content</p>",
+        "<!-- /wp:demo/unknown -->",
+        "<!-- /wp:demo/orphan -->",
+      ].join("\n"),
+      {
+        allowExternalBlockNames: true,
+        knownBlockNames: ["demo/container"],
+        nesting: defineBlockNesting({}),
+        patternFile: "src/patterns/warn.php",
+      }
+    );
+    const formattedWarnings = formatBlockPatternContentNestingDiagnostics(
+      result.warnings
+    );
+
+    expect(result.errors).toEqual([]);
+    expect(result.warnings.map((diagnostic) => diagnostic.code)).toContain(
+      "invalid-block-pattern-attributes"
+    );
+    expect(result.warnings.map((diagnostic) => diagnostic.code)).toContain(
+      "unknown-block"
+    );
+    expect(result.warnings.map((diagnostic) => diagnostic.code)).toContain(
+      "unbalanced-block-pattern-comment"
+    );
+    expect(formattedWarnings).toContain("src/patterns/warn.php");
+    expect(formattedWarnings).toContain('unknown block "demo/unknown"');
+    expect(formattedWarnings).toContain(
+      'closing block "demo/orphan" does not match an open block'
     );
   });
 

--- a/tests/unit/metadata-core.test.ts
+++ b/tests/unit/metadata-core.test.ts
@@ -393,6 +393,36 @@ describe("metadata-core endpoint manifests", () => {
     );
   });
 
+  test("validateBlockPatternContentNesting reports every block dropped by a mid-stack close", () => {
+    const result = validateBlockPatternContentNesting(
+      [
+        "<!-- wp:demo/container -->",
+        "<!-- wp:demo/section -->",
+        "<!-- wp:demo/body -->",
+        "<!-- /wp:demo/container -->",
+      ].join("\n"),
+      {
+        knownBlockNames: ["demo/container", "demo/section", "demo/body"],
+        nesting: defineBlockNesting({}),
+        patternFile: "src/patterns/unbalanced.php",
+      }
+    );
+    const formattedWarnings = formatBlockPatternContentNestingDiagnostics(
+      result.warnings
+    );
+
+    expect(result.errors).toEqual([]);
+    expect(formattedWarnings).toContain(
+      'Serialized opening block "demo/body" was not closed before "demo/container" closed.'
+    );
+    expect(formattedWarnings).toContain(
+      'Serialized opening block "demo/section" was not closed before "demo/container" closed.'
+    );
+    expect(formattedWarnings).toContain(
+      'Serialized closing block "demo/container" appeared before all nested blocks were closed.'
+    );
+  });
+
   test("block nesting contracts can carry generated InnerBlocks templates", () => {
     const nesting = defineBlockNesting({
       "demo/container": {


### PR DESCRIPTION
Closes #986

## Summary
- add serialized WordPress block comment parsing for pattern content nesting validation
- wire PATTERNS validation into generated sync-types scripts for workspace and compound templates
- document parser limitations and add Sampo changeset

## Verification
- bun test tests/unit/metadata-core.test.ts
- bun run --filter @wp-typia/block-runtime build
- bun test packages/wp-typia-project-tools/tests/workspace-add.test.ts -t "canonical CLI can add a basic block to an official workspace template"
- bun test packages/wp-typia-project-tools/tests/workspace-add.test.ts -t "canonical CLI can add a pattern to an official workspace template"
- bun test packages/wp-typia-project-tools/tests/scaffold-compound.test.ts
- bun test packages/wp-typia-project-tools/tests/built-in-block-artifacts.test.ts
- bun test packages/wp-typia-project-tools/tests/template-source.test.ts -t "official workspace"
- bun run typecheck
- bun run lint:repo
- bun run format:check
- bun run changesets:validate
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added block pattern nesting validation during synchronization to prevent drift from block nesting contracts.
  * Pattern files are now parsed and validated against configured block relationships, reporting relationship violations as diagnostics.
  * Unknown or unparseable pattern content is treated as warnings while validation errors block synchronization.

* **Documentation**
  * Updated documentation across workspace templates and runtime packages explaining pattern validation behavior and workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/993)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->