### PR TITLE
docs: add nested block family fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ fail with the pattern file and serialized block path, while unknown or
 unparseable block comments are reported as warnings instead of being rewritten.
 The first validator intentionally reads serialized `<!-- wp:* -->` block
 comment boundaries conservatively and does not execute dynamic PHP content.
+For an end-to-end generic `example/container` → `example/section` → leaf block
+family, see the Nesting Contracts Guide in `apps/docs/src/content/docs/guides`
+and the checked fixture in `tests/fixtures/nested-block-family.ts`.
 
 ### 5. Query Loop variations get a first-class scaffold
 

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -106,6 +106,10 @@ export default defineConfig({
             { label: 'Architecture Guide', link: '/guides/architecture/' },
             { label: 'Interactivity Guide', link: '/guides/interactivity/' },
             { label: 'Migration Guide', link: '/guides/migrations/' },
+            {
+              label: 'Nesting Contracts Guide',
+              link: '/guides/nesting-contracts/',
+            },
             { label: 'Union Support Guide', link: '/guides/union-support/' },
           ],
         },

--- a/apps/docs/src/content/docs/guides/nesting-contracts.md
+++ b/apps/docs/src/content/docs/guides/nesting-contracts.md
@@ -1,0 +1,152 @@
+---
+title: 'Nesting Contracts Guide'
+---
+
+Typed nesting contracts let a workspace describe a reusable block family once and
+then use the same source of truth for generated `block.json` metadata, editor
+`InnerBlocks` templates, and pattern validation.
+
+Use this guide when a plugin owns a small block system such as:
+
+- `example/container`: the top-level parent users insert
+- `example/section`: a repeatable section inside the container
+- `example/title`, `example/body`, and `example/media`: leaf blocks inside a section
+
+The same generic shape is also available as a checked fixture in
+`tests/fixtures/nested-block-family.ts`.
+
+## Define the contract
+
+Author nesting rules in `scripts/block-config.ts`:
+
+```ts
+import {
+  defineBlockNesting,
+  defineInnerBlocksTemplates,
+} from '@wp-typia/block-runtime/metadata-core';
+
+export const BLOCK_NESTING = defineBlockNesting({
+  'example/container': {
+    allowedBlocks: ['example/section'],
+    template: [
+      [
+        'example/section',
+        { role: 'intro' },
+        [
+          ['example/title', { placeholder: 'Add a title' }],
+          ['example/body', { placeholder: 'Add supporting copy' }],
+          ['example/media', { aspectRatio: '16:9' }],
+        ],
+      ],
+    ],
+  },
+  'example/section': {
+    parent: ['example/container'],
+    allowedBlocks: ['example/title', 'example/body', 'example/media'],
+  },
+  'example/title': {
+    parent: ['example/section'],
+  },
+  'example/body': {
+    ancestor: ['example/container'],
+  },
+  'example/media': {
+    parent: ['example/section'],
+  },
+} as const);
+
+export const BLOCK_TEMPLATES = defineInnerBlocksTemplates({
+  'example/container': BLOCK_NESTING['example/container'].template,
+} as const);
+```
+
+Use `allowedBlocks` for direct child allow-lists, `parent` when a child must sit
+directly inside a specific block, and `ancestor` when a block may appear deeper
+inside a family but still requires a containing ancestor.
+
+## Sync generated metadata
+
+Generated workspace sync scripts pass `BLOCK_NESTING` into `syncBlockMetadata`.
+Each owned block keeps its WordPress metadata aligned with the contract:
+
+```json
+{
+  "name": "example/section",
+  "parent": ["example/container"],
+  "allowedBlocks": ["example/title", "example/body", "example/media"]
+}
+```
+
+Run sync in check mode before committing:
+
+```bash
+npm run wp-typia:sync -- --check
+```
+
+Workspace-local unknown names fail with actionable diagnostics. External blocks
+such as `core/group` remain valid when the generated script enables
+`allowExternalBlockNames`.
+
+## Use generated templates
+
+`wp-typia sync` also writes `src/inner-blocks-templates.ts` from
+`BLOCK_TEMPLATES` or from the optional `template` field embedded in
+`BLOCK_NESTING`:
+
+```ts
+import { INNER_BLOCKS_TEMPLATES } from '../../inner-blocks-templates';
+
+const template = INNER_BLOCKS_TEMPLATES['example/container'];
+```
+
+Pass the template to `useInnerBlocksProps()` or `InnerBlocks` in the parent edit
+component:
+
+```tsx
+<InnerBlocks
+  allowedBlocks={['example/section']}
+  template={template}
+  templateLock={false}
+/>
+```
+
+Template tuples are validated against the same `allowedBlocks`, `parent`, and
+`ancestor` rules, so the editor starter state cannot drift from block metadata.
+
+## Validate pattern content
+
+Patterns listed in `PATTERNS` are parsed during `wp-typia sync --check`. The
+validator reads serialized `<!-- wp:* -->` block comments conservatively and
+does not execute dynamic PHP.
+
+This valid pattern follows the same family contract:
+
+```html
+<!-- wp:example/container -->
+<div class="wp-block-example-container">
+  <!-- wp:example/section {"role":"intro"} -->
+  <section class="wp-block-example-section">
+    <!-- wp:example/title {"text":"Nested family title"} /-->
+    <!-- wp:example/body {"content":"Reusable supporting copy."} /-->
+    <!-- wp:example/media {"aspectRatio":"16:9"} /-->
+  </section>
+  <!-- /wp:example/section -->
+</div>
+<!-- /wp:example/container -->
+```
+
+Relationship violations fail sync with the pattern file and serialized block
+path, for example when `example/body` appears directly under
+`example/container`. Unknown blocks, unbalanced comments, and unparseable
+attributes are warnings so teams can adopt validation without rewriting pattern
+files automatically.
+
+## Fixture checklist
+
+For reusable nested block families, keep these pieces together:
+
+- A `BLOCK_NESTING` entry for every owned block in the family.
+- A default `BLOCK_TEMPLATES` entry for the top-level container.
+- Pattern files registered in `PATTERNS` so sync can validate shipped markup.
+- A `sync --check` CI step to catch stale `block.json`, template, or pattern
+  drift before release.

--- a/packages/create-workspace-template/README.md
+++ b/packages/create-workspace-template/README.md
@@ -42,6 +42,9 @@ pattern blocks are reported as warnings so the first implementation stays
 non-mutating.
 The validator reads serialized `<!-- wp:* -->` block comment boundaries
 conservatively and does not execute dynamic PHP content.
+For a complete generic family with a container, section, title, body, and media
+block, see the Nesting Contracts Guide in the hosted docs and the checked
+fixture at `tests/fixtures/nested-block-family.ts`.
 
 ## CLI binary policy
 

--- a/packages/create-workspace-template/README.md.mustache
+++ b/packages/create-workspace-template/README.md.mustache
@@ -59,6 +59,9 @@ pattern blocks are reported as warnings so the first implementation stays
 non-mutating.
 The validator reads serialized `<!-- wp:* -->` block comment boundaries
 conservatively and does not execute dynamic PHP content.
+For a complete generic family with a container, section, title, body, and media
+block, see the Nesting Contracts Guide in the hosted docs and the checked
+fixture at `tests/fixtures/nested-block-family.ts`.
 
 ## CLI Commands
 

--- a/tests/fixtures/nested-block-family.ts
+++ b/tests/fixtures/nested-block-family.ts
@@ -1,0 +1,60 @@
+import type {
+	BlockInnerBlocksTemplateContract,
+	BlockNestingContract,
+} from "@wp-typia/block-runtime/metadata-core";
+
+export const NESTED_BLOCK_FAMILY_BLOCK_NAMES = [
+	"example/container",
+	"example/section",
+	"example/title",
+	"example/body",
+	"example/media",
+] as const;
+
+export const NESTED_BLOCK_FAMILY_NESTING = {
+	"example/container": {
+		allowedBlocks: ["example/section"],
+		template: [
+			[
+				"example/section",
+				{ role: "intro" },
+				[
+					["example/title", { placeholder: "Add a title" }],
+					["example/body", { placeholder: "Add supporting copy" }],
+					["example/media", { aspectRatio: "16:9" }],
+				],
+			],
+		],
+	},
+	"example/section": {
+		allowedBlocks: ["example/title", "example/body", "example/media"],
+		parent: ["example/container"],
+	},
+	"example/title": {
+		parent: ["example/section"],
+	},
+	"example/body": {
+		ancestor: ["example/container"],
+	},
+	"example/media": {
+		parent: ["example/section"],
+	},
+} as const satisfies BlockNestingContract;
+
+export const NESTED_BLOCK_FAMILY_TEMPLATES = {
+	"example/container": NESTED_BLOCK_FAMILY_NESTING["example/container"].template,
+} as const satisfies BlockInnerBlocksTemplateContract;
+
+export const NESTED_BLOCK_FAMILY_PATTERN_CONTENT = [
+	"<!-- wp:example/container -->",
+	'<div class="wp-block-example-container">',
+	'<!-- wp:example/section {"role":"intro"} -->',
+	'<section class="wp-block-example-section">',
+	'<!-- wp:example/title {"text":"Nested family title"} /-->',
+	'<!-- wp:example/body {"content":"Reusable supporting copy."} /-->',
+	'<!-- wp:example/media {"aspectRatio":"16:9"} /-->',
+	"</section>",
+	"<!-- /wp:example/section -->",
+	"</div>",
+	"<!-- /wp:example/container -->",
+].join("\n");

--- a/tests/unit/metadata-core.test.ts
+++ b/tests/unit/metadata-core.test.ts
@@ -26,6 +26,12 @@ import {
   type SyncRestOpenApiManifestOptions,
   type SyncRestOpenApiOptions,
 } from "../../packages/wp-typia-block-runtime/src/metadata-core";
+import {
+  NESTED_BLOCK_FAMILY_BLOCK_NAMES,
+  NESTED_BLOCK_FAMILY_NESTING,
+  NESTED_BLOCK_FAMILY_PATTERN_CONTENT,
+  NESTED_BLOCK_FAMILY_TEMPLATES,
+} from "../fixtures/nested-block-family";
 
 const manifest = defineEndpointManifest({
   contracts: {
@@ -421,6 +427,36 @@ describe("metadata-core endpoint manifests", () => {
     expect(formattedWarnings).toContain(
       'Serialized closing block "demo/container" appeared before all nested blocks were closed.'
     );
+  });
+
+  test("nested block family fixture documents reusable contract, template, and pattern validation", () => {
+    expect(() =>
+      validateBlockNestingContract(NESTED_BLOCK_FAMILY_NESTING, {
+        knownBlockNames: NESTED_BLOCK_FAMILY_BLOCK_NAMES,
+      })
+    ).not.toThrow();
+    expect(() =>
+      validateInnerBlocksTemplates(NESTED_BLOCK_FAMILY_TEMPLATES, {
+        knownBlockNames: NESTED_BLOCK_FAMILY_BLOCK_NAMES,
+        nesting: NESTED_BLOCK_FAMILY_NESTING,
+      })
+    ).not.toThrow();
+
+    const patternValidation = validateBlockPatternContentNesting(
+      NESTED_BLOCK_FAMILY_PATTERN_CONTENT,
+      {
+        knownBlockNames: NESTED_BLOCK_FAMILY_BLOCK_NAMES,
+        nesting: NESTED_BLOCK_FAMILY_NESTING,
+        patternFile: "src/patterns/nested-family.php",
+      }
+    );
+
+    expect(patternValidation.errors).toEqual([]);
+    expect(patternValidation.warnings).toEqual([]);
+    expect(patternValidation.blocks[0]?.blockName).toBe("example/container");
+    expect(
+      renderInnerBlocksTemplateModule(NESTED_BLOCK_FAMILY_TEMPLATES)
+    ).toContain('"example/container"');
   });
 
   test("block nesting contracts can carry generated InnerBlocks templates", () => {


### PR DESCRIPTION
Closes #987

## Summary
- add a generic nested block family fixture for `example/container`, `example/section`, and leaf blocks
- document nesting contracts, generated metadata, InnerBlocks templates, and pattern validation
- link the guide from docs navigation and workspace README surfaces

## Verification
- bun test tests/unit/metadata-core.test.ts
- bun run typecheck
- bun run docs:build
- bun run format:check
- bun run lint:repo
- bun run changesets:validate
- git diff --check