### PR TITLE
feat: validate pattern section role markers

### DIFF
--- a/.sampo/changesets/989-pattern-section-role-markers.md
+++ b/.sampo/changesets/989-pattern-section-role-markers.md
@@ -1,0 +1,9 @@
+---
+npm/@wp-typia/project-tools: minor
+npm/wp-typia: minor
+---
+
+Validate pattern catalog section role markers against serialized pattern
+content, including configurable wrapper conventions, missing or mismatched
+section-scoped markers, unknown roles, and optional duplicate-role warnings for
+full patterns.

--- a/README.md
+++ b/README.md
@@ -147,7 +147,11 @@ comment boundaries conservatively and does not execute dynamic PHP content.
 The typed pattern catalog records `scope`, optional `sectionRole`, `tags`,
 `thumbnailUrl`, and `contentFile` metadata so `wp-typia sync --check` can catch
 duplicate slugs, missing pattern files, and invalid manifest metadata before
-validating markup.
+validating markup. Section-scoped patterns are also checked against their
+serialized wrapper markers: by default, `core/group` wrappers can declare roles
+with `section section--{role}` classes or `metadata.sectionRole` attributes.
+The same validator accepts a custom marker convention when projects use a
+different group-like wrapper block, class pattern, or metadata path.
 For an end-to-end generic `example/container` → `example/section` → leaf block
 family, see the Nesting Contracts Guide in `apps/docs/src/content/docs/guides`
 and the checked fixture in `tests/fixtures/nested-block-family.ts`.

--- a/apps/docs/src/content/docs/guides/nesting-contracts.md
+++ b/apps/docs/src/content/docs/guides/nesting-contracts.md
@@ -141,6 +141,22 @@ path, for example when `example/body` appears directly under
 attributes are warnings so teams can adopt validation without rewriting pattern
 files automatically.
 
+Pattern catalogs can also validate section role markers against the typed
+manifest. By default, section-scoped patterns use `core/group` wrappers with
+`section section--{role}` class tokens or a `metadata.sectionRole` attribute:
+
+```html
+<!-- wp:group {"className":"section section--hero"} -->
+<div class="wp-block-group section section--hero">
+  <!-- wp:heading {"content":"Hero"} /-->
+</div>
+<!-- /wp:group -->
+```
+
+Projects with a different convention can call `validatePatternCatalog()` with a
+custom `sectionRoleConvention`, including another wrapper block name, class
+pattern, metadata path, or duplicate-role policy for full-page patterns.
+
 ## Fixture checklist
 
 For reusable nested block families, keep these pieces together:

--- a/apps/docs/src/content/docs/reference/cli.md
+++ b/apps/docs/src/content/docs/reference/cli.md
@@ -280,7 +280,11 @@ patterns when you need a reusable PHP-registered content layout. Pattern
 catalog entries support typed `scope`, `sectionRole`, `tags`, `thumbnailUrl`,
 and `contentFile` metadata, and `wp-typia sync --check` validates duplicate
 slugs, missing content files, and invalid catalog metadata before checking block
-markup.
+markup. Section-scoped catalog entries are expected to include a matching
+serialized section marker; the default convention accepts `core/group` wrappers
+with `section section--{role}` classes or `metadata.sectionRole` attributes, and
+programmatic callers can pass a custom `sectionRoleConvention` to
+`validatePatternCatalog()`.
 
 Editor plugin scaffolds are slot-aware. The default `sidebar` slot generates a
 `PluginSidebar` shell with a matching more-menu entry, while

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-pattern.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-pattern.ts
@@ -130,9 +130,14 @@ function buildPatternConfigEntry(
 function buildPatternSource(
 	patternSlug: string,
 	namespace: string,
+	sectionRole: string | undefined,
 	textDomain: string,
 	title: string,
 ): string {
+	const content = sectionRole
+		? `'<!-- wp:group {"className":"section section--${sectionRole}"} --><div class="wp-block-group section section--${sectionRole}"><!-- wp:paragraph --><p>' . esc_html__( 'Describe this section pattern here.', '${textDomain}' ) . '</p><!-- /wp:paragraph --></div><!-- /wp:group -->'`
+		: `'<!-- wp:paragraph --><p>' . esc_html__( 'Describe this pattern here.', '${textDomain}' ) . '</p><!-- /wp:paragraph -->'`;
+
 	return `<?php
 if ( ! defined( 'ABSPATH' ) ) {
 \treturn;
@@ -144,7 +149,7 @@ register_block_pattern(
 \t\t'title'       => __( ${JSON.stringify(title)}, '${textDomain}' ),
 \t\t'description' => __( ${JSON.stringify(`A starter pattern for ${title}.`)}, '${textDomain}' ),
 \t\t'categories'  => array( '${namespace}' ),
-\t\t'content'     => '<!-- wp:paragraph --><p>' . esc_html__( 'Describe this pattern here.', '${textDomain}' ) . '</p><!-- /wp:paragraph -->',
+\t\t'content'     => ${content},
 \t)
 );
 `;
@@ -487,6 +492,7 @@ export async function runAddPatternCommand({
 			buildPatternSource(
 				patternSlug,
 				workspace.workspace.namespace,
+				patternCatalogOptions.sectionRole,
 				workspace.workspace.textDomain,
 				patternCatalogOptions.title,
 			),

--- a/packages/wp-typia-project-tools/src/runtime/index.ts
+++ b/packages/wp-typia-project-tools/src/runtime/index.ts
@@ -215,6 +215,8 @@ export {
 	runScaffoldFlow,
 } from "./cli-core.js";
 export {
+	extractPatternSectionRoleMatches,
+	extractPatternSectionRolesFromAttributes,
 	formatPatternCatalogDiagnostics,
 	PATTERN_CATALOG_SCOPE_IDS,
 	resolvePatternCatalogContentFile,
@@ -240,6 +242,8 @@ export type {
 	PatternCatalogDiagnosticSeverity,
 	PatternCatalogEntry,
 	PatternCatalogScope,
+	PatternCatalogSectionRoleConvention,
+	PatternCatalogSectionRoleMatch,
 	PatternCatalogValidationOptions,
 	PatternCatalogValidationResult,
 } from "./pattern-catalog.js";

--- a/packages/wp-typia-project-tools/src/runtime/pattern-catalog.ts
+++ b/packages/wp-typia-project-tools/src/runtime/pattern-catalog.ts
@@ -327,6 +327,17 @@ function collectSectionRoleMatches(
 	});
 }
 
+function unescapeSerializedBlockCommentJsonQuotes(content: string): string {
+	return content.replace(/<!--([\s\S]*?)-->/gu, (comment, body: string) => {
+		const source = body.trim();
+		if (!source.startsWith("wp:") && !source.startsWith("/wp:")) {
+			return comment;
+		}
+
+		return `<!--${body.replace(/\\"/gu, '"')}-->`;
+	});
+}
+
 /**
  * Extract section role slugs from serialized block attributes using the
  * configured class and metadata marker convention.
@@ -427,7 +438,28 @@ function validatePatternContentSectionRoles({
 		nesting: {},
 		patternFile: contentFile,
 	});
-	const matches = collectSectionRoleMatches(parsed.blocks, convention);
+	let matches = collectSectionRoleMatches(parsed.blocks, convention);
+	const unescapedContent = unescapeSerializedBlockCommentJsonQuotes(content);
+	if (unescapedContent !== content) {
+		const unescapedParsed = validateBlockPatternContentNesting(
+			unescapedContent,
+			{
+				allowExternalBlockNames: true,
+				nesting: {},
+				patternFile: contentFile,
+			},
+		);
+		const unescapedMatches = collectSectionRoleMatches(
+			unescapedParsed.blocks,
+			convention,
+		);
+		if (
+			unescapedMatches.some((match) => match.roles.length > 0) ||
+			matches.length === 0
+		) {
+			matches = unescapedMatches;
+		}
+	}
 	const locatedRoles = matches.flatMap<LocatedPatternSectionRole>((match) =>
 		match.roles.map((role) => ({
 			blockPath: match.blockPath,

--- a/packages/wp-typia-project-tools/src/runtime/pattern-catalog.ts
+++ b/packages/wp-typia-project-tools/src/runtime/pattern-catalog.ts
@@ -1,6 +1,11 @@
 import fs from "node:fs";
 import path from "node:path";
 
+import {
+	type ParsedBlockPatternBlock,
+	validateBlockPatternContentNesting,
+} from "@wp-typia/block-runtime/metadata-core";
+
 export const PATTERN_CATALOG_SCOPE_IDS = ["full", "section"] as const;
 
 export type PatternCatalogScope = (typeof PATTERN_CATALOG_SCOPE_IDS)[number];
@@ -23,11 +28,16 @@ export type PatternCatalogDiagnosticCode =
 	| "invalid-pattern-content-file"
 	| "invalid-pattern-scope"
 	| "invalid-pattern-section-role"
+	| "invalid-pattern-section-role-marker"
 	| "invalid-pattern-slug"
 	| "invalid-pattern-tag"
 	| "invalid-pattern-thumbnail-url"
+	| "mismatched-pattern-section-role"
 	| "missing-pattern-content-file"
-	| "missing-pattern-section-role";
+	| "missing-pattern-section-role"
+	| "missing-pattern-section-role-marker"
+	| "duplicate-pattern-section-role-marker"
+	| "unknown-pattern-section-role-marker";
 
 export type PatternCatalogDiagnostic = {
 	code: PatternCatalogDiagnosticCode;
@@ -36,8 +46,39 @@ export type PatternCatalogDiagnostic = {
 	severity: PatternCatalogDiagnosticSeverity;
 };
 
+export type PatternCatalogSectionRoleConvention = {
+	/**
+	 * Serialized block name used as the section wrapper, for example `core/group`.
+	 */
+	wrapperBlockName?: string;
+	/**
+	 * Optional class that marks a wrapper block as section-like even when the
+	 * role marker is missing.
+	 */
+	baseClassName?: string;
+	/**
+	 * Class token pattern where `{role}` is replaced by the section role slug.
+	 */
+	roleClassNamePattern?: string;
+	/**
+	 * Dot-separated block attribute paths that can carry role slugs.
+	 */
+	roleAttributePaths?: readonly string[];
+	/**
+	 * Warn when a full pattern repeats the same section role marker.
+	 */
+	requireUniqueFullPatternRoles?: boolean;
+};
+
+export type PatternCatalogSectionRoleMatch = {
+	blockName: string;
+	blockPath: string;
+	roles: readonly string[];
+};
+
 export type PatternCatalogValidationOptions = {
 	projectDir?: string;
+	sectionRoleConvention?: PatternCatalogSectionRoleConvention | false;
 };
 
 export type PatternCatalogValidationResult = {
@@ -50,6 +91,20 @@ const PATTERN_SLUG_PATTERN = /^[a-z][a-z0-9-]*$/u;
 const PATTERN_SECTION_ROLE_PATTERN = PATTERN_SLUG_PATTERN;
 const PATTERN_TAG_PATTERN = /^[a-z0-9][a-z0-9-]*$/u;
 const PATTERN_CONTENT_FILE_ROOT = "src/patterns/";
+const DEFAULT_SECTION_ROLE_CONVENTION = {
+	baseClassName: "section",
+	requireUniqueFullPatternRoles: false,
+	roleAttributePaths: ["metadata.sectionRole"],
+	roleClassNamePattern: "section--{role}",
+	wrapperBlockName: "core/group",
+} satisfies Required<PatternCatalogSectionRoleConvention>;
+
+type NormalizedPatternCatalogSectionRoleConvention = Required<PatternCatalogSectionRoleConvention>;
+
+type LocatedPatternSectionRole = {
+	blockPath: string;
+	role: string;
+};
 
 function createPatternCatalogDiagnostic(
 	diagnostic: PatternCatalogDiagnostic,
@@ -88,6 +143,200 @@ function isPatternContentFilePath(value: string): boolean {
 	);
 }
 
+function normalizeSectionRoleConvention(
+	convention: PatternCatalogSectionRoleConvention = {},
+): NormalizedPatternCatalogSectionRoleConvention {
+	return {
+		baseClassName:
+			convention.baseClassName ??
+			DEFAULT_SECTION_ROLE_CONVENTION.baseClassName,
+		requireUniqueFullPatternRoles:
+			convention.requireUniqueFullPatternRoles ??
+			DEFAULT_SECTION_ROLE_CONVENTION.requireUniqueFullPatternRoles,
+		roleAttributePaths:
+			convention.roleAttributePaths ??
+			DEFAULT_SECTION_ROLE_CONVENTION.roleAttributePaths,
+		roleClassNamePattern:
+			convention.roleClassNamePattern ??
+			DEFAULT_SECTION_ROLE_CONVENTION.roleClassNamePattern,
+		wrapperBlockName:
+			convention.wrapperBlockName ??
+			DEFAULT_SECTION_ROLE_CONVENTION.wrapperBlockName,
+	};
+}
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+function createRoleClassNamePattern(pattern: string): RegExp {
+	const parts = pattern.split("{role}");
+	if (parts.length !== 2) {
+		throw new Error(
+			`roleClassNamePattern must contain exactly one "{role}" placeholder.`,
+		);
+	}
+
+	return new RegExp(
+		`^${escapeRegExp(parts[0] ?? "")}(?<role>\\S*)${escapeRegExp(parts[1] ?? "")}$`,
+		"u",
+	);
+}
+
+function getClassNameTokens(attributes: Record<string, unknown>): string[] {
+	const className = attributes.className;
+	if (typeof className !== "string") {
+		return [];
+	}
+
+	return className.split(/\s+/u).filter((token) => token.length > 0);
+}
+
+function getAttributePathValue(
+	attributes: Record<string, unknown>,
+	pathName: string,
+): unknown {
+	return pathName.split(".").reduce<unknown>((current, segment) => {
+		if (
+			current !== null &&
+			typeof current === "object" &&
+			!Array.isArray(current) &&
+			Object.prototype.hasOwnProperty.call(current, segment)
+		) {
+			return (current as Record<string, unknown>)[segment];
+		}
+
+		return undefined;
+	}, attributes);
+}
+
+function collectStringValues(value: unknown): string[] {
+	if (typeof value === "string") {
+		return [value];
+	}
+	if (Array.isArray(value)) {
+		return value.filter((item): item is string => typeof item === "string");
+	}
+
+	return [];
+}
+
+function uniqueValues(values: readonly string[]): string[] {
+	return [...new Set(values)];
+}
+
+function formatRoleList(roles: readonly string[]): string {
+	if (roles.length === 0) {
+		return "none";
+	}
+
+	return roles.map((role) => `"${role}"`).join(", ");
+}
+
+function formatBlockPaths(paths: readonly string[]): string {
+	return paths.map((blockPath) => `at ${blockPath}`).join(", ");
+}
+
+function describeRoleMarkerConvention(
+	convention: NormalizedPatternCatalogSectionRoleConvention,
+): string {
+	return `${convention.wrapperBlockName} wrappers with class "${convention.roleClassNamePattern}" or attributes ${convention.roleAttributePaths.join(", ")}`;
+}
+
+function isSectionWrapperCandidate(
+	block: ParsedBlockPatternBlock,
+	roles: readonly string[],
+	convention: NormalizedPatternCatalogSectionRoleConvention,
+): boolean {
+	if (block.blockName !== convention.wrapperBlockName) {
+		return false;
+	}
+	if (roles.length > 0) {
+		return true;
+	}
+
+	return getClassNameTokens(block.attributes).includes(convention.baseClassName);
+}
+
+function collectSectionRoleMatches(
+	blocks: readonly ParsedBlockPatternBlock[],
+	convention: NormalizedPatternCatalogSectionRoleConvention,
+	pathSegments: readonly string[] = [],
+): PatternCatalogSectionRoleMatch[] {
+	return blocks.flatMap((block, index) => {
+		const blockPathSegments = [
+			...pathSegments,
+			`${block.blockName}[${index}]`,
+		];
+		const blockPath = blockPathSegments.join(" > ");
+		const roles = extractPatternSectionRolesFromAttributes(
+			block.attributes,
+			convention,
+		);
+		const matches = isSectionWrapperCandidate(block, roles, convention)
+			? [
+					{
+						blockName: block.blockName,
+						blockPath,
+						roles,
+					},
+				]
+			: [];
+
+		return [
+			...matches,
+			...collectSectionRoleMatches(
+				block.innerBlocks,
+				convention,
+				blockPathSegments,
+			),
+		];
+	});
+}
+
+/**
+ * Extract section role slugs from serialized block attributes using the
+ * configured class and metadata marker convention.
+ *
+ * @param attributes Parsed block attributes from serialized pattern content.
+ * @param convention Optional marker convention override.
+ * @returns Unique role marker values in discovery order.
+ */
+export function extractPatternSectionRolesFromAttributes(
+	attributes: Record<string, unknown>,
+	convention: PatternCatalogSectionRoleConvention = {},
+): string[] {
+	const normalized = normalizeSectionRoleConvention(convention);
+	const roleClassNamePattern = createRoleClassNamePattern(
+		normalized.roleClassNamePattern,
+	);
+	const classRoles = getClassNameTokens(attributes)
+		.map((token) => roleClassNamePattern.exec(token)?.groups?.role)
+		.filter((role): role is string => typeof role === "string");
+	const attributeRoles = normalized.roleAttributePaths.flatMap((pathName) =>
+		collectStringValues(getAttributePathValue(attributes, pathName)),
+	);
+
+	return uniqueValues([...classRoles, ...attributeRoles]);
+}
+
+/**
+ * Find section wrapper blocks and their role markers in parsed pattern content.
+ *
+ * @param blocks Parsed block tree returned by `validateBlockPatternContentNesting`.
+ * @param convention Optional marker convention override.
+ * @returns Section wrapper matches with serialized block paths.
+ */
+export function extractPatternSectionRoleMatches(
+	blocks: readonly ParsedBlockPatternBlock[],
+	convention: PatternCatalogSectionRoleConvention = {},
+): PatternCatalogSectionRoleMatch[] {
+	return collectSectionRoleMatches(
+		blocks,
+		normalizeSectionRoleConvention(convention),
+	);
+}
+
 /**
  * Validate pattern thumbnail references with the same URL/path rules used by
  * catalog diagnostics and `wp-typia add pattern`.
@@ -113,16 +362,147 @@ export function resolvePatternCatalogContentFile(
 	return pattern.contentFile ?? pattern.file;
 }
 
+function createKnownSectionRoleSet(
+	patterns: readonly PatternCatalogEntry[],
+): ReadonlySet<string> {
+	return new Set(
+		patterns
+			.map((pattern) => pattern.sectionRole)
+			.filter(
+				(sectionRole): sectionRole is string =>
+					typeof sectionRole === "string" &&
+					PATTERN_SECTION_ROLE_PATTERN.test(sectionRole),
+			),
+	);
+}
+
+function validatePatternContentSectionRoles({
+	content,
+	contentFile,
+	convention,
+	knownSectionRoles,
+	label,
+	pattern,
+}: {
+	content: string;
+	contentFile: string;
+	convention: NormalizedPatternCatalogSectionRoleConvention;
+	knownSectionRoles: ReadonlySet<string>;
+	label: string;
+	pattern: PatternCatalogEntry;
+}): PatternCatalogDiagnostic[] {
+	const diagnostics: PatternCatalogDiagnostic[] = [];
+	const parsed = validateBlockPatternContentNesting(content, {
+		allowExternalBlockNames: true,
+		nesting: {},
+		patternFile: contentFile,
+	});
+	const matches = collectSectionRoleMatches(parsed.blocks, convention);
+	const locatedRoles = matches.flatMap<LocatedPatternSectionRole>((match) =>
+		match.roles.map((role) => ({
+			blockPath: match.blockPath,
+			role,
+		})),
+	);
+	const invalidRoles = locatedRoles.filter(
+		({ role }) => !PATTERN_SECTION_ROLE_PATTERN.test(role),
+	);
+	for (const invalidRole of uniqueValues(invalidRoles.map(({ role }) => role))) {
+		const paths = invalidRoles
+			.filter(({ role }) => role === invalidRole)
+			.map(({ blockPath }) => blockPath);
+		diagnostics.push(
+			createPatternCatalogDiagnostic({
+				code: "invalid-pattern-section-role-marker",
+				message: `${label}: section role marker "${invalidRole}" in ${contentFile} must start with a lowercase letter and contain only lowercase letters, numbers, and hyphens (${formatBlockPaths(paths)}).`,
+				patternSlug: pattern.slug,
+				severity: "error",
+			}),
+		);
+	}
+
+	const validLocatedRoles = locatedRoles.filter(({ role }) =>
+		PATTERN_SECTION_ROLE_PATTERN.test(role),
+	);
+	const validRoles = validLocatedRoles.map(({ role }) => role);
+	const uniqueValidRoles = uniqueValues(validRoles);
+	const unknownRoles = uniqueValidRoles.filter(
+		(role) => !knownSectionRoles.has(role),
+	);
+	for (const unknownRole of unknownRoles) {
+		const paths = validLocatedRoles
+			.filter(({ role }) => role === unknownRole)
+			.map(({ blockPath }) => blockPath);
+		diagnostics.push(
+			createPatternCatalogDiagnostic({
+				code: "unknown-pattern-section-role-marker",
+				message: `${label}: section role marker "${unknownRole}" in ${contentFile} is not declared by any PATTERNS sectionRole (${formatBlockPaths(paths)}).`,
+				patternSlug: pattern.slug,
+				severity: "warning",
+			}),
+		);
+	}
+
+	const scope = pattern.scope ?? "full";
+	const expectedSectionRole =
+		typeof pattern.sectionRole === "string" &&
+		PATTERN_SECTION_ROLE_PATTERN.test(pattern.sectionRole)
+			? pattern.sectionRole
+			: undefined;
+	if (scope === "section" && expectedSectionRole) {
+		if (validRoles.length === 0) {
+			diagnostics.push(
+				createPatternCatalogDiagnostic({
+					code: "missing-pattern-section-role-marker",
+					message: `${label}: section-scoped pattern content in ${contentFile} must include section role marker "${expectedSectionRole}" using ${describeRoleMarkerConvention(convention)}.`,
+					patternSlug: pattern.slug,
+					severity: "error",
+				}),
+			);
+		} else if (!validRoles.includes(expectedSectionRole)) {
+			diagnostics.push(
+				createPatternCatalogDiagnostic({
+					code: "mismatched-pattern-section-role",
+					message: `${label}: manifest sectionRole "${expectedSectionRole}" was not found in ${contentFile}; found ${formatRoleList(uniqueValidRoles)}.`,
+					patternSlug: pattern.slug,
+					severity: "error",
+				}),
+			);
+		}
+	}
+
+	if (scope === "full" && convention.requireUniqueFullPatternRoles) {
+		for (const role of uniqueValidRoles) {
+			const paths = validLocatedRoles
+				.filter((locatedRole) => locatedRole.role === role)
+				.map(({ blockPath }) => blockPath);
+			if (paths.length <= 1) {
+				continue;
+			}
+			diagnostics.push(
+				createPatternCatalogDiagnostic({
+					code: "duplicate-pattern-section-role-marker",
+					message: `${label}: full pattern content in ${contentFile} repeats section role marker "${role}" (${formatBlockPaths(paths)}).`,
+					patternSlug: pattern.slug,
+					severity: "warning",
+				}),
+			);
+		}
+	}
+
+	return diagnostics;
+}
+
 /**
  * Validate typed pattern catalog metadata declared in `scripts/block-config.ts`.
  *
- * The validator is intentionally metadata-only: it checks catalog shape,
- * duplicate slugs, optional section-role rules, safe content file paths, and
- * missing files when a workspace root is provided. Block markup validation runs
- * separately through the nesting validator.
+ * The validator checks catalog shape, duplicate slugs, optional section-role
+ * rules, safe content file paths, and missing files when a workspace root is
+ * provided. With a workspace root, it also parses serialized block markup and
+ * compares section role markers against the catalog manifest.
  *
  * @param patterns Pattern catalog entries to validate.
- * @param options Optional project root for content-file existence checks.
+ * @param options Optional project root and section role marker convention.
  * @returns Structured diagnostics split into errors and warnings.
  */
 export function validatePatternCatalog(
@@ -131,6 +511,11 @@ export function validatePatternCatalog(
 ): PatternCatalogValidationResult {
 	const diagnostics: PatternCatalogDiagnostic[] = [];
 	const seenSlugs = new Map<string, number>();
+	const sectionRoleConvention =
+		options.sectionRoleConvention === false
+			? null
+			: normalizeSectionRoleConvention(options.sectionRoleConvention);
+	const knownSectionRoles = createKnownSectionRoleSet(patterns);
 
 	for (const [index, pattern] of patterns.entries()) {
 		const label = pattern.slug || `PATTERNS[${index}]`;
@@ -245,13 +630,32 @@ export function validatePatternCatalog(
 			);
 			continue;
 		}
-		if (options.projectDir && !fs.existsSync(path.join(options.projectDir, contentFile))) {
+		if (!options.projectDir) {
+			continue;
+		}
+
+		const absoluteContentFile = path.join(options.projectDir, contentFile);
+		if (!fs.existsSync(absoluteContentFile)) {
 			diagnostics.push(
 				createPatternCatalogDiagnostic({
 					code: "missing-pattern-content-file",
 					message: `${label}: missing pattern content file ${contentFile}.`,
 					patternSlug: pattern.slug,
 					severity: "error",
+				}),
+			);
+			continue;
+		}
+
+		if (sectionRoleConvention) {
+			diagnostics.push(
+				...validatePatternContentSectionRoles({
+					content: fs.readFileSync(absoluteContentFile, "utf8"),
+					contentFile,
+					convention: sectionRoleConvention,
+					knownSectionRoles,
+					label,
+					pattern,
 				}),
 			);
 		}

--- a/packages/wp-typia-project-tools/src/runtime/pattern-catalog.ts
+++ b/packages/wp-typia-project-tools/src/runtime/pattern-catalog.ts
@@ -28,6 +28,7 @@ export type PatternCatalogDiagnosticCode =
 	| "invalid-pattern-content-file"
 	| "invalid-pattern-scope"
 	| "invalid-pattern-section-role"
+	| "invalid-pattern-section-role-convention"
 	| "invalid-pattern-section-role-marker"
 	| "invalid-pattern-slug"
 	| "invalid-pattern-tag"
@@ -46,36 +47,54 @@ export type PatternCatalogDiagnostic = {
 	severity: PatternCatalogDiagnosticSeverity;
 };
 
+/**
+ * Convention used to discover section role markers in serialized pattern
+ * content. Defaults target `core/group` wrappers with a `section` base class,
+ * `section--{role}` role class tokens, and `metadata.sectionRole` attributes.
+ */
 export type PatternCatalogSectionRoleConvention = {
 	/**
-	 * Serialized block name used as the section wrapper, for example `core/group`.
+	 * Serialized block name used as the section wrapper. Defaults to
+	 * `core/group`.
 	 */
 	wrapperBlockName?: string;
 	/**
 	 * Optional class that marks a wrapper block as section-like even when the
-	 * role marker is missing.
+	 * role marker is missing. Defaults to `section`.
 	 */
 	baseClassName?: string;
 	/**
-	 * Class token pattern where `{role}` is replaced by the section role slug.
+	 * Class token pattern where exactly one `{role}` placeholder is replaced by
+	 * the section role slug. Defaults to `section--{role}`.
 	 */
 	roleClassNamePattern?: string;
 	/**
-	 * Dot-separated block attribute paths that can carry role slugs.
+	 * Dot-separated block attribute paths that can carry role slugs. Defaults to
+	 * `metadata.sectionRole`.
 	 */
 	roleAttributePaths?: readonly string[];
 	/**
-	 * Warn when a full pattern repeats the same section role marker.
+	 * Warn when a full pattern repeats the same section role marker. Defaults to
+	 * `false`.
 	 */
 	requireUniqueFullPatternRoles?: boolean;
 };
 
+/**
+ * Section wrapper match extracted from a parsed WordPress block tree.
+ */
 export type PatternCatalogSectionRoleMatch = {
 	blockName: string;
 	blockPath: string;
 	roles: readonly string[];
 };
 
+/**
+ * Options for validating typed pattern catalog entries and, when `projectDir`
+ * is provided, their serialized pattern content. Set `sectionRoleConvention` to
+ * `false` to keep file existence checks but opt out of section-role marker
+ * validation.
+ */
 export type PatternCatalogValidationOptions = {
 	projectDir?: string;
 	sectionRoleConvention?: PatternCatalogSectionRoleConvention | false;
@@ -99,7 +118,9 @@ const DEFAULT_SECTION_ROLE_CONVENTION = {
 	wrapperBlockName: "core/group",
 } satisfies Required<PatternCatalogSectionRoleConvention>;
 
-type NormalizedPatternCatalogSectionRoleConvention = Required<PatternCatalogSectionRoleConvention>;
+type NormalizedPatternCatalogSectionRoleConvention = Required<PatternCatalogSectionRoleConvention> & {
+	roleClassNamePatternRegExp: RegExp;
+};
 
 type LocatedPatternSectionRole = {
 	blockPath: string;
@@ -143,9 +164,9 @@ function isPatternContentFilePath(value: string): boolean {
 	);
 }
 
-function normalizeSectionRoleConvention(
+function normalizeSectionRoleConventionInput(
 	convention: PatternCatalogSectionRoleConvention = {},
-): NormalizedPatternCatalogSectionRoleConvention {
+): Required<PatternCatalogSectionRoleConvention> {
 	return {
 		baseClassName:
 			convention.baseClassName ??
@@ -181,6 +202,18 @@ function createRoleClassNamePattern(pattern: string): RegExp {
 		`^${escapeRegExp(parts[0] ?? "")}(?<role>\\S*)${escapeRegExp(parts[1] ?? "")}$`,
 		"u",
 	);
+}
+
+function normalizeSectionRoleConvention(
+	convention: PatternCatalogSectionRoleConvention = {},
+): NormalizedPatternCatalogSectionRoleConvention {
+	const normalized = normalizeSectionRoleConventionInput(convention);
+	return {
+		...normalized,
+		roleClassNamePatternRegExp: createRoleClassNamePattern(
+			normalized.roleClassNamePattern,
+		),
+	};
 }
 
 function getClassNameTokens(attributes: Record<string, unknown>): string[] {
@@ -307,11 +340,8 @@ export function extractPatternSectionRolesFromAttributes(
 	convention: PatternCatalogSectionRoleConvention = {},
 ): string[] {
 	const normalized = normalizeSectionRoleConvention(convention);
-	const roleClassNamePattern = createRoleClassNamePattern(
-		normalized.roleClassNamePattern,
-	);
 	const classRoles = getClassNameTokens(attributes)
-		.map((token) => roleClassNamePattern.exec(token)?.groups?.role)
+		.map((token) => normalized.roleClassNamePatternRegExp.exec(token)?.groups?.role)
 		.filter((role): role is string => typeof role === "string");
 	const attributeRoles = normalized.roleAttributePaths.flatMap((pathName) =>
 		collectStringValues(getAttributePathValue(attributes, pathName)),
@@ -511,10 +541,25 @@ export function validatePatternCatalog(
 ): PatternCatalogValidationResult {
 	const diagnostics: PatternCatalogDiagnostic[] = [];
 	const seenSlugs = new Map<string, number>();
-	const sectionRoleConvention =
-		options.sectionRoleConvention === false
-			? null
-			: normalizeSectionRoleConvention(options.sectionRoleConvention);
+	let sectionRoleConvention: NormalizedPatternCatalogSectionRoleConvention | null =
+		null;
+	if (options.sectionRoleConvention !== false) {
+		try {
+			sectionRoleConvention = normalizeSectionRoleConvention(
+				options.sectionRoleConvention,
+			);
+		} catch (error) {
+			diagnostics.push(
+				createPatternCatalogDiagnostic({
+					code: "invalid-pattern-section-role-convention",
+					message: `sectionRoleConvention.roleClassNamePattern is invalid: ${
+						error instanceof Error ? error.message : String(error)
+					}`,
+					severity: "error",
+				}),
+			);
+		}
+	}
 	const knownSectionRoles = createKnownSectionRoleSet(patterns);
 
 	for (const [index, pattern] of patterns.entries()) {
@@ -648,9 +693,26 @@ export function validatePatternCatalog(
 		}
 
 		if (sectionRoleConvention) {
+			let content: string;
+			try {
+				content = fs.readFileSync(absoluteContentFile, "utf8");
+			} catch (error) {
+				diagnostics.push(
+					createPatternCatalogDiagnostic({
+						code: "invalid-pattern-content-file",
+						message: `${label}: failed to read pattern content file ${contentFile}: ${
+							error instanceof Error ? error.message : String(error)
+						}.`,
+						patternSlug: pattern.slug,
+						severity: "error",
+					}),
+				);
+				continue;
+			}
+
 			diagnostics.push(
 				...validatePatternContentSectionRoles({
-					content: fs.readFileSync(absoluteContentFile, "utf8"),
+					content,
 					contentFile,
 					convention: sectionRoleConvention,
 					knownSectionRoles,

--- a/packages/wp-typia-project-tools/tests/pattern-catalog.test.ts
+++ b/packages/wp-typia-project-tools/tests/pattern-catalog.test.ts
@@ -4,6 +4,8 @@ import os from "node:os";
 import path from "node:path";
 
 import {
+	extractPatternSectionRoleMatches,
+	extractPatternSectionRolesFromAttributes,
 	formatPatternCatalogDiagnostics,
 	resolvePatternCatalogContentFile,
 	validatePatternCatalog,
@@ -23,12 +25,12 @@ describe("pattern catalog validation", () => {
 			});
 			fs.writeFileSync(
 				path.join(projectDir, "src", "patterns", "full", "landing.php"),
-				"<?php\n",
+				'<?php\n<!-- wp:group {"className":"section section--hero"} --><!-- /wp:group -->\n',
 				"utf8",
 			);
 			fs.writeFileSync(
 				path.join(projectDir, "src", "patterns", "sections", "hero.php"),
-				"<?php\n",
+				'<?php\n<!-- wp:group {"className":"section section--hero"} --><!-- /wp:group -->\n',
 				"utf8",
 			);
 
@@ -56,6 +58,170 @@ describe("pattern catalog validation", () => {
 			);
 
 			expect(result.diagnostics).toEqual([]);
+		} finally {
+			fs.rmSync(projectDir, { force: true, recursive: true });
+		}
+	});
+
+	test("extracts section role markers from class names and metadata", () => {
+		expect(
+			extractPatternSectionRolesFromAttributes({
+				className: "section section--hero",
+				metadata: {
+					sectionRole: "feature",
+				},
+			}),
+		).toEqual(["hero", "feature"]);
+
+		expect(
+			extractPatternSectionRoleMatches([
+				{
+					attributes: {
+						className: "section section--hero",
+					},
+					blockName: "core/group",
+					innerBlocks: [
+						{
+							attributes: {
+								className: "section section--feature",
+							},
+							blockName: "core/group",
+							innerBlocks: [],
+						},
+					],
+				},
+			]).map((match) => ({
+				blockPath: match.blockPath,
+				roles: match.roles,
+			})),
+		).toEqual([
+			{
+				blockPath: "core/group[0]",
+				roles: ["hero"],
+			},
+			{
+				blockPath: "core/group[0] > core/group[0]",
+				roles: ["feature"],
+			},
+		]);
+	});
+
+	test("reports invalid, missing, mismatched, and unknown section role markers", () => {
+		const projectDir = fs.mkdtempSync(
+			path.join(os.tmpdir(), "wp-typia-pattern-catalog-roles-"),
+		);
+		try {
+			fs.mkdirSync(path.join(projectDir, "src", "patterns", "sections"), {
+				recursive: true,
+			});
+			fs.writeFileSync(
+				path.join(projectDir, "src", "patterns", "sections", "missing.php"),
+				'<?php\n<!-- wp:group {"className":"section"} --><!-- /wp:group -->\n',
+				"utf8",
+			);
+			fs.writeFileSync(
+				path.join(projectDir, "src", "patterns", "sections", "invalid.php"),
+				'<?php\n<!-- wp:group {"className":"section section--1hero"} --><!-- /wp:group -->\n',
+				"utf8",
+			);
+			fs.writeFileSync(
+				path.join(projectDir, "src", "patterns", "sections", "mismatch.php"),
+				'<?php\n<!-- wp:group {"className":"section section--unknown"} --><!-- /wp:group -->\n',
+				"utf8",
+			);
+
+			const result = validatePatternCatalog(
+				[
+					{
+						contentFile: "src/patterns/sections/missing.php",
+						scope: "section",
+						sectionRole: "hero",
+						slug: "missing",
+					},
+					{
+						contentFile: "src/patterns/sections/invalid.php",
+						scope: "section",
+						sectionRole: "feature",
+						slug: "invalid",
+					},
+					{
+						contentFile: "src/patterns/sections/mismatch.php",
+						scope: "section",
+						sectionRole: "cta",
+						slug: "mismatch",
+					},
+				],
+				{ projectDir },
+			);
+
+			expect(result.diagnostics.map((diagnostic) => diagnostic.code)).toEqual(
+				expect.arrayContaining([
+					"missing-pattern-section-role-marker",
+					"invalid-pattern-section-role-marker",
+					"unknown-pattern-section-role-marker",
+					"mismatched-pattern-section-role",
+				]),
+			);
+			expect(formatPatternCatalogDiagnostics(result.diagnostics)).toContain(
+				"section--{role}",
+			);
+		} finally {
+			fs.rmSync(projectDir, { force: true, recursive: true });
+		}
+	});
+
+	test("warns for duplicate section role markers in full patterns when uniqueness is expected", () => {
+		const projectDir = fs.mkdtempSync(
+			path.join(os.tmpdir(), "wp-typia-pattern-catalog-full-roles-"),
+		);
+		try {
+			fs.mkdirSync(path.join(projectDir, "src", "patterns", "full"), {
+				recursive: true,
+			});
+			fs.mkdirSync(path.join(projectDir, "src", "patterns", "sections"), {
+				recursive: true,
+			});
+			fs.writeFileSync(
+				path.join(projectDir, "src", "patterns", "full", "landing.php"),
+				[
+					"<?php",
+					'<!-- wp:group {"className":"section section--hero"} --><!-- /wp:group -->',
+					'<!-- wp:group {"metadata":{"sectionRole":"hero"}} --><!-- /wp:group -->',
+				].join("\n"),
+				"utf8",
+			);
+			fs.writeFileSync(
+				path.join(projectDir, "src", "patterns", "sections", "hero.php"),
+				'<?php\n<!-- wp:group {"metadata":{"sectionRole":"hero"}} --><!-- /wp:group -->\n',
+				"utf8",
+			);
+
+			const result = validatePatternCatalog(
+				[
+					{
+						contentFile: "src/patterns/full/landing.php",
+						scope: "full",
+						slug: "landing",
+					},
+					{
+						contentFile: "src/patterns/sections/hero.php",
+						scope: "section",
+						sectionRole: "hero",
+						slug: "hero",
+					},
+				],
+				{
+					projectDir,
+					sectionRoleConvention: {
+						requireUniqueFullPatternRoles: true,
+					},
+				},
+			);
+
+			expect(result.errors).toEqual([]);
+			expect(result.warnings.map((diagnostic) => diagnostic.code)).toEqual([
+				"duplicate-pattern-section-role-marker",
+			]);
 		} finally {
 			fs.rmSync(projectDir, { force: true, recursive: true });
 		}

--- a/packages/wp-typia-project-tools/tests/pattern-catalog.test.ts
+++ b/packages/wp-typia-project-tools/tests/pattern-catalog.test.ts
@@ -170,6 +170,46 @@ describe("pattern catalog validation", () => {
 		}
 	});
 
+	test("accepts section role markers with PHP-escaped JSON attributes", () => {
+		const projectDir = fs.mkdtempSync(
+			path.join(os.tmpdir(), "wp-typia-pattern-catalog-escaped-"),
+		);
+		try {
+			fs.mkdirSync(path.join(projectDir, "src", "patterns", "sections"), {
+				recursive: true,
+			});
+			fs.writeFileSync(
+				path.join(projectDir, "src", "patterns", "sections", "hero.php"),
+				[
+					"<?php",
+					"register_block_pattern(",
+					"\t'demo/hero',",
+					"\tarray(",
+					'\t\t"content" => "<!-- wp:group {\\"className\\":\\"section section--hero\\"} --><!-- /wp:group -->",',
+					"\t)",
+					");",
+				].join("\n"),
+				"utf8",
+			);
+
+			const result = validatePatternCatalog(
+				[
+					{
+						contentFile: "src/patterns/sections/hero.php",
+						scope: "section",
+						sectionRole: "hero",
+						slug: "hero",
+					},
+				],
+				{ projectDir },
+			);
+
+			expect(result.diagnostics).toEqual([]);
+		} finally {
+			fs.rmSync(projectDir, { force: true, recursive: true });
+		}
+	});
+
 	test("warns for duplicate section role markers in full patterns when uniqueness is expected", () => {
 		const projectDir = fs.mkdtempSync(
 			path.join(os.tmpdir(), "wp-typia-pattern-catalog-full-roles-"),

--- a/packages/wp-typia-project-tools/tests/pattern-catalog.test.ts
+++ b/packages/wp-typia-project-tools/tests/pattern-catalog.test.ts
@@ -227,6 +227,80 @@ describe("pattern catalog validation", () => {
 		}
 	});
 
+	test("reports invalid section role conventions without throwing", () => {
+		const projectDir = fs.mkdtempSync(
+			path.join(os.tmpdir(), "wp-typia-pattern-catalog-convention-"),
+		);
+		try {
+			fs.mkdirSync(path.join(projectDir, "src", "patterns", "sections"), {
+				recursive: true,
+			});
+			fs.writeFileSync(
+				path.join(projectDir, "src", "patterns", "sections", "hero.php"),
+				'<?php\n<!-- wp:group {"className":"section section--hero"} --><!-- /wp:group -->\n',
+				"utf8",
+			);
+
+			const result = validatePatternCatalog(
+				[
+					{
+						contentFile: "src/patterns/sections/hero.php",
+						scope: "section",
+						sectionRole: "hero",
+						slug: "hero",
+					},
+				],
+				{
+					projectDir,
+					sectionRoleConvention: {
+						roleClassNamePattern: "section-role",
+					},
+				},
+			);
+
+			expect(result.errors.map((diagnostic) => diagnostic.code)).toEqual([
+				"invalid-pattern-section-role-convention",
+			]);
+		} finally {
+			fs.rmSync(projectDir, { force: true, recursive: true });
+		}
+	});
+
+	test("reports unreadable pattern content files as diagnostics", () => {
+		const projectDir = fs.mkdtempSync(
+			path.join(os.tmpdir(), "wp-typia-pattern-catalog-unreadable-"),
+		);
+		try {
+			fs.mkdirSync(path.join(projectDir, "src", "patterns", "sections"), {
+				recursive: true,
+			});
+			fs.mkdirSync(
+				path.join(projectDir, "src", "patterns", "sections", "hero.php"),
+			);
+
+			const result = validatePatternCatalog(
+				[
+					{
+						contentFile: "src/patterns/sections/hero.php",
+						scope: "section",
+						sectionRole: "hero",
+						slug: "hero",
+					},
+				],
+				{ projectDir },
+			);
+
+			expect(result.errors.map((diagnostic) => diagnostic.code)).toEqual([
+				"invalid-pattern-content-file",
+			]);
+			expect(result.errors[0]?.message).toContain(
+				"failed to read pattern content file",
+			);
+		} finally {
+			fs.rmSync(projectDir, { force: true, recursive: true });
+		}
+	});
+
 	test("reports duplicate slugs, missing files, and invalid metadata", () => {
 		const result = validatePatternCatalog(
 			[

--- a/packages/wp-typia-project-tools/tests/workspace-add.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-add.test.ts
@@ -3061,6 +3061,8 @@ test("canonical CLI can add a pattern to an official workspace template", async 
   expect(bootstrapSource).toContain("/src/patterns/*/*.php");
   expect(patternSource).toContain("demo-space/hero-layout");
   expect(patternSource).toContain("section section--hero");
+  expect(patternSource).toContain("<!-- wp:group");
+  expect(patternSource).toContain('"className":"section section--hero"');
 
   const doctorOutput = runCli("node", [entryPath, "doctor", "--format", "json"], {
     cwd: targetDir,

--- a/packages/wp-typia-project-tools/tests/workspace-add.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-add.test.ts
@@ -3060,6 +3060,7 @@ test("canonical CLI can add a pattern to an official workspace template", async 
   expect(bootstrapSource).toContain("/src/patterns/*.php");
   expect(bootstrapSource).toContain("/src/patterns/*/*.php");
   expect(patternSource).toContain("demo-space/hero-layout");
+  expect(patternSource).toContain("section section--hero");
 
   const doctorOutput = runCli("node", [entryPath, "doctor", "--format", "json"], {
     cwd: targetDir,


### PR DESCRIPTION
Closes #989

## Summary
- add configurable section-role marker extraction for pattern catalog content
- validate section-scoped manifest roles against serialized wrapper markers
- warn on unknown markers and optional duplicate full-pattern role markers
- scaffold section patterns with the default `section section--{role}` wrapper
- document the default and custom section role conventions

## Validation
- `bun run --filter @wp-typia/project-tools build`
- `bun test packages/wp-typia-project-tools/tests/pattern-catalog.test.ts`
- `bun test packages/wp-typia-project-tools/tests/workspace-add.test.ts --test-name-pattern "canonical CLI can add a pattern"`
- `bun run --filter @wp-typia/project-tools test`
- `bun run format:check`
- `bun run changesets:validate`
- `bun run lint:repo`
- `bun run typecheck`

## Notes
- `bun run docs:build:api` was checked, but it currently fails on existing public-doc audit items unrelated to this PR, including missing TypeDoc model entries for `wp-typia-rest/src/react.ts` and missing summary comments in `wp-typia-block-runtime/src/identifiers.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pattern catalog validation for section role markers with configurable conventions.
  * Introduced customizable section role wrapper detection and duplicate-role policies.

* **Documentation**
  * Expanded documentation on typed pattern validator with section-scoped checks.
  * Added guides on validating pattern catalog section role markers and conventions.
  * Updated CLI reference with section marker requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/996)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->