### PR TITLE
refactor: split pattern workspace helpers

### DIFF
--- a/.sampo/changesets/1002-split-pattern-runtime.md
+++ b/.sampo/changesets/1002-split-pattern-runtime.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Split pattern workspace add helpers into focused runtime modules without changing generated output.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-pattern-anchors.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-pattern-anchors.ts
@@ -1,0 +1,144 @@
+import path from "node:path";
+
+import { getWorkspaceBootstrapPath, patchFile } from "./cli-add-shared.js";
+import {
+	appendPhpSnippetBeforeClosingTag,
+	insertPhpSnippetBeforeWorkspaceAnchors,
+} from "./cli-add-workspace-mutation.js";
+import { hasPhpFunctionDefinition } from "./php-utils.js";
+import { toTitleCase } from "./string-case.js";
+import type { WorkspaceProject } from "./workspace-project.js";
+
+const FLAT_PATTERN_GLOB = "glob( __DIR__ . '/src/patterns/*.php' ) ?: array()";
+const NESTED_PATTERN_GLOB =
+	"glob( __DIR__ . '/src/patterns/*/*.php' ) ?: array()";
+const LEGACY_FLAT_PATTERN_MODULES_ASSIGNMENT_PATTERN =
+	/^[ \t]*\$pattern_modules\s*=\s*glob\( __DIR__ \. '\/src\/patterns\/\*\.php' \) \?: array\(\);\s*$/mu;
+const LEGACY_FLAT_PATTERN_FOREACH_PATTERN =
+	/^[ \t]*foreach\s*\(\s*glob\( __DIR__ \. '\/src\/patterns\/\*\.php' \) \?: array\(\)\s+as\s+\$pattern_module\s*\)\s*\{\r?\n[ \t]*require\s+\$pattern_module;\r?\n[ \t]*\}/mu;
+
+function buildNestedPatternModulesAssignment(): string {
+	return [
+		"\t$pattern_modules = array_merge(",
+		`\t\t${FLAT_PATTERN_GLOB},`,
+		`\t\t${NESTED_PATTERN_GLOB}`,
+		"\t);",
+	].join("\n");
+}
+
+function ensureNestedPatternLoaderSource(
+	source: string,
+	bootstrapPath: string,
+): string {
+	if (source.includes(NESTED_PATTERN_GLOB)) {
+		return source;
+	}
+	if (LEGACY_FLAT_PATTERN_FOREACH_PATTERN.test(source)) {
+		return source.replace(
+			LEGACY_FLAT_PATTERN_FOREACH_PATTERN,
+			[
+				buildNestedPatternModulesAssignment(),
+				"\tforeach ( $pattern_modules as $pattern_module ) {",
+				"\t\trequire $pattern_module;",
+				"\t}",
+			].join("\n"),
+		);
+	}
+	if (LEGACY_FLAT_PATTERN_MODULES_ASSIGNMENT_PATTERN.test(source)) {
+		return source.replace(
+			LEGACY_FLAT_PATTERN_MODULES_ASSIGNMENT_PATTERN,
+			buildNestedPatternModulesAssignment(),
+		);
+	}
+	if (source.includes("array_merge(") && source.includes(FLAT_PATTERN_GLOB)) {
+		return source.replace(
+			FLAT_PATTERN_GLOB,
+			`${FLAT_PATTERN_GLOB},\n\t\t${NESTED_PATTERN_GLOB}`,
+		);
+	}
+	throw new Error(
+		`Unable to repair ${path.basename(bootstrapPath)} pattern loader for nested src/patterns directories.`,
+	);
+}
+
+/**
+ * Ensure workspace bootstrap PHP registers pattern categories and loads
+ * generated pattern modules from both flat and nested pattern directories.
+ *
+ * @param workspace Resolved official workspace project metadata.
+ * @returns A promise that resolves after the workspace bootstrap is patched.
+ * @throws {Error} When existing bootstrap source cannot be safely patched.
+ */
+export async function ensurePatternBootstrapAnchors(
+	workspace: WorkspaceProject,
+): Promise<void> {
+	const workspaceBaseName =
+		workspace.packageName.split("/").pop() ?? workspace.packageName;
+	const bootstrapPath = getWorkspaceBootstrapPath(workspace);
+	await patchFile(bootstrapPath, (source) => {
+		let nextSource = source;
+		const patternCategoryFunctionName = `${workspace.workspace.phpPrefix}_register_pattern_category`;
+		const patternRegistrationFunctionName = `${workspace.workspace.phpPrefix}_register_patterns`;
+		const patternCategoryHook = `add_action( 'init', '${patternCategoryFunctionName}' );`;
+		const patternRegistrationHook = `add_action( 'init', '${patternRegistrationFunctionName}', 20 );`;
+		const patternFunctions = `
+
+function ${patternCategoryFunctionName}() {
+	if ( function_exists( 'register_block_pattern_category' ) ) {
+		register_block_pattern_category(
+			'${workspace.workspace.namespace}',
+			array(
+				'label' => __( ${JSON.stringify(`${toTitleCase(workspaceBaseName)} Patterns`)}, '${workspace.workspace.textDomain}' ),
+			)
+		);
+	}
+}
+
+function ${patternRegistrationFunctionName}() {
+	$pattern_modules = array_merge(
+		${FLAT_PATTERN_GLOB},
+		${NESTED_PATTERN_GLOB}
+	);
+	foreach ( $pattern_modules as $pattern_module ) {
+		require $pattern_module;
+	}
+}
+`;
+
+		if (
+			!hasPhpFunctionDefinition(nextSource, patternCategoryFunctionName) &&
+			!hasPhpFunctionDefinition(nextSource, patternRegistrationFunctionName)
+		) {
+			nextSource = insertPhpSnippetBeforeWorkspaceAnchors(
+				nextSource,
+				patternFunctions,
+			);
+		}
+
+		if (
+			!hasPhpFunctionDefinition(nextSource, patternCategoryFunctionName) ||
+			!hasPhpFunctionDefinition(nextSource, patternRegistrationFunctionName)
+		) {
+			throw new Error(
+				`Unable to inject pattern bootstrap functions into ${path.basename(bootstrapPath)}.`,
+			);
+		}
+
+		nextSource = ensureNestedPatternLoaderSource(nextSource, bootstrapPath);
+
+		if (!nextSource.includes(patternCategoryHook)) {
+			nextSource = appendPhpSnippetBeforeClosingTag(
+				nextSource,
+				patternCategoryHook,
+			);
+		}
+		if (!nextSource.includes(patternRegistrationHook)) {
+			nextSource = appendPhpSnippetBeforeClosingTag(
+				nextSource,
+				patternRegistrationHook,
+			);
+		}
+
+		return nextSource;
+	});
+}

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-pattern-options.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-pattern-options.ts
@@ -1,0 +1,202 @@
+import path from "node:path";
+
+import {
+	assertValidGeneratedSlug,
+	normalizeBlockSlug,
+	type RunAddPatternCommandOptions,
+} from "./cli-add-shared.js";
+import {
+	isValidPatternThumbnailUrl,
+	PATTERN_CATALOG_SCOPE_IDS,
+	type PatternCatalogScope,
+} from "./pattern-catalog.js";
+import { toTitleCase } from "./string-case.js";
+
+export type ResolvedPatternCatalogOptions = {
+	contentFile: string;
+	patternScope: PatternCatalogScope;
+	sectionRole?: string;
+	tags: string[];
+	thumbnailUrl?: string;
+	title: string;
+};
+
+const PATTERN_CONTENT_FILE_ROOT = "src/patterns/";
+const PATTERN_TAG_PATTERN = /^[a-z0-9][a-z0-9-]*$/u;
+
+function assertValidPatternRelativePath(
+	label: string,
+	value: string,
+	usage: string,
+): string {
+	const normalizedPath = value.trim().replace(/\\/gu, "/");
+	if (
+		normalizedPath.length === 0 ||
+		path.isAbsolute(normalizedPath) ||
+		normalizedPath.split("/").includes("..") ||
+		/[<>:"|?*\u0000-\u001F]/u.test(normalizedPath)
+	) {
+		throw new Error(
+			`${label} must be a safe relative project path. Use \`${usage}\`.`,
+		);
+	}
+
+	return normalizedPath;
+}
+
+function assertValidPatternContentFile(value: string, usage: string): string {
+	const normalizedPath = assertValidPatternRelativePath(
+		"Pattern content file",
+		value,
+		usage,
+	);
+	if (!isLoadablePatternContentFilePath(normalizedPath)) {
+		throw new Error(
+			"Pattern content file must live directly under `src/patterns/` or one nested directory under `src/patterns/` and end in `.php` so the generated PHP loader can require it.",
+		);
+	}
+
+	return normalizedPath;
+}
+
+function isLoadablePatternContentFilePath(normalizedPath: string): boolean {
+	if (
+		!normalizedPath.startsWith(PATTERN_CONTENT_FILE_ROOT) ||
+		!normalizedPath.endsWith(".php")
+	) {
+		return false;
+	}
+
+	const patternRelativePath = normalizedPath.slice(PATTERN_CONTENT_FILE_ROOT.length);
+	const segments = patternRelativePath.split("/");
+	return (
+		(segments.length === 1 || segments.length === 2) &&
+		segments.every((segment) => segment.length > 0)
+	);
+}
+
+function resolvePatternScope(scope: string | undefined): PatternCatalogScope {
+	if (scope === undefined || scope.trim() === "") {
+		return "full";
+	}
+	const normalizedScope = scope.trim();
+	if (
+		(PATTERN_CATALOG_SCOPE_IDS as readonly string[]).includes(normalizedScope)
+	) {
+		return normalizedScope as PatternCatalogScope;
+	}
+	throw new Error(
+		`Pattern scope must be one of: ${PATTERN_CATALOG_SCOPE_IDS.join(", ")}.`,
+	);
+}
+
+function normalizeOptionalSlug(
+	label: string,
+	value: string | undefined,
+	usage: string,
+): string | undefined {
+	if (value === undefined || value.trim() === "") {
+		return undefined;
+	}
+	return assertValidGeneratedSlug(label, normalizeBlockSlug(value), usage);
+}
+
+function normalizePatternTags(tags: readonly string[] | string | undefined): string[] {
+	const rawTags =
+		typeof tags === "string"
+			? tags.split(",")
+			: Array.isArray(tags)
+				? [...tags]
+				: [];
+	const normalizedTags = rawTags
+		.map((tag) => normalizeBlockSlug(tag))
+		.filter((tag) => tag.length > 0);
+
+	for (const tag of normalizedTags) {
+		if (!PATTERN_TAG_PATTERN.test(tag)) {
+			throw new Error(
+				`Pattern tag "${tag}" must contain only lowercase letters, numbers, and hyphens.`,
+			);
+		}
+	}
+
+	return [...new Set(normalizedTags)].sort();
+}
+
+function normalizePatternThumbnailUrl(value: string | undefined): string | undefined {
+	if (value === undefined || value.trim() === "") {
+		return undefined;
+	}
+	const thumbnailUrl = value.trim();
+	if (!isValidPatternThumbnailUrl(thumbnailUrl)) {
+		throw new Error(
+			"Pattern thumbnail URL must be an http(s) URL or safe relative project path.",
+		);
+	}
+
+	return thumbnailUrl;
+}
+
+function resolvePatternContentFile(
+	patternSlug: string,
+	patternScope: PatternCatalogScope,
+	contentFile: string | undefined,
+): string {
+	if (contentFile && contentFile.trim() !== "") {
+		return assertValidPatternContentFile(
+			contentFile,
+			"wp-typia add pattern <name> [--scope <full|section>]",
+		);
+	}
+
+	const scopeDirectory = patternScope === "section" ? "sections" : "full";
+	return path.posix.join("src", "patterns", scopeDirectory, `${patternSlug}.php`);
+}
+
+/**
+ * Resolve and validate catalog metadata for a generated workspace pattern.
+ *
+ * @param patternSlug Normalized and validated pattern slug.
+ * @param options Raw add-pattern command options from the CLI layer.
+ * @returns Resolved catalog metadata and safe relative content path.
+ * @throws {Error} When scope, section-role coupling, tags, thumbnail URL, or
+ * content file paths are invalid.
+ */
+export function resolvePatternCatalogOptions(
+	patternSlug: string,
+	options: RunAddPatternCommandOptions,
+): ResolvedPatternCatalogOptions {
+	const patternScope = resolvePatternScope(options.patternScope);
+	const sectionRole = normalizeOptionalSlug(
+		"Pattern section role",
+		options.sectionRole,
+		"wp-typia add pattern <name> --scope section --section-role <role>",
+	);
+	if (patternScope === "section" && !sectionRole) {
+		throw new Error(
+			"`wp-typia add pattern --scope section` requires --section-role <role>.",
+		);
+	}
+	if (patternScope !== "section" && sectionRole) {
+		throw new Error("`--section-role` requires `--scope section`.");
+	}
+
+	const title =
+		options.catalogTitle && options.catalogTitle.trim() !== ""
+			? options.catalogTitle.trim()
+			: toTitleCase(patternSlug);
+	const thumbnailUrl = normalizePatternThumbnailUrl(options.thumbnailUrl);
+
+	return {
+		contentFile: resolvePatternContentFile(
+			patternSlug,
+			patternScope,
+			options.contentFile,
+		),
+		patternScope,
+		...(sectionRole ? { sectionRole } : {}),
+		tags: normalizePatternTags(options.tags),
+		...(thumbnailUrl ? { thumbnailUrl } : {}),
+		title,
+	};
+}

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-pattern-source-emitters.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-pattern-source-emitters.ts
@@ -1,0 +1,71 @@
+import { quoteTsString } from "./cli-add-shared.js";
+import type { ResolvedPatternCatalogOptions } from "./cli-add-workspace-pattern-options.js";
+
+/**
+ * Render the block-config inventory entry for a generated pattern.
+ *
+ * @param patternSlug Normalized and validated pattern slug.
+ * @param options Resolved pattern catalog metadata.
+ * @returns A TypeScript object literal snippet for the workspace inventory.
+ */
+export function buildPatternConfigEntry(
+	patternSlug: string,
+	options: ResolvedPatternCatalogOptions,
+): string {
+	const lines = [
+		"\t{",
+		`\t\tcontentFile: ${quoteTsString(options.contentFile)},`,
+		`\t\tfile: ${quoteTsString(options.contentFile)},`,
+		`\t\tscope: ${quoteTsString(options.patternScope)},`,
+		...(options.sectionRole
+			? [`\t\tsectionRole: ${quoteTsString(options.sectionRole)},`]
+			: []),
+		`\t\tslug: ${quoteTsString(patternSlug)},`,
+		`\t\ttags: [${options.tags.map((tag) => quoteTsString(tag)).join(", ")}],`,
+		...(options.thumbnailUrl
+			? [`\t\tthumbnailUrl: ${quoteTsString(options.thumbnailUrl)},`]
+			: []),
+		`\t\ttitle: ${quoteTsString(options.title)},`,
+		"\t},",
+	];
+
+	return lines.join("\n");
+}
+
+/**
+ * Render the PHP pattern module registered by the workspace add command.
+ *
+ * @param patternSlug Normalized and validated pattern slug.
+ * @param namespace WordPress block namespace for the workspace.
+ * @param sectionRole Optional section role for section-scoped patterns.
+ * @param textDomain Translation text domain for generated labels.
+ * @param title Human-readable pattern title.
+ * @returns PHP source for a single generated block pattern module.
+ */
+export function buildPatternSource(
+	patternSlug: string,
+	namespace: string,
+	sectionRole: string | undefined,
+	textDomain: string,
+	title: string,
+): string {
+	const content = sectionRole
+		? `'<!-- wp:group {"className":"section section--${sectionRole}"} --><div class="wp-block-group section section--${sectionRole}"><!-- wp:paragraph --><p>' . esc_html__( 'Describe this section pattern here.', '${textDomain}' ) . '</p><!-- /wp:paragraph --></div><!-- /wp:group -->'`
+		: `'<!-- wp:paragraph --><p>' . esc_html__( 'Describe this pattern here.', '${textDomain}' ) . '</p><!-- /wp:paragraph -->'`;
+
+	return `<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	return;
+}
+
+register_block_pattern(
+	'${namespace}/${patternSlug}',
+	array(
+		'title'       => __( ${JSON.stringify(title)}, '${textDomain}' ),
+		'description' => __( ${JSON.stringify(`A starter pattern for ${title}.`)}, '${textDomain}' ),
+		'categories'  => array( '${namespace}' ),
+		'content'     => ${content},
+	)
+);
+`;
+}

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-pattern.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-pattern.ts
@@ -2,392 +2,27 @@ import { promises as fsp } from "node:fs";
 import path from "node:path";
 
 import {
-	resolveWorkspaceProject,
-	type WorkspaceProject,
-} from "./workspace-project.js";
-import {
-	appendWorkspaceInventoryEntries,
-	readWorkspaceInventoryAsync,
-} from "./workspace-inventory.js";
-import { toTitleCase } from "./string-case.js";
-import { hasPhpFunctionDefinition } from "./php-utils.js";
-import {
 	assertPatternDoesNotExist,
 	assertValidGeneratedSlug,
 	getWorkspaceBootstrapPath,
 	normalizeBlockSlug,
-	patchFile,
-	quoteTsString,
 	rollbackWorkspaceMutation,
 	type RunAddPatternCommandOptions,
 	type WorkspaceMutationSnapshot,
 	snapshotWorkspaceFiles,
 } from "./cli-add-shared.js";
+import { ensurePatternBootstrapAnchors } from "./cli-add-workspace-pattern-anchors.js";
+import { resolvePatternCatalogOptions } from "./cli-add-workspace-pattern-options.js";
 import {
-	isValidPatternThumbnailUrl,
-	PATTERN_CATALOG_SCOPE_IDS,
-	type PatternCatalogScope,
-} from "./pattern-catalog.js";
+	buildPatternConfigEntry,
+	buildPatternSource,
+} from "./cli-add-workspace-pattern-source-emitters.js";
+import type { PatternCatalogScope } from "./pattern-catalog.js";
 import {
-	appendPhpSnippetBeforeClosingTag,
-	insertPhpSnippetBeforeWorkspaceAnchors,
-} from "./cli-add-workspace-mutation.js";
-
-type ResolvedPatternCatalogOptions = {
-	contentFile: string;
-	patternScope: PatternCatalogScope;
-	sectionRole?: string;
-	tags: string[];
-	thumbnailUrl?: string;
-	title: string;
-};
-
-const PATTERN_CONTENT_FILE_ROOT = "src/patterns/";
-const PATTERN_TAG_PATTERN = /^[a-z0-9][a-z0-9-]*$/u;
-const FLAT_PATTERN_GLOB = "glob( __DIR__ . '/src/patterns/*.php' ) ?: array()";
-const NESTED_PATTERN_GLOB =
-	"glob( __DIR__ . '/src/patterns/*/*.php' ) ?: array()";
-const LEGACY_FLAT_PATTERN_MODULES_ASSIGNMENT_PATTERN =
-	/^[ \t]*\$pattern_modules\s*=\s*glob\( __DIR__ \. '\/src\/patterns\/\*\.php' \) \?: array\(\);\s*$/mu;
-const LEGACY_FLAT_PATTERN_FOREACH_PATTERN =
-	/^[ \t]*foreach\s*\(\s*glob\( __DIR__ \. '\/src\/patterns\/\*\.php' \) \?: array\(\)\s+as\s+\$pattern_module\s*\)\s*\{\r?\n[ \t]*require\s+\$pattern_module;\r?\n[ \t]*\}/mu;
-
-function assertValidPatternRelativePath(
-	label: string,
-	value: string,
-	usage: string,
-): string {
-	const normalizedPath = value.trim().replace(/\\/gu, "/");
-	if (
-		normalizedPath.length === 0 ||
-		path.isAbsolute(normalizedPath) ||
-		normalizedPath.split("/").includes("..") ||
-		/[<>:"|?*\u0000-\u001F]/u.test(normalizedPath)
-	) {
-		throw new Error(
-			`${label} must be a safe relative project path. Use \`${usage}\`.`,
-		);
-	}
-
-	return normalizedPath;
-}
-
-function assertValidPatternContentFile(value: string, usage: string): string {
-	const normalizedPath = assertValidPatternRelativePath(
-		"Pattern content file",
-		value,
-		usage,
-	);
-	if (!isLoadablePatternContentFilePath(normalizedPath)) {
-		throw new Error(
-			"Pattern content file must live directly under `src/patterns/` or one nested directory under `src/patterns/` and end in `.php` so the generated PHP loader can require it.",
-		);
-	}
-
-	return normalizedPath;
-}
-
-function isLoadablePatternContentFilePath(normalizedPath: string): boolean {
-	if (
-		!normalizedPath.startsWith(PATTERN_CONTENT_FILE_ROOT) ||
-		!normalizedPath.endsWith(".php")
-	) {
-		return false;
-	}
-
-	const patternRelativePath = normalizedPath.slice(PATTERN_CONTENT_FILE_ROOT.length);
-	const segments = patternRelativePath.split("/");
-	return (
-		(segments.length === 1 || segments.length === 2) &&
-		segments.every((segment) => segment.length > 0)
-	);
-}
-
-function buildPatternConfigEntry(
-	patternSlug: string,
-	options: ResolvedPatternCatalogOptions,
-): string {
-	const lines = [
-		"\t{",
-		`\t\tcontentFile: ${quoteTsString(options.contentFile)},`,
-		`\t\tfile: ${quoteTsString(options.contentFile)},`,
-		`\t\tscope: ${quoteTsString(options.patternScope)},`,
-		...(options.sectionRole
-			? [`\t\tsectionRole: ${quoteTsString(options.sectionRole)},`]
-			: []),
-		`\t\tslug: ${quoteTsString(patternSlug)},`,
-		`\t\ttags: [${options.tags.map((tag) => quoteTsString(tag)).join(", ")}],`,
-		...(options.thumbnailUrl
-			? [`\t\tthumbnailUrl: ${quoteTsString(options.thumbnailUrl)},`]
-			: []),
-		`\t\ttitle: ${quoteTsString(options.title)},`,
-		"\t},",
-	];
-
-	return lines.join("\n");
-}
-
-function buildPatternSource(
-	patternSlug: string,
-	namespace: string,
-	sectionRole: string | undefined,
-	textDomain: string,
-	title: string,
-): string {
-	const content = sectionRole
-		? `'<!-- wp:group {"className":"section section--${sectionRole}"} --><div class="wp-block-group section section--${sectionRole}"><!-- wp:paragraph --><p>' . esc_html__( 'Describe this section pattern here.', '${textDomain}' ) . '</p><!-- /wp:paragraph --></div><!-- /wp:group -->'`
-		: `'<!-- wp:paragraph --><p>' . esc_html__( 'Describe this pattern here.', '${textDomain}' ) . '</p><!-- /wp:paragraph -->'`;
-
-	return `<?php
-if ( ! defined( 'ABSPATH' ) ) {
-\treturn;
-}
-
-register_block_pattern(
-\t'${namespace}/${patternSlug}',
-\tarray(
-\t\t'title'       => __( ${JSON.stringify(title)}, '${textDomain}' ),
-\t\t'description' => __( ${JSON.stringify(`A starter pattern for ${title}.`)}, '${textDomain}' ),
-\t\t'categories'  => array( '${namespace}' ),
-\t\t'content'     => ${content},
-\t)
-);
-`;
-}
-
-function resolvePatternScope(scope: string | undefined): PatternCatalogScope {
-	if (scope === undefined || scope.trim() === "") {
-		return "full";
-	}
-	const normalizedScope = scope.trim();
-	if (
-		(PATTERN_CATALOG_SCOPE_IDS as readonly string[]).includes(normalizedScope)
-	) {
-		return normalizedScope as PatternCatalogScope;
-	}
-	throw new Error(
-		`Pattern scope must be one of: ${PATTERN_CATALOG_SCOPE_IDS.join(", ")}.`,
-	);
-}
-
-function normalizeOptionalSlug(
-	label: string,
-	value: string | undefined,
-	usage: string,
-): string | undefined {
-	if (value === undefined || value.trim() === "") {
-		return undefined;
-	}
-	return assertValidGeneratedSlug(label, normalizeBlockSlug(value), usage);
-}
-
-function normalizePatternTags(tags: readonly string[] | string | undefined): string[] {
-	const rawTags =
-		typeof tags === "string"
-			? tags.split(",")
-			: Array.isArray(tags)
-				? [...tags]
-				: [];
-	const normalizedTags = rawTags
-		.map((tag) => normalizeBlockSlug(tag))
-		.filter((tag) => tag.length > 0);
-
-	for (const tag of normalizedTags) {
-		if (!PATTERN_TAG_PATTERN.test(tag)) {
-			throw new Error(
-				`Pattern tag "${tag}" must contain only lowercase letters, numbers, and hyphens.`,
-			);
-		}
-	}
-
-	return [...new Set(normalizedTags)].sort();
-}
-
-function normalizePatternThumbnailUrl(value: string | undefined): string | undefined {
-	if (value === undefined || value.trim() === "") {
-		return undefined;
-	}
-	const thumbnailUrl = value.trim();
-	if (!isValidPatternThumbnailUrl(thumbnailUrl)) {
-		throw new Error(
-			"Pattern thumbnail URL must be an http(s) URL or safe relative project path.",
-		);
-	}
-
-	return thumbnailUrl;
-}
-
-function resolvePatternContentFile(
-	patternSlug: string,
-	patternScope: PatternCatalogScope,
-	contentFile: string | undefined,
-): string {
-	if (contentFile && contentFile.trim() !== "") {
-		return assertValidPatternContentFile(
-			contentFile,
-			"wp-typia add pattern <name> [--scope <full|section>]",
-		);
-	}
-
-	const scopeDirectory = patternScope === "section" ? "sections" : "full";
-	return path.posix.join("src", "patterns", scopeDirectory, `${patternSlug}.php`);
-}
-
-function resolvePatternCatalogOptions(
-	patternSlug: string,
-	options: RunAddPatternCommandOptions,
-): ResolvedPatternCatalogOptions {
-	const patternScope = resolvePatternScope(options.patternScope);
-	const sectionRole = normalizeOptionalSlug(
-		"Pattern section role",
-		options.sectionRole,
-		"wp-typia add pattern <name> --scope section --section-role <role>",
-	);
-	if (patternScope === "section" && !sectionRole) {
-		throw new Error(
-			"`wp-typia add pattern --scope section` requires --section-role <role>.",
-		);
-	}
-	if (patternScope !== "section" && sectionRole) {
-		throw new Error("`--section-role` requires `--scope section`.");
-	}
-
-	const title =
-		options.catalogTitle && options.catalogTitle.trim() !== ""
-			? options.catalogTitle.trim()
-			: toTitleCase(patternSlug);
-	const thumbnailUrl = normalizePatternThumbnailUrl(options.thumbnailUrl);
-
-	return {
-		contentFile: resolvePatternContentFile(
-			patternSlug,
-			patternScope,
-			options.contentFile,
-		),
-		patternScope,
-		...(sectionRole ? { sectionRole } : {}),
-		tags: normalizePatternTags(options.tags),
-		...(thumbnailUrl ? { thumbnailUrl } : {}),
-		title,
-	};
-}
-
-function buildNestedPatternModulesAssignment(): string {
-	return [
-		"\t$pattern_modules = array_merge(",
-		`\t\t${FLAT_PATTERN_GLOB},`,
-		`\t\t${NESTED_PATTERN_GLOB}`,
-		"\t);",
-	].join("\n");
-}
-
-function ensureNestedPatternLoaderSource(
-	source: string,
-	bootstrapPath: string,
-): string {
-	if (source.includes(NESTED_PATTERN_GLOB)) {
-		return source;
-	}
-	if (LEGACY_FLAT_PATTERN_FOREACH_PATTERN.test(source)) {
-		return source.replace(
-			LEGACY_FLAT_PATTERN_FOREACH_PATTERN,
-			[
-				buildNestedPatternModulesAssignment(),
-				"\tforeach ( $pattern_modules as $pattern_module ) {",
-				"\t\trequire $pattern_module;",
-				"\t}",
-			].join("\n"),
-		);
-	}
-	if (LEGACY_FLAT_PATTERN_MODULES_ASSIGNMENT_PATTERN.test(source)) {
-		return source.replace(
-			LEGACY_FLAT_PATTERN_MODULES_ASSIGNMENT_PATTERN,
-			buildNestedPatternModulesAssignment(),
-		);
-	}
-	if (source.includes("array_merge(") && source.includes(FLAT_PATTERN_GLOB)) {
-		return source.replace(
-			FLAT_PATTERN_GLOB,
-			`${FLAT_PATTERN_GLOB},\n\t\t${NESTED_PATTERN_GLOB}`,
-		);
-	}
-	throw new Error(
-		`Unable to repair ${path.basename(bootstrapPath)} pattern loader for nested src/patterns directories.`,
-	);
-}
-
-async function ensurePatternBootstrapAnchors(
-	workspace: WorkspaceProject,
-): Promise<void> {
-	const workspaceBaseName = workspace.packageName.split("/").pop() ?? workspace.packageName;
-	const bootstrapPath = getWorkspaceBootstrapPath(workspace);
-	await patchFile(bootstrapPath, (source) => {
-		let nextSource = source;
-		const patternCategoryFunctionName = `${workspace.workspace.phpPrefix}_register_pattern_category`;
-		const patternRegistrationFunctionName = `${workspace.workspace.phpPrefix}_register_patterns`;
-		const patternCategoryHook = `add_action( 'init', '${patternCategoryFunctionName}' );`;
-		const patternRegistrationHook = `add_action( 'init', '${patternRegistrationFunctionName}', 20 );`;
-		const patternFunctions = `
-
-function ${patternCategoryFunctionName}() {
-\tif ( function_exists( 'register_block_pattern_category' ) ) {
-\t\tregister_block_pattern_category(
-\t\t\t'${workspace.workspace.namespace}',
-\t\t\tarray(
-\t\t\t\t'label' => __( ${JSON.stringify(`${toTitleCase(workspaceBaseName)} Patterns`)}, '${workspace.workspace.textDomain}' ),
-\t\t\t)
-\t\t);
-\t}
-}
-
-function ${patternRegistrationFunctionName}() {
-\t$pattern_modules = array_merge(
-\t\t${FLAT_PATTERN_GLOB},
-\t\t${NESTED_PATTERN_GLOB}
-\t);
-\tforeach ( $pattern_modules as $pattern_module ) {
-\t\trequire $pattern_module;
-\t}
-}
-`;
-
-		if (
-			!hasPhpFunctionDefinition(nextSource, patternCategoryFunctionName) &&
-			!hasPhpFunctionDefinition(nextSource, patternRegistrationFunctionName)
-		) {
-			nextSource = insertPhpSnippetBeforeWorkspaceAnchors(
-				nextSource,
-				patternFunctions,
-			);
-		}
-
-		if (
-			!hasPhpFunctionDefinition(nextSource, patternCategoryFunctionName) ||
-			!hasPhpFunctionDefinition(nextSource, patternRegistrationFunctionName)
-		) {
-			throw new Error(
-				`Unable to inject pattern bootstrap functions into ${path.basename(bootstrapPath)}.`,
-			);
-		}
-
-		nextSource = ensureNestedPatternLoaderSource(nextSource, bootstrapPath);
-
-		if (!nextSource.includes(patternCategoryHook)) {
-			nextSource = appendPhpSnippetBeforeClosingTag(
-				nextSource,
-				patternCategoryHook,
-			);
-		}
-		if (!nextSource.includes(patternRegistrationHook)) {
-			nextSource = appendPhpSnippetBeforeClosingTag(
-				nextSource,
-				patternRegistrationHook,
-			);
-		}
-
-		return nextSource;
-	});
-}
+	appendWorkspaceInventoryEntries,
+	readWorkspaceInventoryAsync,
+} from "./workspace-inventory.js";
+import { resolveWorkspaceProject } from "./workspace-project.js";
 
 /**
  * Add one PHP block pattern shell to an official workspace project.
@@ -461,21 +96,27 @@ export async function runAddPatternCommand({
 		workspace.projectDir,
 		patternCatalogOptions.contentFile,
 	);
-	if (await fsp.stat(contentFilePath).then(
-		() => true,
-		(error) => {
-			if ((error as { code?: string }).code === "ENOENT") {
-				return false;
-			}
-			throw error;
-		},
-	)) {
+	if (
+		await fsp.stat(contentFilePath).then(
+			() => true,
+			(error) => {
+				if ((error as { code?: string }).code === "ENOENT") {
+					return false;
+				}
+				throw error;
+			},
+		)
+	) {
 		throw new Error(
 			`A pattern already exists at ${patternCatalogOptions.contentFile}. Choose a different name.`,
 		);
 	}
 
-	const blockConfigPath = path.join(workspace.projectDir, "scripts", "block-config.ts");
+	const blockConfigPath = path.join(
+		workspace.projectDir,
+		"scripts",
+		"block-config.ts",
+	);
 	const bootstrapPath = getWorkspaceBootstrapPath(workspace);
 	const patternFilePath = contentFilePath;
 	const mutationSnapshot: WorkspaceMutationSnapshot = {

--- a/packages/wp-typia-project-tools/tests/cli-add-workspace-boundaries.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-add-workspace-boundaries.test.ts
@@ -17,6 +17,18 @@ test('cli-add-workspace delegates workspace add workflows to focused helpers', (
     path.join(runtimeRoot, 'cli-add-workspace-pattern.ts'),
     'utf8',
   );
+  const patternAnchorsSource = fs.readFileSync(
+    path.join(runtimeRoot, 'cli-add-workspace-pattern-anchors.ts'),
+    'utf8',
+  );
+  const patternOptionsSource = fs.readFileSync(
+    path.join(runtimeRoot, 'cli-add-workspace-pattern-options.ts'),
+    'utf8',
+  );
+  const patternSourceEmittersSource = fs.readFileSync(
+    path.join(runtimeRoot, 'cli-add-workspace-pattern-source-emitters.ts'),
+    'utf8',
+  );
   const bindingSource = fs.readFileSync(
     path.join(runtimeRoot, 'cli-add-workspace-binding-source.ts'),
     'utf8',
@@ -306,9 +318,44 @@ test('cli-add-workspace delegates workspace add workflows to focused helpers', (
   expect(assetsSource).not.toContain('function buildPatternSource(');
   expect(assetsSource).not.toContain('function buildBindingSourceServerSource(');
   expect(assetsSource).not.toContain('function buildEditorPluginEntrySource(');
-  expect(patternSource).toContain('function buildPatternSource(');
-  expect(patternSource).toContain('async function ensurePatternBootstrapAnchors(');
+  expect(patternSource).toContain(
+    'from "./cli-add-workspace-pattern-anchors.js"',
+  );
+  expect(patternSource).toContain(
+    'from "./cli-add-workspace-pattern-options.js"',
+  );
+  expect(patternSource).toContain(
+    'from "./cli-add-workspace-pattern-source-emitters.js"',
+  );
+  expect(patternSource).not.toContain('function buildPatternSource(');
+  expect(patternSource).not.toContain(
+    'async function ensurePatternBootstrapAnchors(',
+  );
+  expect(patternSource).not.toContain('function resolvePatternCatalogOptions(');
   expect(patternSource).toContain('export async function runAddPatternCommand(');
+  expect(patternAnchorsSource).toContain(
+    'export async function ensurePatternBootstrapAnchors(',
+  );
+  expect(patternAnchorsSource).toContain(
+    'function ensureNestedPatternLoaderSource(',
+  );
+  expect(patternAnchorsSource).not.toContain('function buildPatternSource(');
+  expect(patternOptionsSource).toContain(
+    'export function resolvePatternCatalogOptions(',
+  );
+  expect(patternOptionsSource).toContain('function normalizePatternTags(');
+  expect(patternOptionsSource).not.toContain(
+    'async function ensurePatternBootstrapAnchors(',
+  );
+  expect(patternSourceEmittersSource).toContain(
+    'export function buildPatternConfigEntry(',
+  );
+  expect(patternSourceEmittersSource).toContain(
+    'export function buildPatternSource(',
+  );
+  expect(patternSourceEmittersSource).not.toContain(
+    'async function ensurePatternBootstrapAnchors(',
+  );
   expect(patternSource).not.toContain('function buildBindingSourceServerSource(');
   expect(patternSource).not.toContain('function buildEditorPluginEntrySource(');
   expect(bindingSource).toContain(
@@ -642,7 +689,7 @@ test('cli-add-workspace delegates workspace add workflows to focused helpers', (
 		aiAnchorsSource,
 		bindingSourceAnchorsSource,
 		editorPluginAnchorsSource,
-		patternSource,
+		patternAnchorsSource,
 		postMetaAnchorsSource,
 		restAnchorsSource,
 	]) {


### PR DESCRIPTION
## Summary

- split pattern workspace add option/path resolution into a focused helper module
- split pattern source and block-config inventory emitters into a focused helper module
- split PHP bootstrap anchor insertion and nested pattern loader repair into a focused helper module
- keep `runAddPatternCommand` as the public orchestration entrypoint with generated output preserved

## Validation

- `bun test packages/wp-typia-project-tools/tests/cli-add-workspace-boundaries.test.ts`
- `bun test packages/wp-typia-project-tools/tests/workspace-add.test.ts --test-name-pattern "pattern"`
- `bun run format:check`
- `bun run changesets:validate`
- `bun run typecheck`
- `bun run lint:repo`
- `bun run --filter @wp-typia/project-tools build`
- `bun run --filter wp-typia build`
- `git diff --check`

Closes #1002
Refs #956
