### PR TITLE
refactor: split REST bootstrap anchors

### DIFF
--- a/.sampo/changesets/1012-split-rest-bootstrap-anchors.md
+++ b/.sampo/changesets/1012-split-rest-bootstrap-anchors.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Split REST workspace bootstrap anchor patching from sync-rest script patching while preserving compatibility exports.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest-anchors.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest-anchors.ts
@@ -1,101 +1,12 @@
 import path from "node:path";
 
-import {
-	getWorkspaceBootstrapPath,
-	patchFile,
-} from "./cli-add-shared.js";
-import {
-	appendPhpSnippetBeforeClosingTag,
-	insertPhpSnippetBeforeWorkspaceAnchors,
-} from "./cli-add-workspace-mutation.js";
-import { hasPhpFunctionDefinition } from "./php-utils.js";
+import { patchFile } from "./cli-add-shared.js";
 import type { WorkspaceProject } from "./workspace-project.js";
 
-const REST_RESOURCE_SERVER_GLOB = "/inc/rest/*.php";
-const REST_SCHEMA_HELPER_PATH = "/inc/rest-schema.php";
-
-/**
- * Ensure the workspace bootstrap loads the shared REST schema helper file.
- *
- * @param workspace Resolved workspace project metadata and PHP prefix.
- * @returns A promise that resolves after the bootstrap is patched.
- * @throws When an existing loader does not reference `inc/rest-schema.php`.
- */
-export async function ensureRestSchemaHelperBootstrapAnchors(
-	workspace: WorkspaceProject,
-): Promise<void> {
-	const bootstrapPath = getWorkspaceBootstrapPath(workspace);
-
-	await patchFile(bootstrapPath, (source) => {
-		let nextSource = source;
-		const loadFunctionName = `${workspace.workspace.phpPrefix}_load_rest_schema_helpers`;
-		const loadCall = `${loadFunctionName}();`;
-		const helperFunction = `
-
-function ${loadFunctionName}() {
-\t$helper_path = __DIR__ . '${REST_SCHEMA_HELPER_PATH}';
-\tif ( is_readable( $helper_path ) ) {
-\t\trequire_once $helper_path;
-\t}
-}
-
-${loadCall}
-`;
-
-		if (!hasPhpFunctionDefinition(nextSource, loadFunctionName)) {
-			nextSource = insertPhpSnippetBeforeWorkspaceAnchors(nextSource, helperFunction);
-		} else if (!nextSource.includes(REST_SCHEMA_HELPER_PATH)) {
-			throw new Error(
-				[
-					`Unable to patch ${path.basename(bootstrapPath)} in ensureRestSchemaHelperBootstrapAnchors.`,
-					`The existing ${loadFunctionName}() definition does not include ${REST_SCHEMA_HELPER_PATH}.`,
-					"Restore the generated bootstrap shape or load inc/rest-schema.php manually before retrying.",
-				].join(" "),
-			);
-		} else if (!nextSource.includes(loadCall)) {
-			nextSource = appendPhpSnippetBeforeClosingTag(nextSource, loadCall);
-		}
-
-		return nextSource;
-	});
-}
-
-export async function ensureRestResourceBootstrapAnchors(
-	workspace: WorkspaceProject,
-): Promise<void> {
-	const bootstrapPath = getWorkspaceBootstrapPath(workspace);
-
-	await patchFile(bootstrapPath, (source) => {
-		let nextSource = source;
-		const registerFunctionName = `${workspace.workspace.phpPrefix}_register_rest_resources`;
-		const registerHook = `add_action( 'init', '${registerFunctionName}', 20 );`;
-		const registerFunction = `
-
-function ${registerFunctionName}() {
-\tforeach ( glob( __DIR__ . '${REST_RESOURCE_SERVER_GLOB}' ) ?: array() as $rest_resource_module ) {
-\t\trequire_once $rest_resource_module;
-\t}
-}
-`;
-		if (!hasPhpFunctionDefinition(nextSource, registerFunctionName)) {
-			nextSource = insertPhpSnippetBeforeWorkspaceAnchors(nextSource, registerFunction);
-		} else if (!nextSource.includes(REST_RESOURCE_SERVER_GLOB)) {
-			throw new Error(
-				[
-					`Unable to patch ${path.basename(bootstrapPath)} in ensureRestResourceBootstrapAnchors.`,
-					`The existing ${registerFunctionName}() definition does not include ${REST_RESOURCE_SERVER_GLOB}.`,
-					"Restore the generated bootstrap shape or wire the REST resource loader manually before retrying.",
-				].join(" "),
-			);
-		}
-
-		if (!nextSource.includes(registerHook)) {
-			nextSource = appendPhpSnippetBeforeClosingTag(nextSource, registerHook);
-		}
-
-		return nextSource;
-	});
-}
+export {
+	ensureRestResourceBootstrapAnchors,
+	ensureRestSchemaHelperBootstrapAnchors,
+} from "./cli-add-workspace-rest-bootstrap-anchors.js";
 
 function assertSyncRestAnchor(
 	nextSource: string,

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest-bootstrap-anchors.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest-bootstrap-anchors.ts
@@ -15,6 +15,32 @@ const REST_RESOURCE_SERVER_GLOB = "/inc/rest/*.php";
 const REST_SCHEMA_HELPER_PATH = "/inc/rest-schema.php";
 
 /**
+ * Check that an expected generated path appears inside the named PHP function.
+ *
+ * @param source Complete PHP bootstrap source.
+ * @param functionName PHP function name to inspect.
+ * @param needle Source fragment that must be present inside the function block.
+ * @returns True when the named function block contains the expected fragment.
+ */
+function phpFunctionBlockIncludes(
+	source: string,
+	functionName: string,
+	needle: string,
+): boolean {
+	const start = source.indexOf(`function ${functionName}(`);
+	if (start === -1) {
+		return false;
+	}
+
+	const nextFunction = source.indexOf("\nfunction ", start + 1);
+	const closingTag = source.indexOf("\n?>", start + 1);
+	const endCandidates = [nextFunction, closingTag].filter((index) => index !== -1);
+	const end = endCandidates.length > 0 ? Math.min(...endCandidates) : source.length;
+
+	return source.slice(start, end).includes(needle);
+}
+
+/**
  * Ensure the workspace bootstrap loads the shared REST schema helper file.
  *
  * @param workspace Resolved workspace project metadata and PHP prefix.
@@ -44,7 +70,13 @@ ${loadCall}
 
 		if (!hasPhpFunctionDefinition(nextSource, loadFunctionName)) {
 			nextSource = insertPhpSnippetBeforeWorkspaceAnchors(nextSource, helperFunction);
-		} else if (!nextSource.includes(REST_SCHEMA_HELPER_PATH)) {
+		} else if (
+			!phpFunctionBlockIncludes(
+				nextSource,
+				loadFunctionName,
+				REST_SCHEMA_HELPER_PATH,
+			)
+		) {
 			throw new Error(
 				[
 					`Unable to patch ${path.basename(bootstrapPath)} in ensureRestSchemaHelperBootstrapAnchors.`,
@@ -86,7 +118,13 @@ function ${registerFunctionName}() {
 `;
 		if (!hasPhpFunctionDefinition(nextSource, registerFunctionName)) {
 			nextSource = insertPhpSnippetBeforeWorkspaceAnchors(nextSource, registerFunction);
-		} else if (!nextSource.includes(REST_RESOURCE_SERVER_GLOB)) {
+		} else if (
+			!phpFunctionBlockIncludes(
+				nextSource,
+				registerFunctionName,
+				REST_RESOURCE_SERVER_GLOB,
+			)
+		) {
 			throw new Error(
 				[
 					`Unable to patch ${path.basename(bootstrapPath)} in ensureRestResourceBootstrapAnchors.`,

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest-bootstrap-anchors.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest-bootstrap-anchors.ts
@@ -1,0 +1,105 @@
+import path from "node:path";
+
+import {
+	getWorkspaceBootstrapPath,
+	patchFile,
+} from "./cli-add-shared.js";
+import {
+	appendPhpSnippetBeforeClosingTag,
+	insertPhpSnippetBeforeWorkspaceAnchors,
+} from "./cli-add-workspace-mutation.js";
+import { hasPhpFunctionDefinition } from "./php-utils.js";
+import type { WorkspaceProject } from "./workspace-project.js";
+
+const REST_RESOURCE_SERVER_GLOB = "/inc/rest/*.php";
+const REST_SCHEMA_HELPER_PATH = "/inc/rest-schema.php";
+
+/**
+ * Ensure the workspace bootstrap loads the shared REST schema helper file.
+ *
+ * @param workspace Resolved workspace project metadata and PHP prefix.
+ * @returns A promise that resolves after the bootstrap is patched.
+ * @throws When an existing loader does not reference `inc/rest-schema.php`.
+ */
+export async function ensureRestSchemaHelperBootstrapAnchors(
+	workspace: WorkspaceProject,
+): Promise<void> {
+	const bootstrapPath = getWorkspaceBootstrapPath(workspace);
+
+	await patchFile(bootstrapPath, (source) => {
+		let nextSource = source;
+		const loadFunctionName = `${workspace.workspace.phpPrefix}_load_rest_schema_helpers`;
+		const loadCall = `${loadFunctionName}();`;
+		const helperFunction = `
+
+function ${loadFunctionName}() {
+\t$helper_path = __DIR__ . '${REST_SCHEMA_HELPER_PATH}';
+\tif ( is_readable( $helper_path ) ) {
+\t\trequire_once $helper_path;
+\t}
+}
+
+${loadCall}
+`;
+
+		if (!hasPhpFunctionDefinition(nextSource, loadFunctionName)) {
+			nextSource = insertPhpSnippetBeforeWorkspaceAnchors(nextSource, helperFunction);
+		} else if (!nextSource.includes(REST_SCHEMA_HELPER_PATH)) {
+			throw new Error(
+				[
+					`Unable to patch ${path.basename(bootstrapPath)} in ensureRestSchemaHelperBootstrapAnchors.`,
+					`The existing ${loadFunctionName}() definition does not include ${REST_SCHEMA_HELPER_PATH}.`,
+					"Restore the generated bootstrap shape or load inc/rest-schema.php manually before retrying.",
+				].join(" "),
+			);
+		} else if (!nextSource.includes(loadCall)) {
+			nextSource = appendPhpSnippetBeforeClosingTag(nextSource, loadCall);
+		}
+
+		return nextSource;
+	});
+}
+
+/**
+ * Ensure the workspace bootstrap loads generated REST resource PHP modules.
+ *
+ * @param workspace Resolved workspace project metadata and PHP prefix.
+ * @returns A promise that resolves after the bootstrap is patched.
+ * @throws When an existing loader does not reference generated REST modules.
+ */
+export async function ensureRestResourceBootstrapAnchors(
+	workspace: WorkspaceProject,
+): Promise<void> {
+	const bootstrapPath = getWorkspaceBootstrapPath(workspace);
+
+	await patchFile(bootstrapPath, (source) => {
+		let nextSource = source;
+		const registerFunctionName = `${workspace.workspace.phpPrefix}_register_rest_resources`;
+		const registerHook = `add_action( 'init', '${registerFunctionName}', 20 );`;
+		const registerFunction = `
+
+function ${registerFunctionName}() {
+\tforeach ( glob( __DIR__ . '${REST_RESOURCE_SERVER_GLOB}' ) ?: array() as $rest_resource_module ) {
+\t\trequire_once $rest_resource_module;
+\t}
+}
+`;
+		if (!hasPhpFunctionDefinition(nextSource, registerFunctionName)) {
+			nextSource = insertPhpSnippetBeforeWorkspaceAnchors(nextSource, registerFunction);
+		} else if (!nextSource.includes(REST_RESOURCE_SERVER_GLOB)) {
+			throw new Error(
+				[
+					`Unable to patch ${path.basename(bootstrapPath)} in ensureRestResourceBootstrapAnchors.`,
+					`The existing ${registerFunctionName}() definition does not include ${REST_RESOURCE_SERVER_GLOB}.`,
+					"Restore the generated bootstrap shape or wire the REST resource loader manually before retrying.",
+				].join(" "),
+			);
+		}
+
+		if (!nextSource.includes(registerHook)) {
+			nextSource = appendPhpSnippetBeforeClosingTag(nextSource, registerHook);
+		}
+
+		return nextSource;
+	});
+}

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest-bootstrap-anchors.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest-bootstrap-anchors.ts
@@ -14,6 +14,10 @@ import type { WorkspaceProject } from "./workspace-project.js";
 const REST_RESOURCE_SERVER_GLOB = "/inc/rest/*.php";
 const REST_SCHEMA_HELPER_PATH = "/inc/rest-schema.php";
 
+function escapeRegex(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
 /**
  * Check that an expected generated path appears inside the named PHP function.
  *
@@ -27,12 +31,19 @@ function phpFunctionBlockIncludes(
 	functionName: string,
 	needle: string,
 ): boolean {
-	const start = source.indexOf(`function ${functionName}(`);
-	if (start === -1) {
+	const functionMatch = new RegExp(
+		`function\\s+${escapeRegex(functionName)}\\s*\\(`,
+		"u",
+	).exec(source);
+	if (functionMatch === null) {
 		return false;
 	}
 
-	const nextFunction = source.indexOf("\nfunction ", start + 1);
+	const start = functionMatch.index;
+	const remainder = source.slice(start + 1);
+	const nextFunctionMatch = /\nfunction\s+/u.exec(remainder);
+	const nextFunction =
+		nextFunctionMatch === null ? -1 : start + 1 + nextFunctionMatch.index;
 	const closingTag = source.indexOf("\n?>", start + 1);
 	const endCandidates = [nextFunction, closingTag].filter((index) => index !== -1);
 	const end = endCandidates.length > 0 ? Math.min(...endCandidates) : source.length;

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest-generated.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest-generated.ts
@@ -15,6 +15,8 @@ import {
 import {
 	ensureRestResourceBootstrapAnchors,
 	ensureRestSchemaHelperBootstrapAnchors,
+} from "./cli-add-workspace-rest-bootstrap-anchors.js";
+import {
 	ensureRestResourceSyncScriptAnchors,
 } from "./cli-add-workspace-rest-anchors.js";
 import {

--- a/packages/wp-typia-project-tools/tests/cli-add-workspace-boundaries.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-add-workspace-boundaries.test.ts
@@ -77,6 +77,10 @@ test('cli-add-workspace delegates workspace add workflows to focused helpers', (
 		path.join(runtimeRoot, 'cli-add-workspace-rest-anchors.ts'),
 		'utf8',
 	);
+	const restBootstrapAnchorsSource = fs.readFileSync(
+		path.join(runtimeRoot, 'cli-add-workspace-rest-bootstrap-anchors.ts'),
+		'utf8',
+	);
 	const restSourceEmittersSource = fs.readFileSync(
 		path.join(runtimeRoot, 'cli-add-workspace-rest-source-emitters.ts'),
 		'utf8',
@@ -545,6 +549,9 @@ test('cli-add-workspace delegates workspace add workflows to focused helpers', (
 	expect(restGeneratedSource).toContain(
 		'from "./cli-add-workspace-rest-generated-source-emitters.js"',
 	);
+	expect(restGeneratedSource).toContain(
+		'from "./cli-add-workspace-rest-bootstrap-anchors.js"',
+	);
 	expect(restGeneratedSource).toContain('syncRestResourceArtifacts');
 	expect(restManualSource).toContain(
 		'export async function scaffoldManualRestContract(',
@@ -597,12 +604,27 @@ test('cli-add-workspace delegates workspace add workflows to focused helpers', (
 	);
 	expect(restSourceUtilsSource).not.toContain('buildRestResource');
 	expect(restSourceUtilsSource).not.toContain('buildManualRestContract');
-  expect(restAnchorsSource).toContain(
-    'async function ensureRestResourceBootstrapAnchors(',
-  );
-  expect(restAnchorsSource).toContain(
-    'async function ensureRestResourceSyncScriptAnchors(',
-  );
+	expect(restAnchorsSource).toContain(
+		'from "./cli-add-workspace-rest-bootstrap-anchors.js"',
+	);
+	expect(restAnchorsSource).not.toContain(
+		'async function ensureRestResourceBootstrapAnchors(',
+	);
+	expect(restAnchorsSource).not.toContain(
+		'async function ensureRestSchemaHelperBootstrapAnchors(',
+	);
+	expect(restAnchorsSource).toContain(
+		'async function ensureRestResourceSyncScriptAnchors(',
+	);
+	expect(restBootstrapAnchorsSource).toContain(
+		'async function ensureRestResourceBootstrapAnchors(',
+	);
+	expect(restBootstrapAnchorsSource).toContain(
+		'async function ensureRestSchemaHelperBootstrapAnchors(',
+	);
+	expect(restBootstrapAnchorsSource).not.toContain(
+		'async function ensureRestResourceSyncScriptAnchors(',
+	);
   expect(postMetaSource).toContain(
     'from "./cli-add-workspace-post-meta-anchors.js"',
   );
@@ -861,7 +883,7 @@ test('cli-add-workspace delegates workspace add workflows to focused helpers', (
 		editorPluginAnchorsSource,
 		patternAnchorsSource,
 		postMetaAnchorsSource,
-		restAnchorsSource,
+		restBootstrapAnchorsSource,
 	]) {
     expect(bootstrapAnchorSource).toContain(
       'insertPhpSnippetBeforeWorkspaceAnchors',

--- a/packages/wp-typia-project-tools/tests/cli-add-workspace-rest-bootstrap-anchors.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-add-workspace-rest-bootstrap-anchors.test.ts
@@ -1,0 +1,69 @@
+import { afterAll, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+	ensureRestResourceBootstrapAnchors,
+	ensureRestSchemaHelperBootstrapAnchors,
+} from "../src/runtime/cli-add-workspace-rest-bootstrap-anchors.js";
+import type { WorkspaceProject } from "../src/runtime/workspace-project.js";
+
+const tempRoot = fs.mkdtempSync(
+	path.join(os.tmpdir(), "wp-typia-rest-bootstrap-anchors-"),
+);
+
+afterAll(() => {
+	fs.rmSync(tempRoot, { force: true, recursive: true });
+});
+
+function createWorkspaceFixture(bootstrapSource: string): WorkspaceProject {
+	const projectDir = fs.mkdtempSync(path.join(tempRoot, "workspace-"));
+	fs.writeFileSync(path.join(projectDir, "demo-workspace.php"), bootstrapSource, "utf8");
+
+	return {
+		author: "Demo",
+		packageManager: "npm",
+		packageName: "demo-workspace",
+		projectDir,
+		workspace: {
+			namespace: "demo/v1",
+			phpPrefix: "demo_space",
+			projectType: "workspace",
+			templatePackage: "@wp-typia/create-workspace-template",
+			textDomain: "demo",
+		},
+	};
+}
+
+test("REST schema helper bootstrap validation inspects the existing loader body", async () => {
+	const workspace = createWorkspaceFixture(`<?php
+// The expected helper path may appear elsewhere without making the loader valid.
+// /inc/rest-schema.php
+function demo_space_load_rest_schema_helpers() {
+\t$helper_path = __DIR__ . '/inc/not-rest-schema.php';
+}
+demo_space_load_rest_schema_helpers();
+`);
+
+	await expect(ensureRestSchemaHelperBootstrapAnchors(workspace)).rejects.toThrow(
+		"does not include /inc/rest-schema.php",
+	);
+});
+
+test("REST resource bootstrap validation inspects the existing loader body", async () => {
+	const workspace = createWorkspaceFixture(`<?php
+// The expected REST glob may appear elsewhere without making the loader valid.
+// /inc/rest/*.php
+function demo_space_register_rest_resources() {
+\tforeach ( glob( __DIR__ . '/inc/not-rest/*.php' ) ?: array() as $rest_resource_module ) {
+\t\trequire_once $rest_resource_module;
+\t}
+}
+add_action( 'init', 'demo_space_register_rest_resources', 20 );
+`);
+
+	await expect(ensureRestResourceBootstrapAnchors(workspace)).rejects.toThrow(
+		"does not include /inc/rest/*.php",
+	);
+});

--- a/packages/wp-typia-project-tools/tests/cli-add-workspace-rest-bootstrap-anchors.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-add-workspace-rest-bootstrap-anchors.test.ts
@@ -51,6 +51,23 @@ demo_space_load_rest_schema_helpers();
 	);
 });
 
+test("REST schema helper bootstrap validation accepts spaced PHP function declarations", async () => {
+	const workspace = createWorkspaceFixture(`<?php
+function demo_space_load_rest_schema_helpers () {
+\t$helper_path = __DIR__ . '/inc/rest-schema.php';
+\tif ( is_readable( $helper_path ) ) {
+\t\trequire_once $helper_path;
+\t}
+}
+
+demo_space_load_rest_schema_helpers();
+`);
+
+	await expect(ensureRestSchemaHelperBootstrapAnchors(workspace)).resolves.toBe(
+		undefined,
+	);
+});
+
 test("REST resource bootstrap validation inspects the existing loader body", async () => {
 	const workspace = createWorkspaceFixture(`<?php
 // The expected REST glob may appear elsewhere without making the loader valid.
@@ -65,5 +82,21 @@ add_action( 'init', 'demo_space_register_rest_resources', 20 );
 
 	await expect(ensureRestResourceBootstrapAnchors(workspace)).rejects.toThrow(
 		"does not include /inc/rest/*.php",
+	);
+});
+
+test("REST resource bootstrap validation accepts spaced PHP function declarations", async () => {
+	const workspace = createWorkspaceFixture(`<?php
+function demo_space_register_rest_resources () {
+\tforeach ( glob( __DIR__ . '/inc/rest/*.php' ) ?: array() as $rest_resource_module ) {
+\t\trequire_once $rest_resource_module;
+\t}
+}
+
+add_action( 'init', 'demo_space_register_rest_resources', 20 );
+`);
+
+	await expect(ensureRestResourceBootstrapAnchors(workspace)).resolves.toBe(
+		undefined,
 	);
 });


### PR DESCRIPTION
## Summary

- move REST schema-helper and REST resource PHP bootstrap patching into `cli-add-workspace-rest-bootstrap-anchors.ts`
- keep `cli-add-workspace-rest-anchors.ts` focused on sync-rest script patching while preserving compatibility re-exports
- update generated REST scaffold imports and boundary tests

## Validation

- `bun test packages/wp-typia-project-tools/tests/cli-add-workspace-boundaries.test.ts`
- `bun run typecheck`
- `bun run format:check`
- `bun run lint:repo`
- `bun run changesets:validate`
- `bun run --filter @wp-typia/project-tools build`
- `bun test packages/wp-typia-project-tools/tests/workspace-add.test.ts --test-name-pattern "plugin-level REST resource|generated REST resource with custom route|rest resource workflow repairs|rest resource workflow fails fast|workspace doctor fails when required REST resource schemas are missing|rest resource workflow rejects invalid namespace"`

Closes #1012
Refs #956

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved REST workspace bootstrap anchor handling with enhanced reliability and backward compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/1013)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->