### PR TITLE
refactor: split REST resource routing template

### DIFF
--- a/.sampo/changesets/1018-split-rest-resource-routing-template.md
+++ b/.sampo/changesets/1018-split-rest-resource-routing-template.md
@@ -1,0 +1,8 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Split generated REST resource PHP routing and controller template helpers from
+the main REST resource PHP template entrypoint while preserving generated
+output compatibility.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest-php-templates.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest-php-templates.ts
@@ -1,168 +1,15 @@
 import { type RestResourceMethodId } from "./cli-add-shared.js";
 import { quotePhpString } from "./php-utils.js";
 import { toTitleCase } from "./string-case.js";
+import {
+	buildRestResourceControllerBootstrapSource,
+	buildRestResourceControllerClassSource,
+	buildRestResourceRouteRegistrations,
+} from "./cli-add-workspace-rest-resource-php-routing-template.js";
 
 export {
 	buildWorkspaceRestSchemaHelperPhpSource,
 } from "./cli-add-workspace-rest-schema-helper-php-template.js";
-
-function buildRestResourceRouteRegistrations(
-	restResourceSlug: string,
-	methods: RestResourceMethodId[],
-	functions: {
-		canWriteFunctionName: string;
-		createHandlerName: string;
-		deleteHandlerName: string;
-		listHandlerName: string;
-		readHandlerName: string;
-		updateHandlerName: string;
-	},
-	options: {
-		controllerVariableName?: string;
-		permissionCallback?: string;
-		routePattern: string;
-	},
-): string {
-	const collectionRoutes: string[] = [];
-	const itemRoutes: string[] = [];
-	const readPermissionCallback = options.permissionCallback
-		? quotePhpString(options.permissionCallback)
-		: quotePhpString("__return_true");
-	const writePermissionCallback = options.permissionCallback
-		? quotePhpString(options.permissionCallback)
-		: options.controllerVariableName
-			? `array( ${options.controllerVariableName}, 'can_manage_rest_resource' )`
-			: quotePhpString(functions.canWriteFunctionName);
-	const buildRouteCallback = (functionName: string, methodName: string) =>
-		options.controllerVariableName
-			? `array( ${options.controllerVariableName}, '${methodName}' )`
-			: quotePhpString(functionName);
-
-	if (methods.includes("list")) {
-		collectionRoutes.push(`\t\tarray(
-\t\t\t'methods'             => WP_REST_Server::READABLE,
-\t\t\t'callback'            => ${buildRouteCallback(functions.listHandlerName, "list_items")},
-\t\t\t'permission_callback' => ${readPermissionCallback},
-\t\t)`);
-	}
-	if (methods.includes("create")) {
-		collectionRoutes.push(`\t\tarray(
-\t\t\t'methods'             => WP_REST_Server::CREATABLE,
-\t\t\t'callback'            => ${buildRouteCallback(functions.createHandlerName, "create_item")},
-\t\t\t'permission_callback' => ${writePermissionCallback},
-\t\t)`);
-	}
-	if (methods.includes("read")) {
-		itemRoutes.push(`\t\tarray(
-\t\t\t'methods'             => WP_REST_Server::READABLE,
-\t\t\t'callback'            => ${buildRouteCallback(functions.readHandlerName, "read_item")},
-\t\t\t'permission_callback' => ${readPermissionCallback},
-\t\t)`);
-	}
-	if (methods.includes("update")) {
-		itemRoutes.push(`\t\tarray(
-\t\t\t'methods'             => WP_REST_Server::EDITABLE,
-\t\t\t'callback'            => ${buildRouteCallback(functions.updateHandlerName, "update_item")},
-\t\t\t'permission_callback' => ${writePermissionCallback},
-\t\t)`);
-	}
-	if (methods.includes("delete")) {
-		itemRoutes.push(`\t\tarray(
-\t\t\t'methods'             => WP_REST_Server::DELETABLE,
-\t\t\t'callback'            => ${buildRouteCallback(functions.deleteHandlerName, "delete_item")},
-\t\t\t'permission_callback' => ${writePermissionCallback},
-\t\t)`);
-	}
-
-	const registrations: string[] = [];
-	if (collectionRoutes.length > 0) {
-		registrations.push(`\tregister_rest_route(
-\t\t$namespace,
-\t\t'/${restResourceSlug}',
-\t\tarray(
-${collectionRoutes.join(",\n")}
-\t\t)
-\t);`);
-	}
-	if (itemRoutes.length > 0) {
-		registrations.push(`\tregister_rest_route(
-\t\t$namespace,
-\t\t${quotePhpString(options.routePattern)},
-\t\tarray(
-${itemRoutes.join(",\n")}
-\t\t)
-\t);`);
-	}
-
-	return registrations.join("\n\n");
-}
-
-function normalizeGlobalPhpClassName(classReference: string): string | undefined {
-	const normalized = classReference.startsWith("\\")
-		? classReference.slice(1)
-		: classReference;
-
-	return /^[A-Za-z_][A-Za-z0-9_]*$/u.test(normalized) ? normalized : undefined;
-}
-
-function toPhpClassConstantReference(classReference: string): string {
-	const normalized = classReference.startsWith("\\")
-		? classReference
-		: `\\${classReference}`;
-	return `${normalized}::class`;
-}
-
-function buildRestResourceControllerClassSource(options: {
-	controllerClass: string;
-	controllerExtends?: string;
-	functions: {
-		canWriteFunctionName: string;
-		createHandlerName: string;
-		deleteHandlerName: string;
-		listHandlerName: string;
-		readHandlerName: string;
-		updateHandlerName: string;
-	};
-}): string {
-	const controllerClassName = normalizeGlobalPhpClassName(options.controllerClass);
-	if (!controllerClassName) {
-		return "";
-	}
-
-	const extendsClause = options.controllerExtends
-		? ` extends ${options.controllerExtends.startsWith("\\") ? options.controllerExtends : `\\${options.controllerExtends}`}`
-		: "";
-
-	return `
-if ( ! class_exists( ${quotePhpString(controllerClassName)} ) ) {
-\tclass ${controllerClassName}${extendsClause} {
-\t\tpublic function can_manage_rest_resource() {
-\t\t\treturn ${options.functions.canWriteFunctionName}();
-\t\t}
-
-\t\tpublic function list_items( WP_REST_Request $request ) {
-\t\t\treturn ${options.functions.listHandlerName}( $request );
-\t\t}
-
-\t\tpublic function read_item( WP_REST_Request $request ) {
-\t\t\treturn ${options.functions.readHandlerName}( $request );
-\t\t}
-
-\t\tpublic function create_item( WP_REST_Request $request ) {
-\t\t\treturn ${options.functions.createHandlerName}( $request );
-\t\t}
-
-\t\tpublic function update_item( WP_REST_Request $request ) {
-\t\t\treturn ${options.functions.updateHandlerName}( $request );
-\t\t}
-
-\t\tpublic function delete_item( WP_REST_Request $request ) {
-\t\t\treturn ${options.functions.deleteHandlerName}( $request );
-\t\t}
-\t}
-}
-`;
-}
 
 /**
  * Build the PHP route/controller glue for generated workspace REST resources.
@@ -231,15 +78,9 @@ export function buildRestResourcePhpSource(
 				},
 			})
 		: "";
-	const controllerBootstrapSource = options.controllerClass
-		? `\t\t$controller_class = ${toPhpClassConstantReference(options.controllerClass)};
-\t\tif ( ! class_exists( $controller_class ) ) {
-\t\t\treturn;
-\t\t}
-\t\t$controller = new $controller_class();
-
-`
-		: "";
+	const controllerBootstrapSource = buildRestResourceControllerBootstrapSource(
+		options.controllerClass,
+	);
 
 	return `<?php
 if ( ! defined( 'ABSPATH' ) ) {

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest-resource-php-routing-template.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-rest-resource-php-routing-template.ts
@@ -1,0 +1,183 @@
+import { type RestResourceMethodId } from "./cli-add-shared.js";
+import { quotePhpString } from "./php-utils.js";
+
+export interface RestResourcePhpFunctionNames {
+	canWriteFunctionName: string;
+	createHandlerName: string;
+	deleteHandlerName: string;
+	listHandlerName: string;
+	readHandlerName: string;
+	updateHandlerName: string;
+}
+
+/**
+ * Build the `register_rest_route` calls for generated REST resource PHP files.
+ */
+export function buildRestResourceRouteRegistrations(
+	restResourceSlug: string,
+	methods: RestResourceMethodId[],
+	functions: RestResourcePhpFunctionNames,
+	options: {
+		controllerVariableName?: string;
+		permissionCallback?: string;
+		routePattern: string;
+	},
+): string {
+	const collectionRoutes: string[] = [];
+	const itemRoutes: string[] = [];
+	const readPermissionCallback = options.permissionCallback
+		? quotePhpString(options.permissionCallback)
+		: quotePhpString("__return_true");
+	const writePermissionCallback = options.permissionCallback
+		? quotePhpString(options.permissionCallback)
+		: options.controllerVariableName
+			? `array( ${options.controllerVariableName}, 'can_manage_rest_resource' )`
+			: quotePhpString(functions.canWriteFunctionName);
+	const buildRouteCallback = (functionName: string, methodName: string) =>
+		options.controllerVariableName
+			? `array( ${options.controllerVariableName}, '${methodName}' )`
+			: quotePhpString(functionName);
+
+	if (methods.includes("list")) {
+		collectionRoutes.push(`\t\tarray(
+\t\t\t'methods'             => WP_REST_Server::READABLE,
+\t\t\t'callback'            => ${buildRouteCallback(functions.listHandlerName, "list_items")},
+\t\t\t'permission_callback' => ${readPermissionCallback},
+\t\t)`);
+	}
+	if (methods.includes("create")) {
+		collectionRoutes.push(`\t\tarray(
+\t\t\t'methods'             => WP_REST_Server::CREATABLE,
+\t\t\t'callback'            => ${buildRouteCallback(functions.createHandlerName, "create_item")},
+\t\t\t'permission_callback' => ${writePermissionCallback},
+\t\t)`);
+	}
+	if (methods.includes("read")) {
+		itemRoutes.push(`\t\tarray(
+\t\t\t'methods'             => WP_REST_Server::READABLE,
+\t\t\t'callback'            => ${buildRouteCallback(functions.readHandlerName, "read_item")},
+\t\t\t'permission_callback' => ${readPermissionCallback},
+\t\t)`);
+	}
+	if (methods.includes("update")) {
+		itemRoutes.push(`\t\tarray(
+\t\t\t'methods'             => WP_REST_Server::EDITABLE,
+\t\t\t'callback'            => ${buildRouteCallback(functions.updateHandlerName, "update_item")},
+\t\t\t'permission_callback' => ${writePermissionCallback},
+\t\t)`);
+	}
+	if (methods.includes("delete")) {
+		itemRoutes.push(`\t\tarray(
+\t\t\t'methods'             => WP_REST_Server::DELETABLE,
+\t\t\t'callback'            => ${buildRouteCallback(functions.deleteHandlerName, "delete_item")},
+\t\t\t'permission_callback' => ${writePermissionCallback},
+\t\t)`);
+	}
+
+	const registrations: string[] = [];
+	if (collectionRoutes.length > 0) {
+		registrations.push(`\tregister_rest_route(
+\t\t$namespace,
+\t\t'/${restResourceSlug}',
+\t\tarray(
+${collectionRoutes.join(",\n")}
+\t\t)
+\t);`);
+	}
+	if (itemRoutes.length > 0) {
+		registrations.push(`\tregister_rest_route(
+\t\t$namespace,
+\t\t${quotePhpString(options.routePattern)},
+\t\tarray(
+${itemRoutes.join(",\n")}
+\t\t)
+\t);`);
+	}
+
+	return registrations.join("\n\n");
+}
+
+function normalizeGlobalPhpClassName(classReference: string): string | undefined {
+	const normalized = classReference.startsWith("\\")
+		? classReference.slice(1)
+		: classReference;
+
+	return /^[A-Za-z_][A-Za-z0-9_]*$/u.test(normalized) ? normalized : undefined;
+}
+
+/**
+ * Normalize a configured PHP class name into a global `::class` reference.
+ */
+export function toPhpClassConstantReference(classReference: string): string {
+	const normalized = classReference.startsWith("\\")
+		? classReference
+		: `\\${classReference}`;
+	return `${normalized}::class`;
+}
+
+/**
+ * Build an optional controller shim class for generated REST resource handlers.
+ */
+export function buildRestResourceControllerClassSource(options: {
+	controllerClass: string;
+	controllerExtends?: string;
+	functions: RestResourcePhpFunctionNames;
+}): string {
+	const controllerClassName = normalizeGlobalPhpClassName(options.controllerClass);
+	if (!controllerClassName) {
+		return "";
+	}
+
+	const extendsClause = options.controllerExtends
+		? ` extends ${options.controllerExtends.startsWith("\\") ? options.controllerExtends : `\\${options.controllerExtends}`}`
+		: "";
+
+	return `
+if ( ! class_exists( ${quotePhpString(controllerClassName)} ) ) {
+\tclass ${controllerClassName}${extendsClause} {
+\t\tpublic function can_manage_rest_resource() {
+\t\t\treturn ${options.functions.canWriteFunctionName}();
+\t\t}
+
+\t\tpublic function list_items( WP_REST_Request $request ) {
+\t\t\treturn ${options.functions.listHandlerName}( $request );
+\t\t}
+
+\t\tpublic function read_item( WP_REST_Request $request ) {
+\t\t\treturn ${options.functions.readHandlerName}( $request );
+\t\t}
+
+\t\tpublic function create_item( WP_REST_Request $request ) {
+\t\t\treturn ${options.functions.createHandlerName}( $request );
+\t\t}
+
+\t\tpublic function update_item( WP_REST_Request $request ) {
+\t\t\treturn ${options.functions.updateHandlerName}( $request );
+\t\t}
+
+\t\tpublic function delete_item( WP_REST_Request $request ) {
+\t\t\treturn ${options.functions.deleteHandlerName}( $request );
+\t\t}
+\t}
+}
+`;
+}
+
+/**
+ * Build the controller instantiation block used inside REST route registration.
+ */
+export function buildRestResourceControllerBootstrapSource(
+	controllerClass: string | undefined,
+): string {
+	if (!controllerClass) {
+		return "";
+	}
+
+	return `\t\t$controller_class = ${toPhpClassConstantReference(controllerClass)};
+\t\tif ( ! class_exists( $controller_class ) ) {
+\t\t\treturn;
+\t\t}
+\t\t$controller = new $controller_class();
+
+`;
+}

--- a/packages/wp-typia-project-tools/tests/cli-add-workspace-boundaries.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-add-workspace-boundaries.test.ts
@@ -77,6 +77,13 @@ test('cli-add-workspace delegates workspace add workflows to focused helpers', (
 		path.join(runtimeRoot, 'cli-add-workspace-rest-php-templates.ts'),
 		'utf8',
 	);
+	const restResourcePhpRoutingTemplateSource = fs.readFileSync(
+		path.join(
+			runtimeRoot,
+			'cli-add-workspace-rest-resource-php-routing-template.ts',
+		),
+		'utf8',
+	);
 	const restSchemaHelperPhpTemplateSource = fs.readFileSync(
 		path.join(
 			runtimeRoot,
@@ -596,10 +603,31 @@ test('cli-add-workspace delegates workspace add workflows to focused helpers', (
 		'export function buildRestResourcePhpSource(',
 	);
 	expect(restPhpTemplatesSource).toContain(
+		'from "./cli-add-workspace-rest-resource-php-routing-template.js"',
+	);
+	expect(restPhpTemplatesSource).toContain(
 		'from "./cli-add-workspace-rest-schema-helper-php-template.js"',
 	);
 	expect(restPhpTemplatesSource).not.toContain(
+		'function buildRestResourceRouteRegistrations(',
+	);
+	expect(restPhpTemplatesSource).not.toContain(
+		'function buildRestResourceControllerClassSource(',
+	);
+	expect(restPhpTemplatesSource).not.toContain(
 		'function buildWorkspaceRestSchemaHelperPhpSource(',
+	);
+	expect(restResourcePhpRoutingTemplateSource).toContain(
+		'export function buildRestResourceRouteRegistrations(',
+	);
+	expect(restResourcePhpRoutingTemplateSource).toContain(
+		'export function buildRestResourceControllerClassSource(',
+	);
+	expect(restResourcePhpRoutingTemplateSource).toContain(
+		'export function buildRestResourceControllerBootstrapSource(',
+	);
+	expect(restResourcePhpRoutingTemplateSource).not.toContain(
+		'buildRestResourcePhpSource',
 	);
 	expect(restSchemaHelperPhpTemplateSource).toContain(
 		'export function buildWorkspaceRestSchemaHelperPhpSource(',


### PR DESCRIPTION
## Summary

- split generated REST resource route registration and controller shim rendering into `cli-add-workspace-rest-resource-php-routing-template.ts`
- keep `buildRestResourcePhpSource` as the public REST PHP template entrypoint
- add boundary assertions so route/controller helpers stay out of the main REST PHP template file
- add a Sampo changeset for the project-tools/wp-typia patch release

## Validation

- `bun test packages/wp-typia-project-tools/tests/cli-add-workspace-boundaries.test.ts`
- `bun test packages/wp-typia-project-tools/tests/workspace-add.test.ts --test-name-pattern "plugin-level REST resource|generated REST resource with custom route|workspace doctor fails when required REST resource schemas are missing|rest resource workflow repairs|rest resource workflow fails fast|rest resource workflow rejects invalid namespace"`
- `bun run typecheck`
- `bun run format:check`
- `bun run lint:repo`
- `bun run changesets:validate`
- `bun run --filter @wp-typia/project-tools build`
- `git diff --check`

Closes #1018
Refs #956