### PR TITLE
refactor: split AI sync script emitter

### DIFF
--- a/.sampo/changesets/1020-split-ai-sync-script-emitter.md
+++ b/.sampo/changesets/1020-split-ai-sync-script-emitter.md
@@ -1,0 +1,7 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Split the generated AI feature sync script source emitter into a focused runtime
+module while preserving compatibility exports and generated output.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai-scaffold.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai-scaffold.ts
@@ -5,11 +5,13 @@ import { ensureBlockConfigCanAddRestManifests } from "./cli-add-block-legacy-val
 import {
 	buildAiFeatureConfigEntry,
 	buildAiFeatureDataSource,
-	buildAiFeatureSyncScriptSource,
 	buildAiFeatureTypesSource,
 	buildAiFeatureValidatorsSource,
 	buildAiFeatureApiSource,
 } from "./cli-add-workspace-ai-source-emitters.js";
+import {
+	buildAiFeatureSyncScriptSource,
+} from "./cli-add-workspace-ai-sync-script-source.js";
 import {
 	ensureAiFeatureBootstrapAnchors,
 	ensureAiFeaturePackageScripts,

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai-source-emitters.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai-source-emitters.ts
@@ -8,6 +8,10 @@ import {
 } from "./scaffold-compatibility.js";
 import { toPascalCase, toTitleCase } from "./string-case.js";
 
+export {
+	buildAiFeatureSyncScriptSource,
+} from "./cli-add-workspace-ai-sync-script-source.js";
+
 function indentMultiline(source: string, prefix: string): string {
 	return source
 		.split("\n")
@@ -360,151 +364,5 @@ export {
 \tisAiFeatureSupportUnavailableError,
 \tresolveAiFeatureUnavailableMessage,
 };
-`;
-}
-
-/**
- * Generate the `scripts/sync-ai-features.ts` source that projects AI-safe schemas for workspace features.
- */
-export function buildAiFeatureSyncScriptSource(): string {
-	return `/* eslint-disable no-console */
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
-import path from 'node:path';
-
-import { projectWordPressAiSchema } from '@wp-typia/project-tools/ai-artifacts';
-
-import {
-\tAI_FEATURES,
-\ttype WorkspaceAiFeatureConfig,
-} from './block-config';
-
-function parseCliOptions( argv: string[] ) {
-\tconst options = {
-\t\tcheck: false,
-\t};
-
-\tfor ( const argument of argv ) {
-\t\tif ( argument === '--check' ) {
-\t\t\toptions.check = true;
-\t\t\tcontinue;
-\t\t}
-
-\t\tthrow new Error( \`Unknown sync-ai flag: \${ argument }\` );
-\t}
-
-\treturn options;
-}
-
-function isWorkspaceAiFeature(
-\tfeature: WorkspaceAiFeatureConfig
-): feature is WorkspaceAiFeatureConfig & {
-\taiSchemaFile: string;
-\ttypesFile: string;
-} {
-\treturn (
-\t\ttypeof feature.aiSchemaFile === 'string' &&
-\t\ttypeof feature.typesFile === 'string'
-\t);
-}
-
-function normalizeGeneratedArtifactContent( content: string ) {
-\treturn content.replace( /\\r\\n?/g, '\\n' );
-}
-
-async function reconcileGeneratedArtifact( options: {
-\tcheck: boolean;
-\tcontent: string;
-\tfilePath: string;
-\tlabel: string;
-} ) {
-\tif ( ! options.check ) {
-\t\tawait mkdir( path.dirname( options.filePath ), {
-\t\t\trecursive: true,
-\t\t} );
-\t\tawait writeFile( options.filePath, options.content, 'utf8' );
-\t\treturn;
-\t}
-
-\tconst current = normalizeGeneratedArtifactContent(
-\t\tawait readFile( options.filePath, 'utf8' )
-\t);
-\tconst expected = normalizeGeneratedArtifactContent( options.content );
-\tif ( current !== expected ) {
-\t\tthrow new Error(
-\t\t\t\`Generated AI feature artifact is stale: \${ options.label } (\${ options.filePath }).\`
-\t\t);
-\t}
-}
-
-async function loadJsonDocument( filePath: string ) {
-\tlet source: string;
-\ttry {
-\t\tsource = await readFile( filePath, 'utf8' );
-\t} catch ( error ) {
-\t\tthrow new Error(
-\t\t\t\`Failed to read AI schema document at \${ filePath }: \${ error instanceof Error ? error.message : String( error ) }\`
-\t\t);
-\t}
-
-\tlet decoded: unknown;
-\ttry {
-\t\tdecoded = JSON.parse( source ) as unknown;
-\t} catch ( error ) {
-\t\tthrow new Error(
-\t\t\t\`Failed to parse AI schema document at \${ filePath }: \${ error instanceof Error ? error.message : String( error ) }\`
-\t\t);
-\t}
-\tif ( ! decoded || typeof decoded !== 'object' || Array.isArray( decoded ) ) {
-\t\tthrow new Error( \`Expected \${ filePath } to decode to a JSON object.\` );
-\t}
-
-\treturn decoded as Parameters< typeof projectWordPressAiSchema >[ 0 ];
-}
-
-async function main() {
-\tconst options = parseCliOptions( process.argv.slice( 2 ) );
-\tconst aiFeatures = AI_FEATURES.filter( isWorkspaceAiFeature );
-\tif ( AI_FEATURES.length > 0 && aiFeatures.length === 0 ) {
-\t\tconsole.warn(
-\t\t\t'⚠️ AI_FEATURES entries exist, but none satisfied the generated sync-ai guard. Check for missing aiSchemaFile/typesFile fields in scripts/block-config.ts.'
-\t\t);
-\t}
-
-\tif ( aiFeatures.length === 0 ) {
-\t\tconsole.log(
-\t\t\toptions.check
-\t\t\t\t? 'ℹ️ No workspace AI features are registered yet. \`sync-ai --check\` is already clean.'
-\t\t\t\t: 'ℹ️ No workspace AI features are registered yet.'
-\t\t);
-\t\treturn;
-\t}
-
-\tfor ( const feature of aiFeatures ) {
-\t\tconst sourceSchemaPath = path.join(
-\t\t\tpath.dirname( feature.typesFile ),
-\t\t\t'api-schemas',
-\t\t\t'feature-result.schema.json'
-\t\t);
-\t\tconst sourceSchema = await loadJsonDocument( sourceSchemaPath );
-\t\tconst aiSchema = projectWordPressAiSchema( sourceSchema );
-\t\tawait reconcileGeneratedArtifact( {
-\t\t\tcheck: options.check,
-\t\t\tcontent: \`\${ JSON.stringify( aiSchema, null, 2 ) }\\n\`,
-\t\t\tfilePath: feature.aiSchemaFile,
-\t\t\tlabel: feature.slug,
-\t\t} );
-\t}
-
-\tconsole.log(
-\t\toptions.check
-\t\t\t? '✅ AI feature structured-output schemas are already synchronized.'
-\t\t\t: '✅ AI feature structured-output schemas were synchronized.'
-\t);
-}
-
-main().catch( ( error ) => {
-\tconsole.error( '❌ AI feature sync failed:', error );
-\tprocess.exit( 1 );
-} );
 `;
 }

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai-sync-script-source.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai-sync-script-source.ts
@@ -1,0 +1,145 @@
+/**
+ * Generate the `scripts/sync-ai-features.ts` source that projects AI-safe schemas for workspace features.
+ */
+export function buildAiFeatureSyncScriptSource(): string {
+	return `/* eslint-disable no-console */
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { projectWordPressAiSchema } from '@wp-typia/project-tools/ai-artifacts';
+
+import {
+\tAI_FEATURES,
+\ttype WorkspaceAiFeatureConfig,
+} from './block-config';
+
+function parseCliOptions( argv: string[] ) {
+\tconst options = {
+\t\tcheck: false,
+\t};
+
+\tfor ( const argument of argv ) {
+\t\tif ( argument === '--check' ) {
+\t\t\toptions.check = true;
+\t\t\tcontinue;
+\t\t}
+
+\t\tthrow new Error( \`Unknown sync-ai flag: \${ argument }\` );
+\t}
+
+\treturn options;
+}
+
+function isWorkspaceAiFeature(
+\tfeature: WorkspaceAiFeatureConfig
+): feature is WorkspaceAiFeatureConfig & {
+\taiSchemaFile: string;
+\ttypesFile: string;
+} {
+\treturn (
+\t\ttypeof feature.aiSchemaFile === 'string' &&
+\t\ttypeof feature.typesFile === 'string'
+\t);
+}
+
+function normalizeGeneratedArtifactContent( content: string ) {
+\treturn content.replace( /\\r\\n?/g, '\\n' );
+}
+
+async function reconcileGeneratedArtifact( options: {
+\tcheck: boolean;
+\tcontent: string;
+\tfilePath: string;
+\tlabel: string;
+} ) {
+\tif ( ! options.check ) {
+\t\tawait mkdir( path.dirname( options.filePath ), {
+\t\t\trecursive: true,
+\t\t} );
+\t\tawait writeFile( options.filePath, options.content, 'utf8' );
+\t\treturn;
+\t}
+
+\tconst current = normalizeGeneratedArtifactContent(
+\t\tawait readFile( options.filePath, 'utf8' )
+\t);
+\tconst expected = normalizeGeneratedArtifactContent( options.content );
+\tif ( current !== expected ) {
+\t\tthrow new Error(
+\t\t\t\`Generated AI feature artifact is stale: \${ options.label } (\${ options.filePath }).\`
+\t\t);
+\t}
+}
+
+async function loadJsonDocument( filePath: string ) {
+\tlet source: string;
+\ttry {
+\t\tsource = await readFile( filePath, 'utf8' );
+\t} catch ( error ) {
+\t\tthrow new Error(
+\t\t\t\`Failed to read AI schema document at \${ filePath }: \${ error instanceof Error ? error.message : String( error ) }\`
+\t\t);
+\t}
+
+\tlet decoded: unknown;
+\ttry {
+\t\tdecoded = JSON.parse( source ) as unknown;
+\t} catch ( error ) {
+\t\tthrow new Error(
+\t\t\t\`Failed to parse AI schema document at \${ filePath }: \${ error instanceof Error ? error.message : String( error ) }\`
+\t\t);
+\t}
+\tif ( ! decoded || typeof decoded !== 'object' || Array.isArray( decoded ) ) {
+\t\tthrow new Error( \`Expected \${ filePath } to decode to a JSON object.\` );
+\t}
+
+\treturn decoded as Parameters< typeof projectWordPressAiSchema >[ 0 ];
+}
+
+async function main() {
+\tconst options = parseCliOptions( process.argv.slice( 2 ) );
+\tconst aiFeatures = AI_FEATURES.filter( isWorkspaceAiFeature );
+\tif ( AI_FEATURES.length > 0 && aiFeatures.length === 0 ) {
+\t\tconsole.warn(
+\t\t\t'⚠️ AI_FEATURES entries exist, but none satisfied the generated sync-ai guard. Check for missing aiSchemaFile/typesFile fields in scripts/block-config.ts.'
+\t\t);
+\t}
+
+\tif ( aiFeatures.length === 0 ) {
+\t\tconsole.log(
+\t\t\toptions.check
+\t\t\t\t? 'ℹ️ No workspace AI features are registered yet. \`sync-ai --check\` is already clean.'
+\t\t\t\t: 'ℹ️ No workspace AI features are registered yet.'
+\t\t);
+\t\treturn;
+\t}
+
+\tfor ( const feature of aiFeatures ) {
+\t\tconst sourceSchemaPath = path.join(
+\t\t\tpath.dirname( feature.typesFile ),
+\t\t\t'api-schemas',
+\t\t\t'feature-result.schema.json'
+\t\t);
+\t\tconst sourceSchema = await loadJsonDocument( sourceSchemaPath );
+\t\tconst aiSchema = projectWordPressAiSchema( sourceSchema );
+\t\tawait reconcileGeneratedArtifact( {
+\t\t\tcheck: options.check,
+\t\t\tcontent: \`\${ JSON.stringify( aiSchema, null, 2 ) }\\n\`,
+\t\t\tfilePath: feature.aiSchemaFile,
+\t\t\tlabel: feature.slug,
+\t\t} );
+\t}
+
+\tconsole.log(
+\t\toptions.check
+\t\t\t? '✅ AI feature structured-output schemas are already synchronized.'
+\t\t\t: '✅ AI feature structured-output schemas were synchronized.'
+\t);
+}
+
+main().catch( ( error ) => {
+\tconsole.error( '❌ AI feature sync failed:', error );
+\tprocess.exit( 1 );
+} );
+`;
+}

--- a/packages/wp-typia-project-tools/tests/cli-add-workspace-boundaries.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-add-workspace-boundaries.test.ts
@@ -161,6 +161,10 @@ test('cli-add-workspace delegates workspace add workflows to focused helpers', (
     path.join(runtimeRoot, 'cli-add-workspace-ai-source-emitters.ts'),
     'utf8',
   );
+  const aiSyncScriptSource = fs.readFileSync(
+    path.join(runtimeRoot, 'cli-add-workspace-ai-sync-script-source.ts'),
+    'utf8',
+  );
   const aiScaffoldSource = fs.readFileSync(
     path.join(runtimeRoot, 'cli-add-workspace-ai-scaffold.ts'),
     'utf8',
@@ -771,6 +775,9 @@ test('cli-add-workspace delegates workspace add workflows to focused helpers', (
   expect(aiScaffoldSource).toContain(
     'from "./cli-add-workspace-ai-source-emitters.js"',
   );
+  expect(aiScaffoldSource).toContain(
+    'from "./cli-add-workspace-ai-sync-script-source.js"',
+  );
   expect(aiScaffoldSource).not.toContain('function buildAiFeatureTypesSource(');
   expect(aiScaffoldSource).not.toContain(
     'async function ensureAiFeatureBootstrapAnchors(',
@@ -786,6 +793,19 @@ test('cli-add-workspace delegates workspace add workflows to focused helpers', (
   expect(aiSourceEmittersSource).toContain(
     'function buildAiFeatureDataSource(',
   );
+  expect(aiSourceEmittersSource).toContain(
+    'from "./cli-add-workspace-ai-sync-script-source.js"',
+  );
+  expect(aiSourceEmittersSource).not.toContain(
+    'function buildAiFeatureSyncScriptSource(',
+  );
+  expect(aiSyncScriptSource).toContain(
+    'export function buildAiFeatureSyncScriptSource(',
+  );
+  expect(aiSyncScriptSource).toContain(
+    "projectWordPressAiSchema",
+  );
+  expect(aiSyncScriptSource).not.toContain('function buildAiFeatureApiSource(');
   expect(aiAnchorsSource).toContain(
     'async function ensureAiFeatureBootstrapAnchors(',
   );


### PR DESCRIPTION
## Summary

- split `buildAiFeatureSyncScriptSource()` into `cli-add-workspace-ai-sync-script-source.ts`
- update AI feature scaffold wiring to import the sync script emitter directly from the focused module
- preserve the compatibility re-export from `cli-add-workspace-ai-source-emitters.ts`
- add boundary coverage so the sync script emitter stays out of the general AI source emitters module
- add a Sampo changeset for the project-tools/wp-typia patch release

## Validation

- `bun test packages/wp-typia-project-tools/tests/cli-add-workspace-boundaries.test.ts`
- `bun test packages/wp-typia-project-tools/tests/cli-add-workspace-ai-templates.test.ts packages/wp-typia-project-tools/tests/cli-add-workspace-ai.test.ts`
- `bun run typecheck`
- `bun run format:check`
- `bun run lint:repo`
- `bun run changesets:validate`
- `bun run --filter @wp-typia/project-tools build`
- `git diff --check`

Closes #1020
Refs #956

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal module structure to improve code maintainability and separation of concerns.

* **Tests**
  * Enhanced test coverage to verify module integration and exports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/1021)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->