### PR TITLE
refactor(block-types): share registration helpers

### DIFF
--- a/.sampo/changesets/1025-shared-block-types-helpers.md
+++ b/.sampo/changesets/1025-shared-block-types-helpers.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/block-types: patch
+---
+
+Share static registration normalization, object-record checks, and diagnostic
+fallback helpers across block bindings, variations, and supports internals.

--- a/packages/wp-typia-block-types/src/blocks/bindings.ts
+++ b/packages/wp-typia-block-types/src/blocks/bindings.ts
@@ -9,6 +9,12 @@ import {
   type WordPressCompatibilitySettings,
   type WordPressVersion,
 } from "./compatibility.js";
+import {
+  getDiagnosticSeverity,
+  handleDiagnostics,
+} from "./shared/diagnostics.js";
+import { isObjectRecord } from "./shared/object-utils.js";
+import { normalizeStaticRegistrationValue } from "./shared/static-registration.js";
 
 export type BindingSourceName = `${string}/${string}`;
 
@@ -231,12 +237,6 @@ const SOURCE_NAME_PATTERN =
   /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\/[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/u;
 const FIELD_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_-]*$/u;
 
-function isObjectRecord(
-  value: unknown,
-): value is Readonly<Record<string, unknown>> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
 function isBindingSourceVersionGates(
   value: WordPressVersion | BindingSourceVersionGates | undefined,
 ): value is BindingSourceVersionGates {
@@ -381,10 +381,6 @@ function resolveDefineBindingSourceSettings(
     onDiagnostic: options.onDiagnostic ?? inlineOptions.onDiagnostic,
     strict,
   };
-}
-
-function getDiagnosticSeverity(strict: boolean): "error" | "warning" {
-  return strict ? "error" : "warning";
 }
 
 function getFeatureMinVersion(
@@ -613,27 +609,9 @@ function handleBindingSourceDiagnostics(
   diagnostics: readonly BindingSourceDiagnostic[],
   onDiagnostic: DefineBindingSourceOptions["onDiagnostic"],
 ): void {
-  const errors = diagnostics.filter(
-    (diagnostic) => diagnostic.severity === "error",
-  );
-
-  if (errors.length > 0) {
-    throw new Error(
-      [
-        "WordPress block binding source check failed:",
-        ...errors.map((diagnostic) => `- ${diagnostic.message}`),
-      ].join("\n"),
-    );
-  }
-
-  for (const diagnostic of diagnostics) {
-    if (onDiagnostic) {
-      onDiagnostic(diagnostic);
-      continue;
-    }
-
-    console.warn(`[wp-typia] ${diagnostic.message}`);
-  }
+  handleDiagnostics(diagnostics, onDiagnostic, {
+    failureHeading: "WordPress block binding source check failed:",
+  });
 }
 
 export function getDefinedBindingSourceMetadata(
@@ -768,55 +746,6 @@ export function createBindingSourceRegistrationPlan(
       source,
     };
   });
-}
-
-function normalizeStaticRegistrationValue(value: unknown, path: string): unknown {
-  if (value === undefined) {
-    return undefined;
-  }
-  if (
-    value === null ||
-    typeof value === "boolean" ||
-    typeof value === "number" ||
-    typeof value === "string"
-  ) {
-    return value;
-  }
-  if (typeof value === "function") {
-    throw new Error(
-      `Cannot generate static binding source registration code for function value at ${path}.`,
-    );
-  }
-  if (typeof value === "bigint" || typeof value === "symbol") {
-    throw new Error(
-      `Cannot generate static binding source registration code for ${typeof value} value at ${path}.`,
-    );
-  }
-  if (Array.isArray(value)) {
-    return value.map((entry, index) =>
-      normalizeStaticRegistrationValue(entry, `${path}[${index}]`),
-    );
-  }
-  if (isObjectRecord(value)) {
-    const normalized: Record<string, unknown> = {};
-
-    for (const [key, nestedValue] of Object.entries(value)) {
-      const nextValue = normalizeStaticRegistrationValue(
-        nestedValue,
-        `${path}.${key}`,
-      );
-
-      if (nextValue !== undefined) {
-        normalized[key] = nextValue;
-      }
-    }
-
-    return normalized;
-  }
-
-  throw new Error(
-    `Cannot generate static binding source registration code for unsupported value at ${path}.`,
-  );
 }
 
 function getBindingEvaluation(
@@ -1043,6 +972,7 @@ function createEditorRegistrationEntries(
           usesContext: entry.source.usesContext,
         },
         `sources.${entry.source.name}`,
+        { description: "binding source" },
       ),
     );
 
@@ -1057,6 +987,7 @@ function createEditorRegistrationEntries(
     fields[entry.source.name] = normalizeStaticRegistrationValue(
       entry.source.fields,
       `fields.${entry.source.name}`,
+      { description: "binding source" },
     ) as readonly BindingSourceField[];
   }
 

--- a/packages/wp-typia-block-types/src/blocks/shared/diagnostics.ts
+++ b/packages/wp-typia-block-types/src/blocks/shared/diagnostics.ts
@@ -1,0 +1,40 @@
+export type DiagnosticSeverity = "error" | "warning";
+
+export interface DiagnosticWithMessage {
+  readonly message: string;
+  readonly severity: DiagnosticSeverity;
+}
+
+export function getDiagnosticSeverity(strict: boolean): DiagnosticSeverity {
+  return strict ? "error" : "warning";
+}
+
+export function handleDiagnostics<TDiagnostic extends DiagnosticWithMessage>(
+  diagnostics: readonly TDiagnostic[],
+  onDiagnostic: ((diagnostic: TDiagnostic) => void) | undefined,
+  options: {
+    readonly failureHeading: string;
+  },
+): void {
+  const errors = diagnostics.filter(
+    (diagnostic) => diagnostic.severity === "error",
+  );
+
+  if (errors.length > 0) {
+    throw new Error(
+      [
+        options.failureHeading,
+        ...errors.map((diagnostic) => `- ${diagnostic.message}`),
+      ].join("\n"),
+    );
+  }
+
+  for (const diagnostic of diagnostics) {
+    if (onDiagnostic) {
+      onDiagnostic(diagnostic);
+      continue;
+    }
+
+    console.warn(`[wp-typia] ${diagnostic.message}`);
+  }
+}

--- a/packages/wp-typia-block-types/src/blocks/shared/object-utils.ts
+++ b/packages/wp-typia-block-types/src/blocks/shared/object-utils.ts
@@ -1,7 +1,11 @@
+export function isNonArrayObject(value: unknown): value is object {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 export function isObjectRecord(
   value: unknown,
 ): value is Readonly<Record<string, unknown>> {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+  if (!isNonArrayObject(value)) {
     return false;
   }
 

--- a/packages/wp-typia-block-types/src/blocks/shared/object-utils.ts
+++ b/packages/wp-typia-block-types/src/blocks/shared/object-utils.ts
@@ -1,0 +1,5 @@
+export function isObjectRecord(
+  value: unknown,
+): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/wp-typia-block-types/src/blocks/shared/object-utils.ts
+++ b/packages/wp-typia-block-types/src/blocks/shared/object-utils.ts
@@ -1,5 +1,11 @@
 export function isObjectRecord(
   value: unknown,
 ): value is Readonly<Record<string, unknown>> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+
+  return prototype === Object.prototype || prototype === null;
 }

--- a/packages/wp-typia-block-types/src/blocks/shared/static-registration.ts
+++ b/packages/wp-typia-block-types/src/blocks/shared/static-registration.ts
@@ -1,0 +1,59 @@
+import { isObjectRecord } from "./object-utils.js";
+
+export interface NormalizeStaticRegistrationValueOptions {
+  readonly description: string;
+}
+
+export function normalizeStaticRegistrationValue(
+  value: unknown,
+  path: string,
+  options: NormalizeStaticRegistrationValueOptions,
+): unknown {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (
+    value === null ||
+    typeof value === "boolean" ||
+    typeof value === "number" ||
+    typeof value === "string"
+  ) {
+    return value;
+  }
+  if (typeof value === "function") {
+    throw new Error(
+      `Cannot generate static ${options.description} registration code for function value at ${path}.`,
+    );
+  }
+  if (typeof value === "bigint" || typeof value === "symbol") {
+    throw new Error(
+      `Cannot generate static ${options.description} registration code for ${typeof value} value at ${path}.`,
+    );
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry, index) =>
+      normalizeStaticRegistrationValue(entry, `${path}[${index}]`, options),
+    );
+  }
+  if (isObjectRecord(value)) {
+    const normalized: Record<string, unknown> = {};
+
+    for (const [key, nestedValue] of Object.entries(value)) {
+      const nextValue = normalizeStaticRegistrationValue(
+        nestedValue,
+        `${path}.${key}`,
+        options,
+      );
+
+      if (nextValue !== undefined) {
+        normalized[key] = nextValue;
+      }
+    }
+
+    return normalized;
+  }
+
+  throw new Error(
+    `Cannot generate static ${options.description} registration code for unsupported value at ${path}.`,
+  );
+}

--- a/packages/wp-typia-block-types/src/blocks/supports.ts
+++ b/packages/wp-typia-block-types/src/blocks/supports.ts
@@ -23,7 +23,10 @@ import {
   type WordPressVersion,
 } from "./compatibility.js";
 import { handleDiagnostics } from "./shared/diagnostics.js";
-import { isObjectRecord } from "./shared/object-utils.js";
+import {
+  isNonArrayObject,
+  isObjectRecord,
+} from "./shared/object-utils.js";
 
 /**
  * Derived from Gutenberg block support keys and commonly used block.json
@@ -492,7 +495,7 @@ function isEnabledSupportValue(value: unknown): boolean {
 
 function isEnabledTopLevelSupportValue(value: unknown): boolean {
   if (!isObjectRecord(value)) {
-    return isEnabledSupportValue(value);
+    return isNonArrayObject(value) ? false : isEnabledSupportValue(value);
   }
 
   return Object.entries(value).some(

--- a/packages/wp-typia-block-types/src/blocks/supports.ts
+++ b/packages/wp-typia-block-types/src/blocks/supports.ts
@@ -22,6 +22,8 @@ import {
   type WordPressCompatibilitySettings,
   type WordPressVersion,
 } from "./compatibility.js";
+import { handleDiagnostics } from "./shared/diagnostics.js";
+import { isObjectRecord } from "./shared/object-utils.js";
 
 /**
  * Derived from Gutenberg block support keys and commonly used block.json
@@ -484,16 +486,12 @@ const TOP_LEVEL_COMPATIBILITY_SUPPORT_KEYS = [
   "visibility",
 ] as const satisfies readonly BlockSupportFeature[];
 
-function isSupportObject(value: unknown): value is Readonly<Record<string, unknown>> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
 function isEnabledSupportValue(value: unknown): boolean {
   return value !== false && value !== null && value !== undefined;
 }
 
 function isEnabledTopLevelSupportValue(value: unknown): boolean {
-  if (!isSupportObject(value)) {
+  if (!isObjectRecord(value)) {
     return isEnabledSupportValue(value);
   }
 
@@ -508,7 +506,7 @@ function hasEnabledNestedSupport(
   section: unknown,
   key: string,
 ): boolean {
-  return isSupportObject(section) && isEnabledSupportValue(section[key]);
+  return isObjectRecord(section) && isEnabledSupportValue(section[key]);
 }
 
 function addCompatibilityFeature(
@@ -556,7 +554,7 @@ export function collectBlockSupportsCompatibilityFeatures(
   }
 
   const color = supports.color;
-  if (isSupportObject(color)) {
+  if (isObjectRecord(color)) {
     for (const key of COLOR_COMPATIBILITY_SUPPORT_KEYS) {
       if (isEnabledSupportValue(color[key])) {
         addCompatibilityFeature(features, seen, `color.${key}`);
@@ -649,33 +647,15 @@ function handleDefineSupportsDiagnostics(
   diagnostics: readonly WordPressBlockApiCompatibilityDiagnostic[],
   onDiagnostic: DefineSupportsOptions["onDiagnostic"],
 ): void {
-  const errors = diagnostics.filter(
-    (diagnostic) => diagnostic.severity === "error",
-  );
-
-  if (errors.length > 0) {
-    throw new Error(
-      [
-        "WordPress block supports compatibility check failed:",
-        ...errors.map((diagnostic) => `- ${diagnostic.message}`),
-      ].join("\n"),
-    );
-  }
-
-  for (const diagnostic of diagnostics) {
-    if (onDiagnostic) {
-      onDiagnostic(diagnostic);
-      continue;
-    }
-
-    console.warn(`[wp-typia] ${diagnostic.message}`);
-  }
+  handleDiagnostics(diagnostics, onDiagnostic, {
+    failureHeading: "WordPress block supports compatibility check failed:",
+  });
 }
 
 export function getDefinedSupportsCompatibilityManifest(
   supports: unknown,
 ): WordPressBlockApiCompatibilityManifest | undefined {
-  return isSupportObject(supports)
+  return isObjectRecord(supports)
     ? (
         supports as {
           readonly [DEFINED_BLOCK_SUPPORTS_METADATA]?:

--- a/packages/wp-typia-block-types/src/blocks/variations.ts
+++ b/packages/wp-typia-block-types/src/blocks/variations.ts
@@ -11,6 +11,12 @@ import {
   type WordPressCompatibilitySettings,
   type WordPressVersion,
 } from "./compatibility.js";
+import {
+  getDiagnosticSeverity,
+  handleDiagnostics,
+} from "./shared/diagnostics.js";
+import { isObjectRecord } from "./shared/object-utils.js";
+import { normalizeStaticRegistrationValue } from "./shared/static-registration.js";
 
 export type BlockVariationAttributeMap<
   TAttributes extends BlockAttributes = BlockAttributes,
@@ -159,10 +165,6 @@ const STABLE_VARIATION_MARKER_ATTRIBUTES = [
   "wpTypiaVariation",
 ] as const;
 
-function isObjectRecord(value: unknown): value is Readonly<Record<string, unknown>> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
 function splitDefineVariationInput<
   TAttributes extends BlockAttributes,
   TVariation extends BlockVariationDefinition<TAttributes> &
@@ -231,10 +233,6 @@ function resolveDefineVariationSettings(
     },
     onDiagnostic: options.onDiagnostic ?? inlineOptions.onDiagnostic,
   };
-}
-
-function getDiagnosticSeverity(strict: boolean): "error" | "warning" {
-  return strict ? "error" : "warning";
 }
 
 export function collectBlockVariationCompatibilityFeatures(): readonly WordPressBlockApiCompatibilityFeature[] {
@@ -330,27 +328,9 @@ function handleVariationDiagnostics(
   diagnostics: readonly BlockVariationDiagnostic[],
   onDiagnostic: DefineVariationOptions["onDiagnostic"],
 ): void {
-  const errors = diagnostics.filter(
-    (diagnostic) => diagnostic.severity === "error",
-  );
-
-  if (errors.length > 0) {
-    throw new Error(
-      [
-        "WordPress block variation check failed:",
-        ...errors.map((diagnostic) => `- ${diagnostic.message}`),
-      ].join("\n"),
-    );
-  }
-
-  for (const diagnostic of diagnostics) {
-    if (onDiagnostic) {
-      onDiagnostic(diagnostic);
-      continue;
-    }
-
-    console.warn(`[wp-typia] ${diagnostic.message}`);
-  }
+  handleDiagnostics(diagnostics, onDiagnostic, {
+    failureHeading: "WordPress block variation check failed:",
+  });
 }
 
 export function getDefinedVariationMetadata(
@@ -544,55 +524,6 @@ export function defineVariations<
   return normalizedVariations;
 }
 
-function normalizeStaticRegistrationValue(value: unknown, path: string): unknown {
-  if (value === undefined) {
-    return undefined;
-  }
-  if (
-    value === null ||
-    typeof value === "boolean" ||
-    typeof value === "number" ||
-    typeof value === "string"
-  ) {
-    return value;
-  }
-  if (typeof value === "function") {
-    throw new Error(
-      `Cannot generate static variation registration code for function value at ${path}.`,
-    );
-  }
-  if (typeof value === "bigint" || typeof value === "symbol") {
-    throw new Error(
-      `Cannot generate static variation registration code for ${typeof value} value at ${path}.`,
-    );
-  }
-  if (Array.isArray(value)) {
-    return value.map((entry, index) =>
-      normalizeStaticRegistrationValue(entry, `${path}[${index}]`),
-    );
-  }
-  if (isObjectRecord(value)) {
-    const normalized: Record<string, unknown> = {};
-
-    for (const [key, nestedValue] of Object.entries(value)) {
-      const nextValue = normalizeStaticRegistrationValue(
-        nestedValue,
-        `${path}.${key}`,
-      );
-
-      if (nextValue !== undefined) {
-        normalized[key] = nextValue;
-      }
-    }
-
-    return normalized;
-  }
-
-  throw new Error(
-    `Cannot generate static variation registration code for unsupported value at ${path}.`,
-  );
-}
-
 export function createStaticBlockVariationRegistrationSource(
   variations: readonly DefinedBlockVariation[],
   options: CreateBlockVariationRegistrationSourceOptions = {},
@@ -601,7 +532,9 @@ export function createStaticBlockVariationRegistrationSource(
   const functionName = options.functionName ?? "registerWpTypiaBlockVariations";
   const entries = createBlockVariationRegistrationPlan(variations).map(
     (entry, index) =>
-      normalizeStaticRegistrationValue(entry, `variations[${index}]`),
+      normalizeStaticRegistrationValue(entry, `variations[${index}]`, {
+        description: "variation",
+      }),
   );
   const serializedEntries = JSON.stringify(entries, null, 2);
 

--- a/packages/wp-typia-block-types/tests/bindings.test.ts
+++ b/packages/wp-typia-block-types/tests/bindings.test.ts
@@ -309,6 +309,31 @@ describe("binding source registration source generation", () => {
     expect(editorSource).toContain("getFieldsList: () => fields");
   });
 
+  test("rejects dynamic field args when generating static editor registration", () => {
+    const source = defineBindingSource({
+      fields: [
+        {
+          args: {
+            formatter: () => "dynamic",
+          },
+          label: "Dynamic",
+          name: "dynamic",
+        },
+      ],
+      getValueCallback: "example_get_dynamic_binding_value",
+      minWordPress: {
+        editor: "6.7",
+        fieldsList: "6.9",
+        server: "6.5",
+      },
+      name: "example/dynamic",
+    });
+
+    expect(() => createEditorBindingSourceRegistrationSource(source)).toThrow(
+      "Cannot generate static binding source registration code for function value at fields.example/dynamic[0].args.formatter.",
+    );
+  });
+
   test("keeps generated PHP filter callbacks unique after sanitization", () => {
     const first = defineBindingSource({
       bindableAttributes: [

--- a/packages/wp-typia-block-types/tests/shared-helpers.test.ts
+++ b/packages/wp-typia-block-types/tests/shared-helpers.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  getDiagnosticSeverity,
+  handleDiagnostics,
+} from "../src/blocks/shared/diagnostics";
+import { isObjectRecord } from "../src/blocks/shared/object-utils";
+import { normalizeStaticRegistrationValue } from "../src/blocks/shared/static-registration";
+
+describe("shared block API helper utilities", () => {
+  test("identifies object records without accepting arrays or null", () => {
+    expect(isObjectRecord({ enabled: true })).toBe(true);
+    expect(isObjectRecord([])).toBe(false);
+    expect(isObjectRecord(null)).toBe(false);
+  });
+
+  test("maps strict mode to authoring diagnostic severity", () => {
+    expect(getDiagnosticSeverity(true)).toBe("error");
+    expect(getDiagnosticSeverity(false)).toBe("warning");
+  });
+
+  test("normalizes nested static registration values and omits undefined fields", () => {
+    expect(
+      normalizeStaticRegistrationValue(
+        {
+          enabled: true,
+          nested: [
+            {
+              label: "Field",
+              omitted: undefined,
+            },
+          ],
+          omitted: undefined,
+        },
+        "entry",
+        { description: "test" },
+      ),
+    ).toEqual({
+      enabled: true,
+      nested: [
+        {
+          label: "Field",
+        },
+      ],
+    });
+  });
+
+  test("rejects unsupported static registration values with contextual paths", () => {
+    expect(() =>
+      normalizeStaticRegistrationValue(
+        {
+          nested: {
+            callback: () => undefined,
+          },
+        },
+        "entry",
+        { description: "test" },
+      ),
+    ).toThrow(
+      "Cannot generate static test registration code for function value at entry.nested.callback.",
+    );
+  });
+
+  test("emits warning diagnostics through callbacks and throws grouped errors", () => {
+    const warnings: Array<{ readonly message: string; readonly severity: "warning" }> =
+      [];
+
+    handleDiagnostics(
+      [
+        {
+          message: "Use a newer WordPress feature.",
+          severity: "warning",
+        },
+      ],
+      (diagnostic) => warnings.push(diagnostic),
+      { failureHeading: "Shared diagnostics failed:" },
+    );
+
+    expect(warnings).toEqual([
+      {
+        message: "Use a newer WordPress feature.",
+        severity: "warning",
+      },
+    ]);
+    expect(() =>
+      handleDiagnostics(
+        [
+          {
+            message: "Required support is unavailable.",
+            severity: "error",
+          },
+        ],
+        undefined,
+        { failureHeading: "Shared diagnostics failed:" },
+      ),
+    ).toThrow(
+      "Shared diagnostics failed:\n- Required support is unavailable.",
+    );
+  });
+});

--- a/packages/wp-typia-block-types/tests/shared-helpers.test.ts
+++ b/packages/wp-typia-block-types/tests/shared-helpers.test.ts
@@ -10,8 +10,12 @@ import { normalizeStaticRegistrationValue } from "../src/blocks/shared/static-re
 describe("shared block API helper utilities", () => {
   test("identifies object records without accepting arrays or null", () => {
     expect(isObjectRecord({ enabled: true })).toBe(true);
+    expect(isObjectRecord(Object.create(null))).toBe(true);
     expect(isObjectRecord([])).toBe(false);
     expect(isObjectRecord(null)).toBe(false);
+    expect(isObjectRecord(new Date())).toBe(false);
+    expect(isObjectRecord(new Map())).toBe(false);
+    expect(isObjectRecord(new (class TestObject {})())).toBe(false);
   });
 
   test("maps strict mode to authoring diagnostic severity", () => {
@@ -58,6 +62,17 @@ describe("shared block API helper utilities", () => {
       ),
     ).toThrow(
       "Cannot generate static test registration code for function value at entry.nested.callback.",
+    );
+    expect(() =>
+      normalizeStaticRegistrationValue(
+        {
+          createdAt: new Date("2026-05-16T00:00:00.000Z"),
+        },
+        "entry",
+        { description: "test" },
+      ),
+    ).toThrow(
+      "Cannot generate static test registration code for unsupported value at entry.createdAt.",
     );
   });
 

--- a/packages/wp-typia-block-types/tests/shared-helpers.test.ts
+++ b/packages/wp-typia-block-types/tests/shared-helpers.test.ts
@@ -4,11 +4,17 @@ import {
   getDiagnosticSeverity,
   handleDiagnostics,
 } from "../src/blocks/shared/diagnostics";
-import { isObjectRecord } from "../src/blocks/shared/object-utils";
+import {
+  isNonArrayObject,
+  isObjectRecord,
+} from "../src/blocks/shared/object-utils";
 import { normalizeStaticRegistrationValue } from "../src/blocks/shared/static-registration";
 
 describe("shared block API helper utilities", () => {
   test("identifies object records without accepting arrays or null", () => {
+    expect(isNonArrayObject({ enabled: true })).toBe(true);
+    expect(isNonArrayObject(new Date())).toBe(true);
+    expect(isNonArrayObject([])).toBe(false);
     expect(isObjectRecord({ enabled: true })).toBe(true);
     expect(isObjectRecord(Object.create(null))).toBe(true);
     expect(isObjectRecord([])).toBe(false);

--- a/packages/wp-typia-block-types/tests/supports.test.ts
+++ b/packages/wp-typia-block-types/tests/supports.test.ts
@@ -157,6 +157,20 @@ describe("defineSupports", () => {
 		expect(enabledFeatures).toEqual(["background", "dimensions", "position"]);
 	});
 
+	test("does not treat non-plain object support values as enabled top-level features", () => {
+		class CustomSupportValue {
+			enabled = true;
+		}
+
+		const features = collectBlockSupportsCompatibilityFeatures({
+			background: new Date() as never,
+			contentRole: new CustomSupportValue() as never,
+			renaming: new Map([["enabled", true]]) as never,
+		}).map((feature) => feature.feature);
+
+		expect(features).toEqual([]);
+	});
+
 	test("throws in strict mode when supports require a newer WordPress floor", () => {
 		expect(() =>
 			defineSupports({


### PR DESCRIPTION
## Summary

- Extract shared block-types helper modules for object-record checks, diagnostic severity/fallback handling, and static registration value normalization.
- Reuse the shared helpers from bindings, variations, and supports without changing public package exports.
- Add shared helper coverage plus a binding source codegen regression test for dynamic static-registration values.

## Validation

- bun run --filter @wp-typia/block-types test
- bun run typecheck
- bun run format:check
- bun run changesets:validate
- git diff --check

Closes #1025

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added test coverage for block API helper utilities including object validation, diagnostic severity handling, and static registration normalization.

* **Refactor**
  * Improved error handling and diagnostic messaging across block bindings, variations, and support configurations for more consistent validation feedback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/1034?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->