### PR TITLE
dx(block-types): make diagnostic output explicit

### DIFF
--- a/.sampo/changesets/1027-diagnostic-output-policy.md
+++ b/.sampo/changesets/1027-diagnostic-output-policy.md
@@ -1,0 +1,8 @@
+---
+npm/@wp-typia/block-types: patch
+---
+
+Make block-types diagnostic output explicit and silent by default. Non-strict
+warnings from Supports, Variations, and Bindings no longer fall back to
+`console.warn`; pass `onDiagnostic` for structured callbacks or `logger:
+console`/a custom logger for visible warning output.

--- a/packages/wp-typia-block-types/README.md
+++ b/packages/wp-typia-block-types/README.md
@@ -119,6 +119,9 @@ Use `onDiagnostic` when callers need callback-driven diagnostics for tests,
 custom reporting, or UI integration:
 
 ```ts
+const diagnostics: Array<{ message: string; severity: 'warning' | 'error' }> =
+  [];
+
 defineSupports(
   {
     allowedBlocks: true,

--- a/packages/wp-typia-block-types/README.md
+++ b/packages/wp-typia-block-types/README.md
@@ -108,6 +108,49 @@ generation. Non-strict mode downgrades them to warnings and recommends guarded
 generation. Unknown future keys are guarded by default, or passed through only
 when `allowUnknownFutureKeys` is enabled.
 
+## Diagnostic output policy
+
+Supports, Variations, and Bindings helpers keep diagnostics structured and
+silent by default. Strict diagnostics still throw grouped errors, but non-strict
+warnings do not write to `console.warn` unless a consumer opts into visible
+output.
+
+Use `onDiagnostic` when callers need callback-driven diagnostics for tests,
+custom reporting, or UI integration:
+
+```ts
+defineSupports(
+  {
+    allowedBlocks: true,
+    minWordPress: '6.8',
+    strict: false,
+  },
+  {
+    onDiagnostic: (diagnostic) => {
+      diagnostics.push(diagnostic);
+    },
+  },
+);
+```
+
+Use `logger` when callers want formatted warning messages without taking over
+the structured callback path. Passing `console` restores console warning output.
+If both `onDiagnostic` and `logger` are provided, `onDiagnostic` handles the
+diagnostic and the logger is not called.
+
+```ts
+defineSupports(
+  {
+    allowedBlocks: true,
+    minWordPress: '6.8',
+    strict: false,
+  },
+  {
+    logger: console,
+  },
+);
+```
+
 ## Validation coverage
 
 `@wp-typia/block-types` now validates itself with a mixed strategy that matches

--- a/packages/wp-typia-block-types/src/blocks/bindings-core.ts
+++ b/packages/wp-typia-block-types/src/blocks/bindings-core.ts
@@ -11,6 +11,7 @@ import {
 import {
   getDiagnosticSeverity,
   handleDiagnostics,
+  type DiagnosticLogger,
 } from "./shared/diagnostics.js";
 import { isObjectRecord } from "./shared/object-utils.js";
 
@@ -73,6 +74,7 @@ export interface DefineBindingSourceInlineOptions {
   readonly allowUnknownFutureKeys?: boolean;
   readonly editor?: boolean;
   readonly fieldsList?: boolean;
+  readonly logger?: DiagnosticLogger<BindingSourceDiagnostic>;
   readonly minVersion?: WordPressVersion;
   readonly minWordPress?: WordPressVersion | BindingSourceVersionGates;
   readonly minWordPressEditor?: WordPressVersion;
@@ -88,6 +90,7 @@ export interface DefineBindingSourceInlineOptions {
 export interface DefineBindingSourceOptions extends WordPressCompatibilitySettings {
   readonly editor?: boolean;
   readonly fieldsList?: boolean;
+  readonly logger?: DiagnosticLogger<BindingSourceDiagnostic>;
   readonly minWordPress?: WordPressVersion | BindingSourceVersionGates;
   readonly minWordPressEditor?: WordPressVersion;
   readonly minWordPressFieldsList?: WordPressVersion;
@@ -207,6 +210,7 @@ const DEFINE_BINDING_SOURCE_INLINE_OPTION_KEYS = new Set<string>([
   "allowUnknownFutureKeys",
   "editor",
   "fieldsList",
+  "logger",
   "minVersion",
   "minWordPress",
   "minWordPressEditor",
@@ -343,6 +347,7 @@ function resolveDefineBindingSourceSettings(
     supportedAttributesFilter: boolean;
   };
   gates: BindingSourceVersionGates;
+  logger: DefineBindingSourceOptions["logger"];
   onDiagnostic: DefineBindingSourceOptions["onDiagnostic"];
   strict: boolean;
 } {
@@ -364,6 +369,7 @@ function resolveDefineBindingSourceSettings(
         hasBindableAttributes,
     },
     gates,
+    logger: options.logger ?? inlineOptions.logger,
     onDiagnostic: options.onDiagnostic ?? inlineOptions.onDiagnostic,
     strict,
   };
@@ -594,9 +600,11 @@ function createBindingSourceDiagnostics(
 function handleBindingSourceDiagnostics(
   diagnostics: readonly BindingSourceDiagnostic[],
   onDiagnostic: DefineBindingSourceOptions["onDiagnostic"],
+  logger: DefineBindingSourceOptions["logger"],
 ): void {
   handleDiagnostics(diagnostics, onDiagnostic, {
     failureHeading: "WordPress block binding source check failed:",
+    logger,
   });
 }
 
@@ -659,7 +667,11 @@ export function defineBindingSource<
     }),
   ];
 
-  handleBindingSourceDiagnostics(diagnostics, resolved.onDiagnostic);
+  handleBindingSourceDiagnostics(
+    diagnostics,
+    resolved.onDiagnostic,
+    resolved.logger,
+  );
 
   Object.defineProperty(
     normalizedSource,

--- a/packages/wp-typia-block-types/src/blocks/shared/diagnostics.ts
+++ b/packages/wp-typia-block-types/src/blocks/shared/diagnostics.ts
@@ -5,6 +5,12 @@ export interface DiagnosticWithMessage {
   readonly severity: DiagnosticSeverity;
 }
 
+export interface DiagnosticLogger<
+  TDiagnostic extends DiagnosticWithMessage = DiagnosticWithMessage,
+> {
+  readonly warn: (message: string, diagnostic: TDiagnostic) => void;
+}
+
 export function getDiagnosticSeverity(strict: boolean): DiagnosticSeverity {
   return strict ? "error" : "warning";
 }
@@ -14,6 +20,7 @@ export function handleDiagnostics<TDiagnostic extends DiagnosticWithMessage>(
   onDiagnostic: ((diagnostic: TDiagnostic) => void) | undefined,
   options: {
     readonly failureHeading: string;
+    readonly logger?: DiagnosticLogger<TDiagnostic> | undefined;
   },
 ): void {
   const errors = diagnostics.filter(
@@ -35,6 +42,6 @@ export function handleDiagnostics<TDiagnostic extends DiagnosticWithMessage>(
       continue;
     }
 
-    console.warn(`[wp-typia] ${diagnostic.message}`);
+    options.logger?.warn(`[wp-typia] ${diagnostic.message}`, diagnostic);
   }
 }

--- a/packages/wp-typia-block-types/src/blocks/supports.ts
+++ b/packages/wp-typia-block-types/src/blocks/supports.ts
@@ -22,7 +22,10 @@ import {
   type WordPressCompatibilitySettings,
   type WordPressVersion,
 } from "./compatibility.js";
-import { handleDiagnostics } from "./shared/diagnostics.js";
+import {
+  handleDiagnostics,
+  type DiagnosticLogger,
+} from "./shared/diagnostics.js";
 import {
   isNonArrayObject,
   isObjectRecord,
@@ -376,6 +379,7 @@ type IfSupport<TCondition, TAttributes> = TCondition extends true
 
 export interface DefineSupportsInlineOptions {
   readonly allowUnknownFutureKeys?: boolean;
+  readonly logger?: DiagnosticLogger<WordPressBlockApiCompatibilityDiagnostic>;
   readonly minVersion?: WordPressVersion;
   readonly minWordPress?: WordPressVersion;
   readonly onDiagnostic?: (diagnostic: WordPressBlockApiCompatibilityDiagnostic) => void;
@@ -383,6 +387,7 @@ export interface DefineSupportsInlineOptions {
 }
 
 export interface DefineSupportsOptions extends WordPressCompatibilitySettings {
+  readonly logger?: DiagnosticLogger<WordPressBlockApiCompatibilityDiagnostic>;
   readonly minWordPress?: WordPressVersion;
   readonly onDiagnostic?: (diagnostic: WordPressBlockApiCompatibilityDiagnostic) => void;
 }
@@ -459,6 +464,7 @@ export type SupportAttributesFromBlockSupports<TSupports> =
 const KNOWN_BLOCK_SUPPORT_FEATURES = new Set<string>(BLOCK_SUPPORT_FEATURES);
 const DEFINE_SUPPORTS_INLINE_OPTION_KEYS = new Set<string>([
   "allowUnknownFutureKeys",
+  "logger",
   "minVersion",
   "minWordPress",
   "onDiagnostic",
@@ -649,9 +655,11 @@ export function createBlockSupportsCompatibilityManifest(
 function handleDefineSupportsDiagnostics(
   diagnostics: readonly WordPressBlockApiCompatibilityDiagnostic[],
   onDiagnostic: DefineSupportsOptions["onDiagnostic"],
+  logger: DefineSupportsOptions["logger"],
 ): void {
   handleDiagnostics(diagnostics, onDiagnostic, {
     failureHeading: "WordPress block supports compatibility check failed:",
+    logger,
   });
 }
 
@@ -686,6 +694,7 @@ export function defineSupports<
   handleDefineSupportsDiagnostics(
     manifest.diagnostics,
     options.onDiagnostic ?? inlineOptions.onDiagnostic,
+    options.logger ?? inlineOptions.logger,
   );
 
   Object.defineProperty(normalizedSupports, DEFINED_BLOCK_SUPPORTS_METADATA, {

--- a/packages/wp-typia-block-types/src/blocks/variations.ts
+++ b/packages/wp-typia-block-types/src/blocks/variations.ts
@@ -14,6 +14,7 @@ import {
 import {
   getDiagnosticSeverity,
   handleDiagnostics,
+  type DiagnosticLogger,
 } from "./shared/diagnostics.js";
 import { isObjectRecord } from "./shared/object-utils.js";
 import { normalizeStaticRegistrationValue } from "./shared/static-registration.js";
@@ -60,6 +61,7 @@ export interface BlockVariationDefinition<
 
 export interface DefineVariationInlineOptions {
   readonly allowMissingIsActive?: boolean;
+  readonly logger?: DiagnosticLogger<BlockVariationDiagnostic>;
   readonly minVersion?: WordPressVersion;
   readonly minWordPress?: WordPressVersion;
   readonly onDiagnostic?: (diagnostic: BlockVariationDiagnostic) => void;
@@ -69,6 +71,7 @@ export interface DefineVariationInlineOptions {
 
 export interface DefineVariationOptions extends WordPressCompatibilitySettings {
   readonly allowMissingIsActive?: boolean;
+  readonly logger?: DiagnosticLogger<BlockVariationDiagnostic>;
   readonly minWordPress?: WordPressVersion;
   readonly onDiagnostic?: (diagnostic: BlockVariationDiagnostic) => void;
   readonly requireIsActive?: boolean;
@@ -152,6 +155,7 @@ export interface CreateBlockVariationRegistrationSourceOptions {
 
 const DEFINE_VARIATION_INLINE_OPTION_KEYS = new Set<string>([
   "allowMissingIsActive",
+  "logger",
   "minVersion",
   "minWordPress",
   "onDiagnostic",
@@ -203,6 +207,7 @@ function resolveDefineVariationSettings(
     requireIsActive: boolean;
     strict: boolean;
   };
+  logger: DefineVariationOptions["logger"];
   onDiagnostic: DefineVariationOptions["onDiagnostic"];
 } {
   const compatibility: WordPressCompatibilitySettings = {};
@@ -231,6 +236,7 @@ function resolveDefineVariationSettings(
         options.requireIsActive ?? inlineOptions.requireIsActive ?? true,
       strict,
     },
+    logger: options.logger ?? inlineOptions.logger,
     onDiagnostic: options.onDiagnostic ?? inlineOptions.onDiagnostic,
   };
 }
@@ -327,9 +333,11 @@ function createVariationDiagnostics<TAttributes extends BlockAttributes>(
 function handleVariationDiagnostics(
   diagnostics: readonly BlockVariationDiagnostic[],
   onDiagnostic: DefineVariationOptions["onDiagnostic"],
+  logger: DefineVariationOptions["logger"],
 ): void {
   handleDiagnostics(diagnostics, onDiagnostic, {
     failureHeading: "WordPress block variation check failed:",
+    logger,
   });
 }
 
@@ -400,7 +408,7 @@ export function defineVariation<
     ),
   ];
 
-  handleVariationDiagnostics(diagnostics, resolved.onDiagnostic);
+  handleVariationDiagnostics(diagnostics, resolved.onDiagnostic, resolved.logger);
 
   Object.defineProperty(normalizedVariation, DEFINED_BLOCK_VARIATION_METADATA, {
     configurable: false,
@@ -501,7 +509,11 @@ export function defineVariations<
     ...collectionDiagnostics,
   ];
 
-  handleVariationDiagnostics(collectionDiagnostics, options.onDiagnostic);
+  handleVariationDiagnostics(
+    collectionDiagnostics,
+    options.onDiagnostic,
+    options.logger,
+  );
 
   const normalizedVariations = [...variations] as unknown as DefinedBlockVariations<
     TVariations

--- a/packages/wp-typia-block-types/tests/bindings.test.ts
+++ b/packages/wp-typia-block-types/tests/bindings.test.ts
@@ -159,6 +159,43 @@ describe("defineBindingSource", () => {
     expect(editorSource).toContain("Skipped getFieldsList()");
   });
 
+  test("reports diagnostics through explicit loggers", () => {
+    const logs: Array<{
+      readonly diagnostic: BindingSourceDiagnostic;
+      readonly message: string;
+    }> = [];
+
+    defineBindingSource(
+      {
+        fields: [
+          {
+            label: "Title",
+            name: "title",
+          },
+        ],
+        getValueCallback: "example_get_post_binding_value",
+        minWordPress: "6.7",
+        name: "example/post-data",
+        strict: false,
+      },
+      {
+        logger: {
+          warn: (message, diagnostic) => {
+            logs.push({ diagnostic, message });
+          },
+        },
+      },
+    );
+
+    expect(logs).toHaveLength(1);
+    expect(logs[0]?.message).toContain("[wp-typia]");
+    expect(logs[0]?.diagnostic).toMatchObject({
+      code: "unsupported-wordpress-block-api-feature",
+      feature: "editorFieldsList",
+      severity: "warning",
+    });
+  });
+
   test("supports server-only sources without editor registration output", () => {
     const source = defineBindingSource({
       editor: false,

--- a/packages/wp-typia-block-types/tests/shared-helpers.test.ts
+++ b/packages/wp-typia-block-types/tests/shared-helpers.test.ts
@@ -118,4 +118,65 @@ describe("shared block API helper utilities", () => {
       "Shared diagnostics failed:\n- Required support is unavailable.",
     );
   });
+
+  test("keeps warning diagnostics silent by default", () => {
+    const originalWarn = console.warn;
+    const consoleWarnings: unknown[][] = [];
+
+    console.warn = (...args: unknown[]) => {
+      consoleWarnings.push(args);
+    };
+
+    try {
+      handleDiagnostics(
+        [
+          {
+            message: "Use a newer WordPress feature.",
+            severity: "warning",
+          },
+        ],
+        undefined,
+        { failureHeading: "Shared diagnostics failed:" },
+      );
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    expect(consoleWarnings).toEqual([]);
+  });
+
+  test("emits warning diagnostics through explicit loggers", () => {
+    const warnings: Array<{
+      readonly diagnostic: { readonly message: string; readonly severity: "warning" };
+      readonly message: string;
+    }> = [];
+
+    handleDiagnostics(
+      [
+        {
+          message: "Use a newer WordPress feature.",
+          severity: "warning",
+        },
+      ],
+      undefined,
+      {
+        failureHeading: "Shared diagnostics failed:",
+        logger: {
+          warn: (message, diagnostic) => {
+            warnings.push({ diagnostic, message });
+          },
+        },
+      },
+    );
+
+    expect(warnings).toEqual([
+      {
+        diagnostic: {
+          message: "Use a newer WordPress feature.",
+          severity: "warning",
+        },
+        message: "[wp-typia] Use a newer WordPress feature.",
+      },
+    ]);
+  });
 });

--- a/packages/wp-typia-block-types/tests/supports.test.ts
+++ b/packages/wp-typia-block-types/tests/supports.test.ts
@@ -222,6 +222,36 @@ describe("defineSupports", () => {
 		});
 	});
 
+	test("reports non-strict compatibility warnings through explicit loggers", () => {
+		const logs: Array<{
+			readonly diagnostic: WordPressBlockApiCompatibilityDiagnostic;
+			readonly message: string;
+		}> = [];
+
+		defineSupports(
+			{
+				allowedBlocks: true,
+				minWordPress: "6.8",
+				strict: false,
+			},
+			{
+				logger: {
+					warn: (message, diagnostic) => {
+						logs.push({ diagnostic, message });
+					},
+				},
+			},
+		);
+
+		expect(logs).toHaveLength(1);
+		expect(logs[0]?.message).toContain("[wp-typia]");
+		expect(logs[0]?.diagnostic).toMatchObject({
+			code: "unsupported-wordpress-block-api-feature",
+			feature: "allowedBlocks",
+			severity: "warning",
+		});
+	});
+
 	test("passes through unknown future keys only when explicitly allowed", () => {
 		const supports = defineSupports({
 			minWordPress: "6.9",

--- a/packages/wp-typia-block-types/tests/variations.test.ts
+++ b/packages/wp-typia-block-types/tests/variations.test.ts
@@ -120,6 +120,39 @@ describe("defineVariation", () => {
 		]);
 	});
 
+	test("reports authoring warnings through explicit loggers", () => {
+		const logs: Array<{
+			readonly diagnostic: BlockVariationDiagnostic;
+			readonly message: string;
+		}> = [];
+
+		defineVariation<ParagraphAttributes>(
+			"core/paragraph",
+			{
+				attributes: {
+					className: "is-style-editorial",
+				},
+				name: "example-editorial-paragraph",
+				title: "Editorial Paragraph",
+			},
+			{
+				logger: {
+					warn: (message, diagnostic) => {
+						logs.push({ diagnostic, message });
+					},
+				},
+			},
+		);
+
+		expect(logs).toHaveLength(1);
+		expect(logs[0]?.message).toContain("[wp-typia]");
+		expect(logs[0]?.diagnostic).toMatchObject({
+			code: "missing-is-active",
+			severity: "warning",
+			variationName: "example-editorial-paragraph",
+		});
+	});
+
 	test("throws in strict mode when editor registration is below the WordPress floor", () => {
 		expect(() =>
 			defineVariation<ParagraphAttributes>("core/paragraph", {


### PR DESCRIPTION
## Summary

- make block-types warning diagnostics silent by default instead of falling back to console.warn
- add an explicit logger option across supports, variations, and bindings while preserving onDiagnostic callback handling
- document the diagnostic output policy and add coverage for default, callback, and logger paths

## Validation

- bun run --filter @wp-typia/block-types test
- bun run typecheck
- bun run format:check
- bun run changesets:validate
- git diff --check

Closes #1027

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Diagnostic warnings for block helpers (supports, variations, bindings) are now silent by default. Use `onDiagnostic` callbacks or custom loggers to capture warnings.

* **Documentation**
  * Added comprehensive documentation on the diagnostic output policy, explaining silent-by-default behavior and logger configuration options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/1037?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->