### PR TITLE
refactor(ai): reuse shared REST nonce helper

### DIFF
--- a/.sampo/changesets/1028-ai-rest-nonce-helper.md
+++ b/.sampo/changesets/1028-ai-rest-nonce-helper.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Reuse the shared REST nonce helper source emitter in generated AI feature API
+sources so REST and AI nonce resolution behavior cannot drift.

--- a/.sampo/changesets/1028-cli-project-tools-coupling.md
+++ b/.sampo/changesets/1028-cli-project-tools-coupling.md
@@ -1,0 +1,6 @@
+---
+npm/wp-typia: patch
+---
+
+Keep the CLI release lane aligned with the planned `@wp-typia/project-tools`
+patch for the shared AI REST nonce source emitter.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai-source-emitters.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-ai-source-emitters.ts
@@ -6,18 +6,15 @@ import {
 	renderScaffoldCompatibilityConfig,
 	resolveScaffoldCompatibilityPolicy,
 } from "./scaffold-compatibility.js";
+import {
+	formatResolveRestNonceSource,
+	indentMultiline,
+} from "./cli-add-workspace-rest-source-utils.js";
 import { toPascalCase, toTitleCase } from "./string-case.js";
 
 export {
 	buildAiFeatureSyncScriptSource,
 } from "./cli-add-workspace-ai-sync-script-source.js";
-
-function indentMultiline(source: string, prefix: string): string {
-	return source
-		.split("\n")
-		.map((line) => `${prefix}${line}`)
-	.join("\n");
-}
 
 /**
  * Build the workspace inventory entry written into `scripts/block-config.ts` for one AI feature.
@@ -215,26 +212,7 @@ import {
 \trun${pascalCase}AiFeatureEndpoint,
 } from './api-client';
 
-function resolveRestNonce( fallback?: string ): string | undefined {
-\tif ( typeof fallback === 'string' && fallback.length > 0 ) {
-\t\treturn fallback;
-\t}
-
-\tif ( typeof window === 'undefined' ) {
-\t\treturn undefined;
-\t}
-
-\tconst wpApiSettings = (
-\t\twindow as typeof window & {
-\t\t\twpApiSettings?: { nonce?: string };
-\t\t}
-\t).wpApiSettings;
-
-\treturn typeof wpApiSettings?.nonce === 'string' &&
-\t\twpApiSettings.nonce.length > 0
-\t\t? wpApiSettings.nonce
-\t\t: undefined;
-}
+${formatResolveRestNonceSource("spaced")}
 
 function isPlainObject( value: unknown ): value is Record< string, unknown > {
 \treturn (

--- a/packages/wp-typia-project-tools/tests/cli-add-workspace-ai-source-emitters.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-add-workspace-ai-source-emitters.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "bun:test";
+
+import { buildAiFeatureApiSource } from "../src/runtime/cli-add-workspace-ai-source-emitters.js";
+import { formatResolveRestNonceSource } from "../src/runtime/cli-add-workspace-rest-source-utils.js";
+
+function countOccurrences(source: string, needle: string): number {
+	return source.split(needle).length - 1;
+}
+
+test("AI feature API source reuses the shared spaced REST nonce helper", () => {
+	const source = buildAiFeatureApiSource("demo-ai-feature");
+
+	expect(source).toContain(formatResolveRestNonceSource("spaced"));
+	expect(source).toContain("\t\tconst nonce = resolveRestNonce();");
+	expect(source).not.toContain(
+		"function resolveRestNonce(fallback?: string): string | undefined {",
+	);
+	expect(countOccurrences(source, "function resolveRestNonce")).toBe(1);
+});


### PR DESCRIPTION
## Summary
- reuse the shared `formatResolveRestNonceSource("spaced")` emitter for generated AI API sources
- remove the AI emitter copy of `resolveRestNonce` and share `indentMultiline` from REST source utils
- add a focused AI source emitter regression test plus a patch changeset

## Validation
- `bun test packages/wp-typia-project-tools/tests/cli-add-workspace-ai-source-emitters.test.ts packages/wp-typia-project-tools/tests/cli-add-workspace-rest-source-emitters.test.ts`
- `bun test packages/wp-typia-project-tools/tests/cli-add-workspace-ai.test.ts`
- `bun run changesets:validate`
- `bun run format:check`
- `bun run typecheck`
- `bun run --filter @wp-typia/project-tools build`
- `bun run lint:repo`
- `git diff --check`

Closes #1028

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved consistency in API request handling between AI and REST features for more reliable behavior across both components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/1038?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->