### PR TITLE
refactor(patterns): split section role validation

### DIFF
--- a/.sampo/changesets/1029-pattern-section-role-validation.md
+++ b/.sampo/changesets/1029-pattern-section-role-validation.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Split pattern catalog section-role marker extraction and content validation into
+a focused runtime module while keeping the public pattern catalog API stable.

--- a/packages/wp-typia-project-tools/src/runtime/pattern-catalog-section-roles.ts
+++ b/packages/wp-typia-project-tools/src/runtime/pattern-catalog-section-roles.ts
@@ -8,6 +8,9 @@ import type {
 	PatternCatalogEntry,
 } from "./pattern-catalog.js";
 
+/**
+ * Validates section role slugs used by pattern manifests and content markers.
+ */
 export const PATTERN_SECTION_ROLE_PATTERN = /^[a-z][a-z0-9-]*$/u;
 
 /**
@@ -52,8 +55,14 @@ export type PatternCatalogSectionRoleMatch = {
 	roles: readonly string[];
 };
 
+/**
+ * Fully resolved section-role marker convention with its compiled class matcher.
+ */
 export type NormalizedPatternCatalogSectionRoleConvention =
 	Required<PatternCatalogSectionRoleConvention> & {
+		/**
+		 * Compiled matcher for role class tokens produced from `roleClassNamePattern`.
+		 */
 		roleClassNamePatternRegExp: RegExp;
 	};
 
@@ -116,6 +125,13 @@ function createRoleClassNamePattern(pattern: string): RegExp {
 	);
 }
 
+/**
+ * Resolve a section-role convention and compile its class-token matcher.
+ *
+ * @param convention Optional marker convention override.
+ * @returns A fully populated convention ready for repeated block traversal.
+ * @throws When `roleClassNamePattern` does not contain exactly one `{role}` placeholder.
+ */
 export function normalizePatternCatalogSectionRoleConvention(
 	convention: PatternCatalogSectionRoleConvention = {},
 ): NormalizedPatternCatalogSectionRoleConvention {
@@ -214,7 +230,7 @@ function collectSectionRoleMatches(
 			`${block.blockName}[${index}]`,
 		];
 		const blockPath = blockPathSegments.join(" > ");
-		const roles = extractPatternSectionRolesFromAttributes(
+		const roles = extractPatternSectionRolesFromNormalizedAttributes(
 			block.attributes,
 			convention,
 		);
@@ -263,6 +279,13 @@ export function extractPatternSectionRolesFromAttributes(
 	convention: PatternCatalogSectionRoleConvention = {},
 ): string[] {
 	const normalized = normalizePatternCatalogSectionRoleConvention(convention);
+	return extractPatternSectionRolesFromNormalizedAttributes(attributes, normalized);
+}
+
+function extractPatternSectionRolesFromNormalizedAttributes(
+	attributes: Record<string, unknown>,
+	normalized: NormalizedPatternCatalogSectionRoleConvention,
+): string[] {
 	const classRoles = getClassNameTokens(attributes)
 		.map((token) => normalized.roleClassNamePatternRegExp.exec(token)?.groups?.role)
 		.filter((role): role is string => typeof role === "string");
@@ -290,6 +313,12 @@ export function extractPatternSectionRoleMatches(
 	);
 }
 
+/**
+ * Build the known valid section-role set from pattern catalog entries.
+ *
+ * @param patterns Catalog entries that may declare a `sectionRole`.
+ * @returns Valid section role slugs declared by the catalog.
+ */
 export function collectKnownPatternSectionRoles(
 	patterns: readonly Pick<PatternCatalogEntry, "sectionRole">[],
 ): ReadonlySet<string> {
@@ -304,6 +333,12 @@ export function collectKnownPatternSectionRoles(
 	);
 }
 
+/**
+ * Validate serialized pattern content against the catalog section-role rules.
+ *
+ * @param options Pattern content, marker convention, known roles, and diagnostic context.
+ * @returns Diagnostics for invalid, missing, mismatched, unknown, or duplicate section-role markers.
+ */
 export function validatePatternContentSectionRoles({
 	content,
 	contentFile,

--- a/packages/wp-typia-project-tools/src/runtime/pattern-catalog-section-roles.ts
+++ b/packages/wp-typia-project-tools/src/runtime/pattern-catalog-section-roles.ts
@@ -1,0 +1,443 @@
+import {
+	type ParsedBlockPatternBlock,
+	validateBlockPatternContentNesting,
+} from "@wp-typia/block-runtime/metadata-core";
+
+import type {
+	PatternCatalogDiagnostic,
+	PatternCatalogEntry,
+} from "./pattern-catalog.js";
+
+export const PATTERN_SECTION_ROLE_PATTERN = /^[a-z][a-z0-9-]*$/u;
+
+/**
+ * Convention used to discover section role markers in serialized pattern
+ * content. Defaults target `core/group` wrappers with a `section` base class,
+ * `section--{role}` role class tokens, and `metadata.sectionRole` attributes.
+ */
+export type PatternCatalogSectionRoleConvention = {
+	/**
+	 * Serialized block name used as the section wrapper. Defaults to
+	 * `core/group`.
+	 */
+	wrapperBlockName?: string;
+	/**
+	 * Optional class that marks a wrapper block as section-like even when the
+	 * role marker is missing. Defaults to `section`.
+	 */
+	baseClassName?: string;
+	/**
+	 * Class token pattern where exactly one `{role}` placeholder is replaced by
+	 * the section role slug. Defaults to `section--{role}`.
+	 */
+	roleClassNamePattern?: string;
+	/**
+	 * Dot-separated block attribute paths that can carry role slugs. Defaults to
+	 * `metadata.sectionRole`.
+	 */
+	roleAttributePaths?: readonly string[];
+	/**
+	 * Warn when a full pattern repeats the same section role marker. Defaults to
+	 * `false`.
+	 */
+	requireUniqueFullPatternRoles?: boolean;
+};
+
+/**
+ * Section wrapper match extracted from a parsed WordPress block tree.
+ */
+export type PatternCatalogSectionRoleMatch = {
+	blockName: string;
+	blockPath: string;
+	roles: readonly string[];
+};
+
+export type NormalizedPatternCatalogSectionRoleConvention =
+	Required<PatternCatalogSectionRoleConvention> & {
+		roleClassNamePatternRegExp: RegExp;
+	};
+
+type LocatedPatternSectionRole = {
+	blockPath: string;
+	role: string;
+};
+
+const DEFAULT_SECTION_ROLE_CONVENTION = {
+	baseClassName: "section",
+	requireUniqueFullPatternRoles: false,
+	roleAttributePaths: ["metadata.sectionRole"],
+	roleClassNamePattern: "section--{role}",
+	wrapperBlockName: "core/group",
+} satisfies Required<PatternCatalogSectionRoleConvention>;
+
+function createPatternCatalogDiagnostic(
+	diagnostic: PatternCatalogDiagnostic,
+): PatternCatalogDiagnostic {
+	return diagnostic;
+}
+
+function normalizeSectionRoleConventionInput(
+	convention: PatternCatalogSectionRoleConvention = {},
+): Required<PatternCatalogSectionRoleConvention> {
+	return {
+		baseClassName:
+			convention.baseClassName ??
+			DEFAULT_SECTION_ROLE_CONVENTION.baseClassName,
+		requireUniqueFullPatternRoles:
+			convention.requireUniqueFullPatternRoles ??
+			DEFAULT_SECTION_ROLE_CONVENTION.requireUniqueFullPatternRoles,
+		roleAttributePaths:
+			convention.roleAttributePaths ??
+			DEFAULT_SECTION_ROLE_CONVENTION.roleAttributePaths,
+		roleClassNamePattern:
+			convention.roleClassNamePattern ??
+			DEFAULT_SECTION_ROLE_CONVENTION.roleClassNamePattern,
+		wrapperBlockName:
+			convention.wrapperBlockName ??
+			DEFAULT_SECTION_ROLE_CONVENTION.wrapperBlockName,
+	};
+}
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+function createRoleClassNamePattern(pattern: string): RegExp {
+	const parts = pattern.split("{role}");
+	if (parts.length !== 2) {
+		throw new Error(
+			`roleClassNamePattern must contain exactly one "{role}" placeholder.`,
+		);
+	}
+
+	return new RegExp(
+		`^${escapeRegExp(parts[0] ?? "")}(?<role>\\S*)${escapeRegExp(parts[1] ?? "")}$`,
+		"u",
+	);
+}
+
+export function normalizePatternCatalogSectionRoleConvention(
+	convention: PatternCatalogSectionRoleConvention = {},
+): NormalizedPatternCatalogSectionRoleConvention {
+	const normalized = normalizeSectionRoleConventionInput(convention);
+	return {
+		...normalized,
+		roleClassNamePatternRegExp: createRoleClassNamePattern(
+			normalized.roleClassNamePattern,
+		),
+	};
+}
+
+function getClassNameTokens(attributes: Record<string, unknown>): string[] {
+	const className = attributes.className;
+	if (typeof className !== "string") {
+		return [];
+	}
+
+	return className.split(/\s+/u).filter((token) => token.length > 0);
+}
+
+function getAttributePathValue(
+	attributes: Record<string, unknown>,
+	pathName: string,
+): unknown {
+	return pathName.split(".").reduce<unknown>((current, segment) => {
+		if (
+			current !== null &&
+			typeof current === "object" &&
+			!Array.isArray(current) &&
+			Object.prototype.hasOwnProperty.call(current, segment)
+		) {
+			return (current as Record<string, unknown>)[segment];
+		}
+
+		return undefined;
+	}, attributes);
+}
+
+function collectStringValues(value: unknown): string[] {
+	if (typeof value === "string") {
+		return [value];
+	}
+	if (Array.isArray(value)) {
+		return value.filter((item): item is string => typeof item === "string");
+	}
+
+	return [];
+}
+
+function uniqueValues(values: readonly string[]): string[] {
+	return [...new Set(values)];
+}
+
+function formatRoleList(roles: readonly string[]): string {
+	if (roles.length === 0) {
+		return "none";
+	}
+
+	return roles.map((role) => `"${role}"`).join(", ");
+}
+
+function formatBlockPaths(paths: readonly string[]): string {
+	return paths.map((blockPath) => `at ${blockPath}`).join(", ");
+}
+
+function describeRoleMarkerConvention(
+	convention: NormalizedPatternCatalogSectionRoleConvention,
+): string {
+	return `${convention.wrapperBlockName} wrappers with class "${convention.roleClassNamePattern}" or attributes ${convention.roleAttributePaths.join(", ")}`;
+}
+
+function isSectionWrapperCandidate(
+	block: ParsedBlockPatternBlock,
+	roles: readonly string[],
+	convention: NormalizedPatternCatalogSectionRoleConvention,
+): boolean {
+	if (block.blockName !== convention.wrapperBlockName) {
+		return false;
+	}
+	if (roles.length > 0) {
+		return true;
+	}
+
+	return getClassNameTokens(block.attributes).includes(convention.baseClassName);
+}
+
+function collectSectionRoleMatches(
+	blocks: readonly ParsedBlockPatternBlock[],
+	convention: NormalizedPatternCatalogSectionRoleConvention,
+	pathSegments: readonly string[] = [],
+): PatternCatalogSectionRoleMatch[] {
+	return blocks.flatMap((block, index) => {
+		const blockPathSegments = [
+			...pathSegments,
+			`${block.blockName}[${index}]`,
+		];
+		const blockPath = blockPathSegments.join(" > ");
+		const roles = extractPatternSectionRolesFromAttributes(
+			block.attributes,
+			convention,
+		);
+		const matches = isSectionWrapperCandidate(block, roles, convention)
+			? [
+					{
+						blockName: block.blockName,
+						blockPath,
+						roles,
+					},
+				]
+			: [];
+
+		return [
+			...matches,
+			...collectSectionRoleMatches(
+				block.innerBlocks,
+				convention,
+				blockPathSegments,
+			),
+		];
+	});
+}
+
+function unescapeSerializedBlockCommentJsonQuotes(content: string): string {
+	return content.replace(/<!--([\s\S]*?)-->/gu, (comment, body: string) => {
+		const source = body.trim();
+		if (!source.startsWith("wp:") && !source.startsWith("/wp:")) {
+			return comment;
+		}
+
+		return `<!--${body.replace(/\\"/gu, '"')}-->`;
+	});
+}
+
+/**
+ * Extract section role slugs from serialized block attributes using the
+ * configured class and metadata marker convention.
+ *
+ * @param attributes Parsed block attributes from serialized pattern content.
+ * @param convention Optional marker convention override.
+ * @returns Unique role marker values in discovery order.
+ */
+export function extractPatternSectionRolesFromAttributes(
+	attributes: Record<string, unknown>,
+	convention: PatternCatalogSectionRoleConvention = {},
+): string[] {
+	const normalized = normalizePatternCatalogSectionRoleConvention(convention);
+	const classRoles = getClassNameTokens(attributes)
+		.map((token) => normalized.roleClassNamePatternRegExp.exec(token)?.groups?.role)
+		.filter((role): role is string => typeof role === "string");
+	const attributeRoles = normalized.roleAttributePaths.flatMap((pathName) =>
+		collectStringValues(getAttributePathValue(attributes, pathName)),
+	);
+
+	return uniqueValues([...classRoles, ...attributeRoles]);
+}
+
+/**
+ * Find section wrapper blocks and their role markers in parsed pattern content.
+ *
+ * @param blocks Parsed block tree returned by `validateBlockPatternContentNesting`.
+ * @param convention Optional marker convention override.
+ * @returns Section wrapper matches with serialized block paths.
+ */
+export function extractPatternSectionRoleMatches(
+	blocks: readonly ParsedBlockPatternBlock[],
+	convention: PatternCatalogSectionRoleConvention = {},
+): PatternCatalogSectionRoleMatch[] {
+	return collectSectionRoleMatches(
+		blocks,
+		normalizePatternCatalogSectionRoleConvention(convention),
+	);
+}
+
+export function collectKnownPatternSectionRoles(
+	patterns: readonly Pick<PatternCatalogEntry, "sectionRole">[],
+): ReadonlySet<string> {
+	return new Set(
+		patterns
+			.map((pattern) => pattern.sectionRole)
+			.filter(
+				(sectionRole): sectionRole is string =>
+					typeof sectionRole === "string" &&
+					PATTERN_SECTION_ROLE_PATTERN.test(sectionRole),
+			),
+	);
+}
+
+export function validatePatternContentSectionRoles({
+	content,
+	contentFile,
+	convention,
+	knownSectionRoles,
+	label,
+	pattern,
+}: {
+	content: string;
+	contentFile: string;
+	convention: NormalizedPatternCatalogSectionRoleConvention;
+	knownSectionRoles: ReadonlySet<string>;
+	label: string;
+	pattern: PatternCatalogEntry;
+}): PatternCatalogDiagnostic[] {
+	const diagnostics: PatternCatalogDiagnostic[] = [];
+	const parsed = validateBlockPatternContentNesting(content, {
+		allowExternalBlockNames: true,
+		nesting: {},
+		patternFile: contentFile,
+	});
+	let matches = collectSectionRoleMatches(parsed.blocks, convention);
+	const unescapedContent = unescapeSerializedBlockCommentJsonQuotes(content);
+	if (unescapedContent !== content) {
+		const unescapedParsed = validateBlockPatternContentNesting(
+			unescapedContent,
+			{
+				allowExternalBlockNames: true,
+				nesting: {},
+				patternFile: contentFile,
+			},
+		);
+		const unescapedMatches = collectSectionRoleMatches(
+			unescapedParsed.blocks,
+			convention,
+		);
+		if (
+			unescapedMatches.some((match) => match.roles.length > 0) ||
+			matches.length === 0
+		) {
+			matches = unescapedMatches;
+		}
+	}
+	const locatedRoles = matches.flatMap<LocatedPatternSectionRole>((match) =>
+		match.roles.map((role) => ({
+			blockPath: match.blockPath,
+			role,
+		})),
+	);
+	const invalidRoles = locatedRoles.filter(
+		({ role }) => !PATTERN_SECTION_ROLE_PATTERN.test(role),
+	);
+	for (const invalidRole of uniqueValues(invalidRoles.map(({ role }) => role))) {
+		const paths = invalidRoles
+			.filter(({ role }) => role === invalidRole)
+			.map(({ blockPath }) => blockPath);
+		diagnostics.push(
+			createPatternCatalogDiagnostic({
+				code: "invalid-pattern-section-role-marker",
+				message: `${label}: section role marker "${invalidRole}" in ${contentFile} must start with a lowercase letter and contain only lowercase letters, numbers, and hyphens (${formatBlockPaths(paths)}).`,
+				patternSlug: pattern.slug,
+				severity: "error",
+			}),
+		);
+	}
+
+	const validLocatedRoles = locatedRoles.filter(({ role }) =>
+		PATTERN_SECTION_ROLE_PATTERN.test(role),
+	);
+	const validRoles = validLocatedRoles.map(({ role }) => role);
+	const uniqueValidRoles = uniqueValues(validRoles);
+	const unknownRoles = uniqueValidRoles.filter(
+		(role) => !knownSectionRoles.has(role),
+	);
+	for (const unknownRole of unknownRoles) {
+		const paths = validLocatedRoles
+			.filter(({ role }) => role === unknownRole)
+			.map(({ blockPath }) => blockPath);
+		diagnostics.push(
+			createPatternCatalogDiagnostic({
+				code: "unknown-pattern-section-role-marker",
+				message: `${label}: section role marker "${unknownRole}" in ${contentFile} is not declared by any PATTERNS sectionRole (${formatBlockPaths(paths)}).`,
+				patternSlug: pattern.slug,
+				severity: "warning",
+			}),
+		);
+	}
+
+	const scope = pattern.scope ?? "full";
+	const expectedSectionRole =
+		typeof pattern.sectionRole === "string" &&
+		PATTERN_SECTION_ROLE_PATTERN.test(pattern.sectionRole)
+			? pattern.sectionRole
+			: undefined;
+	if (scope === "section" && expectedSectionRole) {
+		if (validRoles.length === 0) {
+			diagnostics.push(
+				createPatternCatalogDiagnostic({
+					code: "missing-pattern-section-role-marker",
+					message: `${label}: section-scoped pattern content in ${contentFile} must include section role marker "${expectedSectionRole}" using ${describeRoleMarkerConvention(convention)}.`,
+					patternSlug: pattern.slug,
+					severity: "error",
+				}),
+			);
+		} else if (!validRoles.includes(expectedSectionRole)) {
+			diagnostics.push(
+				createPatternCatalogDiagnostic({
+					code: "mismatched-pattern-section-role",
+					message: `${label}: manifest sectionRole "${expectedSectionRole}" was not found in ${contentFile}; found ${formatRoleList(uniqueValidRoles)}.`,
+					patternSlug: pattern.slug,
+					severity: "error",
+				}),
+			);
+		}
+	}
+
+	if (scope === "full" && convention.requireUniqueFullPatternRoles) {
+		for (const role of uniqueValidRoles) {
+			const paths = validLocatedRoles
+				.filter((locatedRole) => locatedRole.role === role)
+				.map(({ blockPath }) => blockPath);
+			if (paths.length <= 1) {
+				continue;
+			}
+			diagnostics.push(
+				createPatternCatalogDiagnostic({
+					code: "duplicate-pattern-section-role-marker",
+					message: `${label}: full pattern content in ${contentFile} repeats section role marker "${role}" (${formatBlockPaths(paths)}).`,
+					patternSlug: pattern.slug,
+					severity: "warning",
+				}),
+			);
+		}
+	}
+
+	return diagnostics;
+}

--- a/packages/wp-typia-project-tools/src/runtime/pattern-catalog.ts
+++ b/packages/wp-typia-project-tools/src/runtime/pattern-catalog.ts
@@ -2,9 +2,24 @@ import fs from "node:fs";
 import path from "node:path";
 
 import {
-	type ParsedBlockPatternBlock,
-	validateBlockPatternContentNesting,
-} from "@wp-typia/block-runtime/metadata-core";
+	PATTERN_SECTION_ROLE_PATTERN,
+	collectKnownPatternSectionRoles,
+	normalizePatternCatalogSectionRoleConvention,
+	validatePatternContentSectionRoles,
+} from "./pattern-catalog-section-roles.js";
+import type {
+	NormalizedPatternCatalogSectionRoleConvention,
+	PatternCatalogSectionRoleConvention,
+} from "./pattern-catalog-section-roles.js";
+
+export {
+	extractPatternSectionRoleMatches,
+	extractPatternSectionRolesFromAttributes,
+} from "./pattern-catalog-section-roles.js";
+export type {
+	PatternCatalogSectionRoleConvention,
+	PatternCatalogSectionRoleMatch,
+} from "./pattern-catalog-section-roles.js";
 
 export const PATTERN_CATALOG_SCOPE_IDS = ["full", "section"] as const;
 
@@ -48,48 +63,6 @@ export type PatternCatalogDiagnostic = {
 };
 
 /**
- * Convention used to discover section role markers in serialized pattern
- * content. Defaults target `core/group` wrappers with a `section` base class,
- * `section--{role}` role class tokens, and `metadata.sectionRole` attributes.
- */
-export type PatternCatalogSectionRoleConvention = {
-	/**
-	 * Serialized block name used as the section wrapper. Defaults to
-	 * `core/group`.
-	 */
-	wrapperBlockName?: string;
-	/**
-	 * Optional class that marks a wrapper block as section-like even when the
-	 * role marker is missing. Defaults to `section`.
-	 */
-	baseClassName?: string;
-	/**
-	 * Class token pattern where exactly one `{role}` placeholder is replaced by
-	 * the section role slug. Defaults to `section--{role}`.
-	 */
-	roleClassNamePattern?: string;
-	/**
-	 * Dot-separated block attribute paths that can carry role slugs. Defaults to
-	 * `metadata.sectionRole`.
-	 */
-	roleAttributePaths?: readonly string[];
-	/**
-	 * Warn when a full pattern repeats the same section role marker. Defaults to
-	 * `false`.
-	 */
-	requireUniqueFullPatternRoles?: boolean;
-};
-
-/**
- * Section wrapper match extracted from a parsed WordPress block tree.
- */
-export type PatternCatalogSectionRoleMatch = {
-	blockName: string;
-	blockPath: string;
-	roles: readonly string[];
-};
-
-/**
  * Options for validating typed pattern catalog entries and, when `projectDir`
  * is provided, their serialized pattern content. Set `sectionRoleConvention` to
  * `false` to keep file existence checks but opt out of section-role marker
@@ -107,25 +80,8 @@ export type PatternCatalogValidationResult = {
 };
 
 const PATTERN_SLUG_PATTERN = /^[a-z][a-z0-9-]*$/u;
-const PATTERN_SECTION_ROLE_PATTERN = PATTERN_SLUG_PATTERN;
 const PATTERN_TAG_PATTERN = /^[a-z0-9][a-z0-9-]*$/u;
 const PATTERN_CONTENT_FILE_ROOT = "src/patterns/";
-const DEFAULT_SECTION_ROLE_CONVENTION = {
-	baseClassName: "section",
-	requireUniqueFullPatternRoles: false,
-	roleAttributePaths: ["metadata.sectionRole"],
-	roleClassNamePattern: "section--{role}",
-	wrapperBlockName: "core/group",
-} satisfies Required<PatternCatalogSectionRoleConvention>;
-
-type NormalizedPatternCatalogSectionRoleConvention = Required<PatternCatalogSectionRoleConvention> & {
-	roleClassNamePatternRegExp: RegExp;
-};
-
-type LocatedPatternSectionRole = {
-	blockPath: string;
-	role: string;
-};
 
 function createPatternCatalogDiagnostic(
 	diagnostic: PatternCatalogDiagnostic,
@@ -164,220 +120,6 @@ function isPatternContentFilePath(value: string): boolean {
 	);
 }
 
-function normalizeSectionRoleConventionInput(
-	convention: PatternCatalogSectionRoleConvention = {},
-): Required<PatternCatalogSectionRoleConvention> {
-	return {
-		baseClassName:
-			convention.baseClassName ??
-			DEFAULT_SECTION_ROLE_CONVENTION.baseClassName,
-		requireUniqueFullPatternRoles:
-			convention.requireUniqueFullPatternRoles ??
-			DEFAULT_SECTION_ROLE_CONVENTION.requireUniqueFullPatternRoles,
-		roleAttributePaths:
-			convention.roleAttributePaths ??
-			DEFAULT_SECTION_ROLE_CONVENTION.roleAttributePaths,
-		roleClassNamePattern:
-			convention.roleClassNamePattern ??
-			DEFAULT_SECTION_ROLE_CONVENTION.roleClassNamePattern,
-		wrapperBlockName:
-			convention.wrapperBlockName ??
-			DEFAULT_SECTION_ROLE_CONVENTION.wrapperBlockName,
-	};
-}
-
-function escapeRegExp(value: string): string {
-	return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
-}
-
-function createRoleClassNamePattern(pattern: string): RegExp {
-	const parts = pattern.split("{role}");
-	if (parts.length !== 2) {
-		throw new Error(
-			`roleClassNamePattern must contain exactly one "{role}" placeholder.`,
-		);
-	}
-
-	return new RegExp(
-		`^${escapeRegExp(parts[0] ?? "")}(?<role>\\S*)${escapeRegExp(parts[1] ?? "")}$`,
-		"u",
-	);
-}
-
-function normalizeSectionRoleConvention(
-	convention: PatternCatalogSectionRoleConvention = {},
-): NormalizedPatternCatalogSectionRoleConvention {
-	const normalized = normalizeSectionRoleConventionInput(convention);
-	return {
-		...normalized,
-		roleClassNamePatternRegExp: createRoleClassNamePattern(
-			normalized.roleClassNamePattern,
-		),
-	};
-}
-
-function getClassNameTokens(attributes: Record<string, unknown>): string[] {
-	const className = attributes.className;
-	if (typeof className !== "string") {
-		return [];
-	}
-
-	return className.split(/\s+/u).filter((token) => token.length > 0);
-}
-
-function getAttributePathValue(
-	attributes: Record<string, unknown>,
-	pathName: string,
-): unknown {
-	return pathName.split(".").reduce<unknown>((current, segment) => {
-		if (
-			current !== null &&
-			typeof current === "object" &&
-			!Array.isArray(current) &&
-			Object.prototype.hasOwnProperty.call(current, segment)
-		) {
-			return (current as Record<string, unknown>)[segment];
-		}
-
-		return undefined;
-	}, attributes);
-}
-
-function collectStringValues(value: unknown): string[] {
-	if (typeof value === "string") {
-		return [value];
-	}
-	if (Array.isArray(value)) {
-		return value.filter((item): item is string => typeof item === "string");
-	}
-
-	return [];
-}
-
-function uniqueValues(values: readonly string[]): string[] {
-	return [...new Set(values)];
-}
-
-function formatRoleList(roles: readonly string[]): string {
-	if (roles.length === 0) {
-		return "none";
-	}
-
-	return roles.map((role) => `"${role}"`).join(", ");
-}
-
-function formatBlockPaths(paths: readonly string[]): string {
-	return paths.map((blockPath) => `at ${blockPath}`).join(", ");
-}
-
-function describeRoleMarkerConvention(
-	convention: NormalizedPatternCatalogSectionRoleConvention,
-): string {
-	return `${convention.wrapperBlockName} wrappers with class "${convention.roleClassNamePattern}" or attributes ${convention.roleAttributePaths.join(", ")}`;
-}
-
-function isSectionWrapperCandidate(
-	block: ParsedBlockPatternBlock,
-	roles: readonly string[],
-	convention: NormalizedPatternCatalogSectionRoleConvention,
-): boolean {
-	if (block.blockName !== convention.wrapperBlockName) {
-		return false;
-	}
-	if (roles.length > 0) {
-		return true;
-	}
-
-	return getClassNameTokens(block.attributes).includes(convention.baseClassName);
-}
-
-function collectSectionRoleMatches(
-	blocks: readonly ParsedBlockPatternBlock[],
-	convention: NormalizedPatternCatalogSectionRoleConvention,
-	pathSegments: readonly string[] = [],
-): PatternCatalogSectionRoleMatch[] {
-	return blocks.flatMap((block, index) => {
-		const blockPathSegments = [
-			...pathSegments,
-			`${block.blockName}[${index}]`,
-		];
-		const blockPath = blockPathSegments.join(" > ");
-		const roles = extractPatternSectionRolesFromAttributes(
-			block.attributes,
-			convention,
-		);
-		const matches = isSectionWrapperCandidate(block, roles, convention)
-			? [
-					{
-						blockName: block.blockName,
-						blockPath,
-						roles,
-					},
-				]
-			: [];
-
-		return [
-			...matches,
-			...collectSectionRoleMatches(
-				block.innerBlocks,
-				convention,
-				blockPathSegments,
-			),
-		];
-	});
-}
-
-function unescapeSerializedBlockCommentJsonQuotes(content: string): string {
-	return content.replace(/<!--([\s\S]*?)-->/gu, (comment, body: string) => {
-		const source = body.trim();
-		if (!source.startsWith("wp:") && !source.startsWith("/wp:")) {
-			return comment;
-		}
-
-		return `<!--${body.replace(/\\"/gu, '"')}-->`;
-	});
-}
-
-/**
- * Extract section role slugs from serialized block attributes using the
- * configured class and metadata marker convention.
- *
- * @param attributes Parsed block attributes from serialized pattern content.
- * @param convention Optional marker convention override.
- * @returns Unique role marker values in discovery order.
- */
-export function extractPatternSectionRolesFromAttributes(
-	attributes: Record<string, unknown>,
-	convention: PatternCatalogSectionRoleConvention = {},
-): string[] {
-	const normalized = normalizeSectionRoleConvention(convention);
-	const classRoles = getClassNameTokens(attributes)
-		.map((token) => normalized.roleClassNamePatternRegExp.exec(token)?.groups?.role)
-		.filter((role): role is string => typeof role === "string");
-	const attributeRoles = normalized.roleAttributePaths.flatMap((pathName) =>
-		collectStringValues(getAttributePathValue(attributes, pathName)),
-	);
-
-	return uniqueValues([...classRoles, ...attributeRoles]);
-}
-
-/**
- * Find section wrapper blocks and their role markers in parsed pattern content.
- *
- * @param blocks Parsed block tree returned by `validateBlockPatternContentNesting`.
- * @param convention Optional marker convention override.
- * @returns Section wrapper matches with serialized block paths.
- */
-export function extractPatternSectionRoleMatches(
-	blocks: readonly ParsedBlockPatternBlock[],
-	convention: PatternCatalogSectionRoleConvention = {},
-): PatternCatalogSectionRoleMatch[] {
-	return collectSectionRoleMatches(
-		blocks,
-		normalizeSectionRoleConvention(convention),
-	);
-}
-
 /**
  * Validate pattern thumbnail references with the same URL/path rules used by
  * catalog diagnostics and `wp-typia add pattern`.
@@ -403,158 +145,6 @@ export function resolvePatternCatalogContentFile(
 	return pattern.contentFile ?? pattern.file;
 }
 
-function createKnownSectionRoleSet(
-	patterns: readonly PatternCatalogEntry[],
-): ReadonlySet<string> {
-	return new Set(
-		patterns
-			.map((pattern) => pattern.sectionRole)
-			.filter(
-				(sectionRole): sectionRole is string =>
-					typeof sectionRole === "string" &&
-					PATTERN_SECTION_ROLE_PATTERN.test(sectionRole),
-			),
-	);
-}
-
-function validatePatternContentSectionRoles({
-	content,
-	contentFile,
-	convention,
-	knownSectionRoles,
-	label,
-	pattern,
-}: {
-	content: string;
-	contentFile: string;
-	convention: NormalizedPatternCatalogSectionRoleConvention;
-	knownSectionRoles: ReadonlySet<string>;
-	label: string;
-	pattern: PatternCatalogEntry;
-}): PatternCatalogDiagnostic[] {
-	const diagnostics: PatternCatalogDiagnostic[] = [];
-	const parsed = validateBlockPatternContentNesting(content, {
-		allowExternalBlockNames: true,
-		nesting: {},
-		patternFile: contentFile,
-	});
-	let matches = collectSectionRoleMatches(parsed.blocks, convention);
-	const unescapedContent = unescapeSerializedBlockCommentJsonQuotes(content);
-	if (unescapedContent !== content) {
-		const unescapedParsed = validateBlockPatternContentNesting(
-			unescapedContent,
-			{
-				allowExternalBlockNames: true,
-				nesting: {},
-				patternFile: contentFile,
-			},
-		);
-		const unescapedMatches = collectSectionRoleMatches(
-			unescapedParsed.blocks,
-			convention,
-		);
-		if (
-			unescapedMatches.some((match) => match.roles.length > 0) ||
-			matches.length === 0
-		) {
-			matches = unescapedMatches;
-		}
-	}
-	const locatedRoles = matches.flatMap<LocatedPatternSectionRole>((match) =>
-		match.roles.map((role) => ({
-			blockPath: match.blockPath,
-			role,
-		})),
-	);
-	const invalidRoles = locatedRoles.filter(
-		({ role }) => !PATTERN_SECTION_ROLE_PATTERN.test(role),
-	);
-	for (const invalidRole of uniqueValues(invalidRoles.map(({ role }) => role))) {
-		const paths = invalidRoles
-			.filter(({ role }) => role === invalidRole)
-			.map(({ blockPath }) => blockPath);
-		diagnostics.push(
-			createPatternCatalogDiagnostic({
-				code: "invalid-pattern-section-role-marker",
-				message: `${label}: section role marker "${invalidRole}" in ${contentFile} must start with a lowercase letter and contain only lowercase letters, numbers, and hyphens (${formatBlockPaths(paths)}).`,
-				patternSlug: pattern.slug,
-				severity: "error",
-			}),
-		);
-	}
-
-	const validLocatedRoles = locatedRoles.filter(({ role }) =>
-		PATTERN_SECTION_ROLE_PATTERN.test(role),
-	);
-	const validRoles = validLocatedRoles.map(({ role }) => role);
-	const uniqueValidRoles = uniqueValues(validRoles);
-	const unknownRoles = uniqueValidRoles.filter(
-		(role) => !knownSectionRoles.has(role),
-	);
-	for (const unknownRole of unknownRoles) {
-		const paths = validLocatedRoles
-			.filter(({ role }) => role === unknownRole)
-			.map(({ blockPath }) => blockPath);
-		diagnostics.push(
-			createPatternCatalogDiagnostic({
-				code: "unknown-pattern-section-role-marker",
-				message: `${label}: section role marker "${unknownRole}" in ${contentFile} is not declared by any PATTERNS sectionRole (${formatBlockPaths(paths)}).`,
-				patternSlug: pattern.slug,
-				severity: "warning",
-			}),
-		);
-	}
-
-	const scope = pattern.scope ?? "full";
-	const expectedSectionRole =
-		typeof pattern.sectionRole === "string" &&
-		PATTERN_SECTION_ROLE_PATTERN.test(pattern.sectionRole)
-			? pattern.sectionRole
-			: undefined;
-	if (scope === "section" && expectedSectionRole) {
-		if (validRoles.length === 0) {
-			diagnostics.push(
-				createPatternCatalogDiagnostic({
-					code: "missing-pattern-section-role-marker",
-					message: `${label}: section-scoped pattern content in ${contentFile} must include section role marker "${expectedSectionRole}" using ${describeRoleMarkerConvention(convention)}.`,
-					patternSlug: pattern.slug,
-					severity: "error",
-				}),
-			);
-		} else if (!validRoles.includes(expectedSectionRole)) {
-			diagnostics.push(
-				createPatternCatalogDiagnostic({
-					code: "mismatched-pattern-section-role",
-					message: `${label}: manifest sectionRole "${expectedSectionRole}" was not found in ${contentFile}; found ${formatRoleList(uniqueValidRoles)}.`,
-					patternSlug: pattern.slug,
-					severity: "error",
-				}),
-			);
-		}
-	}
-
-	if (scope === "full" && convention.requireUniqueFullPatternRoles) {
-		for (const role of uniqueValidRoles) {
-			const paths = validLocatedRoles
-				.filter((locatedRole) => locatedRole.role === role)
-				.map(({ blockPath }) => blockPath);
-			if (paths.length <= 1) {
-				continue;
-			}
-			diagnostics.push(
-				createPatternCatalogDiagnostic({
-					code: "duplicate-pattern-section-role-marker",
-					message: `${label}: full pattern content in ${contentFile} repeats section role marker "${role}" (${formatBlockPaths(paths)}).`,
-					patternSlug: pattern.slug,
-					severity: "warning",
-				}),
-			);
-		}
-	}
-
-	return diagnostics;
-}
-
 /**
  * Validate typed pattern catalog metadata declared in `scripts/block-config.ts`.
  *
@@ -577,7 +167,7 @@ export function validatePatternCatalog(
 		null;
 	if (options.sectionRoleConvention !== false) {
 		try {
-			sectionRoleConvention = normalizeSectionRoleConvention(
+			sectionRoleConvention = normalizePatternCatalogSectionRoleConvention(
 				options.sectionRoleConvention,
 			);
 		} catch (error) {
@@ -592,7 +182,7 @@ export function validatePatternCatalog(
 			);
 		}
 	}
-	const knownSectionRoles = createKnownSectionRoleSet(patterns);
+	const knownSectionRoles = collectKnownPatternSectionRoles(patterns);
 
 	for (const [index, pattern] of patterns.entries()) {
 		const label = pattern.slug || `PATTERNS[${index}]`;

--- a/packages/wp-typia-project-tools/tests/pattern-catalog.test.ts
+++ b/packages/wp-typia-project-tools/tests/pattern-catalog.test.ts
@@ -12,6 +12,27 @@ import {
 } from "../src/runtime/pattern-catalog.js";
 
 describe("pattern catalog validation", () => {
+	test("keeps section role content validation in a focused runtime module", () => {
+		const runtimeRoot = path.join(import.meta.dir, "..", "src", "runtime");
+		const catalogSource = fs.readFileSync(
+			path.join(runtimeRoot, "pattern-catalog.ts"),
+			"utf8",
+		);
+		const sectionRolesSource = fs.readFileSync(
+			path.join(runtimeRoot, "pattern-catalog-section-roles.ts"),
+			"utf8",
+		);
+
+		expect(catalogSource).toContain(
+			'from "./pattern-catalog-section-roles.js"',
+		);
+		expect(catalogSource).not.toContain("validateBlockPatternContentNesting");
+		expect(sectionRolesSource).toContain("validateBlockPatternContentNesting");
+		expect(sectionRolesSource).toContain(
+			"export function validatePatternContentSectionRoles",
+		);
+	});
+
 	test("accepts a typed full and section pattern catalog", () => {
 		const projectDir = fs.mkdtempSync(
 			path.join(os.tmpdir(), "wp-typia-pattern-catalog-"),


### PR DESCRIPTION
## Summary
- move section-role convention normalization, marker extraction, and pattern content diagnostics into `pattern-catalog-section-roles`
- keep the existing `pattern-catalog` public exports compatible through re-exports
- add a boundary regression test and a project-tools patch changeset

## Validation
- `bun test packages/wp-typia-project-tools/tests/pattern-catalog.test.ts`
- `bun run typecheck`
- `bun run changesets:validate`
- `bun run format:check`
- `bun run runtime-coupling:validate`
- `bun run --filter @wp-typia/project-tools build`
- `bun run lint:repo`
- `git diff --check`
- `bun run --filter @wp-typia/project-tools test`

Closes #1029

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code organization by consolidating pattern catalog section-role validation into a dedicated focused module while maintaining the same public API stability.

* **Tests**
  * Added test coverage to verify proper module separation of pattern validation logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/1039?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->