### PR TITLE
feat(patterns): support repeatable tag flags

### DIFF
--- a/.sampo/changesets/1031-repeatable-pattern-tags.md
+++ b/.sampo/changesets/1031-repeatable-pattern-tags.md
@@ -1,0 +1,7 @@
+---
+npm/wp-typia: patch
+npm/@wp-typia/project-tools: patch
+---
+
+Support repeatable `--tag` and `--tags` flags for pattern scaffolds while
+preserving existing comma-separated tag input and normalized manifest output.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-help.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-help.ts
@@ -23,7 +23,7 @@ export function formatAddHelpText(): string {
 	wp-typia add variation <name> --block <block-slug> [--dry-run]
 	wp-typia add style <name> --block <block-slug> [--dry-run]
 	wp-typia add transform <name> --from <namespace/block> --to <block-slug|namespace/block-slug> [--dry-run]
-  wp-typia add pattern <name> [--scope <full|section>] [--section-role <role>] [--tags <tag,...>] [--thumbnail-url <url>] [--dry-run]
+  wp-typia add pattern <name> [--scope <full|section>] [--section-role <role>] [--tags <tag,...>|--tag <tag>...] [--thumbnail-url <url>] [--dry-run]
   wp-typia add binding-source <name> [--block <block-slug|namespace/block-slug> --attribute <attribute>] [--from-post-meta|--post-meta <post-meta> [--meta-path <field>]] [--dry-run]
   wp-typia add contract <name> [--type <ExportedTypeName>] [--dry-run]
   wp-typia add rest-resource <name> [--namespace <vendor/v1>] [--methods <${REST_RESOURCE_METHOD_IDS.join(",")}>] [--route-pattern <route-pattern>] [--permission-callback <callback>] [--controller-class <ClassName>] [--controller-extends <BaseClass>] [--dry-run]
@@ -50,7 +50,7 @@ Notes:
   \`add variation\` targets an existing block slug from \`scripts/block-config.ts\`.
   \`add style\` registers a Block Styles option for an existing generated block.
   \`add transform\` adds a block-to-block transform into an existing generated block.
-  \`add pattern\` scaffolds a namespaced PHP pattern shell under \`src/patterns/full/\` or \`src/patterns/sections/\` and records typed catalog metadata in \`PATTERNS\`.
+  \`add pattern\` scaffolds a namespaced PHP pattern shell under \`src/patterns/full/\` or \`src/patterns/sections/\` and records typed catalog metadata in \`PATTERNS\`; pass \`--tags hero,landing\` or repeat \`--tag hero --tag landing\` to set catalog tags.
   \`add binding-source\` scaffolds shared PHP and editor registration under \`src/bindings/\`; pass \`--block\` and \`--attribute\` together to declare an end-to-end bindable attribute on an existing generated block. Pass \`--from-post-meta\` or \`--post-meta\` to generate a source backed by a typed post-meta contract; \`--meta-path\` selects one top-level field as the default binding arg.
   \`add contract\` registers a standalone TypeScript wire contract under \`src/contracts/\` and generates a stable JSON Schema artifact without creating PHP route glue.
   \`add rest-resource\` scaffolds plugin-level TypeScript REST contracts under \`src/rest/\` and PHP route glue under \`inc/rest/\`. Use \`--route-pattern\`, \`--permission-callback\`, \`--controller-class\`, and \`--controller-extends\` when an existing WordPress controller or permission model needs to own part of the generated route surface.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-pattern-options.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-pattern-options.ts
@@ -106,7 +106,7 @@ function normalizePatternTags(tags: readonly string[] | string | undefined): str
 		typeof tags === "string"
 			? tags.split(",")
 			: Array.isArray(tags)
-				? [...tags]
+				? tags.flatMap((tag) => tag.split(","))
 				: [];
 	const normalizedTags = rawTags
 		.map((tag) => normalizeBlockSlug(tag))

--- a/packages/wp-typia-project-tools/src/runtime/cli-help.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-help.ts
@@ -28,7 +28,7 @@ export function formatHelpText(): string {
   wp-typia add variation <name> --block <block-slug>
   wp-typia add style <name> --block <block-slug>
   wp-typia add transform <name> --from <namespace/block> --to <block-slug|namespace/block-slug>
-  wp-typia add pattern <name> [--scope <full|section>] [--section-role <role>] [--tags <tag,...>] [--thumbnail-url <url>]
+  wp-typia add pattern <name> [--scope <full|section>] [--section-role <role>] [--tags <tag,...>|--tag <tag>...] [--thumbnail-url <url>]
   wp-typia add binding-source <name> [--block <block-slug|namespace/block-slug> --attribute <attribute>] [--from-post-meta|--post-meta <post-meta> [--meta-path <field>]]
   wp-typia add rest-resource <name> [--namespace <vendor/v1>] [--methods <method[,method...]>]
   wp-typia add rest-resource <name> --manual [--namespace <vendor/v1>] [--method <GET|POST|PUT|PATCH|DELETE>] [--auth <public|authenticated|public-write-protected>] [--path <route-pattern>|--route-pattern <route-pattern>] [--permission-callback <callback>] [--controller-class <ClassName>] [--controller-extends <BaseClass>] [--query-type <Type>] [--body-type <Type>] [--response-type <Type>] [--secret-field <field>] [--secret-state-field|--secret-has-value-field <field>] [--secret-preserve-on-empty <true|false>]
@@ -68,7 +68,7 @@ Notes:
   \`add variation\` uses an existing workspace block from \`scripts/block-config.ts\`.
   \`add style\` registers a Block Styles option for an existing generated block.
   \`add transform\` adds a block-to-block transform into an existing generated block.
-  \`add pattern\` scaffolds a namespaced PHP pattern shell under \`src/patterns/full/\` or \`src/patterns/sections/\`.
+  \`add pattern\` scaffolds a namespaced PHP pattern shell under \`src/patterns/full/\` or \`src/patterns/sections/\`; pass \`--tags hero,landing\` or repeat \`--tag hero --tag landing\` to set catalog tags.
   \`add binding-source\` scaffolds shared PHP and editor registration under \`src/bindings/\`; pass \`--block\` and \`--attribute\` together to declare a bindable generated-block attribute. Pass \`--from-post-meta\` or \`--post-meta\` to back the source from a typed post-meta contract and \`--meta-path\` to choose its default top-level field.
   \`add rest-resource\` scaffolds plugin-level TypeScript REST contracts under \`src/rest/\` and PHP route glue under \`inc/rest/\`.
   \`add rest-resource --manual\` tracks an external/provider REST route with typed schemas, OpenAPI, clients, and drift checks without generating PHP route/controller files while still allowing route-owner metadata such as permission callbacks and controller classes. Settings contracts can add \`--secret-field\` plus \`--secret-preserve-on-empty\` to model write-only credentials and preserve blank submissions.

--- a/packages/wp-typia-project-tools/tests/workspace-add.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-add.test.ts
@@ -3224,6 +3224,34 @@ test("canonical CLI can add a pattern to an official workspace template", async 
   expect(patternSource).toContain("<!-- wp:group");
   expect(patternSource).toContain('"className":"section section--hero"');
 
+  runCli(
+    "node",
+    [
+      entryPath,
+      "add",
+      "pattern",
+      "gallery-grid",
+      "--tags",
+      "gallery,landing",
+      "--tag",
+      "hero",
+      "--tag",
+      "gallery",
+    ],
+    {
+      cwd: targetDir,
+    }
+  );
+
+  const updatedBlockConfigSource = fs.readFileSync(
+    path.join(targetDir, "scripts", "block-config.ts"),
+    "utf8"
+  );
+  expect(updatedBlockConfigSource).toContain('slug: "gallery-grid"');
+  expect(updatedBlockConfigSource).toContain(
+    'tags: ["gallery", "hero", "landing"]'
+  );
+
   const doctorOutput = runCli("node", [entryPath, "doctor", "--format", "json"], {
     cwd: targetDir,
   });

--- a/packages/wp-typia/bin/routing-metadata.generated.js
+++ b/packages/wp-typia/bin/routing-metadata.generated.js
@@ -64,6 +64,7 @@ export const longValueOptions = Object.freeze([
   '--service',
   '--slot',
   '--source',
+  '--tag',
   '--tags',
   '--template',
   '--text-domain',

--- a/packages/wp-typia/src/add-kinds/pattern.ts
+++ b/packages/wp-typia/src/add-kinds/pattern.ts
@@ -26,6 +26,7 @@ export const patternAddKindEntry =
     hiddenStringSubmitFields: [
       'scope',
       'section-role',
+      'tag',
       'tags',
       'thumbnail-url',
     ],
@@ -41,7 +42,7 @@ export const patternAddKindEntry =
           ? context.flags['section-role']
           : undefined;
       const tags =
-        typeof context.flags.tags === 'string' ? context.flags.tags : undefined;
+        normalizePatternTagFlags(context.flags.tags, context.flags.tag);
       const thumbnailUrl =
         typeof context.flags['thumbnail-url'] === 'string'
           ? context.flags['thumbnail-url']
@@ -69,6 +70,33 @@ export const patternAddKindEntry =
     sortOrder: 60,
     supportsDryRun: true,
     usage:
-      'wp-typia add pattern <name> [--scope <full|section>] [--section-role <role>] [--tags <tag,...>] [--thumbnail-url <url>] [--dry-run]',
+      'wp-typia add pattern <name> [--scope <full|section>] [--section-role <role>] [--tags <tag,...>|--tag <tag>...] [--thumbnail-url <url>] [--dry-run]',
     visibleFieldNames: () => NAME_ONLY_VISIBLE_FIELDS,
   });
+
+function collectStringFlagValues(value: unknown): string[] {
+  if (typeof value === 'string') {
+    return [value];
+  }
+  if (Array.isArray(value)) {
+    return value.filter((item): item is string => typeof item === 'string');
+  }
+  return [];
+}
+
+function normalizePatternTagFlags(
+  tagsFlag: unknown,
+  tagFlag: unknown,
+): string[] | string | undefined {
+  const tags = [
+    ...collectStringFlagValues(tagsFlag),
+    ...collectStringFlagValues(tagFlag),
+  ];
+  if (tags.length === 0) {
+    return undefined;
+  }
+  if (tags.length === 1) {
+    return tags[0];
+  }
+  return tags;
+}

--- a/packages/wp-typia/src/command-option-metadata.ts
+++ b/packages/wp-typia/src/command-option-metadata.ts
@@ -89,7 +89,8 @@ export function buildCommandOptions<TOptions extends CommandOptionMetadataMap>(
   {
     argumentKind?: 'flag';
     description: string;
-    schema: z.ZodDefault<z.ZodBoolean> | z.ZodOptional<z.ZodString>;
+    repeatable?: boolean;
+    schema: z.ZodTypeAny;
     short?: string;
   }
 > {
@@ -99,10 +100,13 @@ export function buildCommandOptions<TOptions extends CommandOptionMetadataMap>(
       {
         ...(option.argumentKind ? { argumentKind: option.argumentKind } : {}),
         description: option.description,
+        ...(option.repeatable ? { repeatable: true } : {}),
         schema:
           option.type === 'boolean'
             ? z.boolean().default(false)
-            : z.string().optional(),
+            : option.repeatable
+              ? z.union([z.string(), z.array(z.string())]).optional()
+              : z.string().optional(),
         ...(option.short ? { short: option.short } : {}),
       },
     ]),
@@ -143,6 +147,11 @@ export function buildCommandOptionParser(
 
   return {
     booleanOptionNames: new Set(collectOptionNamesByType(metadata, 'boolean')),
+    repeatableOptionNames: new Set(
+      Object.entries(metadata)
+        .filter(([, option]) => option.repeatable)
+        .map(([name]) => name),
+    ),
     shortFlagMap: new Map<string, ShortOptionDescriptor>(
       Object.entries(metadata).flatMap(([name, option]) =>
         option.short
@@ -152,6 +161,27 @@ export function buildCommandOptionParser(
     ),
     stringOptionNames: new Set(collectOptionNamesByType(metadata, 'string')),
   };
+}
+
+function assignParsedOptionValue(
+  flags: Record<string, unknown>,
+  options: {
+    name: string;
+    parser: CommandOptionParser;
+    value: string | boolean;
+  },
+): void {
+  if (!options.parser.repeatableOptionNames.has(options.name)) {
+    flags[options.name] = options.value;
+    return;
+  }
+
+  const current = flags[options.name];
+  flags[options.name] = Array.isArray(current)
+    ? [...current, options.value]
+    : current === undefined
+      ? [options.value]
+      : [current, options.value];
 }
 
 export function buildArgvWalkerRoutingMetadata(
@@ -234,7 +264,11 @@ export function extractKnownOptionValuesFromArgv(
       if (!next || next.startsWith('-')) {
         throw createMissingOptionValueError(arg);
       }
-      flags[shortFlag.name] = next;
+      assignParsedOptionValue(flags, {
+        name: shortFlag.name,
+        parser: options.parser,
+        value: next,
+      });
       index += 1;
       continue;
     }
@@ -262,14 +296,22 @@ export function extractKnownOptionValuesFromArgv(
         if (!inlineValue) {
           throw createMissingOptionValueError(`--${rawName}`);
         }
-        flags[rawName] = inlineValue;
+        assignParsedOptionValue(flags, {
+          name: rawName,
+          parser: options.parser,
+          value: inlineValue,
+        });
         continue;
       }
       const next = argv[index + 1];
       if (!next || next.startsWith('-')) {
         throw createMissingOptionValueError(`--${rawName}`);
       }
-      flags[rawName] = next;
+      assignParsedOptionValue(flags, {
+        name: rawName,
+        parser: options.parser,
+        value: next,
+      });
       index += 1;
       continue;
     }
@@ -322,7 +364,11 @@ export function parseCommandArgvWithMetadata(
       if (!next || next.startsWith('-')) {
         throw createMissingOptionValueError(arg);
       }
-      flags[shortFlag.name] = next;
+      assignParsedOptionValue(flags, {
+        name: shortFlag.name,
+        parser: options.parser,
+        value: next,
+      });
       index += 1;
       continue;
     }
@@ -345,14 +391,22 @@ export function parseCommandArgvWithMetadata(
         if (!inlineValue) {
           throw createMissingOptionValueError(`--${rawName}`);
         }
-        flags[rawName] = inlineValue;
+        assignParsedOptionValue(flags, {
+          name: rawName,
+          parser: options.parser,
+          value: inlineValue,
+        });
         continue;
       }
       const next = argv[index + 1];
       if (!next || next.startsWith('-')) {
         throw createMissingOptionValueError(`--${rawName}`);
       }
-      flags[rawName] = next;
+      assignParsedOptionValue(flags, {
+        name: rawName,
+        parser: options.parser,
+        value: next,
+      });
       index += 1;
       continue;
     }
@@ -394,6 +448,14 @@ export function resolveCommandOptionValues<
     const value = options.flags?.[name] ?? options.defaults?.[name];
     if (descriptor.type === 'boolean') {
       resolved[name] = Boolean(value ?? false);
+      continue;
+    }
+
+    if (descriptor.repeatable && Array.isArray(value)) {
+      resolved[name] =
+        value.every((item): item is string => typeof item === 'string')
+          ? value.join(',')
+          : undefined;
       continue;
     }
 

--- a/packages/wp-typia/src/command-options/add.ts
+++ b/packages/wp-typia/src/command-options/add.ts
@@ -219,7 +219,14 @@ export const ADD_OPTION_METADATA = {
   },
   tags: {
     description:
-      'Comma-separated tags for typed pattern catalog entries.',
+      'Comma-separated tags for typed pattern catalog entries; may be repeated.',
+    repeatable: true,
+    type: 'string',
+  },
+  tag: {
+    description:
+      'Repeatable singular tag for typed pattern catalog entries.',
+    repeatable: true,
     type: 'string',
   },
   type: {

--- a/packages/wp-typia/src/command-options/types.ts
+++ b/packages/wp-typia/src/command-options/types.ts
@@ -1,6 +1,7 @@
 export type CommandOptionMetadata = {
   argumentKind?: 'flag';
   description: string;
+  repeatable?: boolean;
   short?: string;
   type: 'boolean' | 'string';
 };
@@ -19,6 +20,7 @@ export type ShortOptionDescriptor = {
 
 export type CommandOptionParser = {
   booleanOptionNames: Set<string>;
+  repeatableOptionNames: Set<string>;
   shortFlagMap: Map<string, ShortOptionDescriptor>;
   stringOptionNames: Set<string>;
 };

--- a/packages/wp-typia/src/ui/add-flow-model.ts
+++ b/packages/wp-typia/src/ui/add-flow-model.ts
@@ -64,6 +64,7 @@ export const addFlowSchema = z.object({
   'secret-state-field': z.string().optional(),
   slot: z.string().optional(),
   source: z.string().optional(),
+  tag: z.string().optional(),
   tags: z.string().optional(),
   template: z.string().optional(),
   'thumbnail-url': z.string().optional(),

--- a/packages/wp-typia/tests/add-kind-registry.test.ts
+++ b/packages/wp-typia/tests/add-kind-registry.test.ts
@@ -270,6 +270,52 @@ test('passes typed pattern catalog flags to the runtime', async () => {
   });
 });
 
+test('passes repeatable pattern tag flags to the runtime', async () => {
+  const capturedOptions: Record<string, unknown>[] = [];
+  const plan = await ADD_KIND_REGISTRY.pattern.prepareExecution({
+    addRuntime: {
+      runAddPatternCommand: async (options: Record<string, unknown>) => {
+        capturedOptions.push(options);
+
+        return {
+          contentFile: 'src/patterns/full/hero-photo.php',
+          patternScope: 'full',
+          patternSlug: String(options.patternName),
+          projectDir: String(options.cwd),
+          tags: Array.isArray(options.tags)
+            ? options.tags.map(String)
+            : String(options.tags).split(','),
+          title: 'Hero Photo',
+        };
+      },
+    } as unknown as AddKindExecutionContext['addRuntime'],
+    cwd: '/tmp/wp-typia-pattern-repeatable-test',
+    flags: {
+      tag: ['featured', 'landing'],
+      tags: ['hero,landing', 'gallery'],
+    },
+    getOrCreatePrompt: async () => {
+      throw new Error('pattern add-kind should not prompt in this test');
+    },
+    isInteractiveSession: false,
+    name: 'hero-photo',
+    warnLine: () => {},
+  });
+
+  await plan.execute('/tmp/wp-typia-pattern-repeatable-test');
+
+  expect(capturedOptions).toEqual([
+    {
+      cwd: '/tmp/wp-typia-pattern-repeatable-test',
+      patternName: 'hero-photo',
+      patternScope: undefined,
+      sectionRole: undefined,
+      tags: ['hero,landing', 'gallery', 'featured', 'landing'],
+      thumbnailUrl: undefined,
+    },
+  ]);
+});
+
 async function captureRestResourceRuntimeOptions(
   flags: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {

--- a/packages/wp-typia/tests/command-option-metadata.test.ts
+++ b/packages/wp-typia/tests/command-option-metadata.test.ts
@@ -234,6 +234,35 @@ describe('command option metadata helpers', () => {
     expect(parsed.positionals).toEqual(['transform', 'quote-to-counter']);
   });
 
+  test('accumulates repeatable pattern tag flags from shared add metadata', () => {
+    const parsed = parseCommandArgvWithMetadata(
+      [
+        'pattern',
+        'hero-photo',
+        '--tags',
+        'hero,landing',
+        '--tag',
+        'featured',
+        '--tag=hero',
+        '--tags',
+        'gallery',
+      ],
+      {
+        extraBooleanOptionNames: ['help', 'version'],
+        parser: buildCommandOptionParser(
+          GLOBAL_OPTION_METADATA,
+          ADD_OPTION_METADATA,
+        ),
+      },
+    );
+
+    expect(parsed.flags).toEqual({
+      tag: ['featured', 'hero'],
+      tags: ['hero,landing', 'gallery'],
+    });
+    expect(parsed.positionals).toEqual(['pattern', 'hero-photo']);
+  });
+
   test('parses manual REST secret flags from shared add metadata', () => {
     const parsed = parseCommandArgvWithMetadata(
       [

--- a/packages/wp-typia/tests/tui-interaction-models.test.ts
+++ b/packages/wp-typia/tests/tui-interaction-models.test.ts
@@ -246,6 +246,20 @@ describe("first-party TUI interaction models", () => {
 
 		expect(
 			sanitizeAddSubmitValues({
+				kind: "pattern",
+				name: "hero-photo",
+				tag: " hero ",
+				tags: " landing,featured ",
+			}),
+		).toEqual({
+			kind: "pattern",
+			name: "hero-photo",
+			tag: "hero",
+			tags: "landing,featured",
+		});
+
+		expect(
+			sanitizeAddSubmitValues({
 				anchor: "",
 				block: "",
 				kind: "admin-view",


### PR DESCRIPTION
## Summary
- add repeatable `--tag` and repeatable `--tags` support to the shared CLI option metadata/parser
- preserve comma-separated `--tags` behavior while normalizing mixed/repeated inputs into sorted unique pattern tags
- document both accepted help forms and cover parser, registry, and workspace CLI behavior

## Validation
- bun test packages/wp-typia/tests/command-option-metadata.test.ts packages/wp-typia/tests/add-kind-registry.test.ts
- bun test packages/wp-typia-project-tools/tests/workspace-add.test.ts --test-name-pattern "canonical CLI can add a pattern"
- bun run typecheck
- bun run lint:repo
- bun run format:check
- bun run changesets:validate
- bun run --filter wp-typia validate:routing
- bun run --filter wp-typia test
- git diff --check

Closes #1031

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for repeatable `--tag` flags when adding patterns. Tags can now be specified via `--tags <comma-separated>`, repeated `--tag` options, or both—all values merge into the final manifest.

* **Documentation**
  * Updated CLI help text to document the new repeatable `--tag` option syntax for pattern scaffolding.

* **Tests**
  * Added test coverage for repeatable tag flag handling in pattern addition workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/1040?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->