### PR TITLE
feat(patterns): expose catalog title flag

### DIFF
--- a/.sampo/changesets/1032-pattern-catalog-title.md
+++ b/.sampo/changesets/1032-pattern-catalog-title.md
@@ -1,0 +1,7 @@
+---
+npm/wp-typia: patch
+npm/@wp-typia/project-tools: patch
+---
+
+Expose `--catalog-title` for pattern scaffolds so CLI-created catalog entries
+can set the same human-readable title metadata already supported by the runtime.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-help.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-help.ts
@@ -23,7 +23,7 @@ export function formatAddHelpText(): string {
 	wp-typia add variation <name> --block <block-slug> [--dry-run]
 	wp-typia add style <name> --block <block-slug> [--dry-run]
 	wp-typia add transform <name> --from <namespace/block> --to <block-slug|namespace/block-slug> [--dry-run]
-  wp-typia add pattern <name> [--scope <full|section>] [--section-role <role>] [--tags <tag,...>|--tag <tag>...] [--thumbnail-url <url>] [--dry-run]
+  wp-typia add pattern <name> [--scope <full|section>] [--section-role <role>] [--catalog-title <title>] [--tags <tag,...>|--tag <tag>...] [--thumbnail-url <url>] [--dry-run]
   wp-typia add binding-source <name> [--block <block-slug|namespace/block-slug> --attribute <attribute>] [--from-post-meta|--post-meta <post-meta> [--meta-path <field>]] [--dry-run]
   wp-typia add contract <name> [--type <ExportedTypeName>] [--dry-run]
   wp-typia add rest-resource <name> [--namespace <vendor/v1>] [--methods <${REST_RESOURCE_METHOD_IDS.join(",")}>] [--route-pattern <route-pattern>] [--permission-callback <callback>] [--controller-class <ClassName>] [--controller-extends <BaseClass>] [--dry-run]
@@ -50,7 +50,7 @@ Notes:
   \`add variation\` targets an existing block slug from \`scripts/block-config.ts\`.
   \`add style\` registers a Block Styles option for an existing generated block.
   \`add transform\` adds a block-to-block transform into an existing generated block.
-  \`add pattern\` scaffolds a namespaced PHP pattern shell under \`src/patterns/full/\` or \`src/patterns/sections/\` and records typed catalog metadata in \`PATTERNS\`; pass \`--tags hero,landing\` or repeat \`--tag hero --tag landing\` to set catalog tags.
+  \`add pattern\` scaffolds a namespaced PHP pattern shell under \`src/patterns/full/\` or \`src/patterns/sections/\` and records typed catalog metadata in \`PATTERNS\`; pass \`--catalog-title "Hero Photo"\` to override the generated catalog title, and pass \`--tags hero,landing\` or repeat \`--tag hero --tag landing\` to set catalog tags.
   \`add binding-source\` scaffolds shared PHP and editor registration under \`src/bindings/\`; pass \`--block\` and \`--attribute\` together to declare an end-to-end bindable attribute on an existing generated block. Pass \`--from-post-meta\` or \`--post-meta\` to generate a source backed by a typed post-meta contract; \`--meta-path\` selects one top-level field as the default binding arg.
   \`add contract\` registers a standalone TypeScript wire contract under \`src/contracts/\` and generates a stable JSON Schema artifact without creating PHP route glue.
   \`add rest-resource\` scaffolds plugin-level TypeScript REST contracts under \`src/rest/\` and PHP route glue under \`inc/rest/\`. Use \`--route-pattern\`, \`--permission-callback\`, \`--controller-class\`, and \`--controller-extends\` when an existing WordPress controller or permission model needs to own part of the generated route surface.

--- a/packages/wp-typia-project-tools/src/runtime/cli-help.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-help.ts
@@ -28,7 +28,7 @@ export function formatHelpText(): string {
   wp-typia add variation <name> --block <block-slug>
   wp-typia add style <name> --block <block-slug>
   wp-typia add transform <name> --from <namespace/block> --to <block-slug|namespace/block-slug>
-  wp-typia add pattern <name> [--scope <full|section>] [--section-role <role>] [--tags <tag,...>|--tag <tag>...] [--thumbnail-url <url>]
+  wp-typia add pattern <name> [--scope <full|section>] [--section-role <role>] [--catalog-title <title>] [--tags <tag,...>|--tag <tag>...] [--thumbnail-url <url>]
   wp-typia add binding-source <name> [--block <block-slug|namespace/block-slug> --attribute <attribute>] [--from-post-meta|--post-meta <post-meta> [--meta-path <field>]]
   wp-typia add rest-resource <name> [--namespace <vendor/v1>] [--methods <method[,method...]>]
   wp-typia add rest-resource <name> --manual [--namespace <vendor/v1>] [--method <GET|POST|PUT|PATCH|DELETE>] [--auth <public|authenticated|public-write-protected>] [--path <route-pattern>|--route-pattern <route-pattern>] [--permission-callback <callback>] [--controller-class <ClassName>] [--controller-extends <BaseClass>] [--query-type <Type>] [--body-type <Type>] [--response-type <Type>] [--secret-field <field>] [--secret-state-field|--secret-has-value-field <field>] [--secret-preserve-on-empty <true|false>]
@@ -68,7 +68,7 @@ Notes:
   \`add variation\` uses an existing workspace block from \`scripts/block-config.ts\`.
   \`add style\` registers a Block Styles option for an existing generated block.
   \`add transform\` adds a block-to-block transform into an existing generated block.
-  \`add pattern\` scaffolds a namespaced PHP pattern shell under \`src/patterns/full/\` or \`src/patterns/sections/\`; pass \`--tags hero,landing\` or repeat \`--tag hero --tag landing\` to set catalog tags.
+  \`add pattern\` scaffolds a namespaced PHP pattern shell under \`src/patterns/full/\` or \`src/patterns/sections/\`; pass \`--catalog-title "Hero Photo"\` to override the generated catalog title, and pass \`--tags hero,landing\` or repeat \`--tag hero --tag landing\` to set catalog tags.
   \`add binding-source\` scaffolds shared PHP and editor registration under \`src/bindings/\`; pass \`--block\` and \`--attribute\` together to declare a bindable generated-block attribute. Pass \`--from-post-meta\` or \`--post-meta\` to back the source from a typed post-meta contract and \`--meta-path\` to choose its default top-level field.
   \`add rest-resource\` scaffolds plugin-level TypeScript REST contracts under \`src/rest/\` and PHP route glue under \`inc/rest/\`.
   \`add rest-resource --manual\` tracks an external/provider REST route with typed schemas, OpenAPI, clients, and drift checks without generating PHP route/controller files while still allowing route-owner metadata such as permission callbacks and controller classes. Settings contracts can add \`--secret-field\` plus \`--secret-preserve-on-empty\` to model write-only credentials and preserve blank submissions.

--- a/packages/wp-typia-project-tools/tests/workspace-add.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-add.test.ts
@@ -3186,6 +3186,8 @@ test("canonical CLI can add a pattern to an official workspace template", async 
       "section",
       "--section-role",
       "hero",
+      "--catalog-title",
+      "Homepage Hero",
       "--tags",
       "landing,hero",
       "--thumbnail-url",
@@ -3213,6 +3215,7 @@ test("canonical CLI can add a pattern to an official workspace template", async 
   expect(blockConfigSource).toContain('scope: "section"');
   expect(blockConfigSource).toContain('sectionRole: "hero"');
   expect(blockConfigSource).toContain('tags: ["hero", "landing"]');
+  expect(blockConfigSource).toContain('title: "Homepage Hero"');
   expect(blockConfigSource).toContain(
     'thumbnailUrl: "./thumbnails/hero-layout.png"'
   );
@@ -3221,6 +3224,7 @@ test("canonical CLI can add a pattern to an official workspace template", async 
   expect(bootstrapSource).toContain("/src/patterns/*/*.php");
   expect(patternSource).toContain("demo-space/hero-layout");
   expect(patternSource).toContain("section section--hero");
+  expect(patternSource).toContain('"Homepage Hero"');
   expect(patternSource).toContain("<!-- wp:group");
   expect(patternSource).toContain('"className":"section section--hero"');
 

--- a/packages/wp-typia/bin/routing-metadata.generated.js
+++ b/packages/wp-typia/bin/routing-metadata.generated.js
@@ -19,6 +19,7 @@ export const longValueOptions = Object.freeze([
   '--auth',
   '--block',
   '--body-type',
+  '--catalog-title',
   '--config',
   '--controller-class',
   '--controller-extends',

--- a/packages/wp-typia/src/add-kinds/pattern.ts
+++ b/packages/wp-typia/src/add-kinds/pattern.ts
@@ -24,6 +24,7 @@ export const patternAddKindEntry =
     },
     description: 'Add a PHP block pattern shell',
     hiddenStringSubmitFields: [
+      'catalog-title',
       'scope',
       'section-role',
       'tag',
@@ -41,6 +42,10 @@ export const patternAddKindEntry =
         typeof context.flags['section-role'] === 'string'
           ? context.flags['section-role']
           : undefined;
+      const catalogTitle =
+        typeof context.flags['catalog-title'] === 'string'
+          ? context.flags['catalog-title']
+          : undefined;
       const tags =
         normalizePatternTagFlags(context.flags.tags, context.flags.tag);
       const thumbnailUrl =
@@ -51,6 +56,7 @@ export const patternAddKindEntry =
       return {
         execute: (cwd) =>
           context.addRuntime.runAddPatternCommand({
+            catalogTitle,
             cwd,
             patternScope: scope,
             patternName: name,
@@ -70,7 +76,7 @@ export const patternAddKindEntry =
     sortOrder: 60,
     supportsDryRun: true,
     usage:
-      'wp-typia add pattern <name> [--scope <full|section>] [--section-role <role>] [--tags <tag,...>|--tag <tag>...] [--thumbnail-url <url>] [--dry-run]',
+      'wp-typia add pattern <name> [--scope <full|section>] [--section-role <role>] [--catalog-title <title>] [--tags <tag,...>|--tag <tag>...] [--thumbnail-url <url>] [--dry-run]',
     visibleFieldNames: () => NAME_ONLY_VISIBLE_FIELDS,
   });
 

--- a/packages/wp-typia/src/command-options/add.ts
+++ b/packages/wp-typia/src/command-options/add.ts
@@ -28,6 +28,11 @@ export const ADD_OPTION_METADATA = {
       'Target block slug/name for variation, core-variation, style, and end-to-end binding-source workflows.',
     type: 'string',
   },
+  'catalog-title': {
+    description:
+      'Human-readable title for typed pattern catalog entries; defaults to the pattern slug title.',
+    type: 'string',
+  },
   'controller-class': {
     description:
       'REST resource controller class used for generated route callbacks or declared manual/provider route ownership.',

--- a/packages/wp-typia/src/ui/add-flow-model.ts
+++ b/packages/wp-typia/src/ui/add-flow-model.ts
@@ -28,6 +28,7 @@ export const addFlowSchema = z.object({
   auth: z.string().optional(),
   block: z.string().optional(),
   'body-type': z.string().optional(),
+  'catalog-title': z.string().optional(),
   'controller-class': z.string().optional(),
   'controller-extends': z.string().optional(),
   'data-storage': z.string().optional(),

--- a/packages/wp-typia/tests/add-kind-registry.test.ts
+++ b/packages/wp-typia/tests/add-kind-registry.test.ts
@@ -238,6 +238,7 @@ test('passes typed pattern catalog flags to the runtime', async () => {
     } as unknown as AddKindExecutionContext['addRuntime'],
     cwd: '/tmp/wp-typia-pattern-test',
     flags: {
+      'catalog-title': 'Homepage Hero',
       scope: 'section',
       'section-role': 'hero',
       tags: 'landing,hero',
@@ -255,6 +256,7 @@ test('passes typed pattern catalog flags to the runtime', async () => {
 
   expect(capturedOptions).toEqual([
     {
+      catalogTitle: 'Homepage Hero',
       cwd: '/tmp/wp-typia-pattern-test',
       patternName: 'hero-photo',
       patternScope: 'section',

--- a/packages/wp-typia/tests/command-option-metadata.test.ts
+++ b/packages/wp-typia/tests/command-option-metadata.test.ts
@@ -239,6 +239,8 @@ describe('command option metadata helpers', () => {
       [
         'pattern',
         'hero-photo',
+        '--catalog-title',
+        'Hero Photo',
         '--tags',
         'hero,landing',
         '--tag',
@@ -257,6 +259,7 @@ describe('command option metadata helpers', () => {
     );
 
     expect(parsed.flags).toEqual({
+      'catalog-title': 'Hero Photo',
       tag: ['featured', 'hero'],
       tags: ['hero,landing', 'gallery'],
     });

--- a/packages/wp-typia/tests/tui-interaction-models.test.ts
+++ b/packages/wp-typia/tests/tui-interaction-models.test.ts
@@ -246,12 +246,14 @@ describe("first-party TUI interaction models", () => {
 
 		expect(
 			sanitizeAddSubmitValues({
+				"catalog-title": " Homepage Hero ",
 				kind: "pattern",
 				name: "hero-photo",
 				tag: " hero ",
 				tags: " landing,featured ",
 			}),
 		).toEqual({
+			"catalog-title": "Homepage Hero",
 			kind: "pattern",
 			name: "hero-photo",
 			tag: "hero",


### PR DESCRIPTION
## Summary
- add `--catalog-title` to `wp-typia add pattern` and map it to runtime `catalogTitle`
- preserve existing default title behavior when the flag is omitted
- document the new flag in add/general help and cover CLI/TUI parsing paths

## Validation
- bun test packages/wp-typia/tests/command-option-metadata.test.ts packages/wp-typia/tests/add-kind-registry.test.ts packages/wp-typia/tests/tui-interaction-models.test.ts
- bun run --filter wp-typia validate:routing
- bun run --filter @wp-typia/project-tools build
- bun run --filter wp-typia build
- bun test packages/wp-typia-project-tools/tests/workspace-add.test.ts --test-name-pattern "canonical CLI can add a pattern"
- bun run typecheck
- bun run lint:repo
- bun run format:check
- bun run changesets:validate
- bun run --filter wp-typia test
- git diff --check

Closes #1032

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--catalog-title` option to the `wp-typia add pattern` CLI command, allowing users to set custom catalog titles when scaffolding patterns via the CLI to match existing runtime functionality.

* **Tests**
  * Expanded test coverage to verify the `--catalog-title` option propagates correctly through pattern scaffolding workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/1041?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->