### PR TITLE
feat(core-variation): warn on unknown core targets

### DIFF
--- a/.sampo/changesets/1030-core-variation-target-warnings.md
+++ b/.sampo/changesets/1030-core-variation-target-warnings.md
@@ -1,0 +1,7 @@
+---
+npm/wp-typia: patch
+npm/@wp-typia/project-tools: patch
+---
+
+Warn when `wp-typia add core-variation` targets an unknown `core/*` block while
+preserving third-party namespaces and future core-block compatibility.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-help.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-help.ts
@@ -39,6 +39,7 @@ Notes:
   Pass \`--dry-run\` to preview the workspace files that would change without writing them.
   Interactive add flows let you choose a template when \`--template\` is omitted; non-interactive runs default to \`basic\`.
   \`add core-variation\` registers editor-side variations for existing core or external blocks without generating block.json or Typia manifests.
+  Unknown \`core/*\` core-variation targets warn instead of failing so newer WordPress core blocks remain scaffoldable; third-party namespaces are allowed without local discovery.
   \`add admin-view\` scaffolds an opt-in DataViews-powered WordPress admin screen under \`src/admin-views/\`.
   Pass \`--source rest-resource:<slug>\` to reuse a list-capable REST resource.
   Pass \`--source core-data:postType/post\` or \`--source core-data:taxonomy/category\` to bind a WordPress-owned entity collection.

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-core-variation.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-core-variation.ts
@@ -25,6 +25,101 @@ import { resolveWorkspaceProject } from "./workspace-project.js";
 const CORE_VARIATIONS_EDITOR_PLUGIN_SLUG = "core-variations";
 const CORE_VARIATION_USAGE =
 	"wp-typia add core-variation <block-name> <name> or wp-typia add core-variation <name> --block <namespace/block>";
+const KNOWN_CORE_VARIATION_TARGETS = new Set([
+	"core/archives",
+	"core/audio",
+	"core/avatar",
+	"core/block",
+	"core/button",
+	"core/buttons",
+	"core/calendar",
+	"core/categories",
+	"core/code",
+	"core/column",
+	"core/columns",
+	"core/comment-author-name",
+	"core/comment-content",
+	"core/comment-date",
+	"core/comment-edit-link",
+	"core/comment-reply-link",
+	"core/comment-template",
+	"core/comments",
+	"core/comments-pagination",
+	"core/comments-pagination-next",
+	"core/comments-pagination-numbers",
+	"core/comments-pagination-previous",
+	"core/comments-title",
+	"core/cover",
+	"core/details",
+	"core/embed",
+	"core/file",
+	"core/footnotes",
+	"core/freeform",
+	"core/gallery",
+	"core/group",
+	"core/heading",
+	"core/home-link",
+	"core/html",
+	"core/image",
+	"core/latest-comments",
+	"core/latest-posts",
+	"core/legacy-widget",
+	"core/list",
+	"core/list-item",
+	"core/loginout",
+	"core/media-text",
+	"core/missing",
+	"core/more",
+	"core/navigation",
+	"core/navigation-link",
+	"core/navigation-submenu",
+	"core/nextpage",
+	"core/page-list",
+	"core/paragraph",
+	"core/pattern",
+	"core/post-author",
+	"core/post-author-biography",
+	"core/post-author-name",
+	"core/post-comments",
+	"core/post-comments-form",
+	"core/post-content",
+	"core/post-date",
+	"core/post-excerpt",
+	"core/post-featured-image",
+	"core/post-navigation-link",
+	"core/post-terms",
+	"core/post-template",
+	"core/post-title",
+	"core/preformatted",
+	"core/pullquote",
+	"core/query",
+	"core/query-no-results",
+	"core/query-pagination",
+	"core/query-pagination-next",
+	"core/query-pagination-numbers",
+	"core/query-pagination-previous",
+	"core/query-title",
+	"core/quote",
+	"core/read-more",
+	"core/rss",
+	"core/search",
+	"core/separator",
+	"core/shortcode",
+	"core/site-logo",
+	"core/site-tagline",
+	"core/site-title",
+	"core/social-link",
+	"core/social-links",
+	"core/spacer",
+	"core/table",
+	"core/table-of-contents",
+	"core/tag-cloud",
+	"core/template-part",
+	"core/term-description",
+	"core/text-columns",
+	"core/verse",
+	"core/video",
+]);
 const CORE_VARIATION_SIMPLE_CONTAINER_BLOCKS = new Set([
 	"core/column",
 	"core/cover",
@@ -113,6 +208,19 @@ function buildCoreVariationImportPath(ref: CoreVariationModuleRef): string {
 
 function formatCoreVariationTitle(variationSlug: string): string {
 	return toTitleCase(variationSlug);
+}
+
+function getUnknownCoreVariationTargetWarning(
+	targetBlockName: string,
+): string | undefined {
+	if (
+		!targetBlockName.startsWith("core/") ||
+		KNOWN_CORE_VARIATION_TARGETS.has(targetBlockName)
+	) {
+		return undefined;
+	}
+
+	return `Target block "${targetBlockName}" uses the WordPress core namespace but is not in wp-typia's known core block list. The variation was generated for forward compatibility; verify the block name or update wp-typia if this is a newer core block.`;
 }
 
 function assertCoreVariationDoesNotExist(
@@ -398,7 +506,8 @@ async function writeCoreVariationRegistry(
  * Defaults to `process.cwd()`.
  * @param options.targetBlockName Full `namespace/block` name that receives the variation.
  * @param options.variationName Human-entered variation name normalized into the generated slug.
- * @returns The normalized variation metadata and owning workspace directory.
+ * @returns The normalized variation metadata, owning workspace directory, and
+ * optional warnings for suspicious but forward-compatible targets.
  * @throws {Error} When the command is run outside an official workspace, the
  * target block name is not full `namespace/block` form, or the generated file
  * already exists.
@@ -412,6 +521,7 @@ export async function runAddCoreVariationCommand({
 	targetBlockName: string;
 	variationFile: string;
 	variationSlug: string;
+	warnings?: string[];
 }> {
 	const workspace = resolveWorkspaceProject(cwd);
 	const resolvedTargetBlockName = assertFullBlockName(
@@ -423,6 +533,8 @@ export async function runAddCoreVariationCommand({
 		normalizeBlockSlug(variationName),
 		CORE_VARIATION_USAGE,
 	);
+	const unknownCoreTargetWarning =
+		getUnknownCoreVariationTargetWarning(resolvedTargetBlockName);
 	assertCoreVariationSlugIsNotRegistryIndex(variationSlug);
 
 	assertCoreVariationDoesNotExist(
@@ -499,6 +611,9 @@ export async function runAddCoreVariationCommand({
 			targetBlockName: resolvedTargetBlockName,
 			variationFile: path.relative(workspace.projectDir, variationFilePath),
 			variationSlug,
+			...(unknownCoreTargetWarning
+				? { warnings: [unknownCoreTargetWarning] }
+				: {}),
 		};
 	} catch (error) {
 		await rollbackWorkspaceMutation(mutationSnapshot);

--- a/packages/wp-typia-project-tools/src/runtime/cli-help.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-help.ts
@@ -57,6 +57,7 @@ Notes:
   Use \`--template workspace\` as shorthand for \`@wp-typia/create-workspace-template\`, the official empty workspace scaffold behind \`wp-typia add ...\`.
   Use \`--profile plugin-qa\` with \`--template workspace\` when a plugin needs local wp-env smoke checks, \`.env.example\`, and release zip scripts from day one; omit it for the minimal workspace shell.
   Interactive add flows let you choose a template when \`--template\` is omitted; non-interactive runs default to \`basic\`.
+  Unknown \`core/*\` targets for \`add core-variation\` warn instead of failing so newer WordPress core blocks remain scaffoldable; third-party namespaces are allowed without local discovery.
   \`add admin-view\` scaffolds an opt-in DataViews-powered WordPress admin screen under \`src/admin-views/\`.
   Pass \`--source rest-resource:<slug>\` to reuse a list-capable REST resource.
   Pass \`--source core-data:postType/post\` or \`--source core-data:taxonomy/category\` to bind a WordPress-owned entity collection.

--- a/packages/wp-typia-project-tools/tests/workspace-add.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-add.test.ts
@@ -775,6 +775,26 @@ test("canonical CLI can add core block variations without generating block manif
       variationName: "index",
     })
   ).rejects.toThrow("Core variation name must not normalize to `index`.");
+  const knownCoreResult = await runAddCoreVariationCommand({
+    cwd: targetDir,
+    targetBlockName: "core/heading",
+    variationName: "hero-heading",
+  });
+  expect(knownCoreResult.warnings).toBeUndefined();
+  const thirdPartyResult = await runAddCoreVariationCommand({
+    cwd: targetDir,
+    targetBlockName: "demo-space/feature-card",
+    variationName: "brand-feature",
+  });
+  expect(thirdPartyResult.warnings).toBeUndefined();
+  const unknownCoreResult = await runAddCoreVariationCommand({
+    cwd: targetDir,
+    targetBlockName: "core/groub",
+    variationName: "typo-target",
+  });
+  expect(unknownCoreResult.warnings).toEqual([
+    'Target block "core/groub" uses the WordPress core namespace but is not in wp-typia\'s known core block list. The variation was generated for forward compatibility; verify the block name or update wp-typia if this is a newer core block.',
+  ]);
 
   const editorPluginIndexSource = fs.readFileSync(
     path.join(targetDir, "src", "editor-plugins", "index.ts"),

--- a/packages/wp-typia/src/add-kinds/core-variation.ts
+++ b/packages/wp-typia/src/add-kinds/core-variation.ts
@@ -99,6 +99,7 @@ export const coreVariationAddKindEntry =
           variationFile: result.variationFile,
           variationSlug: result.variationSlug,
         }),
+        getWarnings: (result) => result.warnings,
         missingNameMessage: CORE_VARIATION_MISSING_NAME_MESSAGE,
         name: variationName,
         warnLine: context.warnLine,

--- a/packages/wp-typia/tests/add-kind-registry.test.ts
+++ b/packages/wp-typia/tests/add-kind-registry.test.ts
@@ -318,6 +318,37 @@ test('passes repeatable pattern tag flags to the runtime', async () => {
   ]);
 });
 
+test('surfaces core-variation runtime warnings through the add plan', async () => {
+  const plan = await ADD_KIND_REGISTRY['core-variation'].prepareExecution({
+    addRuntime: {
+      runAddCoreVariationCommand: async () => ({
+        projectDir: '/tmp/wp-typia-core-variation-warning-test',
+        targetBlockName: 'core/groub',
+        variationFile:
+          'src/editor-plugins/core-variations/core/groub/typo-target.ts',
+        variationSlug: 'typo-target',
+        warnings: ['Unknown core variation target'],
+      }),
+    } as unknown as AddKindExecutionContext['addRuntime'],
+    cwd: '/tmp/wp-typia-core-variation-warning-test',
+    flags: {
+      block: 'core/groub',
+    },
+    getOrCreatePrompt: async () => {
+      throw new Error('core-variation add-kind should not prompt in this test');
+    },
+    isInteractiveSession: false,
+    name: 'typo-target',
+    warnLine: () => {},
+  });
+
+  const result = await plan.execute('/tmp/wp-typia-core-variation-warning-test');
+
+  expect(plan.getWarnings?.(result)).toEqual([
+    'Unknown core variation target',
+  ]);
+});
+
 async function captureRestResourceRuntimeOptions(
   flags: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {


### PR DESCRIPTION
## Summary
- warn when `wp-typia add core-variation` targets an unknown `core/*` block
- preserve forward compatibility by keeping the scaffold non-fatal and allowing third-party namespaces
- document the behavior in add/general help and surface runtime warnings through add completion output

## Validation
- bun test packages/wp-typia/tests/add-kind-registry.test.ts
- bun run --filter @wp-typia/project-tools build
- bun run --filter wp-typia build
- bun test packages/wp-typia-project-tools/tests/workspace-add.test.ts --test-name-pattern "canonical CLI can add core block variations"
- bun run format:check
- bun run typecheck
- bun run lint:repo
- bun run changesets:validate
- bun run --filter wp-typia validate:routing
- bun run --filter wp-typia test
- git diff --check

Closes #1030