### PR TITLE
fix(project-tools): route remaining runtime json parses

### DIFF
--- a/.sampo/changesets/1033-json-utils-runtime-parses.md
+++ b/.sampo/changesets/1033-json-utils-runtime-parses.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+---
+
+Route remaining runtime package-version and template-cache marker JSON parsing
+through shared JSON utilities while preserving cache fallback behavior.

--- a/packages/wp-typia-project-tools/src/runtime/json-utils.ts
+++ b/packages/wp-typia-project-tools/src/runtime/json-utils.ts
@@ -7,11 +7,8 @@ import { promises as fsp } from "node:fs";
  * File-backed runtime JSON readers should use `safeJsonParse`,
  * `readJsonFileSync`, or `readJsonFile` so malformed JSON reports the file path
  * and operation context. Raw `JSON.parse` remains intentional for trusted
- * in-memory clones, subprocess output, test fixtures, generated workspace
- * script templates that embed their own path-aware parse handling,
- * package-version manifest cache probes with colocated path-aware wrappers,
- * and cache/discovery probes that immediately catch malformed documents to
- * continue with fallback behavior.
+ * in-memory clones, subprocess output, test fixtures, and generated workspace
+ * script templates that embed their own path-aware parse handling.
  *
  * This module keeps `cloneJsonValue` local instead of re-exporting the
  * block-runtime helper so Bunli CLI bundles that only need project-tools JSON

--- a/packages/wp-typia-project-tools/src/runtime/package-versions.ts
+++ b/packages/wp-typia-project-tools/src/runtime/package-versions.ts
@@ -3,6 +3,7 @@ import { createRequire } from 'node:module';
 import path from 'node:path';
 
 import { getOptionalNodeErrorCode } from './fs-async.js';
+import { safeJsonParse } from './json-utils.js';
 import { PROJECT_TOOLS_PACKAGE_ROOT } from './template-registry.js';
 
 interface PackageManifest {
@@ -143,15 +144,10 @@ function readPackageManifest(
     return null;
   }
 
-  try {
-    return JSON.parse(location.source) as PackageManifest;
-  } catch (error) {
-    throw new Error(
-      `Failed to parse package version manifest at ${
-        location.packageJsonPath
-      }: ${error instanceof Error ? error.message : String(error)}`,
-    );
-  }
+  return safeJsonParse<PackageManifest>(location.source, {
+    context: 'package version manifest',
+    filePath: location.packageJsonPath,
+  });
 }
 
 function tryReadPackageManifest(

--- a/packages/wp-typia-project-tools/src/runtime/template-source-cache-markers.ts
+++ b/packages/wp-typia-project-tools/src/runtime/template-source-cache-markers.ts
@@ -1,3 +1,5 @@
+import { safeJsonParse } from './json-utils.js'
+
 /**
  * Marker file written after a cache entry is fully populated.
  */
@@ -73,7 +75,9 @@ export function parseExternalTemplateCacheEntryMarker(
 ): ExternalTemplateCacheEntryMarker | null {
   let marker: unknown
   try {
-    marker = JSON.parse(markerText)
+    marker = safeJsonParse(markerText, {
+      context: 'external template cache entry marker',
+    })
   } catch {
     return null
   }
@@ -128,7 +132,9 @@ export function parseExternalTemplateCachePruneMarker(
 ): ExternalTemplateCachePruneMarker | null {
   let marker: unknown
   try {
-    marker = JSON.parse(markerText)
+    marker = safeJsonParse(markerText, {
+      context: 'external template cache prune marker',
+    })
   } catch {
     return null
   }

--- a/packages/wp-typia-project-tools/tests/package-versions.test.ts
+++ b/packages/wp-typia-project-tools/tests/package-versions.test.ts
@@ -147,6 +147,62 @@ describe('package version cache invalidation', () => {
     );
   });
 
+  test('reports malformed package manifests with path-aware context', () => {
+    const linkedProjectToolsRoot = fs.mkdtempSync(
+      path.join(tempRoot, 'malformed-project-tools-'),
+    );
+    const packageJsonPath = path.join(linkedProjectToolsRoot, 'package.json');
+    writeProjectToolsManifest(linkedProjectToolsRoot, {
+      apiClientVersion: '^0.4.0',
+      projectToolsVersion: '1.2.3',
+    });
+
+    const packageVersionsModuleUrl = pathToFileURL(
+      path.join(import.meta.dir, '..', 'src', 'runtime', 'package-versions.ts'),
+    ).href;
+    const script = `
+			import assert from "node:assert/strict";
+			import fs from "node:fs";
+			import { getPackageVersions } from ${JSON.stringify(packageVersionsModuleUrl)};
+
+			const packageJsonPath = ${JSON.stringify(packageJsonPath)};
+			fs.writeFileSync(packageJsonPath, "{", "utf8");
+
+			assert.throws(
+				() => getPackageVersions(),
+				(error) => {
+					assert(error instanceof Error);
+					assert.match(error.message, /Failed to parse package version manifest at /);
+					assert.ok(error.message.includes(packageJsonPath));
+					return true;
+				}
+			);
+		`;
+
+    const bunBinary =
+      process.env.BUN_BINARY ??
+      ('Bun' in globalThis ? process.execPath : 'bun');
+    const result = spawnSync(bunBinary, ['--eval', script], {
+      cwd: linkedProjectToolsRoot,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        WP_TYPIA_PROJECT_TOOLS_PACKAGE_ROOT: linkedProjectToolsRoot,
+      },
+    });
+
+    if (result.status !== 0) {
+      throw new Error(
+        `malformed package-versions script failed (status=${
+          result.status
+        }, error=${result.error?.message ?? 'none'}):\n${result.stderr}`,
+      );
+    }
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toBe('');
+  });
+
   test('centralizes managed workspace dependency fallback ranges', async () => {
     const packageVersionsModuleUrl = pathToFileURL(
       path.join(import.meta.dir, '..', 'src', 'runtime', 'package-versions.ts'),

--- a/packages/wp-typia-project-tools/tests/template-source-cache-boundaries.test.ts
+++ b/packages/wp-typia-project-tools/tests/template-source-cache-boundaries.test.ts
@@ -103,6 +103,7 @@ test('template source cache marker helpers sanitize metadata and parse TTL marke
       }),
     ),
   ).toBeNull()
+  expect(parseExternalTemplateCacheEntryMarker('{')).toBeNull()
 
   const pruneMarker = parseExternalTemplateCachePruneMarker(
     formatExternalTemplateCachePruneMarker({
@@ -118,4 +119,5 @@ test('template source cache marker helpers sanitize metadata and parse TTL marke
     ttlMs: 86_400_000,
   })
   expect(parseExternalTemplateCachePruneMarker('{}')).toBeNull()
+  expect(parseExternalTemplateCachePruneMarker('{')).toBeNull()
 })

--- a/tests/unit/package-versions.test.ts
+++ b/tests/unit/package-versions.test.ts
@@ -23,6 +23,13 @@ const FS_ASYNC_SOURCE = fs.readFileSync(
 	),
 	"utf8",
 );
+const JSON_UTILS_SOURCE = fs.readFileSync(
+	path.resolve(
+		import.meta.dir,
+		"../../packages/wp-typia-project-tools/src/runtime/json-utils.ts",
+	),
+	"utf8",
+);
 
 async function importPackageVersionsModule(options: {
 	createPackageRoot: string;
@@ -52,6 +59,7 @@ async function importPackageVersionsModule(options: {
 		PACKAGE_VERSIONS_SOURCE,
 	);
 	writeTextFile(path.join(runtimeDir, "fs-async.ts"), FS_ASYNC_SOURCE);
+	writeTextFile(path.join(runtimeDir, "json-utils.ts"), JSON_UTILS_SOURCE);
 	writeTextFile(
 		path.join(runtimeDir, "template-registry.js"),
 		`export const PROJECT_TOOLS_PACKAGE_ROOT = ${JSON.stringify(options.createPackageRoot)};\n`,


### PR DESCRIPTION
## Summary
- route package-version manifest parsing through shared safeJsonParse while preserving path-aware errors
- route external template cache marker parsing through safeJsonParse while preserving null fallback behavior
- document the remaining intentional runtime JSON.parse cases and add malformed JSON coverage

## Validation
- bun test packages/wp-typia-project-tools/tests/package-versions.test.ts
- bun test packages/wp-typia-project-tools/tests/template-source-cache-boundaries.test.ts
- bun run --filter @wp-typia/project-tools build
- bun run typecheck
- bun run lint:repo
- bun run format:check
- bun run changesets:validate
- git diff --check

Closes #1033

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when encountering malformed JSON configuration files, now providing clearer diagnostic messages with file paths for faster issue resolution.

* **Tests**
  * Added test coverage for error scenarios involving invalid JSON in package manifests and cache marker files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/1043?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->