### PR TITLE
refactor(cli): share option argv walking

### DIFF
--- a/.sampo/changesets/gallant-wolfkin-louhi.md
+++ b/.sampo/changesets/gallant-wolfkin-louhi.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Share CLI option argv walking and guard add option schema drift.

--- a/packages/wp-typia/src/add-kinds/integration-env.ts
+++ b/packages/wp-typia/src/add-kinds/integration-env.ts
@@ -65,4 +65,5 @@ export const integrationEnvAddKindEntry =
       'wp-typia add integration-env <name> [--wp-env] [--release-zip] [--service <none|docker-compose>] [--dry-run]',
     visibleFieldNames: () => NAME_ONLY_VISIBLE_FIELDS,
     hiddenBooleanSubmitFields: ['wp-env', 'release-zip'],
+    hiddenStringSubmitFields: ['service'],
   });

--- a/packages/wp-typia/src/command-option-metadata.ts
+++ b/packages/wp-typia/src/command-option-metadata.ts
@@ -225,11 +225,13 @@ function createUnknownOptionError(
   );
 }
 
-export function extractKnownOptionValuesFromArgv(
+function walkArgvOptions(
   argv: string[],
   options: {
-    optionNames: Iterable<string>;
+    extraBooleanOptionNames?: Iterable<string>;
+    optionNames?: Iterable<string>;
     parser: CommandOptionParser;
+    strict: boolean;
   },
 ): {
   argv: string[];
@@ -237,104 +239,8 @@ export function extractKnownOptionValuesFromArgv(
 } {
   const flags: Record<string, unknown> = {};
   const nextArgv: string[] = [];
-  const optionNames = new Set(options.optionNames);
-
-  for (let index = 0; index < argv.length; index += 1) {
-    const arg = argv[index];
-    if (!arg) {
-      continue;
-    }
-
-    if (arg === '--') {
-      nextArgv.push(...argv.slice(index));
-      break;
-    }
-
-    if (arg.length === 2 && arg.startsWith('-')) {
-      const shortFlag = options.parser.shortFlagMap.get(arg.slice(1));
-      if (!shortFlag || !optionNames.has(shortFlag.name)) {
-        nextArgv.push(arg);
-        continue;
-      }
-      if (shortFlag.type === 'boolean') {
-        flags[shortFlag.name] = true;
-        continue;
-      }
-      const next = argv[index + 1];
-      if (!next || next.startsWith('-')) {
-        throw createMissingOptionValueError(arg);
-      }
-      assignParsedOptionValue(flags, {
-        name: shortFlag.name,
-        parser: options.parser,
-        value: next,
-      });
-      index += 1;
-      continue;
-    }
-
-    if (arg.startsWith('--')) {
-      const option = arg.slice(2);
-      const separatorIndex = option.indexOf('=');
-      const rawName =
-        separatorIndex === -1 ? option : option.slice(0, separatorIndex);
-      const inlineValue =
-        separatorIndex === -1 ? undefined : option.slice(separatorIndex + 1);
-      if (!optionNames.has(rawName)) {
-        nextArgv.push(arg);
-        continue;
-      }
-      if (options.parser.booleanOptionNames.has(rawName)) {
-        flags[rawName] = true;
-        continue;
-      }
-      if (!options.parser.stringOptionNames.has(rawName)) {
-        nextArgv.push(arg);
-        continue;
-      }
-      if (inlineValue !== undefined) {
-        if (!inlineValue) {
-          throw createMissingOptionValueError(`--${rawName}`);
-        }
-        assignParsedOptionValue(flags, {
-          name: rawName,
-          parser: options.parser,
-          value: inlineValue,
-        });
-        continue;
-      }
-      const next = argv[index + 1];
-      if (!next || next.startsWith('-')) {
-        throw createMissingOptionValueError(`--${rawName}`);
-      }
-      assignParsedOptionValue(flags, {
-        name: rawName,
-        parser: options.parser,
-        value: next,
-      });
-      index += 1;
-      continue;
-    }
-
-    nextArgv.push(arg);
-  }
-
-  return {
-    argv: nextArgv,
-    flags,
-  };
-}
-
-export function parseCommandArgvWithMetadata(
-  argv: string[],
-  options: {
-    extraBooleanOptionNames?: Iterable<string>;
-    parser: CommandOptionParser;
-  },
-): ParsedCommandArgv {
-  const flags: Record<string, unknown> = {};
-  const positionals: string[] = [];
   const booleanOptionNames = new Set(options.parser.booleanOptionNames);
+  const optionNames = new Set(options.optionNames ?? []);
 
   for (const optionName of options.extraBooleanOptionNames ?? []) {
     booleanOptionNames.add(optionName);
@@ -347,14 +253,21 @@ export function parseCommandArgvWithMetadata(
     }
 
     if (arg === '--') {
-      positionals.push(...argv.slice(index + 1));
+      nextArgv.push(...argv.slice(index + (options.strict ? 1 : 0)));
       break;
     }
 
     if (arg.length === 2 && arg.startsWith('-')) {
       const shortFlag = options.parser.shortFlagMap.get(arg.slice(1));
-      if (!shortFlag) {
-        throw createUnknownOptionError(arg);
+      if (
+        !shortFlag ||
+        (!options.strict && !optionNames.has(shortFlag.name))
+      ) {
+        if (options.strict) {
+          throw createUnknownOptionError(arg);
+        }
+        nextArgv.push(arg);
+        continue;
       }
       if (shortFlag.type === 'boolean') {
         flags[shortFlag.name] = true;
@@ -380,12 +293,20 @@ export function parseCommandArgvWithMetadata(
         separatorIndex === -1 ? option : option.slice(0, separatorIndex);
       const inlineValue =
         separatorIndex === -1 ? undefined : option.slice(separatorIndex + 1);
+      if (!options.strict && !optionNames.has(rawName)) {
+        nextArgv.push(arg);
+        continue;
+      }
       if (booleanOptionNames.has(rawName)) {
         flags[rawName] = true;
         continue;
       }
       if (!options.parser.stringOptionNames.has(rawName)) {
-        throw createUnknownOptionError(`--${rawName}`);
+        if (options.strict) {
+          throw createUnknownOptionError(`--${rawName}`);
+        }
+        nextArgv.push(arg);
+        continue;
       }
       if (inlineValue !== undefined) {
         if (!inlineValue) {
@@ -411,12 +332,48 @@ export function parseCommandArgvWithMetadata(
       continue;
     }
 
-    if (arg.startsWith('-')) {
+    if (arg.startsWith('-') && options.strict) {
       throw createUnknownOptionError(arg);
     }
 
-    positionals.push(arg);
+    nextArgv.push(arg);
   }
+
+  return {
+    argv: nextArgv,
+    flags,
+  };
+}
+
+export function extractKnownOptionValuesFromArgv(
+  argv: string[],
+  options: {
+    optionNames: Iterable<string>;
+    parser: CommandOptionParser;
+  },
+): {
+  argv: string[];
+  flags: Record<string, unknown>;
+} {
+  return walkArgvOptions(argv, {
+    optionNames: options.optionNames,
+    parser: options.parser,
+    strict: false,
+  });
+}
+
+export function parseCommandArgvWithMetadata(
+  argv: string[],
+  options: {
+    extraBooleanOptionNames?: Iterable<string>;
+    parser: CommandOptionParser;
+  },
+): ParsedCommandArgv {
+  const { argv: positionals, flags } = walkArgvOptions(argv, {
+    extraBooleanOptionNames: options.extraBooleanOptionNames,
+    parser: options.parser,
+    strict: true,
+  });
 
   return {
     flags,

--- a/packages/wp-typia/src/ui/add-flow-model.ts
+++ b/packages/wp-typia/src/ui/add-flow-model.ts
@@ -63,6 +63,7 @@ export const addFlowSchema = z.object({
   'secret-masked-response-field': z.string().optional(),
   'secret-preserve-on-empty': z.string().optional(),
   'secret-state-field': z.string().optional(),
+  service: z.string().optional(),
   slot: z.string().optional(),
   source: z.string().optional(),
   tag: z.string().optional(),
@@ -99,6 +100,10 @@ const ADD_FIELD_HEIGHTS: Record<AddFieldName, number> = {
   type: FIRST_PARTY_TEXT_FIELD_BODY_HEIGHT,
   to: FIRST_PARTY_TEXT_FIELD_BODY_HEIGHT,
 };
+
+export function getAddFieldLayoutNames(): AddFieldName[] {
+  return Object.keys(ADD_FIELD_HEIGHTS) as AddFieldName[];
+}
 
 export function isAddPersistenceTemplate(template?: string): boolean {
   return isRegisteredAddPersistenceTemplate(template);

--- a/packages/wp-typia/tests/command-option-metadata.test.ts
+++ b/packages/wp-typia/tests/command-option-metadata.test.ts
@@ -21,6 +21,7 @@ import {
   SYNC_OPTION_METADATA,
   TEMPLATES_OPTION_METADATA,
 } from '../src/command-option-metadata';
+import { ADD_KIND_IDS } from '../src/add-kind-registry';
 import { ADD_OPTION_METADATA as FOCUSED_ADD_OPTION_METADATA } from '../src/command-options/add';
 import { CREATE_OPTION_METADATA as FOCUSED_CREATE_OPTION_METADATA } from '../src/command-options/create';
 import { DOCTOR_OPTION_METADATA as FOCUSED_DOCTOR_OPTION_METADATA } from '../src/command-options/doctor';
@@ -30,6 +31,11 @@ import { MCP_OPTION_METADATA as FOCUSED_MCP_OPTION_METADATA } from '../src/comma
 import { MIGRATE_OPTION_METADATA as FOCUSED_MIGRATE_OPTION_METADATA } from '../src/command-options/migrate';
 import { SYNC_OPTION_METADATA as FOCUSED_SYNC_OPTION_METADATA } from '../src/command-options/sync';
 import { TEMPLATES_OPTION_METADATA as FOCUSED_TEMPLATES_OPTION_METADATA } from '../src/command-options/templates';
+import {
+  addFlowSchema,
+  getAddFieldLayoutNames,
+  getVisibleAddFieldNames,
+} from '../src/ui/add-flow-model';
 
 describe('command option metadata helpers', () => {
   function expectDiagnosticCode(
@@ -438,6 +444,122 @@ describe('command option metadata helpers', () => {
       id: 'basic',
     });
     expect(extracted.argv).toEqual(['templates', 'inspect', '--', '--format']);
+  });
+
+  test('keeps loose extraction permissive for unknown options', () => {
+    const parser = buildCommandOptionParser(ALL_COMMAND_OPTION_METADATA);
+    const extracted = extractKnownOptionValuesFromArgv(
+      [
+        '--unknown',
+        'value',
+        '--format=json',
+        '-c',
+        'wp-typia.config.ts',
+        '-z',
+        '--',
+        '--id',
+        'literal',
+      ],
+      {
+        optionNames: ['config', 'format', 'id'],
+        parser,
+      },
+    );
+
+    expect(extracted.flags).toEqual({
+      config: 'wp-typia.config.ts',
+      format: 'json',
+    });
+    expect(extracted.argv).toEqual([
+      '--unknown',
+      'value',
+      '-z',
+      '--',
+      '--id',
+      'literal',
+    ]);
+  });
+
+  test('keeps strict parsing terminator and repeatable option behavior stable', () => {
+    const parsed = parseCommandArgvWithMetadata(
+      [
+        'pattern',
+        'hero-photo',
+        '--tag',
+        'featured',
+        '--tag=landing',
+        '--',
+        '--tag',
+        'literal',
+      ],
+      {
+        parser: buildCommandOptionParser(
+          GLOBAL_OPTION_METADATA,
+          ADD_OPTION_METADATA,
+        ),
+      },
+    );
+
+    expect(parsed.flags).toEqual({
+      tag: ['featured', 'landing'],
+    });
+    expect(parsed.positionals).toEqual([
+      'pattern',
+      'hero-photo',
+      '--tag',
+      'literal',
+    ]);
+  });
+
+  test('keeps add option metadata aligned with interactive schema fields', () => {
+    const metadataOptionNames = Object.keys(ADD_OPTION_METADATA).filter(
+      (optionName) => optionName !== 'dry-run',
+    );
+    const schemaOptionNames = Object.keys(addFlowSchema.shape).filter(
+      (fieldName) => fieldName !== 'kind' && fieldName !== 'name',
+    );
+
+    expect(schemaOptionNames.sort()).toEqual(metadataOptionNames.sort());
+  });
+
+  test('keeps visible add fields covered by metadata, schema, and layout', () => {
+    const metadataOptionNames = new Set(Object.keys(ADD_OPTION_METADATA));
+    const schemaFieldNames = new Set(Object.keys(addFlowSchema.shape));
+    const layoutFieldNames = new Set<string>(getAddFieldLayoutNames());
+    const visibleFieldNames = new Set<string>();
+    const nonOptionFieldNames = new Set(['kind', 'name']);
+
+    for (const kind of ADD_KIND_IDS) {
+      for (const template of [
+        undefined,
+        'basic',
+        'interactivity',
+        'persistence',
+        'compound',
+      ]) {
+        for (const fieldName of getVisibleAddFieldNames({ kind, template })) {
+          visibleFieldNames.add(fieldName);
+        }
+      }
+    }
+
+    const missingMetadata = [...visibleFieldNames]
+      .filter(
+        (fieldName) =>
+          !nonOptionFieldNames.has(fieldName) &&
+          !metadataOptionNames.has(fieldName),
+      )
+      .sort();
+    const missingSchema = [...visibleFieldNames]
+      .filter((fieldName) => !schemaFieldNames.has(fieldName))
+      .sort();
+    const missingLayout = [...visibleFieldNames]
+      .filter((fieldName) => !layoutFieldNames.has(fieldName))
+      .sort();
+
+    expect(missingMetadata).toEqual([]);
+    expect(missingSchema).toEqual([]);
+    expect(missingLayout).toEqual([]);
   });
 
   test('throws diagnostic-coded errors for parser option failures', () => {

--- a/packages/wp-typia/tests/tui-interaction-models.test.ts
+++ b/packages/wp-typia/tests/tui-interaction-models.test.ts
@@ -158,12 +158,14 @@ describe("first-party TUI interaction models", () => {
 				kind: "integration-env",
 				name: "local-smoke",
 				"release-zip": true,
+				service: " docker-compose ",
 				"wp-env": true,
 			}),
 		).toEqual({
 			kind: "integration-env",
 			name: "local-smoke",
 			"release-zip": true,
+			service: "docker-compose",
 			"wp-env": true,
 		});
 


### PR DESCRIPTION
## Summary
- Share the CLI argv option walker used by loose global option extraction and strict command parsing.
- Add regression coverage for loose unknown options, strict terminators, repeatable flags, and add option metadata/schema/layout consistency.
- Preserve `wp-typia add integration-env --service` through the interactive hidden-submit path caught by the new coverage.

## Validation
- `bun test packages/wp-typia/tests/command-option-metadata.test.ts packages/wp-typia/tests/tui-interaction-models.test.ts`
- `bun run --filter wp-typia build`
- `bun run --filter wp-typia test`
- `bun run test:unit`
- `bun run lint:repo`
- `bun run typecheck`
- `bun run format:check`
- `bun run changesets:validate`
- `bun run maintenance-automation:validate`
- `bun run formatting-policy:validate`
- `bun run manifest-policy:validate`
- `bun run runtime-coupling:validate`
- `bun run typescript-strictness:validate`
- `bun run typescript-runtime:validate`
- `bun run publish:validate`
- `git diff --check`

Closes #1045

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for the `service` field in integration environment configuration options.
  * Enhanced CLI argument parsing with improved strict and non-strict validation modes.

* **Improvements**
  * Refactored command option metadata handling for better consistency.
  * Added validation to ensure CLI options remain aligned with interactive form fields across all configuration types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/1049?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->