### PR TITLE
Clarify core-variation positional missing-name diagnostics

### DIFF
--- a/.sampo/changesets/core-variation-positional-diagnostic.md
+++ b/.sampo/changesets/core-variation-positional-diagnostic.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Clarify missing-name diagnostics for incomplete positional core-variation add usage.

--- a/packages/wp-typia/src/add-kinds/core-variation.ts
+++ b/packages/wp-typia/src/add-kinds/core-variation.ts
@@ -18,13 +18,15 @@ const CORE_VARIATION_MISSING_NAME_MESSAGE =
 const CORE_VARIATION_MISSING_BLOCK_MESSAGE =
   '`wp-typia add core-variation` requires <block-name>. Usage: wp-typia add core-variation <block-name> <name> or wp-typia add core-variation <name> --block <namespace/block>.';
 
+const CORE_VARIATION_BLOCK_NAME_PATTERN = /^[^/\s]+\/[^/\s]+$/u;
+
 function formatCoreVariationMissingPositionalNameMessage(
   blockName: string,
 ): string {
   return [
     `\`wp-typia add core-variation ${blockName}\` is missing <name>.`,
     'Usage: wp-typia add core-variation <block-name> <name>',
-    'Alternative: wp-typia add core-variation <name> --block <block-name>',
+    'Alternative: wp-typia add core-variation <name> --block <namespace/block>',
   ].join('\n');
 }
 
@@ -53,7 +55,7 @@ function resolveCoreVariationInputs(context: AddKindExecutionContext): {
   const missingPositionalNameTarget =
     context.name !== undefined &&
     positionalTargetBlockName === context.name &&
-    context.name.includes('/')
+    CORE_VARIATION_BLOCK_NAME_PATTERN.test(context.name)
       ? context.name
       : undefined;
 

--- a/packages/wp-typia/src/add-kinds/core-variation.ts
+++ b/packages/wp-typia/src/add-kinds/core-variation.ts
@@ -18,6 +18,16 @@ const CORE_VARIATION_MISSING_NAME_MESSAGE =
 const CORE_VARIATION_MISSING_BLOCK_MESSAGE =
   '`wp-typia add core-variation` requires <block-name>. Usage: wp-typia add core-variation <block-name> <name> or wp-typia add core-variation <name> --block <namespace/block>.';
 
+function formatCoreVariationMissingPositionalNameMessage(
+  blockName: string,
+): string {
+  return [
+    `\`wp-typia add core-variation ${blockName}\` is missing <name>.`,
+    'Usage: wp-typia add core-variation <block-name> <name>',
+    'Alternative: wp-typia add core-variation <name> --block <block-name>',
+  ].join('\n');
+}
+
 function resolveCoreVariationInputs(context: AddKindExecutionContext): {
   targetBlockName: string;
   variationName: string;
@@ -39,13 +49,20 @@ function resolveCoreVariationInputs(context: AddKindExecutionContext): {
     };
   }
 
-  if (
-    context.name?.includes('/') &&
-    !readOptionalStrictStringFlag(context.flags, 'block')
-  ) {
+  const targetBlockFlag = readOptionalStrictStringFlag(context.flags, 'block');
+  const missingPositionalNameTarget =
+    context.name !== undefined &&
+    positionalTargetBlockName === context.name &&
+    context.name.includes('/')
+      ? context.name
+      : undefined;
+
+  if (missingPositionalNameTarget && !targetBlockFlag) {
     throw createCliDiagnosticCodeError(
       CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
-      CORE_VARIATION_MISSING_NAME_MESSAGE,
+      formatCoreVariationMissingPositionalNameMessage(
+        missingPositionalNameTarget,
+      ),
     );
   }
 
@@ -53,8 +70,7 @@ function resolveCoreVariationInputs(context: AddKindExecutionContext): {
     context,
     CORE_VARIATION_MISSING_NAME_MESSAGE,
   );
-  const targetBlockName = readOptionalStrictStringFlag(context.flags, 'block');
-  if (!targetBlockName) {
+  if (!targetBlockFlag) {
     throw createCliDiagnosticCodeError(
       CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
       CORE_VARIATION_MISSING_BLOCK_MESSAGE,
@@ -62,7 +78,7 @@ function resolveCoreVariationInputs(context: AddKindExecutionContext): {
   }
 
   return {
-    targetBlockName,
+    targetBlockName: targetBlockFlag,
     variationName,
   };
 }

--- a/packages/wp-typia/tests/add-command.test.ts
+++ b/packages/wp-typia/tests/add-command.test.ts
@@ -661,7 +661,7 @@ describe('wp-typia add command bridge', () => {
         message: [
           '`wp-typia add core-variation core/group` is missing <name>.',
           'Usage: wp-typia add core-variation <block-name> <name>',
-          'Alternative: wp-typia add core-variation <name> --block <block-name>',
+          'Alternative: wp-typia add core-variation <name> --block <namespace/block>',
         ].join('\n'),
         name: 'core/group',
         positionalArgs: ['core-variation', 'core/group'],
@@ -672,6 +672,13 @@ describe('wp-typia add command bridge', () => {
           '`wp-typia add core-variation` requires <block-name>. Usage: wp-typia add core-variation <block-name> <name> or wp-typia add core-variation <name> --block <namespace/block>.',
         name: 'section-hero',
         positionalArgs: ['core-variation', 'section-hero'],
+      },
+      {
+        flags: {},
+        message:
+          '`wp-typia add core-variation` requires <block-name>. Usage: wp-typia add core-variation <block-name> <name> or wp-typia add core-variation <name> --block <namespace/block>.',
+        name: 'core/group/extra',
+        positionalArgs: ['core-variation', 'core/group/extra'],
       },
     ] satisfies Array<{
       flags: Record<string, unknown>;

--- a/packages/wp-typia/tests/add-command.test.ts
+++ b/packages/wp-typia/tests/add-command.test.ts
@@ -654,6 +654,57 @@ describe('wp-typia add command bridge', () => {
     }
   }, 15_000);
 
+  test('core-variation missing arguments distinguish positional and flag usage', async () => {
+    const cases = [
+      {
+        flags: {},
+        message: [
+          '`wp-typia add core-variation core/group` is missing <name>.',
+          'Usage: wp-typia add core-variation <block-name> <name>',
+          'Alternative: wp-typia add core-variation <name> --block <block-name>',
+        ].join('\n'),
+        name: 'core/group',
+        positionalArgs: ['core-variation', 'core/group'],
+      },
+      {
+        flags: {},
+        message:
+          '`wp-typia add core-variation` requires <block-name>. Usage: wp-typia add core-variation <block-name> <name> or wp-typia add core-variation <name> --block <namespace/block>.',
+        name: 'section-hero',
+        positionalArgs: ['core-variation', 'section-hero'],
+      },
+    ] satisfies Array<{
+      flags: Record<string, unknown>;
+      message: string;
+      name: string;
+      positionalArgs: string[];
+    }>;
+
+    for (const { flags, message, name, positionalArgs } of cases) {
+      let error: unknown;
+
+      try {
+        await executeAddCommand({
+          cwd: path.join(tempRoot, 'outside-workspace'),
+          emitOutput: false,
+          flags,
+          interactive: false,
+          kind: 'core-variation',
+          name,
+          positionalArgs,
+        });
+      } catch (caughtError) {
+        error = caughtError;
+      }
+
+      expect(error).toBeInstanceOf(Error);
+      expect((error as { code?: string }).code).toBe(
+        CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
+      );
+      expect((error as Error).message).toBe(message);
+    }
+  });
+
   test('rest-resource missing-name guidance separates generated and manual modes', async () => {
     let error: unknown;
 


### PR DESCRIPTION
## Summary
- add a targeted diagnostic for incomplete positional core-variation usage like `wp-typia add core-variation core/group`
- keep the existing `--block` flag missing-block guidance unchanged
- cover positional missing-name and flag missing-block cases in add command tests

## Tests
- bun test packages/wp-typia/tests/add-command.test.ts --test-name-pattern "core-variation missing arguments"
- bun test packages/wp-typia/tests/add-command.test.ts --test-name-pattern "named add commands validate"
- bun test packages/wp-typia/tests/add-command.test.ts packages/wp-typia/tests/add-command-package.test.ts packages/wp-typia/tests/tui-lifecycle.test.ts
- bun run typecheck
- bun run lint:repo
- bun run format:check
- bun run changesets:validate
- bun run --filter wp-typia test

Closes #1048

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error messages and diagnostics when positional arguments in commands are incomplete, offering users clearer guidance on which required flags and arguments need to be provided.

* **Tests**
  * Added new test cases to verify proper error handling and reporting across different missing argument and flag scenarios in the command flow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/1053?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->