### PR TITLE
Stabilize project tools coverage timeout

### DIFF
--- a/packages/wp-typia-project-tools/tests/workspace-add.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-add.test.ts
@@ -5229,7 +5229,7 @@ test("canonical CLI can add a plugin-level REST resource to an official workspac
 
   runCli("npm", ["run", "sync-rest", "--", "--check"], { cwd: targetDir });
   typecheckGeneratedProject(targetDir);
-}, 30_000);
+}, 60_000);
 
 test("sync-rest package check flags stale packaged schemas after REST resources are removed", async () => {
   const targetDir = path.join(tempRoot, "demo-workspace-empty-rest-schema-package");


### PR DESCRIPTION
## Summary
- Increase the timeout for the plugin-level REST resource workspace-add integration test under project-tools coverage.
- Keep the change test-only so the release package surface is unchanged.

## Context
The release merge main CI failed in `Project Tools Coverage` because this integration test timed out at 30s while coverage instrumentation was enabled. The same test completed locally under targeted coverage in ~15s, but the full coverage suite adds enough contention that the existing 30s cap is too tight.

## Tests
- bun test packages/wp-typia-project-tools/tests/workspace-add.test.ts -t "canonical CLI can add a plugin-level REST resource" --coverage --coverage-reporter=lcov --coverage-dir=/tmp/wp-typia-project-tools-single-coverage
- bun run format:check
- bun run changesets:validate
- bun run typecheck
- bun run lint:repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased test timeout to ensure workspace operations complete within the required timeframe.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/1058?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->