### PR TITLE
dx(patterns): expose catalog metadata fields

### DIFF
--- a/.sampo/changesets/1056-pattern-catalog-tui-fields.md
+++ b/.sampo/changesets/1056-pattern-catalog-tui-fields.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Expose optional pattern catalog tags and thumbnail fields in the interactive add flow.

--- a/packages/wp-typia/src/add-kind-registry-shared.ts
+++ b/packages/wp-typia/src/add-kind-registry-shared.ts
@@ -19,8 +19,10 @@ export type AddFieldName =
   | 'source'
   | 'section-role'
   | 'scope'
+  | 'tags'
   | 'type'
   | 'template'
+  | 'thumbnail-url'
   | 'block'
   | 'from'
   | 'attribute'
@@ -175,6 +177,8 @@ export const PATTERN_CATALOG_VISIBLE_FIELDS = [
   'scope',
   'section-role',
   'catalog-title',
+  'tags',
+  'thumbnail-url',
 ] as const satisfies ReadonlyArray<AddFieldName>;
 export const NAME_SOURCE_VISIBLE_FIELDS = [
   'kind',

--- a/packages/wp-typia/src/add-kinds/pattern.ts
+++ b/packages/wp-typia/src/add-kinds/pattern.ts
@@ -29,7 +29,8 @@ export const patternAddKindEntry =
       title: 'Added workspace pattern',
     },
     description: 'Add a PHP block pattern shell',
-    hiddenStringSubmitFields: ['tag', 'tags', 'thumbnail-url'],
+    // Repeatable --tag remains CLI-only; the TUI exposes comma-separated --tags.
+    hiddenStringSubmitFields: ['tag'],
     nameLabel: 'Pattern name',
     async prepareExecution(context) {
       const name = requireAddKindName(context, PATTERN_MISSING_NAME_MESSAGE);

--- a/packages/wp-typia/src/ui/add-flow-field-groups.tsx
+++ b/packages/wp-typia/src/ui/add-flow-field-groups.tsx
@@ -274,11 +274,33 @@ function createPatternCatalogFields(
       ? createElement(FirstPartyTextField, {
           ...getFieldNeighbors(context, 'catalog-title'),
           description:
-            'Defaults to the pattern slug title. Use --tag, --tags, or --thumbnail-url for additional catalog metadata.',
+            'Defaults to the pattern slug title. Optional tags and thumbnails can be set below.',
           key: 'catalog-title',
           label: 'Catalog title',
           name: 'catalog-title',
           placeholder: 'Homepage Hero',
+        })
+      : null,
+    isVisible(context, 'tags')
+      ? createElement(FirstPartyTextField, {
+          ...getFieldNeighbors(context, 'tags'),
+          description:
+            'Optional comma-separated catalog tags. The repeatable --tag flag remains CLI-only.',
+          key: 'tags',
+          label: 'Pattern tags',
+          name: 'tags',
+          placeholder: 'hero,landing',
+        })
+      : null,
+    isVisible(context, 'thumbnail-url')
+      ? createElement(FirstPartyTextField, {
+          ...getFieldNeighbors(context, 'thumbnail-url'),
+          description:
+            'Optional catalog thumbnail URL or relative path for this pattern.',
+          key: 'thumbnail-url',
+          label: 'Thumbnail URL',
+          name: 'thumbnail-url',
+          placeholder: './thumbnail.png',
         })
       : null,
   ];

--- a/packages/wp-typia/src/ui/add-flow-model.ts
+++ b/packages/wp-typia/src/ui/add-flow-model.ts
@@ -66,6 +66,8 @@ export const addFlowSchema = z.object({
   service: z.string().optional(),
   slot: z.string().optional(),
   source: z.string().optional(),
+  // Repeatable --tag is a CLI-only round-trip field. Interactive users can
+  // enter comma-separated catalog tags through the visible `tags` field.
   tag: z.string().optional(),
   tags: z.string().optional(),
   template: z.string().optional(),
@@ -99,7 +101,9 @@ const ADD_FIELD_HEIGHTS: Record<AddFieldName, number> = {
   slot: FIRST_PARTY_SELECT_FIELD_BODY_HEIGHT,
   source: FIRST_PARTY_TEXT_FIELD_BODY_HEIGHT,
   scope: FIRST_PARTY_SELECT_FIELD_BODY_HEIGHT,
+  tags: FIRST_PARTY_TEXT_FIELD_BODY_HEIGHT,
   template: FIRST_PARTY_SELECT_FIELD_BODY_HEIGHT,
+  'thumbnail-url': FIRST_PARTY_TEXT_FIELD_BODY_HEIGHT,
   type: FIRST_PARTY_TEXT_FIELD_BODY_HEIGHT,
   to: FIRST_PARTY_TEXT_FIELD_BODY_HEIGHT,
 };

--- a/packages/wp-typia/tests/add-kind-registry.test.ts
+++ b/packages/wp-typia/tests/add-kind-registry.test.ts
@@ -517,6 +517,15 @@ test('keeps shared visible-field groups aligned for refactored add kinds', () =>
     'post-meta',
     'meta-path',
   ]);
+  expect(getAddVisibleFieldNames({ kind: 'pattern' })).toEqual([
+    'kind',
+    'name',
+    'scope',
+    'section-role',
+    'catalog-title',
+    'tags',
+    'thumbnail-url',
+  ]);
   expect(getAddVisibleFieldNames({ kind: 'block', template: 'basic' })).toEqual(
     ['kind', 'name', 'template'],
   );

--- a/packages/wp-typia/tests/tui-interaction-models.test.ts
+++ b/packages/wp-typia/tests/tui-interaction-models.test.ts
@@ -113,6 +113,8 @@ describe("first-party TUI interaction models", () => {
 			"scope",
 			"section-role",
 			"catalog-title",
+			"tags",
+			"thumbnail-url",
 		]);
 		expect(isAddPersistenceTemplate("compound")).toBe(true);
 		expect(isAddPersistenceTemplate("basic")).toBe(false);


### PR DESCRIPTION
## Summary

- Expose pattern catalog `tags` and `thumbnail-url` in the interactive add flow.
- Keep repeatable `--tag` as a CLI-only round-trip field and document that policy in the schema/add-kind path.
- Extend visible-field/layout metadata and tests so the new TUI fields stay covered.

## Validation

- `bun test packages/wp-typia/tests/tui-interaction-models.test.ts packages/wp-typia/tests/command-option-metadata.test.ts packages/wp-typia/tests/add-kind-registry.test.ts`
- `bun run typecheck`
- `bun run changesets:validate`
- `bun run format:check`
- `bun run --filter wp-typia test`
- `bun run --filter wp-typia build`
- `bun run lint:repo`

Closes #1056
