### PR TITLE
dx(cli): clarify positional block target diagnostics

### DIFF
--- a/.sampo/changesets/1065-positional-block-diagnostics.md
+++ b/.sampo/changesets/1065-positional-block-diagnostics.md
@@ -1,0 +1,6 @@
+---
+npm/wp-typia: patch
+npm/@wp-typia/project-tools: patch
+---
+
+Clarify positional core-variation target diagnostics while preserving flag-style block validation messages.

--- a/packages/wp-typia-project-tools/src/runtime/block-targets.ts
+++ b/packages/wp-typia-project-tools/src/runtime/block-targets.ts
@@ -2,6 +2,20 @@ import { normalizeBlockSlug } from "./scaffold-identifiers.js";
 
 const FULL_BLOCK_NAME_PATTERN = /^[a-z0-9-]+\/[a-z0-9-]+$/u;
 
+/**
+ * Caller-owned error messages for full block name validation.
+ */
+export interface FullBlockNameDiagnostics {
+	/**
+	 * Message returned when the candidate block name is empty.
+	 */
+	empty: () => string;
+	/**
+	 * Message returned when the candidate is not `namespace/block-slug`.
+	 */
+	invalidFormat: () => string;
+}
+
 export interface WorkspaceBlockTargetName {
 	blockName: string;
 	blockSlug: string;
@@ -14,21 +28,39 @@ export interface WorkspaceBlockTargetDiagnostics {
 	namespaceMismatch: (input: string, actualNamespace: string, expectedNamespace: string) => string;
 }
 
+function resolveFullBlockNameDiagnostics(
+	diagnostics: string | FullBlockNameDiagnostics,
+): FullBlockNameDiagnostics {
+	if (typeof diagnostics !== "string") {
+		return diagnostics;
+	}
+
+	return {
+		empty: () => `\`${diagnostics}\` requires a block name.`,
+		invalidFormat: () =>
+			`\`${diagnostics}\` must use <namespace/block-slug> format.`,
+	};
+}
+
 /**
  * Validate a full `namespace/block-slug` block name.
  *
  * @param blockName Candidate block name.
- * @param flagName CLI flag name used in diagnostics.
+ * @param diagnostics CLI flag name or diagnostic builders for caller-owned UX.
  * @returns The trimmed full block name.
  * @throws {Error} When the block name is empty or not a full block name.
  */
-export function assertFullBlockName(blockName: string, flagName: string): string {
+export function assertFullBlockName(
+	blockName: string,
+	diagnostics: string | FullBlockNameDiagnostics,
+): string {
+	const messages = resolveFullBlockNameDiagnostics(diagnostics);
 	const trimmed = blockName.trim();
 	if (!trimmed) {
-		throw new Error(`\`${flagName}\` requires a block name.`);
+		throw new Error(messages.empty());
 	}
 	if (!FULL_BLOCK_NAME_PATTERN.test(trimmed)) {
-		throw new Error(`\`${flagName}\` must use <namespace/block-slug> format.`);
+		throw new Error(messages.invalidFormat());
 	}
 
 	return trimmed;

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-types.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-types.ts
@@ -5,6 +5,7 @@ import {
 	PATTERN_TAG_PATTERN,
 	type PatternCatalogScope,
 } from "./pattern-catalog.js";
+import type { FullBlockNameDiagnostics } from "./block-targets.js";
 
 export { ADD_KIND_IDS } from "./cli-add-kind-ids.js";
 export type { AddKindId } from "./cli-add-kind-ids.js";
@@ -162,11 +163,14 @@ export interface RunAddVariationCommandOptions {
  *
  * @property cwd Working directory used to resolve the nearest official workspace.
  * @property targetBlockName Full `namespace/block` name that receives the variation.
+ * @property targetBlockNameDiagnostics Optional diagnostics for positional target
+ * block names. Omitted callers keep legacy target diagnostics.
  * @property variationName Human-entered variation name normalized into a slug.
  */
 export interface RunAddCoreVariationCommandOptions {
 	cwd?: string;
 	targetBlockName: string;
+	targetBlockNameDiagnostics?: string | FullBlockNameDiagnostics;
 	variationName: string;
 }
 

--- a/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-core-variation.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli-add-workspace-core-variation.ts
@@ -515,6 +515,7 @@ async function writeCoreVariationRegistry(
 export async function runAddCoreVariationCommand({
 	cwd = process.cwd(),
 	targetBlockName,
+	targetBlockNameDiagnostics = "core-variation target",
 	variationName,
 }: RunAddCoreVariationCommandOptions): Promise<{
 	projectDir: string;
@@ -526,7 +527,7 @@ export async function runAddCoreVariationCommand({
 	const workspace = resolveWorkspaceProject(cwd);
 	const resolvedTargetBlockName = assertFullBlockName(
 		targetBlockName,
-		"core-variation target",
+		targetBlockNameDiagnostics,
 	);
 	const variationSlug = assertValidGeneratedSlug(
 		"Core variation name",

--- a/packages/wp-typia-project-tools/tests/runtime-helper-consolidation.test.ts
+++ b/packages/wp-typia-project-tools/tests/runtime-helper-consolidation.test.ts
@@ -167,6 +167,16 @@ test('shared block target helpers preserve workspace target diagnostics', () => 
   expect(() => assertFullBlockName('counter-card', '--from')).toThrow(
     '`--from` must use <namespace/block-slug> format.',
   );
+  expect(() =>
+    assertFullBlockName('counter-card', {
+      empty: () =>
+        'The first positional argument (target block name) requires a block name.',
+      invalidFormat: () =>
+        'The first positional argument (target block name) must use <namespace/block-slug> format.',
+    }),
+  ).toThrow(
+    'The first positional argument (target block name) must use <namespace/block-slug> format.',
+  );
   expect(resolveWorkspaceTargetBlockName('counter-card', 'demo-space', '--to')).toEqual({
     blockName: 'demo-space/counter-card',
     blockSlug: 'counter-card',

--- a/packages/wp-typia/src/add-kinds/core-variation.ts
+++ b/packages/wp-typia/src/add-kinds/core-variation.ts
@@ -19,6 +19,12 @@ const CORE_VARIATION_MISSING_BLOCK_MESSAGE =
   '`wp-typia add core-variation` requires <block-name>. Usage: wp-typia add core-variation <block-name> <name> or wp-typia add core-variation <name> --block <namespace/block>.';
 
 const CORE_VARIATION_BLOCK_NAME_PATTERN = /^[^/\s]+\/[^/\s]+$/u;
+const CORE_VARIATION_POSITIONAL_TARGET_DIAGNOSTICS = {
+  empty: () =>
+    'The first positional argument (target block name) requires a block name.',
+  invalidFormat: () =>
+    'The first positional argument (target block name) must use <namespace/block-slug> format.',
+} as const;
 
 function formatCoreVariationMissingPositionalNameMessage(
   blockName: string,
@@ -32,6 +38,9 @@ function formatCoreVariationMissingPositionalNameMessage(
 
 function resolveCoreVariationInputs(context: AddKindExecutionContext): {
   targetBlockName: string;
+  targetBlockNameDiagnostics:
+    | '--block'
+    | typeof CORE_VARIATION_POSITIONAL_TARGET_DIAGNOSTICS;
   variationName: string;
 } {
   const positionalTargetBlockName = context.positionalArgs?.[1];
@@ -47,6 +56,7 @@ function resolveCoreVariationInputs(context: AddKindExecutionContext): {
 
     return {
       targetBlockName: positionalTargetBlockName,
+      targetBlockNameDiagnostics: CORE_VARIATION_POSITIONAL_TARGET_DIAGNOSTICS,
       variationName: positionalVariationName,
     };
   }
@@ -81,6 +91,7 @@ function resolveCoreVariationInputs(context: AddKindExecutionContext): {
 
   return {
     targetBlockName: targetBlockFlag,
+    targetBlockNameDiagnostics: '--block',
     variationName,
   };
 }
@@ -102,7 +113,7 @@ export const coreVariationAddKindEntry =
     description: 'Add an editor-side variation for an existing core or external block',
     nameLabel: 'Variation name',
     async prepareExecution(context) {
-      const { targetBlockName, variationName } =
+      const { targetBlockName, targetBlockNameDiagnostics, variationName } =
         resolveCoreVariationInputs(context);
 
       return createNamedExecutionPlan(context, {
@@ -110,6 +121,7 @@ export const coreVariationAddKindEntry =
           context.addRuntime.runAddCoreVariationCommand({
             cwd,
             targetBlockName,
+            targetBlockNameDiagnostics,
             variationName: name,
           }),
         getValues: (result) => ({

--- a/packages/wp-typia/tests/add-command.test.ts
+++ b/packages/wp-typia/tests/add-command.test.ts
@@ -712,6 +712,98 @@ describe('wp-typia add command bridge', () => {
     }
   });
 
+  test('core-variation preserves positional and flag block diagnostics', async () => {
+    const capturedOptions: Record<string, unknown>[] = [];
+    const addRuntime = ({
+      runAddCoreVariationCommand: async (options: Record<string, unknown>) => {
+        capturedOptions.push(options);
+
+        return {
+          projectDir: String(options.cwd),
+          targetBlockName: String(options.targetBlockName),
+          variationFile: 'src/editor-plugins/core-variations/core-group/hero.ts',
+          variationSlug: String(options.variationName),
+        };
+      },
+    } as unknown) as AddKindExecutionContext['addRuntime'];
+    const baseContext = {
+      addRuntime,
+      cwd: '/tmp/wp-typia-core-variation',
+      getOrCreatePrompt: async () => {
+        throw new Error('prompt should not be used');
+      },
+      isInteractiveSession: false,
+      warnLine: () => {},
+    } satisfies Pick<
+      AddKindExecutionContext,
+      | 'addRuntime'
+      | 'cwd'
+      | 'getOrCreatePrompt'
+      | 'isInteractiveSession'
+      | 'warnLine'
+    >;
+
+    const positionalPlan =
+      await ADD_KIND_REGISTRY['core-variation'].prepareExecution({
+        ...baseContext,
+        flags: {},
+        name: 'hero-card',
+        positionalArgs: ['core-variation', 'core-group', 'hero-card'],
+      });
+    await positionalPlan.execute('/tmp/wp-typia-core-variation');
+    const flagPlan = await ADD_KIND_REGISTRY['core-variation'].prepareExecution({
+      ...baseContext,
+      flags: {
+        block: 'core-group',
+      },
+      name: 'hero-card',
+      positionalArgs: ['core-variation', 'hero-card'],
+    });
+    await flagPlan.execute('/tmp/wp-typia-core-variation');
+
+    const positionalDiagnostics = capturedOptions[0]
+      ?.targetBlockNameDiagnostics as {
+      invalidFormat: () => string;
+    };
+    expect(positionalDiagnostics.invalidFormat()).toBe(
+      'The first positional argument (target block name) must use <namespace/block-slug> format.',
+    );
+    expect(capturedOptions[1]?.targetBlockNameDiagnostics).toBe('--block');
+  });
+
+  test('core-variation invalid target diagnostics distinguish positional and flag usage', async () => {
+    const projectDir = path.join(tempRoot, 'demo-core-variation-diagnostics');
+
+    await scaffoldOfficialWorkspace(projectDir);
+    linkWorkspaceNodeModules(projectDir);
+    await expect(
+      executeAddCommand({
+        cwd: projectDir,
+        emitOutput: false,
+        flags: {},
+        interactive: false,
+        kind: 'core-variation',
+        name: 'hero-card',
+        positionalArgs: ['core-variation', 'core-group', 'hero-card'],
+      }),
+    ).rejects.toThrow(
+      'The first positional argument (target block name) must use <namespace/block-slug> format.',
+    );
+    await expect(
+      executeAddCommand({
+        cwd: projectDir,
+        emitOutput: false,
+        flags: {
+          block: 'core-group',
+        },
+        interactive: false,
+        kind: 'core-variation',
+        name: 'hero-card',
+        positionalArgs: ['core-variation', 'hero-card'],
+      }),
+    ).rejects.toThrow('`--block` must use <namespace/block-slug> format.');
+  });
+
   test('rest-resource missing-name guidance separates generated and manual modes', async () => {
     let error: unknown;
 


### PR DESCRIPTION
## Summary
- Allow shared full block-name validation to use caller-owned diagnostic messages.
- Pass positional vs `--block` context through the core-variation add flow.
- Cover both the helper behavior and actual core-variation CLI error messages.

## Validation
- `bun test packages/wp-typia-project-tools/tests/runtime-helper-consolidation.test.ts packages/wp-typia/tests/add-command.test.ts`
- `bun run --filter @wp-typia/project-tools build`
- `bun run --filter wp-typia build`
- `bun run format:check`
- `bun run changesets:validate`
- `bun run lint:repo`

Closes #1065

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messages for the `wp-typia add core-variation` command. Diagnostic output is now more specific and context-aware when block names are empty or invalid. Messages adapt based on whether positional arguments or command flags are used, improving clarity during command execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/1066?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->