### PR TITLE
refactor(cli): preserve typed add option shapes

### DIFF
--- a/.sampo/changesets/1064-typed-add-flow-options.md
+++ b/.sampo/changesets/1064-typed-add-flow-options.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Preserve repeatable add option arrays when requested and validate interactive add flow select fields with enum-backed schemas.

--- a/packages/wp-typia/src/command-option-metadata.ts
+++ b/packages/wp-typia/src/command-option-metadata.ts
@@ -381,6 +381,13 @@ export function parseCommandArgvWithMetadata(
   };
 }
 
+/**
+ * Resolve CLI option values from defaults and parsed flags.
+ *
+ * Repeatable string options keep the historical comma-joined value by default
+ * for TUI initial values. Pass `preserveArrays` when downstream code needs the
+ * parsed repeated flag boundaries.
+ */
 export function resolveCommandOptionValues<
   TMetadata extends CommandOptionMetadataMap,
 >(
@@ -389,9 +396,32 @@ export function resolveCommandOptionValues<
     defaults?: Record<string, unknown>;
     flags?: Record<string, unknown>;
     optionNames?: Iterable<keyof TMetadata | string>;
+    preserveArrays: true;
   },
-): Record<string, string | boolean | undefined> {
-  const resolved: Record<string, string | boolean | undefined> = {};
+): Record<string, string | boolean | string[] | undefined>;
+export function resolveCommandOptionValues<
+  TMetadata extends CommandOptionMetadataMap,
+>(
+  metadata: TMetadata,
+  options: {
+    defaults?: Record<string, unknown>;
+    flags?: Record<string, unknown>;
+    optionNames?: Iterable<keyof TMetadata | string>;
+    preserveArrays?: false;
+  },
+): Record<string, string | boolean | undefined>;
+export function resolveCommandOptionValues<
+  TMetadata extends CommandOptionMetadataMap,
+>(
+  metadata: TMetadata,
+  options: {
+    defaults?: Record<string, unknown>;
+    flags?: Record<string, unknown>;
+    optionNames?: Iterable<keyof TMetadata | string>;
+    preserveArrays?: boolean;
+  },
+): Record<string, string | boolean | string[] | undefined> {
+  const resolved: Record<string, string | boolean | string[] | undefined> = {};
   const optionNames =
     options.optionNames ?? (Object.keys(metadata) as Array<keyof TMetadata>);
 
@@ -409,10 +439,12 @@ export function resolveCommandOptionValues<
     }
 
     if (descriptor.repeatable && Array.isArray(value)) {
-      resolved[name] =
-        value.every((item): item is string => typeof item === 'string')
-          ? value.join(',')
-          : undefined;
+      if (!value.every((item): item is string => typeof item === 'string')) {
+        resolved[name] = undefined;
+        continue;
+      }
+
+      resolved[name] = options.preserveArrays ? [...value] : value.join(',');
       continue;
     }
 

--- a/packages/wp-typia/src/ui/add-flow-model.ts
+++ b/packages/wp-typia/src/ui/add-flow-model.ts
@@ -1,5 +1,13 @@
 import { z } from 'zod';
 
+import { COMPOUND_INNER_BLOCKS_PRESET_IDS } from '@wp-typia/project-tools/compound-inner-blocks';
+import {
+  ADD_BLOCK_TEMPLATE_IDS,
+  EDITOR_PLUGIN_SLOT_IDS,
+  PATTERN_CATALOG_SCOPE_IDS,
+} from '@wp-typia/project-tools/cli-add';
+import { HOOKED_BLOCK_POSITION_IDS } from '@wp-typia/project-tools/hooked-blocks';
+
 import {
   ADD_KIND_IDS,
   type AddFieldName,
@@ -21,6 +29,19 @@ import {
   getFirstPartyViewportHeight,
 } from './first-party-form-model';
 
+export const ADD_FLOW_DATA_STORAGE_IDS = [
+  'custom-table',
+  'post-meta',
+] as const;
+export const ADD_FLOW_PERSISTENCE_POLICY_IDS = [
+  'authenticated',
+  'public',
+] as const;
+
+const repeatableStringFieldSchema = z
+  .union([z.string(), z.array(z.string())])
+  .optional();
+
 export const addFlowSchema = z.object({
   'alternate-render-targets': z.string().optional(),
   anchor: z.string().optional(),
@@ -31,11 +52,11 @@ export const addFlowSchema = z.object({
   'catalog-title': z.string().optional(),
   'controller-class': z.string().optional(),
   'controller-extends': z.string().optional(),
-  'data-storage': z.string().optional(),
+  'data-storage': z.enum(ADD_FLOW_DATA_STORAGE_IDS).optional(),
   'external-layer-id': z.string().optional(),
   'external-layer-source': z.string().optional(),
   from: z.string().optional(),
-  'inner-blocks-preset': z.string().optional(),
+  'inner-blocks-preset': z.enum(COMPOUND_INNER_BLOCKS_PRESET_IDS).optional(),
   kind: z.enum(ADD_KIND_IDS).default('block'),
   manual: z.boolean().optional(),
   'hide-from-rest': z.boolean().optional(),
@@ -48,15 +69,15 @@ export const addFlowSchema = z.object({
   namespace: z.string().optional(),
   path: z.string().optional(),
   'permission-callback': z.string().optional(),
-  'persistence-policy': z.string().optional(),
+  'persistence-policy': z.enum(ADD_FLOW_PERSISTENCE_POLICY_IDS).optional(),
   'post-type': z.string().optional(),
   'post-meta': z.string().optional(),
-  position: z.string().optional(),
+  position: z.enum(HOOKED_BLOCK_POSITION_IDS).optional(),
   'query-type': z.string().optional(),
   'release-zip': z.boolean().optional(),
   'response-type': z.string().optional(),
   'route-pattern': z.string().optional(),
-  scope: z.string().optional(),
+  scope: z.enum(PATTERN_CATALOG_SCOPE_IDS).optional(),
   'section-role': z.string().optional(),
   'secret-field': z.string().optional(),
   'secret-has-value-field': z.string().optional(),
@@ -64,13 +85,13 @@ export const addFlowSchema = z.object({
   'secret-preserve-on-empty': z.string().optional(),
   'secret-state-field': z.string().optional(),
   service: z.string().optional(),
-  slot: z.string().optional(),
+  slot: z.enum(EDITOR_PLUGIN_SLOT_IDS).optional(),
   source: z.string().optional(),
   // Repeatable --tag is a CLI-only round-trip field. Interactive users can
   // enter comma-separated catalog tags through the visible `tags` field.
-  tag: z.string().optional(),
-  tags: z.string().optional(),
-  template: z.string().optional(),
+  tag: repeatableStringFieldSchema,
+  tags: repeatableStringFieldSchema,
+  template: z.enum(ADD_BLOCK_TEMPLATE_IDS).optional(),
   'thumbnail-url': z.string().optional(),
   type: z.string().optional(),
   to: z.string().optional(),

--- a/packages/wp-typia/src/ui/add-flow-model.ts
+++ b/packages/wp-typia/src/ui/add-flow-model.ts
@@ -37,10 +37,16 @@ export const ADD_FLOW_PERSISTENCE_POLICY_IDS = [
   'authenticated',
   'public',
 ] as const;
+const ADD_FLOW_EDITOR_PLUGIN_SLOT_IDS = [
+  ...EDITOR_PLUGIN_SLOT_IDS,
+  'PluginSidebar',
+  'PluginDocumentSettingPanel',
+] as const;
 
 const repeatableStringFieldSchema = z
   .union([z.string(), z.array(z.string())])
   .optional();
+const emptySelectValueSchema = z.literal('');
 
 export const addFlowSchema = z.object({
   'alternate-render-targets': z.string().optional(),
@@ -52,11 +58,15 @@ export const addFlowSchema = z.object({
   'catalog-title': z.string().optional(),
   'controller-class': z.string().optional(),
   'controller-extends': z.string().optional(),
-  'data-storage': z.enum(ADD_FLOW_DATA_STORAGE_IDS).optional(),
+  'data-storage': z
+    .union([z.enum(ADD_FLOW_DATA_STORAGE_IDS), emptySelectValueSchema])
+    .optional(),
   'external-layer-id': z.string().optional(),
   'external-layer-source': z.string().optional(),
   from: z.string().optional(),
-  'inner-blocks-preset': z.enum(COMPOUND_INNER_BLOCKS_PRESET_IDS).optional(),
+  'inner-blocks-preset': z
+    .union([z.enum(COMPOUND_INNER_BLOCKS_PRESET_IDS), emptySelectValueSchema])
+    .optional(),
   kind: z.enum(ADD_KIND_IDS).default('block'),
   manual: z.boolean().optional(),
   'hide-from-rest': z.boolean().optional(),
@@ -69,15 +79,21 @@ export const addFlowSchema = z.object({
   namespace: z.string().optional(),
   path: z.string().optional(),
   'permission-callback': z.string().optional(),
-  'persistence-policy': z.enum(ADD_FLOW_PERSISTENCE_POLICY_IDS).optional(),
+  'persistence-policy': z
+    .union([z.enum(ADD_FLOW_PERSISTENCE_POLICY_IDS), emptySelectValueSchema])
+    .optional(),
   'post-type': z.string().optional(),
   'post-meta': z.string().optional(),
-  position: z.enum(HOOKED_BLOCK_POSITION_IDS).optional(),
+  position: z
+    .union([z.enum(HOOKED_BLOCK_POSITION_IDS), emptySelectValueSchema])
+    .optional(),
   'query-type': z.string().optional(),
   'release-zip': z.boolean().optional(),
   'response-type': z.string().optional(),
   'route-pattern': z.string().optional(),
-  scope: z.enum(PATTERN_CATALOG_SCOPE_IDS).optional(),
+  scope: z
+    .union([z.enum(PATTERN_CATALOG_SCOPE_IDS), emptySelectValueSchema])
+    .optional(),
   'section-role': z.string().optional(),
   'secret-field': z.string().optional(),
   'secret-has-value-field': z.string().optional(),
@@ -85,13 +101,17 @@ export const addFlowSchema = z.object({
   'secret-preserve-on-empty': z.string().optional(),
   'secret-state-field': z.string().optional(),
   service: z.string().optional(),
-  slot: z.enum(EDITOR_PLUGIN_SLOT_IDS).optional(),
+  slot: z
+    .union([z.enum(ADD_FLOW_EDITOR_PLUGIN_SLOT_IDS), emptySelectValueSchema])
+    .optional(),
   source: z.string().optional(),
   // Repeatable --tag is a CLI-only round-trip field. Interactive users can
   // enter comma-separated catalog tags through the visible `tags` field.
   tag: repeatableStringFieldSchema,
   tags: repeatableStringFieldSchema,
-  template: z.enum(ADD_BLOCK_TEMPLATE_IDS).optional(),
+  template: z
+    .union([z.enum(ADD_BLOCK_TEMPLATE_IDS), emptySelectValueSchema])
+    .optional(),
   'thumbnail-url': z.string().optional(),
   type: z.string().optional(),
   to: z.string().optional(),

--- a/packages/wp-typia/tests/command-option-metadata.test.ts
+++ b/packages/wp-typia/tests/command-option-metadata.test.ts
@@ -557,10 +557,23 @@ describe('command option metadata helpers', () => {
         'persistence-policy': 'public',
         position: 'after',
         scope: 'section',
-        slot: 'sidebar',
+        slot: 'PluginSidebar',
         tag: ['featured', 'landing'],
         tags: ['hero,landing'],
         template: 'compound',
+      }).success,
+    ).toBe(true);
+    expect(
+      addFlowSchema.safeParse({
+        'data-storage': '',
+        'inner-blocks-preset': '',
+        kind: 'block',
+        name: 'hero-card',
+        'persistence-policy': '',
+        position: '',
+        scope: '',
+        slot: '',
+        template: '',
       }).success,
     ).toBe(true);
 
@@ -597,7 +610,7 @@ describe('command option metadata helpers', () => {
         'interactivity',
         'persistence',
         'compound',
-      ]) {
+      ] as const) {
         for (const fieldName of getVisibleAddFieldNames({ kind, template })) {
           visibleFieldNames.add(fieldName);
         }

--- a/packages/wp-typia/tests/command-option-metadata.test.ts
+++ b/packages/wp-typia/tests/command-option-metadata.test.ts
@@ -272,6 +272,31 @@ describe('command option metadata helpers', () => {
     expect(parsed.positionals).toEqual(['pattern', 'hero-photo']);
   });
 
+  test('keeps repeatable option arrays available through opt-in resolution', () => {
+    const flags = {
+      tag: ['featured', 'hero'],
+      tags: ['hero,landing', 'gallery'],
+    };
+    const flattened = resolveCommandOptionValues(ADD_OPTION_METADATA, {
+      flags,
+      optionNames: ['tag', 'tags'],
+    });
+    const preserved = resolveCommandOptionValues(ADD_OPTION_METADATA, {
+      flags,
+      optionNames: ['tag', 'tags'],
+      preserveArrays: true,
+    });
+
+    expect(flattened).toEqual({
+      tag: 'featured,hero',
+      tags: 'hero,landing,gallery',
+    });
+    expect(preserved).toEqual({
+      tag: ['featured', 'hero'],
+      tags: ['hero,landing', 'gallery'],
+    });
+  });
+
   test('parses manual REST secret flags from shared add metadata', () => {
     const parsed = parseCommandArgvWithMetadata(
       [
@@ -520,6 +545,42 @@ describe('command option metadata helpers', () => {
     );
 
     expect(schemaOptionNames.sort()).toEqual(metadataOptionNames.sort());
+  });
+
+  test('validates add flow select fields against registered option ids', () => {
+    expect(
+      addFlowSchema.safeParse({
+        'data-storage': 'post-meta',
+        'inner-blocks-preset': 'ordered',
+        kind: 'block',
+        name: 'hero-card',
+        'persistence-policy': 'public',
+        position: 'after',
+        scope: 'section',
+        slot: 'sidebar',
+        tag: ['featured', 'landing'],
+        tags: ['hero,landing'],
+        template: 'compound',
+      }).success,
+    ).toBe(true);
+
+    for (const [fieldName, value] of [
+      ['data-storage', 'sqlite'],
+      ['inner-blocks-preset', 'stacked'],
+      ['persistence-policy', 'anonymous'],
+      ['position', 'middle'],
+      ['scope', 'landing'],
+      ['slot', 'toolbar'],
+      ['template', 'workspace'],
+    ] as const) {
+      expect(
+        addFlowSchema.safeParse({
+          kind: 'block',
+          name: 'hero-card',
+          [fieldName]: value,
+        }).success,
+      ).toBe(false);
+    }
   });
 
   test('keeps visible add fields covered by metadata, schema, and layout', () => {

--- a/packages/wp-typia/tests/tui-interaction-models.test.ts
+++ b/packages/wp-typia/tests/tui-interaction-models.test.ts
@@ -277,7 +277,7 @@ describe("first-party TUI interaction models", () => {
 				"catalog-title": " Homepage Hero ",
 				kind: "pattern",
 				name: "hero-photo",
-				scope: " section ",
+				scope: "section",
 				"section-role": " hero ",
 				tag: " hero ",
 				tags: " landing,featured ",


### PR DESCRIPTION
## Summary
- tighten interactive add flow select validation with enum-backed schemas
- allow repeatable add options to preserve array boundaries via `resolveCommandOptionValues(..., { preserveArrays: true })` while keeping default comma-joined behavior
- cover enum validation and repeatable array preservation in command metadata tests

## Validation
- `bun test packages/wp-typia/tests/command-option-metadata.test.ts`
- `bun test packages/wp-typia/tests/tui-interaction-models.test.ts`
- `bun run --filter wp-typia build`
- `bun run changesets:validate`
- `bun run format:check`
- `bun run lint:repo`
- `git diff --check`

Closes #1064