### PR TITLE
dx(patterns): preview dry-run catalog metadata

### DIFF
--- a/.sampo/changesets/1063-pattern-dry-run-metadata.md
+++ b/.sampo/changesets/1063-pattern-dry-run-metadata.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Show resolved pattern catalog metadata and normalization notes in add-pattern dry-run output.

--- a/packages/wp-typia/src/add-kind-registry-shared.ts
+++ b/packages/wp-typia/src/add-kind-registry-shared.ts
@@ -55,6 +55,7 @@ export type AddKindExecutionPlan<
   TResult extends AddKindExecutionResultBase = AddKindExecutionResultBase,
 > = {
   execute: (cwd: string) => Promise<TResult>;
+  getDryRunSummaryLines?: (result: TResult) => string[] | undefined;
   getValues: (result: TResult) => Record<string, string>;
   getWarnings?: (result: TResult) => string[] | undefined;
   warnLine?: PrintLine;

--- a/packages/wp-typia/src/add-kinds/pattern.ts
+++ b/packages/wp-typia/src/add-kinds/pattern.ts
@@ -34,18 +34,26 @@ export const patternAddKindEntry =
     nameLabel: 'Pattern name',
     async prepareExecution(context) {
       const name = requireAddKindName(context, PATTERN_MISSING_NAME_MESSAGE);
-      const scope = resolvePatternScopeFlag(context);
-      const sectionRole = resolvePatternSectionRoleFlag(context, scope);
-      const catalogTitle =
+      const rawScope =
+        typeof context.flags.scope === 'string' ? context.flags.scope : undefined;
+      const rawSectionRole =
+        typeof context.flags['section-role'] === 'string'
+          ? context.flags['section-role']
+          : undefined;
+      const rawCatalogTitle =
         typeof context.flags['catalog-title'] === 'string'
           ? context.flags['catalog-title']
           : undefined;
-      const tags =
-        normalizePatternTagFlags(context.flags.tags, context.flags.tag);
-      const thumbnailUrl =
+      const rawThumbnailUrl =
         typeof context.flags['thumbnail-url'] === 'string'
           ? context.flags['thumbnail-url']
           : undefined;
+      const scope = resolvePatternScopeFlag(context);
+      const sectionRole = resolvePatternSectionRoleFlag(context, scope);
+      const catalogTitle = rawCatalogTitle;
+      const tags =
+        normalizePatternTagFlags(context.flags.tags, context.flags.tag);
+      const thumbnailUrl = rawThumbnailUrl;
 
       return {
         execute: (cwd) =>
@@ -57,6 +65,14 @@ export const patternAddKindEntry =
             sectionRole,
             tags,
             thumbnailUrl,
+          }),
+        getDryRunSummaryLines: (result: AddPatternResult) =>
+          buildPatternCatalogDryRunSummaryLines(result, {
+            rawCatalogTitle,
+            rawScope,
+            rawSectionRole,
+            rawTags: tags,
+            rawThumbnailUrl,
           }),
         getValues: (result: AddPatternResult) => ({
           contentFile: result.contentFile,
@@ -169,4 +185,128 @@ function normalizePatternTagFlags(
     ...collectStringFlagValues(tagFlag),
   ];
   return tags.length > 0 ? tags : undefined;
+}
+
+function quoteValue(value: string): string {
+  return `"${value}"`;
+}
+
+function formatTags(tags: readonly string[]): string {
+  return tags.length > 0 ? tags.join(', ') : 'no tags';
+}
+
+function collectPatternTagTokens(tags: readonly string[] | undefined): string[] {
+  return (tags ?? [])
+    .flatMap((tag) => tag.split(','))
+    .map((tag) => tag.trim())
+    .filter((tag) => tag.length > 0);
+}
+
+function valuesMatch(left: readonly string[], right: readonly string[]): boolean {
+  return (
+    left.length === right.length &&
+    left.every((value, index) => value === right[index])
+  );
+}
+
+function createNormalizationNote(options: {
+  fieldLabel: string;
+  rawValue: string | undefined;
+  resolvedValue: string | undefined;
+}): string | undefined {
+  const rawValue = options.rawValue;
+  if (
+    rawValue === undefined ||
+    rawValue.trim().length === 0 ||
+    !options.resolvedValue ||
+    rawValue === options.resolvedValue
+  ) {
+    return undefined;
+  }
+
+  return `${options.fieldLabel} normalized from ${quoteValue(
+    rawValue,
+  )} to ${quoteValue(options.resolvedValue)}.`;
+}
+
+function collectPatternCatalogNormalizationNotes(
+  result: AddPatternResult,
+  options: {
+    rawCatalogTitle?: string;
+    rawScope?: string;
+    rawSectionRole?: string;
+    rawTags?: readonly string[];
+    rawThumbnailUrl?: string;
+  },
+): string[] {
+  const notes = [
+    createNormalizationNote({
+      fieldLabel: 'Scope',
+      rawValue: options.rawScope,
+      resolvedValue: result.patternScope,
+    }),
+    createNormalizationNote({
+      fieldLabel: 'Section role',
+      rawValue: options.rawSectionRole,
+      resolvedValue: result.sectionRole,
+    }),
+    createNormalizationNote({
+      fieldLabel: 'Title',
+      rawValue: options.rawCatalogTitle,
+      resolvedValue: result.title,
+    }),
+    createNormalizationNote({
+      fieldLabel: 'Thumbnail URL',
+      rawValue: options.rawThumbnailUrl,
+      resolvedValue: result.thumbnailUrl,
+    }),
+  ].filter((note): note is string => typeof note === 'string');
+  const rawTags = collectPatternTagTokens(options.rawTags);
+  if (rawTags.length > 0 && !valuesMatch(rawTags, result.tags)) {
+    notes.push(
+      `Tags normalized from ${quoteValue(formatTags(rawTags))} to ${quoteValue(
+        formatTags(result.tags),
+      )}.`,
+    );
+  }
+
+  return notes;
+}
+
+function buildPatternCatalogDryRunSummaryLines(
+  result: AddPatternResult,
+  options: {
+    rawCatalogTitle?: string;
+    rawScope?: string;
+    rawSectionRole?: string;
+    rawTags?: readonly string[];
+    rawThumbnailUrl?: string;
+  },
+): string[] {
+  const catalogLines = [
+    '',
+    'Catalog metadata:',
+    `  Scope: ${result.patternScope}`,
+    ...(result.sectionRole ? [`  Section role: ${result.sectionRole}`] : []),
+    `  Title: ${result.title}`,
+    ...(result.tags.length > 0 ? [`  Tags: ${formatTags(result.tags)}`] : []),
+    ...(result.thumbnailUrl
+      ? [`  Thumbnail URL: ${result.thumbnailUrl}`]
+      : []),
+  ];
+  const normalizationNotes = collectPatternCatalogNormalizationNotes(
+    result,
+    options,
+  );
+
+  if (normalizationNotes.length === 0) {
+    return catalogLines;
+  }
+
+  return [
+    ...catalogLines,
+    '',
+    'Normalization notes:',
+    ...normalizationNotes.map((note) => `  ${note}`),
+  ];
 }

--- a/packages/wp-typia/src/runtime-bridge-add.ts
+++ b/packages/wp-typia/src/runtime-bridge-add.ts
@@ -53,6 +53,7 @@ async function executeWorkspaceAddWithOptionalDryRun<TResult>(options: {
   buildCompletion: (
     result: TResult,
   ) => ReturnType<typeof buildAddCompletionPayload>;
+  buildDryRunSummaryLines?: (result: TResult) => string[] | undefined;
   cwd: string;
   dryRun: boolean;
   emitOutput: boolean | undefined;
@@ -81,6 +82,7 @@ async function executeWorkspaceAddWithOptionalDryRun<TResult>(options: {
     buildAddDryRunPayload({
       completion,
       fileOperations: simulated!.fileOperations,
+      summaryLines: options.buildDryRunSummaryLines?.(result),
     }),
     {
       emitOutput: options.emitOutput ?? true,
@@ -108,6 +110,7 @@ function executePreparedAddKind<TKey extends AddKindId>(
         values: plan.getValues(result),
         warnings: plan.getWarnings?.(result),
       }),
+    buildDryRunSummaryLines: (result) => plan.getDryRunSummaryLines?.(result),
     cwd: context.cwd,
     dryRun: context.dryRun,
     emitOutput: context.emitOutput,

--- a/packages/wp-typia/src/runtime-output/add.ts
+++ b/packages/wp-typia/src/runtime-output/add.ts
@@ -66,6 +66,7 @@ export function buildAddDryRunPayload(
   options: {
     completion: AlternateBufferCompletionPayload;
     fileOperations: string[];
+    summaryLines?: string[];
   },
   markerOptions?: OutputMarkerOptions,
 ): AlternateBufferCompletionPayload {
@@ -73,6 +74,10 @@ export function buildAddDryRunPayload(
     options.completion.title,
     'success',
   ).replace(/^Added\s*/u, '');
+  const summaryLines = [
+    ...(options.completion.summaryLines ?? []),
+    ...(options.summaryLines ?? []),
+  ];
 
   return {
     optionalLines: options.fileOperations,
@@ -80,7 +85,7 @@ export function buildAddDryRunPayload(
       'No workspace files were changed because --dry-run was enabled. Re-run without --dry-run to apply this add command.',
     optionalTitle: `Planned workspace updates (${options.fileOperations.length}):`,
     preambleLines: options.completion.preambleLines,
-    summaryLines: options.completion.summaryLines,
+    summaryLines: summaryLines.length > 0 ? summaryLines : undefined,
     title: formatOutputMarker(
       'dryRun',
       `Dry run for ${normalizedTitle || 'workspace add command'}`,

--- a/packages/wp-typia/tests/add-command.test.ts
+++ b/packages/wp-typia/tests/add-command.test.ts
@@ -902,6 +902,56 @@ describe('wp-typia add command bridge', () => {
     }
   });
 
+  test('pattern dry-run previews resolved catalog metadata and normalization notes', async () => {
+    const projectDir = path.join(tempRoot, 'demo-pattern-dry-run-metadata');
+
+    await scaffoldOfficialWorkspace(projectDir);
+    linkWorkspaceNodeModules(projectDir);
+
+    const payload = await executeAddCommand({
+      cwd: projectDir,
+      emitOutput: false,
+      flags: {
+        'catalog-title': 'Hero Layout',
+        'dry-run': true,
+        scope: 'section',
+        'section-role': 'My Hero Section!!',
+        tag: ['Hero'],
+        tags: ['Hero,landing', 'gallery'],
+        'thumbnail-url': './thumbnails/hero.png',
+      },
+      interactive: false,
+      kind: 'pattern',
+      name: 'hero-layout',
+    });
+
+    expect(payload?.title).toContain('Dry run for workspace pattern');
+    expect(payload?.summaryLines).toEqual(
+      expect.arrayContaining([
+        'Catalog metadata:',
+        '  Scope: section',
+        '  Section role: my-hero-section',
+        '  Title: Hero Layout',
+        '  Tags: gallery, hero, landing',
+        '  Thumbnail URL: ./thumbnails/hero.png',
+        'Normalization notes:',
+        '  Section role normalized from "My Hero Section!!" to "my-hero-section".',
+        '  Tags normalized from "Hero, landing, gallery, Hero" to "gallery, hero, landing".',
+      ]),
+    );
+    expect(payload?.optionalLines).toEqual(
+      expect.arrayContaining([
+        'write src/patterns/sections/hero-layout.php',
+        'update scripts/block-config.ts',
+      ]),
+    );
+    expect(
+      fs.existsSync(
+        path.join(projectDir, 'src', 'patterns', 'sections', 'hero-layout.php'),
+      ),
+    ).toBe(false);
+  });
+
   test('every registered add kind currently advertises dry-run support', () => {
     expect(ADD_KIND_IDS.every((kind) => supportsAddKindDryRun(kind))).toBe(
       true,


### PR DESCRIPTION
## Summary
- add a dry-run summary hook for add-kind execution plans
- show resolved pattern catalog metadata during `wp-typia add pattern --dry-run`
- surface normalization notes for section roles and tags before writes are applied

## Validation
- `bun test packages/wp-typia/tests/add-command.test.ts packages/wp-typia/tests/add-kind-registry.test.ts packages/wp-typia/tests/completion-output.test.ts`
- `bun test packages/wp-typia/tests/add-command.test.ts packages/wp-typia/tests/completion-output.test.ts`
- `bun run typecheck`
- `bun run --filter wp-typia build`
- `bun run format:check`
- `bun run lint:repo`
- `bun run changesets:validate`
- `git diff --check`

Closes #1063


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced `add-pattern` dry-run output to display resolved pattern catalog metadata and normalization notes, showing how input values are transformed during the resolution process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/1069?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->