### PR TITLE
test(rest): suppress expected react hook error output

### DIFF
--- a/packages/wp-typia-rest/tests/react.test.tsx
+++ b/packages/wp-typia-rest/tests/react.test.tsx
@@ -153,6 +153,36 @@ async function waitForAssertion(
     : new Error('Timed out waiting for assertion to pass.');
 }
 
+function isExpectedReactErrorBoundaryNotice(args: readonly unknown[]): boolean {
+  return args.some(
+    (arg) =>
+      typeof arg === 'string' &&
+      arg.includes('The above error occurred in the <Harness> component:') &&
+      arg.includes(
+        'Consider adding an error boundary to your tree to customize error handling behavior.',
+      ),
+  );
+}
+
+async function withExpectedReactErrorBoundaryNoticeSuppressed<T>(
+  action: () => Promise<T>,
+): Promise<T> {
+  const originalError = console.error;
+  console.error = (...args: unknown[]) => {
+    if (isExpectedReactErrorBoundaryNotice(args)) {
+      return;
+    }
+
+    originalError(...args);
+  };
+
+  try {
+    return await action();
+  } finally {
+    console.error = originalError;
+  }
+}
+
 afterEach(() => {
   for (const unmount of [...activeUnmounts]) {
     void unmount();
@@ -183,9 +213,13 @@ describe('@wp-typia/rest/react', () => {
             ),
     });
 
-    await expect(
-      createHookRenderer(() => useEndpointQuery(endpoint, { title: 'Hello' })),
-    ).rejects.toBeInstanceOf(RestQueryHookUsageError);
+    await withExpectedReactErrorBoundaryNoticeSuppressed(async () => {
+      await expect(
+        createHookRenderer(() =>
+          useEndpointQuery(endpoint, { title: 'Hello' }),
+        ),
+      ).rejects.toBeInstanceOf(RestQueryHookUsageError);
+    });
   });
 
   test('useEndpointQuery performs the initial fetch and reuses cached data across consumers', async () => {


### PR DESCRIPTION
## Summary
- suppress the expected React error-boundary guidance only around the invalid hook usage test
- keep non-matching `console.error` calls flowing through to the original logger
- preserve the existing `RestQueryHookUsageError` assertions

## Validation
- `bun run --filter @wp-typia/rest test`
- `bun run typecheck`
- `bun run format:check`
- `bun run lint:repo`
- `bun run changesets:validate`
- `git diff --check`

Closes #1073


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Added test helpers to suppress expected React development warnings from test output
* Updated hook usage-error tests with cleaner console output while preserving proper error assertion validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/1075?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->