### PR TITLE
chore(ts): ratchet strictness for smaller packages

### DIFF
--- a/.sampo/changesets/typescript-strictness-ratchet.md
+++ b/.sampo/changesets/typescript-strictness-ratchet.md
@@ -1,0 +1,7 @@
+---
+npm/@wp-typia/api-client: patch
+npm/@wp-typia/dataviews: patch
+npm/@wp-typia/rest: patch
+---
+
+Enable the next package-level TypeScript strictness ratchet for the smaller runtime packages.

--- a/apps/docs/src/content/docs/maintainers/typescript-strictness-policy.md
+++ b/apps/docs/src/content/docs/maintainers/typescript-strictness-policy.md
@@ -43,6 +43,13 @@ fails stale allowlist entries once the matching override disappears.
 
 ### Current targeted ratchet
 
+- `packages/wp-typia-api-client/tsconfig.json`
+  - `exactOptionalPropertyTypes: true`
+  - `noUncheckedIndexedAccess: true`
+  - rationale: the transport request builders now omit absent optional
+    properties instead of passing explicit `undefined`, and the shared
+    validation result types document the runtime helpers' existing
+    `undefined`-bearing output shape.
 - `packages/wp-typia-block-types/tsconfig.json`
   - `exactOptionalPropertyTypes: true`
   - `noUncheckedIndexedAccess: true`
@@ -50,6 +57,18 @@ fails stale allowlist entries once the matching override disappears.
     plus the JSON artifact/helper cleanup from `#280`, `#281`, and `#286`,
     reduced the package's cast-heavy boundaries enough for both flags to pass
     cleanly.
+- `packages/wp-typia-dataviews/tsconfig.json`
+  - `exactOptionalPropertyTypes: true`
+  - `noUncheckedIndexedAccess: true`
+  - rationale: the package-owned facade now has focused helpers for DataViews,
+    DataForm, and query adapters, and its public types explicitly reflect the
+    helper output fields that can be present with `undefined` values.
+- `packages/wp-typia-rest/tsconfig.json`
+  - `exactOptionalPropertyTypes: true`
+  - `noUncheckedIndexedAccess: true`
+  - rationale: the WordPress REST transport path now mirrors the api-client
+    optional-property cleanup while preserving the `@wordpress/api-fetch`
+    request shape and React helper call option behavior.
 
 ## Current blockers
 
@@ -58,7 +77,10 @@ Focused trials on `2026-04-15` produced the following result set:
 - `@wp-typia/block-types`: passes `exactOptionalPropertyTypes` and
   `noUncheckedIndexedAccess` cleanly, so the package-level ratchet is now
   enabled.
-- `@wp-typia/block-runtime`: remains deferred for both flags.
+- `@wp-typia/api-client`, `@wp-typia/dataviews`, and `@wp-typia/rest`:
+  passed both flags in the `2026-05-18` focused ratchet and are now enabled.
+- `@wp-typia/block-runtime`: remains deferred for both flags after the
+  `2026-05-18` follow-up trial.
 
 ### `@wp-typia/block-runtime` blockers
 
@@ -66,10 +88,9 @@ Focused trials on `2026-04-15` produced the following result set:
   - optional-property ownership still leaks `undefined` through runtime-facing
     descriptors such as `EditorFieldDescriptor`, `InspectorComponentMap`,
     metadata parsing nodes, validation results, and sync/report option bags
-  - the experiment also surfaced shared-graph fallout in
-    `packages/wp-typia-api-client/src/internal/runtime-primitives.ts`, so a
-    clean ratchet there needs coordinated optional-property cleanup across that
-    boundary rather than a one-off tsconfig flip
+  - the shared api-client fallout is resolved, but block-runtime still needs
+    local descriptor, inspector, metadata, and sync option cleanup before a
+    package-level ratchet is safe
 - `noUncheckedIndexedAccess`
   - remaining hotspots are concentrated in runtime indexing code:
     identifier segments, metadata parser tree walks, diagnostic/root-node
@@ -80,7 +101,8 @@ Focused trials on `2026-04-15` produced the following result set:
 
 ### Current decision
 
-- landed: package-level ratchet for `@wp-typia/block-types`
+- landed: package-level ratchet for `@wp-typia/api-client`,
+  `@wp-typia/block-types`, `@wp-typia/dataviews`, and `@wp-typia/rest`
 - deferred: `@wp-typia/block-runtime`
 - no explicit `@wp-typia/block-runtime` exception is recorded yet
 

--- a/packages/wp-typia-api-client/src/client-utils.ts
+++ b/packages/wp-typia-api-client/src/client-utils.ts
@@ -72,7 +72,7 @@ export function joinPathWithQuery(path: string, query: string): string {
 		return path;
 	}
 
-	const [pathWithoutHash, hash = ""] = path.split("#", 2);
+	const [pathWithoutHash = "", hash = ""] = path.split("#", 2);
 	const nextPath = pathWithoutHash.includes("?")
 		? `${pathWithoutHash}&${query}`
 		: `${pathWithoutHash}?${query}`;
@@ -85,7 +85,7 @@ export function joinUrlWithQuery(url: string, query: string): string {
 		return url;
 	}
 
-	const [urlWithoutHash, hash = ""] = url.split("#", 2);
+	const [urlWithoutHash = "", hash = ""] = url.split("#", 2);
 	const nextUrl = urlWithoutHash.includes("?")
 		? `${urlWithoutHash}&${query}`
 		: `${urlWithoutHash}?${query}`;

--- a/packages/wp-typia-api-client/src/client.ts
+++ b/packages/wp-typia-api-client/src/client.ts
@@ -162,16 +162,19 @@ function buildQueryRequestOptions<Req>(
   request: unknown,
 ): EndpointTransportRequest {
   const query = encodeGetLikeRequest(request);
-  const resolvedUrl = baseOptions.url
-    ? joinUrlWithQuery(baseOptions.url, query)
-    : undefined;
-  return {
-    ...baseOptions,
-    method: endpoint.method,
-    ...(resolvedUrl
-      ? { path: undefined, url: resolvedUrl }
-      : { path: joinPathWithQuery(baseOptions.path ?? endpoint.path, query) }),
-  };
+  const { path: basePath, url: baseUrl, ...transportOptions } = baseOptions;
+
+  return baseUrl
+    ? {
+        ...transportOptions,
+        method: endpoint.method,
+        url: joinUrlWithQuery(baseUrl, query),
+      }
+    : {
+        ...transportOptions,
+        method: endpoint.method,
+        path: joinPathWithQuery(basePath ?? endpoint.path, query),
+      };
 }
 
 function buildBodyRequestOptions<Req>(
@@ -179,28 +182,31 @@ function buildBodyRequestOptions<Req>(
   baseOptions: Partial<EndpointTransportRequest>,
   request: unknown,
 ): EndpointTransportRequest {
+  const { path: basePath, url: baseUrl, ...transportOptions } = baseOptions;
+  const locationOptions = baseUrl
+    ? { url: baseUrl }
+    : { path: basePath ?? endpoint.path };
+
   if (isFormDataLike(request)) {
     return {
-      ...baseOptions,
+      ...transportOptions,
       body: request,
       method: endpoint.method,
-      ...(baseOptions.url
-        ? { path: undefined, url: baseOptions.url }
-        : { path: baseOptions.path ?? endpoint.path }),
+      ...locationOptions,
     };
   }
 
+  const headers = mergeHeaderInputs(
+    { 'Content-Type': 'application/json' },
+    baseOptions.headers,
+  );
+
   return {
-    ...baseOptions,
+    ...transportOptions,
     body: typeof request === 'string' ? request : JSON.stringify(request),
-    headers: mergeHeaderInputs(
-      { 'Content-Type': 'application/json' },
-      baseOptions.headers,
-    ),
     method: endpoint.method,
-    ...(baseOptions.url
-      ? { path: undefined, url: baseOptions.url }
-      : { path: baseOptions.path ?? endpoint.path }),
+    ...(headers === undefined ? {} : { headers }),
+    ...locationOptions,
   };
 }
 
@@ -270,11 +276,12 @@ function mergeTransportOptions(
   }
 
   const { headers: requestHeaders, ...transportOptions } = requestOptions;
+  const headers = mergeHeaderInputs(baseOptions.headers, requestHeaders);
 
   return {
     ...baseOptions,
     ...transportOptions,
-    headers: mergeHeaderInputs(baseOptions.headers, requestHeaders),
+    ...(headers === undefined ? {} : { headers }),
   };
 }
 
@@ -302,11 +309,13 @@ export function createFetchTransport(
   return async <T = unknown, Parse extends boolean = true>(
     options: EndpointTransportRequest & { parse?: Parse },
   ): Promise<Parse extends false ? Response : T> => {
-    const response = await fetchFn(resolveRequestUrl(options, baseUrl), {
-      body: options.body,
-      headers: mergeHeaderInputs(defaultHeaders, options.headers),
+    const headers = mergeHeaderInputs(defaultHeaders, options.headers);
+    const requestInit: RequestInit = {
       method: options.method ?? 'GET',
-    });
+      ...(options.body === undefined ? {} : { body: options.body }),
+      ...(headers === undefined ? {} : { headers }),
+    };
+    const response = await fetchFn(resolveRequestUrl(options, baseUrl), requestInit);
 
     if (options.parse === false) {
       return response as Parse extends false ? Response : T;
@@ -355,10 +364,11 @@ export function withComputedHeaders(
     const computedHeaders = await resolveHeaders(
       createReadonlyTransportRequest(options),
     );
+    const headers = mergeHeaderInputs(computedHeaders, options.headers);
 
     return transport<T, Parse>({
       ...options,
-      headers: mergeHeaderInputs(computedHeaders, options.headers),
+      ...(headers === undefined ? {} : { headers }),
     });
   };
 }

--- a/packages/wp-typia-api-client/src/internal/runtime-primitives.ts
+++ b/packages/wp-typia-api-client/src/internal/runtime-primitives.ts
@@ -6,7 +6,7 @@ import type { IValidation } from "@typia/interface";
  * @category Types
  */
 export interface ValidationError {
-	description?: string;
+	description?: string | undefined;
 	expected: string;
 	path: string;
 	value: unknown;
@@ -18,7 +18,7 @@ export interface ValidationError {
  * @category Types
  */
 export interface ValidationResult<T> {
-	data?: T;
+	data?: T | undefined;
 	errors: ValidationError[];
 	isValid: boolean;
 }

--- a/packages/wp-typia-api-client/tsconfig.json
+++ b/packages/wp-typia-api-client/tsconfig.json
@@ -2,6 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
     "rootDir": "./src",
     "types": []
   },

--- a/packages/wp-typia-dataviews/src/define-data-views.ts
+++ b/packages/wp-typia-dataviews/src/define-data-views.ts
@@ -214,14 +214,16 @@ function normalizeDataViewsFieldValidation<TItem extends object, TValue>(
   if (schema?.enum !== undefined || schema?.const !== undefined) {
     schemaValidation.elements = true;
   }
-  if (schema?.max !== undefined || schema?.maximum !== undefined) {
-    schemaValidation.max = schema.max ?? schema.maximum;
+  const max = schema?.max ?? schema?.maximum;
+  if (max !== undefined) {
+    schemaValidation.max = max;
   }
   if (schema?.maxLength !== undefined) {
     schemaValidation.maxLength = schema.maxLength;
   }
-  if (schema?.min !== undefined || schema?.minimum !== undefined) {
-    schemaValidation.min = schema.min ?? schema.minimum;
+  const min = schema?.min ?? schema?.minimum;
+  if (min !== undefined) {
+    schemaValidation.min = min;
   }
   if (schema?.minLength !== undefined) {
     schemaValidation.minLength = schema.minLength;

--- a/packages/wp-typia-dataviews/src/types.ts
+++ b/packages/wp-typia-dataviews/src/types.ts
@@ -169,8 +169,10 @@ export interface DataViewsField<
   TItem extends object = DataViewsRecord,
   TValue = unknown,
 > {
-  readonly description?: string;
-  readonly elements?: readonly DataViewsFieldElement<DataViewsFieldElementValue<TValue>>[];
+  readonly description?: string | undefined;
+  readonly elements?:
+    | readonly DataViewsFieldElement<DataViewsFieldElementValue<TValue>>[]
+    | undefined;
   readonly enableGlobalSearch?: boolean;
   readonly enableHiding?: boolean;
   readonly enableSorting?: boolean;
@@ -191,7 +193,7 @@ export interface DataViewsField<
     right: TItem,
     direction: DataViewsSortDirection,
   ) => number;
-  readonly type?: DataViewsFieldType;
+  readonly type?: DataViewsFieldType | undefined;
 }
 
 export interface DataViewsFilter<
@@ -279,19 +281,19 @@ export type DataViewsConfigField<TItem extends object = DataViewsRecord> =
   | DataViewsResolvedField<TItem>;
 
 export interface DataViewsConfig<TItem extends object = DataViewsRecord> {
-  readonly actions?: readonly DataViewsAction<TItem>[];
+  readonly actions?: readonly DataViewsAction<TItem>[] | undefined;
   readonly data: readonly TItem[];
-  readonly defaultLayouts?: DataViewsDefaultLayouts;
+  readonly defaultLayouts?: DataViewsDefaultLayouts | undefined;
   readonly fields: readonly DataViewsConfigField<TItem>[];
-  readonly getItemId?: (item: TItem) => string;
-  readonly getItemLevel?: (item: TItem) => number;
-  readonly isLoading?: boolean;
-  readonly onChangeView?: (view: DataViewsView<TItem>) => void;
-  readonly paginationInfo?: DataViewsPaginationInfo;
-  readonly search?: boolean;
-  readonly searchLabel?: string;
-  readonly onChangeSelection?: (selection: readonly string[]) => void;
-  readonly selection?: readonly string[];
+  readonly getItemId?: ((item: TItem) => string) | undefined;
+  readonly getItemLevel?: ((item: TItem) => number) | undefined;
+  readonly isLoading?: boolean | undefined;
+  readonly onChangeView?: ((view: DataViewsView<TItem>) => void) | undefined;
+  readonly paginationInfo?: DataViewsPaginationInfo | undefined;
+  readonly search?: boolean | undefined;
+  readonly searchLabel?: string | undefined;
+  readonly onChangeSelection?: ((selection: readonly string[]) => void) | undefined;
+  readonly selection?: readonly string[] | undefined;
   readonly view: DataViewsView<TItem>;
 }
 
@@ -342,11 +344,11 @@ export type DataFormFieldLayout<TItem extends object = DataViewsRecord> =
   | DataFormCardFieldLayout<TItem>;
 
 export interface DataFormField<TItem extends object = DataViewsRecord> {
-  readonly children?: readonly DataFormField<TItem>[];
-  readonly description?: string;
+  readonly children?: readonly DataFormField<TItem>[] | undefined;
+  readonly description?: string | undefined;
   readonly id: DataViewsFieldId<TItem>;
-  readonly label?: string;
-  readonly layout?: DataFormFieldLayout<TItem>;
+  readonly label?: string | undefined;
+  readonly layout?: DataFormFieldLayout<TItem> | undefined;
 }
 
 export interface DataFormConfig<TItem extends object = DataViewsRecord> {
@@ -599,17 +601,17 @@ export type DefinedDataViewsFieldMap<TItem extends object> = Readonly<
 >;
 
 export interface DefinedDataViews<TItem extends object> {
-  readonly actions?: readonly DataViewsAction<TItem>[];
-  readonly defaultLayouts?: DataViewsDefaultLayouts;
+  readonly actions?: readonly DataViewsAction<TItem>[] | undefined;
+  readonly defaultLayouts?: DataViewsDefaultLayouts | undefined;
   readonly defaultView: DataViewsView<TItem>;
   readonly fieldMap: DefinedDataViewsFieldMap<TItem>;
   readonly fields: readonly DataViewsResolvedField<TItem>[];
-  readonly getItemId?: (item: TItem) => string;
-  readonly getItemLevel?: (item: TItem) => number;
-  readonly idField?: DataViewsItemIdField<TItem>;
-  readonly search?: boolean;
-  readonly searchLabel?: string;
-  readonly titleField?: DataViewsFieldId<TItem>;
+  readonly getItemId?: ((item: TItem) => string) | undefined;
+  readonly getItemLevel?: ((item: TItem) => number) | undefined;
+  readonly idField?: DataViewsItemIdField<TItem> | undefined;
+  readonly search?: boolean | undefined;
+  readonly searchLabel?: string | undefined;
+  readonly titleField?: DataViewsFieldId<TItem> | undefined;
   readonly createConfig: (options: DefineDataViewsConfigOptions<TItem>) => DataViewsConfig<TItem>;
   readonly toFormConfig: (options?: DataFormConfigOptions<TItem>) => DataFormConfig<TItem>;
   readonly toQueryArgs: <TQuery extends object = DataViewsQueryArgs>(

--- a/packages/wp-typia-dataviews/tsconfig.json
+++ b/packages/wp-typia-dataviews/tsconfig.json
@@ -2,6 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
     "rootDir": "./src",
     "types": []
   },

--- a/packages/wp-typia-rest/src/client.ts
+++ b/packages/wp-typia-rest/src/client.ts
@@ -146,8 +146,8 @@ export function resolveRestRouteUrl(
   routePath: string,
   root = getDefaultRestRoot(),
 ): string {
-  const [pathWithQuery, hash = ''] = routePath.split('#', 2);
-  const [rawPath, rawQuery = ''] = pathWithQuery.split('?', 2);
+  const [pathWithQuery = '', hash = ''] = routePath.split('#', 2);
+  const [rawPath = '', rawQuery = ''] = pathWithQuery.split('?', 2);
   const normalizedRoute = `/${rawPath.replace(/^\/+/, '').replace(/\/+$/, '')}/`;
   const queryParams = new URLSearchParams(rawQuery);
   const resolvedRoot =
@@ -196,12 +196,17 @@ function resolveFetchUrl(options: APIFetchOptions): string {
 async function defaultFetch<T = unknown, Parse extends boolean = true>(
   options: APIFetchOptions<Parse>,
 ): Promise<Parse extends false ? Response : T> {
-  const response = await fetch(resolveFetchUrl(options), {
-    body: options.body as BodyInit | null | undefined,
+  const requestInit: RequestInit = {
     credentials: 'same-origin',
-    headers: options.headers as HeadersInit | undefined,
     method: options.method ?? 'GET',
-  });
+    ...(options.body === undefined
+      ? {}
+      : { body: options.body as BodyInit | null }),
+    ...(options.headers === undefined
+      ? {}
+      : { headers: options.headers as HeadersInit }),
+  };
+  const response = await fetch(resolveFetchUrl(options), requestInit);
 
   if (options.parse === false) {
     return response as Parse extends false ? Response : T;
@@ -229,16 +234,26 @@ function buildQueryRequestOptions<Req>(
   request: unknown,
 ): APIFetchOptions {
   const query = encodeGetLikeRequest(request);
-  const resolvedUrl = baseOptions.url
-    ? joinUrlWithQuery(baseOptions.url, query)
-    : undefined;
-  return {
-    ...baseOptions,
-    method: endpoint.method,
-    ...(resolvedUrl
-      ? { path: undefined, url: resolvedUrl }
-      : { path: joinPathWithQuery(baseOptions.path ?? endpoint.path, query) }),
-  };
+  const {
+    headers: baseHeaders,
+    path: basePath,
+    url: baseUrl,
+    ...fetchOptions
+  } = baseOptions;
+
+  return baseUrl
+    ? {
+        ...fetchOptions,
+        ...(baseHeaders === undefined ? {} : { headers: baseHeaders }),
+        method: endpoint.method,
+        url: joinUrlWithQuery(baseUrl, query),
+      }
+    : {
+        ...fetchOptions,
+        ...(baseHeaders === undefined ? {} : { headers: baseHeaders }),
+        method: endpoint.method,
+        path: joinPathWithQuery(basePath ?? endpoint.path, query),
+      };
 }
 
 function buildBodyRequestOptions<Req>(
@@ -246,28 +261,37 @@ function buildBodyRequestOptions<Req>(
   baseOptions: Partial<APIFetchOptions>,
   request: unknown,
 ): APIFetchOptions {
+  const {
+    headers: baseHeaders,
+    path: basePath,
+    url: baseUrl,
+    ...fetchOptions
+  } = baseOptions;
+  const locationOptions = baseUrl
+    ? { url: baseUrl }
+    : { path: basePath ?? endpoint.path };
+
   if (isFormDataLike(request)) {
     return {
-      ...baseOptions,
+      ...fetchOptions,
       body: request as FormData,
+      ...(baseHeaders === undefined ? {} : { headers: baseHeaders }),
       method: endpoint.method,
-      ...(baseOptions.url
-        ? { path: undefined, url: baseOptions.url }
-        : { path: baseOptions.path ?? endpoint.path }),
+      ...locationOptions,
     };
   }
 
+  const headers = mergeHeaderInputs(
+    { 'Content-Type': 'application/json' },
+    baseHeaders as HeadersInit | undefined,
+  );
+
   return {
-    ...baseOptions,
+    ...fetchOptions,
     body: typeof request === 'string' ? request : JSON.stringify(request),
-    headers: mergeHeaderInputs(
-      { 'Content-Type': 'application/json' },
-      baseOptions.headers as HeadersInit | undefined,
-    ),
+    ...(headers === undefined ? {} : { headers }),
     method: endpoint.method,
-    ...(baseOptions.url
-      ? { path: undefined, url: baseOptions.url }
-      : { path: baseOptions.path ?? endpoint.path }),
+    ...locationOptions,
   };
 }
 
@@ -346,11 +370,12 @@ function mergeFetchOptions(
   }
 
   const { headers: requestHeaders, ...transportOptions } = requestOptions;
+  const headers = mergeHeaderInputs(baseOptions.headers, requestHeaders);
 
   return {
     ...baseOptions,
     ...transportOptions,
-    headers: mergeHeaderInputs(baseOptions.headers, requestHeaders),
+    ...(headers === undefined ? {} : { headers }),
   };
 }
 

--- a/packages/wp-typia-rest/src/react-mutation.ts
+++ b/packages/wp-typia-rest/src/react-mutation.ts
@@ -88,9 +88,11 @@ export function useEndpointMutation<Req, Res, Context = unknown>(
           ? await latest.onMutate(variables, latest.client)
           : undefined;
         const callOptions = latest.resolveCallOptions?.(variables);
+        const fetchFn = callOptions?.fetchFn ?? latest.fetchFn;
+        const requestOptions = callOptions?.requestOptions;
         const result = await callEndpoint(latest.endpoint, variables, {
-          fetchFn: callOptions?.fetchFn ?? latest.fetchFn,
-          requestOptions: callOptions?.requestOptions,
+          ...(fetchFn === undefined ? {} : { fetchFn }),
+          ...(requestOptions === undefined ? {} : { requestOptions }),
         });
         setValidation(result);
 

--- a/packages/wp-typia-rest/src/react-query.ts
+++ b/packages/wp-typia-rest/src/react-query.ts
@@ -122,12 +122,14 @@ export function useEndpointQuery<Req, Res, Selected = Res>(
 
       try {
         const callOptions = latest.resolveCallOptions?.();
+        const fetchFn = callOptions?.fetchFn ?? latest.fetchFn;
+        const requestOptions = callOptions?.requestOptions;
         const validation = await latest.client.__runQuery(
           latest.cacheKey,
           () =>
             callEndpoint(latest.endpoint, latest.request, {
-              fetchFn: callOptions?.fetchFn ?? latest.fetchFn,
-              requestOptions: callOptions?.requestOptions,
+              ...(fetchFn === undefined ? {} : { fetchFn }),
+              ...(requestOptions === undefined ? {} : { requestOptions }),
             }),
           { force, staleTime: latest.staleTime },
         );

--- a/packages/wp-typia-rest/tsconfig.json
+++ b/packages/wp-typia-rest/tsconfig.json
@@ -2,6 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
     "rootDir": "./src",
     "types": []
   },

--- a/scripts/validate-typescript-strictness-policy.mjs
+++ b/scripts/validate-typescript-strictness-policy.mjs
@@ -21,7 +21,19 @@ export const TYPESCRIPT_STRICTNESS_DEFERRED_FLAGS = Object.freeze([
 // This allowlist covers both temporary exceptions and intentional
 // package-level ratchets that land ahead of the repo-wide baseline.
 export const TYPESCRIPT_STRICTNESS_POLICY_EXCEPTIONS = Object.freeze({
+	"packages/wp-typia-api-client/tsconfig.json": Object.freeze({
+		exactOptionalPropertyTypes: true,
+		noUncheckedIndexedAccess: true,
+	}),
 	"packages/wp-typia-block-types/tsconfig.json": Object.freeze({
+		exactOptionalPropertyTypes: true,
+		noUncheckedIndexedAccess: true,
+	}),
+	"packages/wp-typia-dataviews/tsconfig.json": Object.freeze({
+		exactOptionalPropertyTypes: true,
+		noUncheckedIndexedAccess: true,
+	}),
+	"packages/wp-typia-rest/tsconfig.json": Object.freeze({
 		exactOptionalPropertyTypes: true,
 		noUncheckedIndexedAccess: true,
 	}),


### PR DESCRIPTION
## Summary
- Enable exactOptionalPropertyTypes and noUncheckedIndexedAccess for @wp-typia/api-client, @wp-typia/dataviews, and @wp-typia/rest.
- Clean up optional request/validation shapes without adding broad casts, and keep DataViews helper output types aligned with existing runtime shapes.
- Update the TypeScript strictness policy allowlist/docs and add patch changesets for the affected packages.
- Re-evaluate @wp-typia/block-runtime and document that it remains deferred because inspector, metadata, parser, and validation hotspots are still broad.

Closes #1074

## Validation
- bun run typescript-strictness:validate
- bun run --filter @wp-typia/api-client typecheck
- bun run --filter @wp-typia/dataviews typecheck
- bun run --filter @wp-typia/rest typecheck
- bun run format:check
- bun run lint:repo
- bun run typecheck
- bun run --filter @wp-typia/api-client test
- bun run --filter @wp-typia/dataviews test
- bun run --filter @wp-typia/rest test
- bun test tests/unit/typescript-strictness-policy.test.ts
- bun run changesets:validate
- bun run runtime-coupling:validate
- bun run test:repo:fast
- bun run docs:build
- git diff --check
- git diff --cached --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled stricter TypeScript compiler options across multiple packages for improved type safety and consistency.

* **Documentation**
  * Updated TypeScript strictness policy to reflect newly-enabled strict compiler flags.

* **Refactor**
  * Improved optional property type definitions with explicit `undefined` handling throughout the codebase.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/imjlk/wp-typia/pull/1078?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->