### PR TITLE
fix(project-tools): align boundary tests with runtime domains

### DIFF
--- a/packages/wp-typia-project-tools/tests/built-in-block-artifacts-boundaries.test.ts
+++ b/packages/wp-typia-project-tools/tests/built-in-block-artifacts-boundaries.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
-const runtimeRoot = resolve(import.meta.dir, "..", "src", "runtime");
+const runtimeRoot = resolve(import.meta.dir, "..", "src", "runtime", "templates");
 
 test("built-in block artifacts delegate type and document helpers to focused modules", () => {
 	const artifactSource = readFileSync(

--- a/packages/wp-typia-project-tools/tests/built-in-block-non-ts-artifacts-boundaries.test.ts
+++ b/packages/wp-typia-project-tools/tests/built-in-block-non-ts-artifacts-boundaries.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test";
 import fs from "node:fs";
 import path from "node:path";
 
-const runtimeRoot = path.join(import.meta.dir, "..", "src", "runtime");
+const runtimeRoot = path.join(import.meta.dir, "..", "src", "runtime", "templates");
 
 test("built-in non-ts artifacts delegate family emitters and render helpers to focused modules", () => {
 	const facadeSource = fs.readFileSync(

--- a/packages/wp-typia-project-tools/tests/cli-add-block-boundaries.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-add-block-boundaries.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test";
 import fs from "node:fs";
 import path from "node:path";
 
-const runtimeRoot = path.join(import.meta.dir, "..", "src", "runtime");
+const runtimeRoot = path.join(import.meta.dir, "..", "src", "runtime", "add");
 
 test("cli-add-block delegates config generation and legacy validator repair to focused modules", () => {
 	const addBlockSource = fs.readFileSync(

--- a/packages/wp-typia-project-tools/tests/cli-add-rest-secret-preserve-boundaries.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-add-rest-secret-preserve-boundaries.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test";
 import fs from "node:fs";
 import path from "node:path";
 
-const runtimeRoot = path.join(import.meta.dir, "..", "src", "runtime");
+const runtimeRoot = path.join(import.meta.dir, "..", "src", "runtime", "add");
 
 test("REST secret preserve options cross project-tools APIs as normalized booleans", () => {
 	const addTypesSource = fs.readFileSync(

--- a/packages/wp-typia-project-tools/tests/cli-add-shared.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-add-shared.test.ts
@@ -32,7 +32,7 @@ import {
 } from '../src/runtime/cli-add-validation.js';
 import type { WorkspaceInventory } from '../src/runtime/workspace-inventory.js';
 
-const runtimeRoot = path.join(import.meta.dir, '..', 'src', 'runtime');
+const runtimeRoot = path.join(import.meta.dir, '..', 'src', 'runtime', 'add');
 const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wp-typia-add-shared-'));
 
 afterAll(() => {
@@ -87,7 +87,7 @@ test('shared add runtime keeps compatibility exports around focused modules', ()
   expect(sharedSource).toContain('export * from "./cli-add-block-json.js";');
   expect(sharedSource).toContain('export * from "./cli-add-collision.js";');
   expect(sharedSource).toContain('export * from "./cli-add-help.js";');
-  expect(sharedSource).toContain('from "./scaffold-identifiers.js"');
+  expect(sharedSource).toContain('from "../templates/scaffold-identifiers.js"');
   expect(sharedSource).not.toContain('export interface RunAddBlockCommandOptions');
   expect(sharedSource).not.toContain('export function assertValidGeneratedSlug');
   expect(sharedSource).not.toContain('export async function patchFile');

--- a/packages/wp-typia-project-tools/tests/cli-add-workspace-boundaries.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-add-workspace-boundaries.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from 'bun:test';
 import fs from 'node:fs';
 import path from 'node:path';
 
-const runtimeRoot = path.join(import.meta.dir, '..', 'src', 'runtime');
+const runtimeRoot = path.join(import.meta.dir, '..', 'src', 'runtime', 'add');
 
 test('cli-add-workspace delegates workspace add workflows to focused helpers', () => {
   const addWorkspaceSource = fs.readFileSync(
@@ -915,7 +915,7 @@ test('cli-add-workspace delegates workspace add workflows to focused helpers', (
   expect(adminViewScaffoldSource).toContain(
     "from './cli-add-workspace-admin-view-templates.js'",
   );
-  expect(adminViewScaffoldSource).toContain("from './package-versions.js'");
+  expect(adminViewScaffoldSource).toContain("from '../shared/package-versions.js'");
   expect(adminViewScaffoldSource).toContain(
     'async function ensureAdminViewBootstrapAnchors(',
   );

--- a/packages/wp-typia-project-tools/tests/cli-doctor-boundaries.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-doctor-boundaries.test.ts
@@ -6,7 +6,8 @@ import { join, resolve } from "node:path";
 import { runDoctor } from "../src/runtime/cli-doctor.js";
 import { resolveWorkspaceBootstrapPath } from "../src/runtime/cli-doctor-workspace-shared.js";
 
-const sourceRoot = resolve(import.meta.dir, "..", "src", "runtime");
+const sourceRoot = resolve(import.meta.dir, "..", "src", "runtime", "doctor");
+const migrationRoot = resolve(import.meta.dir, "..", "src", "runtime", "migration");
 
 test("cli-doctor keeps environment and workspace checks in dedicated modules", () => {
 	const cliDoctorSource = readFileSync(resolve(sourceRoot, "cli-doctor.ts"), "utf8");
@@ -75,7 +76,7 @@ test("cli-doctor keeps environment and workspace checks in dedicated modules", (
 		"utf8",
 	);
 	const migrationDoctorSource = readFileSync(
-		resolve(sourceRoot, "migration-maintenance-verify.ts"),
+		resolve(migrationRoot, "migration-maintenance-verify.ts"),
 		"utf8",
 	);
 
@@ -162,7 +163,7 @@ test("cli-doctor keeps environment and workspace checks in dedicated modules", (
 	expect(workspacePackageSource).toContain(
 		"export async function prepareWorkspacePackageDoctorSnapshot(",
 	);
-	expect(workspacePackageSource).toContain('from "./fs-async.js"');
+	expect(workspacePackageSource).toContain('from "../shared/fs-async.js"');
 	expect(workspacePackageSource).toContain("Promise.all([");
 	expect(workspacePackageSource).not.toMatch(
 		/\bfs\.(?:existsSync|readFileSync|readdirSync)\b/u,

--- a/packages/wp-typia-project-tools/tests/migration-diff-boundaries.test.ts
+++ b/packages/wp-typia-project-tools/tests/migration-diff-boundaries.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
-const sourceRoot = resolve(import.meta.dir, "..", "src", "runtime");
+const sourceRoot = resolve(import.meta.dir, "..", "src", "runtime", "migration");
 
 test("migration-diff keeps rename and transform helpers in dedicated modules", () => {
 	const migrationDiffSource = readFileSync(

--- a/packages/wp-typia-project-tools/tests/pattern-catalog.test.ts
+++ b/packages/wp-typia-project-tools/tests/pattern-catalog.test.ts
@@ -14,7 +14,7 @@ import {
 
 describe("pattern catalog validation", () => {
 	test("keeps section role content validation in a focused runtime module", () => {
-		const runtimeRoot = path.join(import.meta.dir, "..", "src", "runtime");
+		const runtimeRoot = path.join(import.meta.dir, "..", "src", "runtime", "add");
 		const catalogSource = fs.readFileSync(
 			path.join(runtimeRoot, "pattern-catalog.ts"),
 			"utf8",
@@ -35,7 +35,7 @@ describe("pattern catalog validation", () => {
 	});
 
 	test("shares one pattern tag validation regex across catalog and add flows", () => {
-		const runtimeRoot = path.join(import.meta.dir, "..", "src", "runtime");
+		const runtimeRoot = path.join(import.meta.dir, "..", "src", "runtime", "add");
 		const catalogSource = fs.readFileSync(
 			path.join(runtimeRoot, "pattern-catalog.ts"),
 			"utf8",

--- a/packages/wp-typia-project-tools/tests/runtime-helper-consolidation.test.ts
+++ b/packages/wp-typia-project-tools/tests/runtime-helper-consolidation.test.ts
@@ -26,7 +26,19 @@ afterAll(() => {
 });
 
 function readRuntimeSource(fileName: string): string {
-  return fs.readFileSync(path.join(runtimeRoot, fileName), 'utf8');
+  const sourcePath = path.join(runtimeRoot, fileName);
+  const source = fs.readFileSync(sourcePath, 'utf8');
+  const facadeMatch = source
+    .trim()
+    .match(/^export \* from ["']\.\/(.+)\.js["'];$/u);
+  if (!facadeMatch) {
+    return source;
+  }
+
+  return fs.readFileSync(
+    path.join(path.dirname(sourcePath), `${facadeMatch[1]}.ts`),
+    'utf8',
+  );
 }
 
 test('runtime helper modules own filesystem and TypeScript property-name helpers', () => {

--- a/packages/wp-typia-project-tools/tests/scaffold-runtime-boundaries.test.ts
+++ b/packages/wp-typia-project-tools/tests/scaffold-runtime-boundaries.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test";
 import fs from "node:fs";
 import path from "node:path";
 
-const runtimeRoot = path.join(import.meta.dir, "..", "src", "runtime");
+const runtimeRoot = path.join(import.meta.dir, "..", "src", "runtime", "templates");
 
 test("scaffold runtime delegates identifier, document, bootstrap, and package helpers to focused modules", () => {
 	const scaffoldSource = fs.readFileSync(
@@ -66,8 +66,10 @@ test("scaffold runtime delegates identifier, document, bootstrap, and package he
 	expect(documentsSource).toContain("export function mergeTextLines(");
 	expect(bootstrapSource).toContain("export async function ensureScaffoldDirectory(");
 	expect(bootstrapSource).toContain("export async function applyWorkspaceMigrationCapability(");
-	expect(bootstrapSource).toContain('from "./package-json-types.js"');
-	expect(packageManagerFilesSource).toContain('from "./package-json-types.js"');
+	expect(bootstrapSource).toContain('from "../shared/package-json-types.js"');
+	expect(packageManagerFilesSource).toContain(
+		'from "../shared/package-json-types.js"',
+	);
 	expect(packageManagerFilesSource).toContain("export async function normalizePackageJson(");
 	expect(packageManagerFilesSource).toContain("export async function defaultInstallDependencies(");
 });

--- a/packages/wp-typia-project-tools/tests/temp-roots.test.ts
+++ b/packages/wp-typia-project-tools/tests/temp-roots.test.ts
@@ -68,7 +68,7 @@ describe("@wp-typia/project-tools temp root management", () => {
 
 	test("documents why process-exit cleanup ignores rm failures", async () => {
 		const source = await fs.promises.readFile(
-			new URL("../src/runtime/temp-roots.ts", import.meta.url),
+			new URL("../src/runtime/shared/temp-roots.ts", import.meta.url),
 			"utf8",
 		);
 

--- a/packages/wp-typia-project-tools/tests/typia-llm-boundaries.test.ts
+++ b/packages/wp-typia-project-tools/tests/typia-llm-boundaries.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from 'bun:test';
 import fs from 'node:fs';
 import path from 'node:path';
 
-const runtimeRoot = path.join(import.meta.dir, '..', 'src', 'runtime');
+const runtimeRoot = path.join(import.meta.dir, '..', 'src', 'runtime', 'schema');
 
 test('typia-llm delegates rendering, sync, projection, and OpenAPI constraint helpers to focused modules', () => {
   const facadeSource = fs.readFileSync(


### PR DESCRIPTION
## Summary
- update project-tools source-boundary tests to inspect the focused runtime domain modules introduced behind root facades
- adjust expected shared import paths for add, doctor, scaffold, migration, schema, and template domains
- keep runtime code unchanged; this fixes the main-branch Project Tools Coverage failure after the Gunshi merge

## Validation
- bun test packages/wp-typia-project-tools/tests/cli-add-workspace-boundaries.test.ts packages/wp-typia-project-tools/tests/cli-add-shared.test.ts packages/wp-typia-project-tools/tests/pattern-catalog.test.ts packages/wp-typia-project-tools/tests/runtime-helper-consolidation.test.ts packages/wp-typia-project-tools/tests/built-in-block-artifacts-boundaries.test.ts packages/wp-typia-project-tools/tests/typia-llm-boundaries.test.ts packages/wp-typia-project-tools/tests/scaffold-runtime-boundaries.test.ts packages/wp-typia-project-tools/tests/cli-add-block-boundaries.test.ts packages/wp-typia-project-tools/tests/built-in-block-non-ts-artifacts-boundaries.test.ts packages/wp-typia-project-tools/tests/temp-roots.test.ts packages/wp-typia-project-tools/tests/cli-add-rest-secret-preserve-boundaries.test.ts packages/wp-typia-project-tools/tests/cli-doctor-boundaries.test.ts packages/wp-typia-project-tools/tests/migration-diff-boundaries.test.ts
- bun run --filter @wp-typia/project-tools test:coverage
- bun run format:check
- bun run typecheck
- bun run lint:repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reorganized runtime test infrastructure by updating root paths to reference more specific subdirectories (templates, add, doctor, migration, schema, shared) across multiple test suites for improved code organization and test isolation.
  * Adjusted test assertions to reflect reorganized import paths and module locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->