### PR TITLE
chore(cli): remove stale runtime wording from help

### DIFF
--- a/packages/wp-typia-project-tools/tests/cli-entry.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-entry.test.ts
@@ -1363,7 +1363,7 @@ test("node entry exposes portable CLI help and rejects the removed migrations al
     runCli("node", [entryPath, "migrations", "init"], { stdio: "pipe" })
   );
 
-  expect(helpOutput).toContain("Runtime: Gunshi CLI");
+  expect(helpOutput).toContain("Runtime: Node-first wp-typia CLI");
   expect(helpOutput).toContain("Scaffold a new wp-typia project.");
   expect(helpOutput).toContain("Run migration workflows.");
   expect(helpOutput).toContain(
@@ -1413,7 +1413,7 @@ test("bun entry exposes portable CLI help and rejects the removed migrations ali
     runCli("bun", [entryPath, "migrations", "init"], { stdio: "pipe" })
   );
 
-  expect(helpOutput).toContain("Runtime: Gunshi CLI");
+  expect(helpOutput).toContain("Runtime: Node-first wp-typia CLI");
   expect(helpOutput).toContain("Scaffold a new wp-typia project.");
   expect(helpOutput).toContain("Run migration workflows.");
   expect(helpOutput).toContain(

--- a/packages/wp-typia/src/node-fallback/help.ts
+++ b/packages/wp-typia/src/node-fallback/help.ts
@@ -24,12 +24,13 @@ import { printBlock } from '../print-block';
 import type { NodeFallbackExecutableCommandName } from './types';
 
 export const STANDALONE_GUIDANCE_LINE =
-  'Prefer not to install Bun? Use the standalone wp-typia binary from the GitHub release assets.';
+  'Standalone wp-typia binaries are available from the GitHub release assets.';
 
 export const NODE_FALLBACK_RUNTIME_SUMMARY_LINES = [
-  'Runtime: Gunshi CLI',
-  'Portable Node-first runtime for create/init/add/migrate flows, doctor, sync, templates, MCP metadata, skills, completions, --help, and --version.',
-  `TUI rendering was removed from the published CLI path. ${STANDALONE_GUIDANCE_LINE}`,
+  'Runtime: Node-first wp-typia CLI',
+  'Gunshi provides the `complete` integration; the command registry owns shared dispatch and diagnostics.',
+  'Supported command surfaces include create/init/add/migrate flows, doctor, sync, templates, MCP metadata, skills, completions, --help, and --version.',
+  STANDALONE_GUIDANCE_LINE,
   'Output markers: WP_TYPIA_ASCII=1 forces ASCII markers, WP_TYPIA_ASCII=0 opts back into Unicode markers, and non-empty NO_COLOR requests ASCII markers when WP_TYPIA_ASCII is unset.',
 ];
 

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -203,7 +203,7 @@ describe('wp-typia package', () => {
     for (const commandName of WP_TYPIA_TOP_LEVEL_COMMAND_NAMES) {
       expect(helpOutput).toContain(commandName);
     }
-    expect(helpOutput).toContain('Runtime: Gunshi CLI');
+    expect(helpOutput).toContain('Runtime: Node-first wp-typia CLI');
     expect(helpOutput).toContain('non-empty NO_COLOR requests ASCII markers');
     expect(helpOutput).toContain('create: Scaffold a new wp-typia project.');
     expect(createHelpOutput).toContain('--external-layer-source');
@@ -421,7 +421,7 @@ describe('wp-typia package', () => {
 
     expect(topHelp.status).toBe(0);
     expect(topHelp.stderr).toBe('');
-    expect(topHelp.stdout).toContain('Runtime: Gunshi CLI');
+    expect(topHelp.stdout).toContain('Runtime: Node-first wp-typia CLI');
     expect(createHelp.status).toBe(0);
     expect(createHelp.stderr).toBe('');
     expect(createHelp.stdout).toContain('Usage: wp-typia create');
@@ -623,15 +623,15 @@ process.exit(0);
     expect(noCommandResult.stdout).toContain(
       'No command provided. Run wp-typia --help for usage information.',
     );
-    expect(noCommandResult.stdout).toContain('Runtime: Gunshi CLI');
+    expect(noCommandResult.stdout).toContain('Runtime: Node-first wp-typia CLI');
     expect(helpResult.status).toBe(0);
     expect(helpResult.stderr).toBe('');
     expect(helpResult.stdout).not.toContain('No command provided.');
     expect(helpResult.stdout).toContain(
       'Canonical CLI package for wp-typia scaffolding',
     );
-    expect(helpResult.stdout).toContain('Runtime: Gunshi CLI');
-    expect(helpResult.stdout).toContain('standalone wp-typia binary');
+    expect(helpResult.stdout).toContain('Runtime: Node-first wp-typia CLI');
+    expect(helpResult.stdout).toContain('Standalone wp-typia binaries');
     expect(helpResult.stdout).toContain(
       'WP_TYPIA_ASCII=1 forces ASCII markers',
     );
@@ -656,7 +656,7 @@ process.exit(0);
       expect(result.stderr).toBe('');
       expect(result.stdout).not.toContain('does not support');
       if (commandName !== 'version') {
-        expect(result.stdout).toContain('Runtime: Gunshi CLI');
+        expect(result.stdout).toContain('Runtime: Node-first wp-typia CLI');
       }
     }
   });

--- a/packages/wp-typia/tests/node-cli-core.test.ts
+++ b/packages/wp-typia/tests/node-cli-core.test.ts
@@ -144,7 +144,7 @@ describe('Gunshi CLI core routing', () => {
     expect(result.stdout).toContain(
       'Canonical CLI package for wp-typia scaffolding',
     );
-    expect(result.stdout).toContain('Runtime: Gunshi CLI');
+    expect(result.stdout).toContain('Runtime: Node-first wp-typia CLI');
     expect(result.stdout).toContain('Commands:');
 
     const directResult = await captureNodeCli([]);
@@ -196,7 +196,7 @@ describe('Gunshi CLI core routing', () => {
     expect(generalHelp.error).toBeUndefined();
     expect(generalHelp.exitCode).toBe(0);
     expect(generalHelp.stdout).toContain('Commands:');
-    expect(generalHelp.stdout).toContain('standalone wp-typia binary');
+    expect(generalHelp.stdout).toContain('Standalone wp-typia binaries');
     expect(generalHelp.stdout).not.toContain('No command provided.');
 
     expect(addHelp.error).toBeUndefined();
@@ -209,14 +209,14 @@ describe('Gunshi CLI core routing', () => {
     expect(createHelp.error).toBeUndefined();
     expect(createHelp.exitCode).toBe(0);
     expect(createHelp.stdout).toContain('Usage: wp-typia create <project-dir>');
-    expect(createHelp.stdout).toContain('Runtime: Gunshi CLI');
+    expect(createHelp.stdout).toContain('Runtime: Node-first wp-typia CLI');
     expect(createHelp.stdout).toContain('Supported flags:');
     expect(createHelp.stdout).toContain('--template');
 
     expect(commandHelp.error).toBeUndefined();
     expect(commandHelp.exitCode).toBe(0);
     expect(commandHelp.stdout).toContain('wp-typia templates <list|inspect>');
-    expect(commandHelp.stdout).toContain('Runtime: Gunshi CLI');
+    expect(commandHelp.stdout).toContain('Runtime: Node-first wp-typia CLI');
     expect(commandHelp.stdout).toContain('Supported flags:');
     expect(commandHelp.stdout).toContain('--id');
   });


### PR DESCRIPTION
## Summary
- Refresh runtime help copy to describe the Node-first wp-typia CLI after the Gunshi migration.
- Remove user-facing TUI/Bun-install guidance from help screens.
- Update help assertions for the new runtime summary.

## Validation
- bun run --filter wp-typia test
- bun run format:check
- bun run typecheck
- bun run lint:repo
- Checked wp-typia --help, add --help, mcp --help, skills --help, and completions --help for stale runtime wording.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI runtime identifier in help output to "Node-first wp-typia CLI"
  * Enhanced help descriptions with comprehensive command and feature documentation
  * Improved guidance text for standalone wp-typia binaries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->