### PR TITLE
docs(cli): align runtime usage docs with Gunshi migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,18 +45,21 @@ Use **`wp-typia`** when you need a block that will grow:
 ## Quick Start
 
 ```bash
-bunx wp-typia create my-block
-# or
 npx wp-typia create my-block
-# or install the full standalone CLI first
+# or use Bun as the package runner
+bunx wp-typia create my-block
+# or install the standalone CLI first
 curl -fsSL https://github.com/imjlk/wp-typia/releases/latest/download/install-wp-typia.sh | sh
 ```
+
+The npm-installed CLI runs on the Node-first runtime. `bunx` is supported as a
+package-runner convenience, not as a runtime requirement for `wp-typia`.
 
 `wp-typia <project-dir>` remains available as a backward-compatible alias to
 `create` when `<project-dir>` is the only positional argument.
 
-For a portable install that does not require a local Bun installation, prefer
-the standalone installers published with each GitHub Release:
+For an install outside package runners, use the standalone installers published
+with each GitHub Release:
 
 - macOS / Linux: `curl -fsSL https://github.com/imjlk/wp-typia/releases/latest/download/install-wp-typia.sh | sh`
 - Windows: `irm https://github.com/imjlk/wp-typia/releases/latest/download/install-wp-typia.ps1 | iex`

--- a/apps/docs/src/content/docs/reference/api.md
+++ b/apps/docs/src/content/docs/reference/api.md
@@ -86,8 +86,8 @@ secondary imports compared with the core package roots and primary subpaths.
 The CLI is the primary entrypoint for new users.
 
 ```bash
-bunx wp-typia create my-block
 npx wp-typia create my-block
+bunx wp-typia create my-block
 ```
 
 For command-by-command usage and flags, see the

--- a/apps/docs/src/content/docs/reference/cli.md
+++ b/apps/docs/src/content/docs/reference/cli.md
@@ -11,9 +11,10 @@ bunx wp-typia --help
 wp-typia --version
 ```
 
-The published binary runs through the Node-first Gunshi runtime. Bun remains the
-repository development and build toolchain, but npm-installed CLI commands such
-as `mcp`, `skills`, and shell `completions` do not require a local Bun binary.
+The published binary runs through the Node-first CLI runtime. Bun remains the
+repository development and build toolchain, and `bunx` remains a supported
+package-runner invocation, but npm-installed CLI commands such as `mcp`,
+`skills`, and shell `completions` do not require a local Bun binary.
 
 ## Global flags
 
@@ -465,7 +466,7 @@ supported.
 
 ## Node-first utility commands
 
-These commands run through the published Node-first Gunshi runtime and do not
+These commands run through the published Node-first CLI runtime and do not
 require a local Bun binary.
 
 ```bash

--- a/packages/wp-typia-project-tools/README.md
+++ b/packages/wp-typia-project-tools/README.md
@@ -4,7 +4,7 @@ Programmatic project orchestration package for `wp-typia`.
 
 Package roles:
 
-- `wp-typia` owns the CLI, help, TUI, completions, skills, MCP, and bin entry.
+- `wp-typia` owns the CLI, help, completions, skills, MCP, and bin entry.
 - `@wp-typia/project-tools` owns scaffold, add-block, migrate, template, doctor, and schema project helpers.
   It also owns the typed generator boundary via `BlockSpec`, `BlockGeneratorService`,
   and `inspectBlockGeneration(...)`,

--- a/packages/wp-typia/README.md
+++ b/packages/wp-typia/README.md
@@ -11,6 +11,10 @@ Use this package for new projects:
 - `npx wp-typia create my-plugin --template workspace --profile plugin-qa`
 - `npx wp-typia create my-books --template query-loop --query-post-type book`
 
+The published package executes through the Node-first CLI runtime. `bunx` is a
+supported package-runner invocation, not a requirement for npm-installed
+commands.
+
 Extend an existing workspace with:
 
 - `wp-typia add block counter-card --template basic`
@@ -45,17 +49,16 @@ Configuration files:
 Compatibility notes:
 
 - `@wp-typia/project-tools` is the canonical programmatic project orchestration package
-- the published CLI now ships a built `dist` Gunshi runtime, and the canonical Node bin supports `create`, `add`, `migrate`, `doctor`, `sync`, `skills`, `completions`, `mcp`, `--version`, `--help`, and template inspection without requiring a locally installed Bun binary
+- the published CLI ships a built `dist` runtime, and the canonical Node bin supports `create`, `add`, `migrate`, `doctor`, `sync`, `skills`, `completions`, `mcp`, `--version`, `--help`, and template inspection without requiring a locally installed Bun binary
 - Bun remains supported for repository development, tests, and builds, while Node is the canonical npm runtime for the published CLI
 - when you request machine-readable output with `--format json`, CLI failures now include a stable `error.code` field so wrappers and CI can branch without parsing English text
 - the stable machine-handled branching key is `error.code`. Structured context like `error.command`, `error.kind`, and `error.tag` may also be useful to consumers, while free-form text like `error.message`, `error.summary`, and `error.detailLines` stays human-facing guidance and can evolve without notice
-- interactive TUI rendering has been removed from the published CLI; flag-driven, text, and JSON workflows remain supported
 - standalone release assets are published per platform together with checksum manifests and install scripts: `install-wp-typia.sh` for macOS/Linux and `install-wp-typia.ps1` for Windows
 - internal runtime-bridge helper modules are implementation details; integrations
   should target the CLI or `@wp-typia/project-tools`, not CLI internals
 
 Maintainers: see [`docs/bunli-cli-migration.md`](https://imjlk.github.io/wp-typia/maintainers/bunli-cli-migration/)
-for the active CLI ownership contract and Gunshi migration notes.
+for historical Gunshi migration notes.
 
 Project meta docs:
 


### PR DESCRIPTION
## Summary
- Clarify that npx is the default package-runner example while bunx remains a supported package-runner convenience.
- Remove current-tense TUI ownership from user-facing package role docs.
- Reword CLI reference/runtime usage docs around the Node-first CLI runtime without implying Bun is required for npm-installed commands.

## Validation
- bun run format:check
- bun run typecheck
- bun run lint:repo
- bun run docs:build
- Checked wp-typia help surfaces for stale runtime wording

## Notes
- bun run --filter wp-typia test was run twice locally, but the local desktop run timed out on long scaffold/standalone tests unrelated to this docs-only diff. CI should provide the authoritative package test result.