### PR TITLE
docs(runtime): document Gunshi and dispatcher boundaries

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -196,7 +196,7 @@ export default defineConfig({
           label: 'Maintainers',
           items: [
             {
-              label: 'Bunli CLI Migration',
+              label: 'Gunshi Runtime Contract',
               link: '/maintainers/bunli-cli-migration/',
             },
             {

--- a/apps/docs/src/content/docs/architecture/runtime-import-policy.md
+++ b/apps/docs/src/content/docs/architecture/runtime-import-policy.md
@@ -151,7 +151,7 @@ catch contract.
 These areas are not covered by the generated-project compatibility promise:
 
 - CLI implementation internals
-- Bunli command composition
+- CLI command composition internals
 - template rendering internals
 - Mustache-vs-emitter implementation details below the current generator boundary
 - project-scaffold orchestration internals

--- a/apps/docs/src/content/docs/architecture/runtime-surface.md
+++ b/apps/docs/src/content/docs/architecture/runtime-surface.md
@@ -8,7 +8,8 @@ This document is descriptive, not normative. For support guarantees, see
 ## Current exported surfaces
 
 - `wp-typia`
-  CLI package and Bunli command tree.
+  Node-first CLI package, command registry, help surface, completions, skills,
+  MCP metadata, and bin entry.
 - `@wp-typia/api-client`
 - `@wp-typia/api-client/client-utils`
 - `@wp-typia/api-client/runtime-primitives`
@@ -96,10 +97,14 @@ This document is descriptive, not normative. For support guarantees, see
   surface is the canonical convenience entry, `./client` is the focused
   transport/runtime entry, `./http` is the focused decoder entry, and `./react`
   owns hooks.
-- `wp-typia` owns the CLI, help, TUI, completions, skills, MCP, and bin entry.
-- `wp-typia` keeps its public CLI flow stable while the internal runtime bridge
-  now delegates focused output and sync helpers behind the facade. That split is
-  an implementation detail, not a new CLI surface area.
+- `wp-typia` owns the Node-first CLI runtime, help, completions, skills, MCP,
+  command registry, Gunshi completion integration, and bin entry.
+- General command dispatch is currently owned by the existing command
+  registry/custom dispatcher. Gunshi is part of the CLI runtime where
+  applicable, with `complete` routed through the Gunshi completion integration;
+  `completions` remains the legacy alias. The internal runtime bridge delegates
+  focused output and sync helpers behind the facade. Those splits are
+  implementation details, not new CLI surface areas.
 - `@wp-typia/project-tools` owns scaffold, add-block, migrate, template,
   doctor, package-manager, starter-manifest, the typed generator boundary, the
   opt-in WordPress AI and `typia.llm` adapter emitters, the built-in

--- a/apps/docs/src/content/docs/guides/architecture.md
+++ b/apps/docs/src/content/docs/guides/architecture.md
@@ -51,7 +51,7 @@ Release publishing is intentionally package-only and rerun-safe. Example builds 
 
 Example-specific root commands use the `examples:*` namespace so the boundary between product packages and the reference app stays explicit.
 
-Maintainers: the staged Bunli cutover for `packages/wp-typia` is tracked in
+Maintainers: the completed Gunshi CLI migration record for `packages/wp-typia` lives in
 [`docs/bunli-cli-migration.md`](../maintainers/bunli-cli-migration.md).
 
 ## Template Model

--- a/apps/docs/src/content/docs/maintainers/bunli-cli-migration.md
+++ b/apps/docs/src/content/docs/maintainers/bunli-cli-migration.md
@@ -8,10 +8,22 @@ and the project-tools split.
 ## Current state
 
 - `packages/wp-typia` owns the published CLI package, top-level command
-  taxonomy, help surface, Gunshi runtime entrypoint, and `bin/wp-typia.js`.
+  taxonomy, help surface, Gunshi integration, command dispatch facade, and
+  `bin/wp-typia.js`.
 - The authored runtime lives in `packages/wp-typia/src/gunshi-cli.ts` and
   `packages/wp-typia/src/node-cli.ts`, and is compiled into
   `packages/wp-typia/dist/cli.js` for the published package.
+- `runGunshiCli()` is the published entrypoint wrapper. It applies standalone
+  support setup and routes Node `wp-typia complete <shell>` requests through the
+  Gunshi completion plugin.
+- General command dispatch is still owned by `runNodeCli()`, the shared command
+  registry, and the custom dispatchers. That path owns global flag parsing,
+  config defaults, AI-agent structured-output defaults, shared diagnostics, and
+  the public command handlers for `create`, `init`, `sync`, `add`, `migrate`,
+  `templates`, `doctor`, `mcp`, `skills`, and the legacy `completions` alias.
+- This is the current maintained boundary after the migration, not a temporary
+  compatibility lane. Future parser work should document any change that moves
+  general command dispatch away from the registry/custom dispatcher layer.
 - `packages/wp-typia/bin/wp-typia.js` must launch built artifacts only:
   `dist/cli.js` plus the generated `bin/` routing helpers. It must not shell
   out to source TypeScript.
@@ -139,7 +151,11 @@ to the canonical `create` surface in docs and review notes.
   `bufferMode: "alternate"`, or OpenTUI lifecycle helpers.
 - Flag-driven text and JSON flows are the supported user-facing surfaces.
 
-## Canonical Gunshi command tree
+## Canonical CLI command surface
+
+The command surface below is registry-owned today. Gunshi owns the Node
+completion integration for `complete`; `completions` remains supported as the
+legacy alias through the shared dispatcher.
 
 - `create`
 - `init`


### PR DESCRIPTION
## Summary

- Document the current Node-first CLI runtime boundary after the Gunshi migration.
- Clarify that general command dispatch remains owned by the registry/custom dispatcher while Gunshi owns the Node `complete` integration.
- Remove stale current-tense Bunli/TUI wording from runtime surface docs and maintainer navigation.

## Validation

- `bun run format:check`
- `bun run typecheck`
- `bun run lint:repo`
- `bun run docs:build`
- `bun run --filter wp-typia build`
- CLI help stale-wording smoke for `--help`, `add --help`, `mcp --help`, `skills --help`, and `completions --help`

## Notes

- `bun run --filter wp-typia test` was attempted locally and failed with existing timeout-style failures in CLI/standalone/add tests: 277 pass, 6 timeout failures, 1 JSON EOF from a killed timed-out command. No failure appears tied to this docs-only diff; CI should be authoritative for the full suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI architecture documentation to clarify command surface ownership, component exports, and completion routing behavior.
  * Revised documentation to reflect the completion of the Gunshi CLI migration and updated maintainer references accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->