### PR TITLE
chore(cli): clarify historical node-fallback naming

### DIFF
--- a/apps/docs/src/content/docs/maintainers/bunli-cli-migration.md
+++ b/apps/docs/src/content/docs/maintainers/bunli-cli-migration.md
@@ -13,6 +13,10 @@ and the project-tools split.
 - The authored runtime lives in `packages/wp-typia/src/gunshi-cli.ts` and
   `packages/wp-typia/src/node-cli.ts`, and is compiled into
   `packages/wp-typia/dist/cli.js` for the published package.
+- `packages/wp-typia/src/node-fallback/**` is a historical internal path and
+  symbol namespace retained to avoid a broad rename. It now houses portable CLI
+  dispatcher/help modules and should not be described in user-facing text as a
+  secondary runtime.
 - `runGunshiCli()` is the published entrypoint wrapper. It applies standalone
   support setup and routes Node `wp-typia complete <shell>` requests through the
   Gunshi completion plugin.

--- a/packages/wp-typia-project-tools/src/runtime/cli/cli-diagnostics.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli/cli-diagnostics.ts
@@ -378,12 +378,11 @@ function inferCliDiagnosticCode(options: {
 		return CLI_DIAGNOSTIC_CODES.UNKNOWN_TEMPLATE;
 	}
 	if (
-		/Unknown .*subcommand|Unknown add kind|removed in favor|does not support|The Bun-free fallback runtime does not support|The positional alias only accepts/u.test(
+		/Unknown .*subcommand|Unknown add kind|removed in favor|does not support|The positional alias only accepts/u.test(
 			haystack,
 		)
 	) {
-		return haystack.includes("does not support") ||
-			haystack.includes("The Bun-free fallback runtime does not support")
+		return haystack.includes("does not support")
 			? CLI_DIAGNOSTIC_CODES.UNSUPPORTED_COMMAND
 			: CLI_DIAGNOSTIC_CODES.INVALID_COMMAND;
 	}

--- a/packages/wp-typia-project-tools/src/runtime/shared/json-utils.ts
+++ b/packages/wp-typia-project-tools/src/runtime/shared/json-utils.ts
@@ -11,7 +11,7 @@ import { promises as fsp } from "node:fs";
  * script templates that embed their own path-aware parse handling.
  *
  * This module keeps `cloneJsonValue` local instead of re-exporting the
- * block-runtime helper so Bunli CLI bundles that only need project-tools JSON
+ * block-runtime helper so CLI runtime bundles that only need project-tools JSON
  * readers do not need to resolve the block-runtime subpath at runtime.
  *
  * @module

--- a/packages/wp-typia/src/add-kinds/pattern.ts
+++ b/packages/wp-typia/src/add-kinds/pattern.ts
@@ -29,7 +29,7 @@ export const patternAddKindEntry =
       title: 'Added workspace pattern',
     },
     description: 'Add a PHP block pattern shell',
-    // Repeatable --tag remains CLI-only; the TUI exposes comma-separated --tags.
+    // Repeatable --tag remains CLI-only; prompt values use comma-separated --tags.
     hiddenStringSubmitFields: ['tag'],
     nameLabel: 'Pattern name',
     async prepareExecution(context) {

--- a/packages/wp-typia/src/runtime-output/create.ts
+++ b/packages/wp-typia/src/runtime-output/create.ts
@@ -59,7 +59,7 @@ function resolveCreateCompletionPackageManager(
 }
 
 /**
- * Formats a lightweight create-progress line for fallback CLI output.
+ * Formats a lightweight create-progress line for portable CLI output.
  *
  * @param payload User-facing scaffold progress payload.
  * @returns A single readable status line.

--- a/packages/wp-typia/tests/add-command-package.test.ts
+++ b/packages/wp-typia/tests/add-command-package.test.ts
@@ -121,7 +121,7 @@ test('formats add failures with a shared non-interactive diagnostic block', () =
   );
 });
 
-test('emits structured add completion output in Node fallback JSON mode', async () => {
+test('emits structured add completion output in portable CLI JSON mode', async () => {
   const projectDir = fs.mkdtempSync(
     path.join(os.tmpdir(), 'wp-typia-add-json-'),
   );
@@ -179,7 +179,7 @@ test('emits structured add completion output in Node fallback JSON mode', async 
   }
 });
 
-test('preserves add diagnostic metadata in Node fallback JSON mode on failure', () => {
+test('preserves add diagnostic metadata in portable CLI JSON mode on failure', () => {
   const result = runCapturedCommand(
     process.execPath,
     [entryPath, 'add', 'variation', 'promo-card', '--format', 'json'],
@@ -218,7 +218,7 @@ test('treats missing add kinds as an error while still printing help text', () =
   );
 });
 
-test('node fallback rest-resource missing-name output keeps usage split by mode', () => {
+test('portable CLI rest-resource missing-name output keeps usage split by mode', () => {
   const result = runCapturedCommand(
     process.execPath,
     [entryPath, 'add', 'rest-resource'],
@@ -240,7 +240,7 @@ test('node fallback rest-resource missing-name output keeps usage split by mode'
   expect(result.stderr).not.toContain(' or wp-typia add rest-resource ');
 });
 
-test('node fallback source entry treats missing add kinds as an error while printing add help', async () => {
+test('portable CLI source entry treats missing add kinds as an error while printing add help', async () => {
   const originalLog = console.log;
   const capturedStdout: string[] = [];
   console.log = (line = '') => {

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -661,7 +661,7 @@ process.exit(0);
     }
   });
 
-  test('runs former Bun-only commands through the Gunshi CLI without Bun', () => {
+  test('runs portable command surfaces through the Gunshi CLI without Bun', () => {
     const result = runCapturedCommand(
       process.execPath,
       [entryPath, 'skills', 'list', '--format', 'json'],

--- a/packages/wp-typia/tests/create-command-package.test.ts
+++ b/packages/wp-typia/tests/create-command-package.test.ts
@@ -14,7 +14,7 @@ import {
   withoutLocalBunEnv,
 } from './cli-package-test-helpers';
 
-test('emits structured create completion output in Node fallback JSON mode', () => {
+test('emits structured create completion output in portable CLI JSON mode', () => {
   const tempRoot = fs.mkdtempSync(
     path.join(os.tmpdir(), 'wp-typia-create-json-'),
   );
@@ -75,7 +75,7 @@ test('emits structured create completion output in Node fallback JSON mode', () 
   }
 });
 
-test('honors NO_COLOR for ASCII-safe status markers through the Node fallback bin', () => {
+test('honors NO_COLOR for ASCII-safe status markers through the portable CLI bin', () => {
   const tempRoot = fs.mkdtempSync(
     path.join(os.tmpdir(), 'wp-typia-no-color-markers-'),
   );
@@ -253,7 +253,7 @@ test('formats create failures with a shared non-interactive diagnostic block', (
   );
 });
 
-test('emits a machine-readable missing-argument error code for create in Node fallback JSON mode', () => {
+test('emits a machine-readable missing-argument error code for create in portable CLI JSON mode', () => {
   const result = runCapturedCommand(
     process.execPath,
     [entryPath, 'create', '--format', 'json'],
@@ -381,7 +381,7 @@ test('emits a machine-readable missing-argument error code for create in Gunshi 
   expect(parsed.error?.code).toBe('missing-argument');
 });
 
-test('loads baseline create defaults from package.json#wp-typia in the Node fallback', () => {
+test('loads baseline create defaults from package.json#wp-typia in the portable CLI', () => {
   const tempRoot = fs.mkdtempSync(
     path.join(os.tmpdir(), 'wp-typia-node-config-defaults-'),
   );

--- a/packages/wp-typia/tests/node-cli-core.test.ts
+++ b/packages/wp-typia/tests/node-cli-core.test.ts
@@ -233,7 +233,7 @@ describe('Gunshi CLI core routing', () => {
     expect(result.stdout).not.toContain('Usage: wp-typia create <project-dir>');
   });
 
-  test('keeps Node fallback dispatcher and help modules focused', () => {
+  test('keeps historical node-fallback dispatcher and help modules focused', () => {
     const packageRoot = path.resolve(import.meta.dir, '..');
     const nodeCliSource = fs.readFileSync(
       path.join(packageRoot, 'src', 'node-cli.ts'),
@@ -357,7 +357,7 @@ describe('Gunshi CLI core routing', () => {
     );
   });
 
-  test('prints human and structured version output from the fallback runtime', async () => {
+  test('prints human and structured version output from the portable CLI runtime', async () => {
     const human = await captureNodeCli(['--version']);
     const text = await captureNodeCli(['version', '--format', 'text']);
     const legacyToon = await captureNodeCli(['version', '--format', 'toon']);
@@ -387,7 +387,7 @@ describe('Gunshi CLI core routing', () => {
     expect(parsed.data?.version).toBe(packageJson.version);
   });
 
-  test('dispatches create dry-runs through the Node fallback runtime', async () => {
+  test('dispatches create dry-runs through the portable CLI runtime', async () => {
     const tempRoot = createTempRoot('wp-typia-node-create-');
 
     try {
@@ -430,7 +430,7 @@ describe('Gunshi CLI core routing', () => {
     }
   });
 
-  test('routes Node fallback completion warnings through stderr', async () => {
+  test('routes portable CLI completion warnings through stderr', async () => {
     const tempRoot = createTempRoot('wp-typia-node-init-warning-');
     writeJson(path.join(tempRoot, 'package.json'), {
       name: 'node-init-warning',
@@ -494,7 +494,7 @@ describe('Gunshi CLI core routing', () => {
     expect(parsed.error?.detailLines).toEqual(buildMissingAddKindDetailLines());
   });
 
-  test('dispatches init structured previews from the Node fallback runtime', async () => {
+  test('dispatches init structured previews from the portable CLI runtime', async () => {
     const tempRoot = createTempRoot('wp-typia-node-init-');
 
     try {
@@ -524,7 +524,7 @@ describe('Gunshi CLI core routing', () => {
     }
   });
 
-  test('rejects invalid output formats before Node fallback dispatch', async () => {
+  test('rejects invalid output formats before portable CLI dispatch', async () => {
     const result = await captureNodeCli(['templates', 'list', '--format', 'jso']);
 
     expect(result.stdout).toBe('');
@@ -539,7 +539,7 @@ describe('Gunshi CLI core routing', () => {
     );
   });
 
-  test('reports missing output format values before Node fallback dispatch', async () => {
+  test('reports missing output format values before portable CLI dispatch', async () => {
     const result = await captureNodeCli(['doctor', '--format']);
 
     expect(result.stdout).toBe('');

--- a/packages/wp-typia/tests/sync-command-package.test.ts
+++ b/packages/wp-typia/tests/sync-command-package.test.ts
@@ -292,7 +292,7 @@ describe('wp-typia sync package command', () => {
     }
   });
 
-  test('runs sync ai through the dedicated sync-ai script in Node fallback', () => {
+  test('runs sync ai through the dedicated sync-ai script in the portable CLI', () => {
     const { fixtureRoot, logPath } = createSyncFixture({
       scripts: {
         sync: 'node scripts/record.mjs sync',
@@ -317,7 +317,7 @@ describe('wp-typia sync package command', () => {
     }
   });
 
-  test('previews sync commands without running scripts in Node fallback dry-run JSON mode', () => {
+  test('previews sync commands without running scripts in portable CLI dry-run JSON mode', () => {
     const { fixtureRoot, logPath } = createSyncFixture({
       scripts: {
         'sync-rest': 'node scripts/record.mjs sync-rest',
@@ -360,7 +360,7 @@ describe('wp-typia sync package command', () => {
     }
   });
 
-  test('previews sync ai commands without running scripts in Node fallback dry-run JSON mode', () => {
+  test('previews sync ai commands without running scripts in portable CLI dry-run JSON mode', () => {
     const { fixtureRoot, logPath } = createSyncFixture({
       scripts: {
         'sync-ai': 'node scripts/record.mjs sync-ai',
@@ -407,7 +407,7 @@ describe('wp-typia sync package command', () => {
     }
   });
 
-  test('renders sync help with preview-oriented dry-run guidance in Node fallback', () => {
+  test('renders sync help with preview-oriented dry-run guidance in the portable CLI', () => {
     const result = runCapturedCommand(
       process.execPath,
       [entryPath, 'sync', '--help'],
@@ -422,7 +422,7 @@ describe('wp-typia sync package command', () => {
     expect(result.stdout).toContain('--dry-run');
   });
 
-  test('emits a machine-readable outside-project-root error code for sync in Node fallback JSON mode', () => {
+  test('emits a machine-readable outside-project-root error code for sync in portable CLI JSON mode', () => {
     const tempRoot = fs.mkdtempSync(
       path.join(os.tmpdir(), 'wp-typia-sync-json-'),
     );
@@ -452,7 +452,7 @@ describe('wp-typia sync package command', () => {
     }
   });
 
-  test('emits a machine-readable malformed package JSON code for sync in Node fallback JSON mode', () => {
+  test('emits a machine-readable malformed package JSON code for sync in portable CLI JSON mode', () => {
     const tempRoot = fs.mkdtempSync(
       path.join(os.tmpdir(), 'wp-typia-sync-malformed-json-'),
     );
@@ -496,7 +496,7 @@ describe('wp-typia sync package command', () => {
     }
   });
 
-  test('emits a machine-readable invalid-command error code for sync subcommands in Node fallback JSON mode', () => {
+  test('emits a machine-readable invalid-command error code for sync subcommands in portable CLI JSON mode', () => {
     const result = runCapturedCommand(
       process.execPath,
       [entryPath, 'sync', 'unknown', '--format', 'json'],


### PR DESCRIPTION
## Summary
- Document that `packages/wp-typia/src/node-fallback/**` is a historical internal path name for the portable CLI modules.
- Rename maintainer-facing comments and test descriptions from Node fallback wording to portable CLI wording.
- Remove a redundant legacy diagnostic classifier phrase for the old Bun-free fallback runtime wording.

## Validation
- `bun run format:check`
- `bun run typecheck`
- `bun run lint:repo`
- `bun run docs:build`
- `bun run --filter wp-typia build`
- Help stale-runtime grep for `--help`, `add --help`, `mcp --help`, `skills --help`, and `completions --help`
- `bun run --filter wp-typia test` attempted locally: 279 pass, 4 timeout failures, 1 JSON EOF from a killed timed-out command. The failures were timeout-style package command tests also seen during this wording cleanup sequence, so CI should remain the authoritative signal.