### PR TITLE
fix(project-tools): align dataviews fallback range

### DIFF
--- a/.sampo/changesets/dataviews-fallback-release-range.md
+++ b/.sampo/changesets/dataviews-fallback-release-range.md
@@ -1,0 +1,6 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Align the managed `@wp-typia/dataviews` fallback range with the published package version.

--- a/packages/wp-typia-project-tools/src/runtime/shared/package-versions.ts
+++ b/packages/wp-typia-project-tools/src/runtime/shared/package-versions.ts
@@ -50,7 +50,7 @@ export const DEFAULT_WORDPRESS_CORE_DATA_VERSION = '~7.46.0';
 export const DEFAULT_WORDPRESS_DATA_VERSION = '~10.46.0';
 export const DEFAULT_WORDPRESS_DATAVIEWS_VERSION = '~14.3.0';
 export const DEFAULT_WORDPRESS_ENV_VERSION = '^11.2.0';
-export const DEFAULT_WP_TYPIA_DATAVIEWS_VERSION = '^0.1.1';
+export const DEFAULT_WP_TYPIA_DATAVIEWS_VERSION = '^0.1.2';
 
 let cachedPackageVersions: {
   cacheKey: string;


### PR DESCRIPTION
## Summary
- Align the managed `@wp-typia/dataviews` fallback range with the newly published `0.1.2` package.
- Add a Sampo patch changeset so the corrected fallback range is included in the next package release.

## Context
Main CI for release commit `884dac3a` failed in `Project Tools: Scaffold Core` and `Project Tools Coverage` because `packages/wp-typia-project-tools/tests/package-versions.test.ts` expected `^0.1.2` while the fallback constant still returned `^0.1.1`.

## Validation
- `bun run changesets:validate`
- `bun test packages/wp-typia-project-tools/tests/package-versions.test.ts`
- `bun run --filter @wp-typia/project-tools test:scaffold-core`
- `bun run test:coverage:project-tools`
- `bun run format:check`
- `bun run typecheck`
- `bun run lint:repo`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal version configuration and DataViews compatibility alignment for patch releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->