### PR TITLE
fix(cli): unify completion alias output

### DIFF
--- a/.sampo/changesets/cli-completion-alias-unify.md
+++ b/.sampo/changesets/cli-completion-alias-unify.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Route the legacy `wp-typia completions <shell>` alias through the same Gunshi completion output as `wp-typia complete <shell>`.

--- a/packages/wp-typia/src/gunshi-cli.ts
+++ b/packages/wp-typia/src/gunshi-cli.ts
@@ -60,12 +60,17 @@ export function shouldUseGunshiCompletion(
   const [command] = argv;
   return (
     typeof versions.bun !== 'string' &&
-    command === 'complete' &&
+    (command === 'complete' || command === 'completions') &&
     !hasFlagBeforeTerminator(argv, '--help') &&
     !hasFlagBeforeTerminator(argv, '-h') &&
     !hasFlagBeforeTerminator(argv, '--version') &&
     !hasFlagBeforeTerminator(argv, '-v')
   );
+}
+
+function normalizeGunshiCompletionArgv(argv: string[]): string[] {
+  const [command, ...rest] = argv;
+  return command === 'completions' ? ['complete', ...rest] : argv;
 }
 
 function completionEntries() {
@@ -105,7 +110,7 @@ export async function runGunshiCli(
     return;
   }
 
-  await cli(argv, wpTypiaGunshiCommand, {
+  await cli(normalizeGunshiCompletionArgv(argv), wpTypiaGunshiCommand, {
     fallbackToEntry: true,
     name: 'wp-typia',
     plugins: [

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -1050,10 +1050,38 @@ process.exit(0);
   });
 
   test('exposes shell completions through the Gunshi CLI surface', () => {
-    const output = runUtf8Command('node', [entryPath, 'completions', 'bash']);
+    const completeOutput = runUtf8Command('node', [
+      entryPath,
+      'complete',
+      'bash',
+    ]);
+    const completionsOutput = runUtf8Command('node', [
+      entryPath,
+      'completions',
+      'bash',
+    ]);
 
-    expect(output).toContain('# bash completion for wp-typia');
-    expect(output).toContain('wp-typia complete --');
+    expect(completionsOutput).toBe(completeOutput);
+    expect(completionsOutput).toContain('# bash completion for wp-typia');
+    expect(completionsOutput).toContain(' complete --');
+  });
+
+  test('keeps completion alias output aligned for zsh and fish', () => {
+    for (const shell of ['zsh', 'fish']) {
+      const completeOutput = runUtf8Command('node', [
+        entryPath,
+        'complete',
+        shell,
+      ]);
+      const completionsOutput = runUtf8Command('node', [
+        entryPath,
+        'completions',
+        shell,
+      ]);
+
+      expect(completionsOutput).toBe(completeOutput);
+      expect(completionsOutput).toContain(' complete --');
+    }
   });
 
   test('exposes skills listing through the Gunshi CLI surface', () => {

--- a/packages/wp-typia/tests/gunshi-prep.test.ts
+++ b/packages/wp-typia/tests/gunshi-prep.test.ts
@@ -93,7 +93,7 @@ describe('wp-typia Gunshi runtime preparation', () => {
     );
     expect(
       shouldUseGunshiCompletion(['completions', 'bash'], nodeVersions),
-    ).toBe(false);
+    ).toBe(true);
     expect(shouldUseGunshiCompletion(['complete', '--help'], nodeVersions)).toBe(
       false,
     );


### PR DESCRIPTION
## Summary

- routes the legacy `wp-typia completions <shell>` alias through the same Gunshi completion output path as `wp-typia complete <shell>`
- preserves `complete -- <argv>` dynamic completion behavior
- adds bash/zsh/fish alias parity coverage and a Sampo patch changeset for `wp-typia`

## Validation

- `bun run --filter wp-typia build`
- `bun test packages/wp-typia/tests/gunshi-prep.test.ts packages/wp-typia/tests/cli-package.test.ts`
- `bun run --filter wp-typia test`
- `bun run format:check`
- `bun run typecheck`
- `bun run lint:repo`
- help/completion smoke for `--help`, `add --help`, `mcp --help`, `skills --help`, `complete bash`, and `completions bash`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unified CLI shell completion behavior: the legacy `completions <shell>` command alias now produces identical output as the `complete <shell>` command across all supported shells.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->