### PR TITLE
fix(cli): reject likely top-level command typos

### DIFF
--- a/.sampo/changesets/cli-positional-typo-guard.md
+++ b/.sampo/changesets/cli-positional-typo-guard.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Reject likely top-level command typos before treating them as positional create aliases, while preserving intentional `wp-typia <project-dir>` usage.

--- a/packages/wp-typia/src/command-contract.ts
+++ b/packages/wp-typia/src/command-contract.ts
@@ -155,6 +155,17 @@ function getEditDistance(left: string, right: string): number {
   return previous[right.length] as number;
 }
 
+function isEdgeInsertionOrDeletionTypo(left: string, right: string): boolean {
+  if (Math.abs(left.length - right.length) !== 1) {
+    return false;
+  }
+
+  const [shorter, longer] =
+    left.length < right.length ? [left, right] : [right, left];
+
+  return longer.startsWith(shorter) || longer.endsWith(shorter);
+}
+
 function suggestTopLevelCommandTypo(
   value: string,
 ): WpTypiaReservedTopLevelCommandName | null {
@@ -172,6 +183,12 @@ function suggestTopLevelCommandTypo(
     const normalizedCommand = command.toLowerCase();
     const distance = getEditDistance(normalizedValue, normalizedCommand);
     if (distance > 2) {
+      continue;
+    }
+    if (
+      distance === 1 &&
+      isEdgeInsertionOrDeletionTypo(normalizedValue, normalizedCommand)
+    ) {
       continue;
     }
     if (

--- a/packages/wp-typia/src/command-contract.ts
+++ b/packages/wp-typia/src/command-contract.ts
@@ -131,6 +131,75 @@ function hasUnknownOptionBefore(argv: string[], endIndex: number): boolean {
   return false;
 }
 
+function getEditDistance(left: string, right: string): number {
+  const previous = Array.from({ length: right.length + 1 }, (_, index) => index);
+  const current = new Array<number>(right.length + 1);
+
+  for (let leftIndex = 0; leftIndex < left.length; leftIndex += 1) {
+    current[0] = leftIndex + 1;
+
+    for (let rightIndex = 0; rightIndex < right.length; rightIndex += 1) {
+      const substitutionCost = left[leftIndex] === right[rightIndex] ? 0 : 1;
+      current[rightIndex + 1] = Math.min(
+        current[rightIndex] + 1,
+        previous[rightIndex + 1] + 1,
+        previous[rightIndex] + substitutionCost,
+      );
+    }
+
+    for (let index = 0; index < current.length; index += 1) {
+      previous[index] = current[index] as number;
+    }
+  }
+
+  return previous[right.length] as number;
+}
+
+function suggestTopLevelCommandTypo(
+  value: string,
+): WpTypiaReservedTopLevelCommandName | null {
+  const normalizedValue = value.trim().toLowerCase();
+  if (normalizedValue.length < 4) {
+    return null;
+  }
+
+  let bestCandidate: {
+    command: WpTypiaReservedTopLevelCommandName;
+    distance: number;
+  } | null = null;
+
+  for (const command of WP_TYPIA_RESERVED_TOP_LEVEL_COMMAND_NAMES) {
+    const normalizedCommand = command.toLowerCase();
+    const distance = getEditDistance(normalizedValue, normalizedCommand);
+    if (distance > 2) {
+      continue;
+    }
+    if (
+      distance > 1 &&
+      normalizedValue[0] !== normalizedCommand[0]
+    ) {
+      continue;
+    }
+    if (bestCandidate === null || distance < bestCandidate.distance) {
+      bestCandidate = { command, distance };
+    }
+  }
+
+  return bestCandidate?.command ?? null;
+}
+
+function assertNoLikelyTopLevelCommandTypo(value: string): void {
+  const suggestion = suggestTopLevelCommandTypo(value);
+  if (!suggestion) {
+    return;
+  }
+
+  throw createCliDiagnosticCodeError(
+    CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
+    `Unknown top-level command "${value}". Did you mean "${suggestion}"? If you meant to create a project named "${value}", run \`${WP_TYPIA_CANONICAL_CREATE_USAGE.replace('<project-dir>', value)}\`.`,
+  );
+}
+
 export function resolveCanonicalCommandContext(argv: string[]): string {
   const positionalIndexes = collectPositionalIndexes(
     argv,
@@ -151,6 +220,10 @@ export function resolveCanonicalCommandContext(argv: string[]): string {
   }
 
   if (isReservedTopLevelCommandName(firstPositional)) {
+    return firstPositional;
+  }
+
+  if (suggestTopLevelCommandTypo(firstPositional)) {
     return firstPositional;
   }
 
@@ -291,6 +364,7 @@ export function normalizeWpTypiaArgv(argv: string[]): string[] {
   }
 
   assertPositionalAliasProjectDir(firstPositional);
+  assertNoLikelyTopLevelCommandTypo(firstPositional);
 
   const normalizedArgv = [
     ...argv.slice(0, firstPositionalIndex),

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -1302,6 +1302,38 @@ process.exit(0);
     expect(parsed.error?.code).toBe('invalid-argument');
   });
 
+  test('emits machine-readable top-level typo suggestions without consuming create aliases', () => {
+    const result = runCapturedCommand(
+      process.execPath,
+      [runtimeEntrypoint, 'docotr', '--format', 'json'],
+      {
+        env: withoutAIAgentEnv(),
+      },
+    );
+    const parsed = JSON.parse(result.stderr.trim()) as {
+      error?: {
+        code?: string;
+        command?: string;
+        detailLines?: string[];
+        kind?: string;
+      };
+      ok?: boolean;
+    };
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe('');
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error?.kind).toBe('command-execution');
+    expect(parsed.error?.command).toBe('docotr');
+    expect(parsed.error?.code).toBe('invalid-argument');
+    expect(parsed.error?.detailLines?.join('\n')).toContain(
+      'Did you mean "doctor"?',
+    );
+    expect(parsed.error?.detailLines?.join('\n')).toContain(
+      'wp-typia create docotr',
+    );
+  });
+
   test('loads MCP schema sources from an explicit --config override', () => {
     const tempRoot = fs.mkdtempSync(
       path.join(os.tmpdir(), 'wp-typia-mcp-config-'),

--- a/packages/wp-typia/tests/create-command-package.test.ts
+++ b/packages/wp-typia/tests/create-command-package.test.ts
@@ -237,6 +237,17 @@ test('rejects typo-like positional alias invocations with extra arguments', () =
   expect(result.stderr).toContain('`list`');
 });
 
+test('rejects single positional command typos with create alias guidance', () => {
+  const result = runCapturedCommand('node', [entryPath, 'docotr'], {
+    env: withoutAIAgentEnv(),
+  });
+
+  expect(result.status).toBe(1);
+  expect(result.stderr).toContain('Unknown top-level command "docotr".');
+  expect(result.stderr).toContain('Did you mean "doctor"?');
+  expect(result.stderr).toContain('wp-typia create docotr');
+});
+
 test('formats create failures with a shared non-interactive diagnostic block', () => {
   const result = runCapturedCommand('node', [entryPath, 'create'], {
     env: withoutAIAgentEnv(),

--- a/packages/wp-typia/tests/gunshi-prep.test.ts
+++ b/packages/wp-typia/tests/gunshi-prep.test.ts
@@ -127,6 +127,10 @@ describe('wp-typia Gunshi runtime preparation', () => {
       'create',
       'storybook',
     ]);
+    expect(normalizeWpTypiaArgv(['doctors'])).toEqual([
+      'create',
+      'doctors',
+    ]);
     expectInvalidArgument(
       () => normalizeWpTypiaArgv(['migrations', 'plan']),
       /`wp-typia migrations` was removed/,
@@ -134,6 +138,10 @@ describe('wp-typia Gunshi runtime preparation', () => {
     expectInvalidArgument(
       () => normalizeWpTypiaArgv(['docotr']),
       /Did you mean "doctor"/,
+    );
+    expectInvalidArgument(
+      () => normalizeWpTypiaArgv(['temlates']),
+      /Did you mean "templates"/,
     );
     expect(WP_TYPIA_CANONICAL_CREATE_USAGE).toBe(
       'wp-typia create <project-dir>',

--- a/packages/wp-typia/tests/gunshi-prep.test.ts
+++ b/packages/wp-typia/tests/gunshi-prep.test.ts
@@ -123,9 +123,17 @@ describe('wp-typia Gunshi runtime preparation', () => {
 
   test('normalizes canonical create and migrate aliases before runtime dispatch', () => {
     expect(normalizeWpTypiaArgv(['demo-block'])).toEqual(['create', 'demo-block']);
+    expect(normalizeWpTypiaArgv(['storybook'])).toEqual([
+      'create',
+      'storybook',
+    ]);
     expectInvalidArgument(
       () => normalizeWpTypiaArgv(['migrations', 'plan']),
       /`wp-typia migrations` was removed/,
+    );
+    expectInvalidArgument(
+      () => normalizeWpTypiaArgv(['docotr']),
+      /Did you mean "doctor"/,
     );
     expect(WP_TYPIA_CANONICAL_CREATE_USAGE).toBe(
       'wp-typia create <project-dir>',


### PR DESCRIPTION
## Summary
- reject likely misspelled top-level commands before treating a single positional token as the create alias
- preserve intentional positional create aliases such as `wp-typia storybook`
- add text and JSON diagnostic coverage plus a Sampo patch changeset

## Validation
- bun run --filter wp-typia build
- bun test packages/wp-typia/tests/gunshi-prep.test.ts packages/wp-typia/tests/create-command-package.test.ts packages/wp-typia/tests/cli-package.test.ts
- bun run --filter wp-typia test
- bun run format:check
- bun run typecheck
- bun run lint:repo
- node packages/wp-typia/bin/wp-typia.js --help
- node packages/wp-typia/bin/wp-typia.js add --help
- node packages/wp-typia/bin/wp-typia.js mcp --help
- node packages/wp-typia/bin/wp-typia.js skills --help
- node packages/wp-typia/bin/wp-typia.js complete bash
- node packages/wp-typia/bin/wp-typia.js completions bash
- node packages/wp-typia/bin/wp-typia.js docotr --format json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced CLI to detect misspelled top-level commands and provide helpful suggestions for corrections rather than silently accepting them as input.
  * The CLI now rejects likely command typos with clear diagnostic messages rather than misinterpreting them as project directory arguments, while fully preserving support for the intentional `wp-typia <project-dir>` project creation syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->