### PR TITLE
docs(runtime): clarify Gunshi dispatch roadmap

### DIFF
--- a/apps/docs/src/content/docs/architecture/runtime-surface.md
+++ b/apps/docs/src/content/docs/architecture/runtime-surface.md
@@ -101,10 +101,10 @@ This document is descriptive, not normative. For support guarantees, see
   command registry, Gunshi completion integration, and bin entry.
 - General command dispatch is currently owned by the existing command
   registry/custom dispatcher. Gunshi is part of the CLI runtime where
-  applicable, with `complete` routed through the Gunshi completion integration;
-  `completions` remains the legacy alias. The internal runtime bridge delegates
-  focused output and sync helpers behind the facade. Those splits are
-  implementation details, not new CLI surface areas.
+  applicable, with `complete <shell>` and the legacy `completions <shell>` alias
+  normalized through the Gunshi completion integration. The internal runtime
+  bridge delegates focused output and sync helpers behind the facade. Those
+  splits are implementation details, not new CLI surface areas.
 - `@wp-typia/project-tools` owns scaffold, add-block, migrate, template,
   doctor, package-manager, starter-manifest, the typed generator boundary, the
   opt-in WordPress AI and `typia.llm` adapter emitters, the built-in
@@ -138,3 +138,25 @@ This document is descriptive, not normative. For support guarantees, see
   types/model/controls, metadata-core artifact/client-render/sync-routines, and
   schema-core auth/document/projection helpers into focused internal modules for
   maintainability.
+
+## CLI dispatch boundary
+
+The published `wp-typia` entrypoint is Node-first and starts in
+`runGunshiCli()`, but that does not mean every command is Gunshi-native today.
+The current boundary is:
+
+- Gunshi owns the completion integration for `complete <shell>`,
+  `completions <shell>`, and dynamic completion requests routed through
+  `complete -- ...`.
+- The shared command registry owns the public command taxonomy, option metadata,
+  and completion entry labels.
+- The portable CLI dispatcher owns parsing, global flag normalization, help
+  rendering, config loading, AI-agent structured-output defaults, diagnostics,
+  and command execution.
+- `@wp-typia/project-tools` owns the reusable project orchestration logic behind
+  create, add, sync, migrate, templates, and doctor flows.
+
+Moving more command dispatch into Gunshi would be a future architecture change,
+not a cleanup task. That work should land only after parity tests cover help
+output, option parsing, aliases, JSON/text diagnostics, AI-agent structured
+output defaults, and every public command listed in the registry.

--- a/apps/docs/src/content/docs/maintainers/bunli-cli-migration.md
+++ b/apps/docs/src/content/docs/maintainers/bunli-cli-migration.md
@@ -17,13 +17,13 @@ and the project-tools split.
   and help modules. User-facing text should describe this as the maintained CLI
   runtime path, not as a secondary runtime.
 - `runGunshiCli()` is the published entrypoint wrapper. It applies standalone
-  support setup and routes Node `wp-typia complete <shell>` requests through the
-  Gunshi completion plugin.
+  support setup and routes Node `wp-typia complete <shell>` plus the legacy
+  `wp-typia completions <shell>` alias through the Gunshi completion plugin.
 - General command dispatch is still owned by `runNodeCli()`, the shared command
   registry, and the custom dispatchers. That path owns global flag parsing,
   config defaults, AI-agent structured-output defaults, shared diagnostics, and
   the public command handlers for `create`, `init`, `sync`, `add`, `migrate`,
-  `templates`, `doctor`, `mcp`, `skills`, and the legacy `completions` alias.
+  `templates`, `doctor`, `mcp`, and `skills`.
 - This is the current maintained boundary after the migration, not a temporary
   compatibility lane. Future parser work should document any change that moves
   general command dispatch away from the registry/custom dispatcher layer.
@@ -158,7 +158,8 @@ to the canonical `create` surface in docs and review notes.
 
 The command surface below is registry-owned today. Gunshi owns the Node
 completion integration for `complete`; `completions` remains supported as the
-legacy alias through the shared dispatcher.
+legacy alias and is normalized onto that same Gunshi completion path for shell
+script output.
 
 - `create`
 - `init`
@@ -181,3 +182,24 @@ Compatibility alias:
 Breaking change:
 
 - `wp-typia migrations` is removed. Use `wp-typia migrate` instead.
+
+## Gunshi dispatch roadmap
+
+Do not treat "migrate to Gunshi" as a license to move general command dispatch
+piecemeal. The maintained boundary is intentionally split: Gunshi handles
+completion integration, while the command registry and portable CLI dispatcher
+handle parsing, help, diagnostics, config loading, structured-output defaults,
+and command execution.
+
+A future Gunshi-native dispatch migration should start only after these
+prerequisites are in place:
+
+- parity tests for every public command and supported alias
+- option metadata ownership that avoids duplicate flag definitions
+- help output parity for top-level, command, and subcommand help
+- JSON/text diagnostic parity, including top-level parser failures
+- AI-agent structured-output compatibility
+- completion parity for `complete`, `completions`, and `complete -- ...`
+
+Until then, new behavior should be added through the registry/custom dispatcher
+path unless the behavior is specifically part of shell completion integration.


### PR DESCRIPTION
## Summary
- document the current Gunshi/completion boundary versus registry-owned command dispatch
- clarify that `completions <shell>` is the legacy alias normalized onto the Gunshi completion path
- add roadmap prerequisites before any future Gunshi-native command dispatch migration

## Validation
- bun run docs:build
- bun run format:check
- bun run typecheck
- bun run lint:repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined CLI architecture documentation to clarify completion command handling and responsibility boundaries across system components
  * Updated maintainer documentation with ownership boundaries following recent migrations and added a dispatch roadmap for future architectural improvements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->