### PR TITLE
docs(runtime): add Gunshi-native dispatch migration RFC

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -200,6 +200,10 @@ export default defineConfig({
               link: '/maintainers/bunli-cli-migration/',
             },
             {
+              label: 'Gunshi Dispatch RFC',
+              link: '/maintainers/gunshi-dispatch-rfc/',
+            },
+            {
               label: 'Core Data Adapter Boundary',
               link: '/maintainers/core-data-adapter-boundary/',
             },

--- a/apps/docs/src/content/docs/maintainers/bunli-cli-migration.md
+++ b/apps/docs/src/content/docs/maintainers/bunli-cli-migration.md
@@ -191,6 +191,9 @@ completion integration, while the command registry and portable CLI dispatcher
 handle parsing, help, diagnostics, config loading, structured-output defaults,
 and command execution.
 
+For the future migration gates and command-by-command opt-in shape, see the
+[Gunshi-native Dispatch Migration RFC](./gunshi-dispatch-rfc.md).
+
 A future Gunshi-native dispatch migration should start only after these
 prerequisites are in place:
 

--- a/apps/docs/src/content/docs/maintainers/gunshi-dispatch-rfc.md
+++ b/apps/docs/src/content/docs/maintainers/gunshi-dispatch-rfc.md
@@ -1,0 +1,92 @@
+---
+title: 'Gunshi-native Dispatch Migration RFC'
+description: 'Future migration gates for moving wp-typia command dispatch into Gunshi.'
+---
+
+This RFC records the safe path for any future migration from the current split
+runtime boundary to Gunshi-native command dispatch. It is intentionally not an
+implementation plan for an immediate all-command rewrite.
+
+## Status
+
+- Status: proposed
+- Scope: maintainer architecture and migration gates
+- Public behavior impact: none
+- Release impact: none until a later PR changes command execution behavior
+
+## Current Boundary
+
+`wp-typia` now runs through the Node-first CLI runtime. The published entrypoint
+is `runGunshiCli()`, but the command surface is not fully Gunshi-native today.
+
+Gunshi currently owns:
+
+- Node shell completion integration for `wp-typia complete <shell>`
+- the legacy `wp-typia completions <shell>` alias, normalized onto the same
+  completion path
+- dynamic completion requests that arrive through `wp-typia complete -- ...`
+
+The registry/custom dispatcher currently owns:
+
+- top-level command normalization
+- positional `create` alias handling
+- global and command option parsing
+- config override loading
+- AI-agent structured-output defaults
+- help output
+- structured and human-readable diagnostics
+- command execution for `create`, `init`, `sync`, `add`, `migrate`,
+  `templates`, `doctor`, `mcp`, and `skills`
+
+This split is the maintained production boundary. New behavior should continue
+to use the registry/custom dispatcher unless it is specifically part of shell
+completion integration.
+
+## Migration Gates
+
+A Gunshi-native dispatch migration may start only after these gates are met:
+
+- The dispatch parity harness stays green for every public command, supported
+  alias, and structured-output default.
+- Option metadata has a single owner, or there is an adapter that proves Gunshi
+  and the registry cannot diverge on flags, defaults, repeatable options, and
+  short aliases.
+- Help output parity is covered for top-level help, command help, subcommand
+  help, short aliases, and unknown help targets.
+- A structured diagnostic adapter preserves the current `--format json`
+  contract, including top-level parser failures before command execution.
+- AI-agent detection still defaults agent runs toward structured output unless
+  `--format text` is explicit.
+- Completion parity remains covered for `complete <shell>`,
+  `completions <shell>`, and `complete -- ...`.
+- Published install smoke passes under Node without requiring Bun on `PATH`.
+
+## Suggested Migration Shape
+
+Prefer command-by-command opt-in over a broad parser replacement.
+
+1. Add Gunshi adapters that consume the existing command registry and option
+   metadata without duplicating flag definitions.
+2. Start with read-only commands whose outputs are already covered by parity
+   tests, such as `version`, `help`, or `templates list`.
+3. Keep mutation-heavy commands on the registry/custom dispatcher until create,
+   add, sync, migrate, MCP, and skills JSON/text parity is fully covered.
+4. Add release smoke for each command before switching its dispatch owner.
+5. Remove custom dispatch code only after all public commands have passed
+   parity under the Gunshi-native path and a release candidate has completed
+   published install smoke.
+
+## Non-goals
+
+- No immediate all-command Gunshi-native rewrite.
+- No public command, flag, completion, MCP, skills, or shell execution behavior
+  change in this RFC.
+- No Bun removal from the repository development, build, or test toolchain.
+- No rollback to Bunli or OpenTUI command surfaces.
+
+## Test Anchor
+
+The current boundary is codified by
+`packages/wp-typia/tests/gunshi-dispatch-parity.test.ts`. Treat that test as a
+contract: if a future PR intentionally changes dispatch ownership, update the
+test and explain the new ownership boundary in the PR.


### PR DESCRIPTION
## Summary
- add a maintainer RFC for future Gunshi-native dispatch migration gates
- document the current split boundary between Gunshi completion integration and the registry/custom dispatcher
- link the RFC from the existing Gunshi runtime contract page and docs sidebar

## Validation
- bun run format:check
- bun run typecheck
- bun run lint:repo
- bun run docs:build
- rg -n "wp-typia completions|bunli-cli-migration|Gunshi Runtime Contract" README.md apps packages --glob "!**/dist/**" --glob "!**/CHANGELOG.md"