### PR TITLE
feat(cli): support boolean short flag clusters

### DIFF
--- a/.sampo/changesets/cli-boolean-short-clusters.md
+++ b/.sampo/changesets/cli-boolean-short-clusters.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Support boolean-only short flag clusters while rejecting clusters that include value-taking short flags.

--- a/apps/docs/src/content/docs/reference/cli.md
+++ b/apps/docs/src/content/docs/reference/cli.md
@@ -32,6 +32,13 @@ The legacy internal value `toon` remains accepted as a compatibility alias for
 human-readable output, but help and invalid-format guidance advertise the public
 `text` spelling instead.
 
+Boolean short flags can be clustered when every character is a valid boolean
+flag for the current CLI parser. For example, `-dy` is accepted as `-d -y` when
+both `-d` and `-y` are valid boolean flags for that invocation. Value-taking
+short flags must stay separate, such as `-t basic`, `-b core/group`,
+`-n vendor/v1`, `-p npm`, or `-c wp-typia.config.ts`; clusters containing a
+value flag are rejected.
+
 ## Configuration Files
 
 `wp-typia` loads user config from `~/.config/wp-typia/config.json`,

--- a/packages/wp-typia/src/command-option-metadata.ts
+++ b/packages/wp-typia/src/command-option-metadata.ts
@@ -201,6 +201,16 @@ function createUnknownOptionError(
   );
 }
 
+function createValueShortFlagClusterError(
+  clusterLabel: string,
+  optionLabel: string,
+): ReturnType<typeof createCliDiagnosticCodeError> {
+  return createCliDiagnosticCodeError(
+    CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
+    `Short flag cluster \`${clusterLabel}\` contains value-taking short flag \`${optionLabel}\`; spell value flags separately.`,
+  );
+}
+
 function walkArgvOptions(
   argv: string[],
   options: {
@@ -231,6 +241,24 @@ function walkArgvOptions(
     if (arg === '--') {
       nextArgv.push(...argv.slice(index + (options.strict ? 1 : 0)));
       break;
+    }
+
+    if (arg.length > 2 && arg.startsWith('-') && !arg.startsWith('--')) {
+      if (!options.strict) {
+        nextArgv.push(arg);
+        continue;
+      }
+      for (const shortName of arg.slice(1)) {
+        const shortFlag = options.parser.shortFlagMap.get(shortName);
+        if (!shortFlag) {
+          throw createUnknownOptionError(`-${shortName}`);
+        }
+        if (shortFlag.type !== 'boolean') {
+          throw createValueShortFlagClusterError(arg, `-${shortName}`);
+        }
+        flags[shortFlag.name] = true;
+      }
+      continue;
     }
 
     if (arg.length === 2 && arg.startsWith('-')) {

--- a/packages/wp-typia/tests/command-option-metadata.test.ts
+++ b/packages/wp-typia/tests/command-option-metadata.test.ts
@@ -211,6 +211,62 @@ describe('command option metadata helpers', () => {
     expect(parsed.positionals).toEqual(['block', 'counter-card']);
   });
 
+  test('supports boolean-only short flag clusters', () => {
+    const parsed = parseCommandArgvWithMetadata(['block', 'counter-card', '-dy'], {
+      extraBooleanOptionNames: ['help', 'version'],
+      parser: buildCommandOptionParser(
+        GLOBAL_OPTION_METADATA,
+        ADD_OPTION_METADATA,
+        CREATE_OPTION_METADATA,
+      ),
+    });
+
+    expect(parsed.flags).toEqual({
+      'dry-run': true,
+      yes: true,
+    });
+    expect(parsed.positionals).toEqual(['block', 'counter-card']);
+  });
+
+  test('rejects clustered value-taking or unknown short flags', () => {
+    const parser = buildCommandOptionParser(
+      GLOBAL_OPTION_METADATA,
+      ADD_OPTION_METADATA,
+      CREATE_OPTION_METADATA,
+    );
+
+    expectDiagnosticCode(
+      () => parseCommandArgvWithMetadata(['block', 'counter-card', '-dt'], {
+        parser,
+      }),
+      CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
+      'Short flag cluster `-dt` contains value-taking short flag `-t`; spell value flags separately.',
+    );
+    expectDiagnosticCode(
+      () => parseCommandArgvWithMetadata(['block', 'counter-card', '-dz'], {
+        parser,
+      }),
+      CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
+      'Unknown option `-z`.',
+    );
+  });
+
+  test('preserves short flag clusters after the argv terminator', () => {
+    const parsed = parseCommandArgvWithMetadata(
+      ['block', 'counter-card', '--', '-dy'],
+      {
+        parser: buildCommandOptionParser(
+          GLOBAL_OPTION_METADATA,
+          ADD_OPTION_METADATA,
+          CREATE_OPTION_METADATA,
+        ),
+      },
+    );
+
+    expect(parsed.flags).toEqual({});
+    expect(parsed.positionals).toEqual(['block', 'counter-card', '-dy']);
+  });
+
   test('parses plugin QA profile flags from shared create and add metadata', () => {
     const createParsed = parseCommandArgvWithMetadata(
       ['--template', 'workspace', '--profile', 'plugin-qa', 'demo-plugin'],
@@ -520,6 +576,7 @@ describe('command option metadata helpers', () => {
         '--format=json',
         '-c',
         'wp-typia.config.ts',
+        '-dy',
         '-z',
         '--',
         '--id',
@@ -538,6 +595,7 @@ describe('command option metadata helpers', () => {
     expect(extracted.argv).toEqual([
       '--unknown',
       'value',
+      '-dy',
       '-z',
       '--',
       '--id',


### PR DESCRIPTION
## Summary
- support boolean-only short flag clusters such as `-dy`
- reject clusters containing value-taking short flags with an actionable diagnostic
- document cluster behavior and preserve terminator/loose parsing behavior

## Validation
- bun test packages/wp-typia/tests/command-option-metadata.test.ts
- bun run --filter wp-typia build
- node packages/wp-typia/bin/wp-typia.js create cluster-smoke -dy --format json --no-install
- node packages/wp-typia/bin/wp-typia.js add block counter-card -dt --format json
- bun run --filter wp-typia test
- bun run format:check
- bun run typecheck
- bun run lint:repo
- bun run docs:build