### PR TITLE
feat(cli): prompt for add kind in interactive runs

### DIFF
--- a/.sampo/changesets/cli-interactive-add-kind-selection.md
+++ b/.sampo/changesets/cli-interactive-add-kind-selection.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Prompt for an add kind when `wp-typia add` runs in an interactive terminal without a kind argument.

--- a/packages/wp-typia/src/portable-cli/dispatchers/add.ts
+++ b/packages/wp-typia/src/portable-cli/dispatchers/add.ts
@@ -1,11 +1,4 @@
-import {
-  CLI_DIAGNOSTIC_CODES,
-  createCliCommandError,
-} from '@wp-typia/project-tools/cli-diagnostics';
-import {
-  buildMissingAddKindDetailLines,
-  shouldPrintMissingAddKindHelp,
-} from '../../cli-error-messages';
+import { createCliCommandError } from '@wp-typia/project-tools/cli-diagnostics';
 import { executeAddCommand } from '../../runtime-bridge';
 import {
   buildStructuredCompletionSuccessPayload,
@@ -30,19 +23,6 @@ export async function dispatchPortableCliAdd({
   printLine,
   warnLine,
 }: PortableCliDispatchContext): Promise<void> {
-  if (!positionals[1]) {
-    if (shouldPrintMissingAddKindHelp({ format: mergedFlags.format })) {
-      const { formatAddHelpText } =
-        await import('@wp-typia/project-tools/cli-add');
-      printLine(formatAddHelpText());
-    }
-    throw createCliCommandError({
-      code: CLI_DIAGNOSTIC_CODES.MISSING_ARGUMENT,
-      command: 'add',
-      detailLines: buildMissingAddKindDetailLines(),
-    });
-  }
-
   // Add-specific normalization stays here: map positionals to kind/name and
   // switch JSON mode to structured completion output.
   const kind = positionals[1];

--- a/packages/wp-typia/src/runtime-bridge-add.ts
+++ b/packages/wp-typia/src/runtime-bridge-add.ts
@@ -9,7 +9,9 @@ import {
   type AddKindExecutionContext,
   type AddKindId,
   formatAddKindList,
+  getAddKindOptions,
   getAddKindExecutionPlan,
+  getAddNameLabel,
   isAddKindId,
   supportsAddKindDryRun,
 } from './add-kind-registry';
@@ -138,6 +140,10 @@ async function executePlannedAddKind<TKey extends AddKindId>(
   );
 }
 
+function contextAllowsInteractivePrompts(flags: Record<string, unknown>): boolean {
+  return flags.format !== 'json';
+}
+
 export async function executeAddCommand({
   cwd,
   emitOutput = true,
@@ -156,8 +162,38 @@ export async function executeAddCommand({
   try {
     const addRuntime = await loadCliAddRuntime();
     const isInteractiveSession = interactive ?? isInteractiveTerminal();
+    const getOrCreatePrompt = async () => {
+      if (activePrompt) {
+        return activePrompt;
+      }
 
-    if (!kind) {
+      const { createReadlinePrompt } = await loadCliPromptRuntime();
+      activePrompt = prompt ?? createReadlinePrompt();
+      return activePrompt;
+    };
+    let resolvedKind = kind;
+    let resolvedName = name;
+    let promptedForKind = false;
+
+    if (
+      !resolvedKind &&
+      isInteractiveSession &&
+      contextAllowsInteractivePrompts(flags)
+    ) {
+      const kindPrompt = await getOrCreatePrompt();
+      resolvedKind = await kindPrompt.select(
+        'Select what to add',
+        getAddKindOptions().map((option) => ({
+          hint: option.description,
+          label: option.name,
+          value: option.value,
+        })),
+        1,
+      );
+      promptedForKind = true;
+    }
+
+    if (!resolvedKind) {
       if (shouldPrintMissingAddKindHelp({ emitOutput })) {
         printLine(addRuntime.formatAddHelpText());
       }
@@ -166,16 +202,24 @@ export async function executeAddCommand({
         formatMissingAddKindDetailLine(),
       );
     }
-    if (!isAddKindId(kind)) {
+    if (!isAddKindId(resolvedKind)) {
       throw createCliDiagnosticCodeError(
         CLI_DIAGNOSTIC_CODES.INVALID_COMMAND,
-        `Unknown add kind "${kind}". Expected one of: ${formatAddKindList()}.`,
+        `Unknown add kind "${resolvedKind}". Expected one of: ${formatAddKindList()}.`,
       );
     }
-    if (dryRun && !supportsAddKindDryRun(kind)) {
+    if (!resolvedName && promptedForKind) {
+      const namePrompt = await getOrCreatePrompt();
+      resolvedName = await namePrompt.text(getAddNameLabel(resolvedKind), '', (value) =>
+        value.trim().length > 0
+          ? true
+          : `${getAddNameLabel(resolvedKind)} is required.`,
+      );
+    }
+    if (dryRun && !supportsAddKindDryRun(resolvedKind)) {
       throw createCliDiagnosticCodeError(
         CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
-        `\`wp-typia add ${kind}\` does not support \`--dry-run\` yet.`,
+        `\`wp-typia add ${resolvedKind}\` does not support \`--dry-run\` yet.`,
       );
     }
 
@@ -183,21 +227,13 @@ export async function executeAddCommand({
       addRuntime,
       cwd,
       flags,
-      getOrCreatePrompt: async () => {
-        if (activePrompt) {
-          return activePrompt;
-        }
-
-        const { createReadlinePrompt } = await loadCliPromptRuntime();
-        activePrompt = prompt ?? createReadlinePrompt();
-        return activePrompt;
-      },
+      getOrCreatePrompt,
       isInteractiveSession,
-      name,
+      name: resolvedName,
       positionalArgs,
       warnLine,
     };
-    return await executePlannedAddKind(kind, executionContext, {
+    return await executePlannedAddKind(resolvedKind, executionContext, {
       cwd,
       dryRun,
       emitOutput,

--- a/packages/wp-typia/tests/add-command.test.ts
+++ b/packages/wp-typia/tests/add-command.test.ts
@@ -505,6 +505,67 @@ describe('wp-typia add command bridge', () => {
     ).toBe(true);
   }, 30_000);
 
+  test('interactive plain add prompts for kind and selected kind name', async () => {
+    const projectDir = path.join(tempRoot, 'demo-add-interactive-kind-prompt');
+    const selectedPrompts: string[] = [];
+    const textPrompts: string[] = [];
+    const prompt: ReadlinePrompt = {
+      close() {},
+      async select<T extends string>(
+        message: string,
+        options: Array<{ value: T }>,
+      ) {
+        selectedPrompts.push(message);
+        if (message === 'Select what to add') {
+          expect(options.map((option) => String(option.value))).toEqual([
+            ...ADD_KIND_IDS,
+          ]);
+          return 'block' as T;
+        }
+        if (message === 'Select a block template') {
+          expect(options.map((option) => String(option.value))).toEqual([
+            'basic',
+            'interactivity',
+            'persistence',
+            'compound',
+          ]);
+          return 'basic' as T;
+        }
+        throw new Error(`Unexpected select prompt: ${message}`);
+      },
+      async text(message, defaultValue, validate) {
+        textPrompts.push(message);
+        expect(defaultValue).toBe('');
+        expect(validate?.('')).toBe('Block name is required.');
+        expect(validate?.('prompted-card')).toBe(true);
+        return 'prompted-card';
+      },
+    };
+
+    await scaffoldOfficialWorkspace(projectDir);
+    linkWorkspaceNodeModules(projectDir);
+
+    const payload = await executeAddCommand({
+      cwd: projectDir,
+      emitOutput: false,
+      flags: {},
+      interactive: true,
+      prompt,
+    });
+
+    expect(selectedPrompts).toEqual([
+      'Select what to add',
+      'Select a block template',
+    ]);
+    expect(textPrompts).toEqual(['Block name']);
+    expect(payload?.summaryLines).toContain('Template family: basic');
+    expect(
+      fs.existsSync(
+        path.join(projectDir, 'src', 'blocks', 'prompted-card', 'block.json'),
+      ),
+    ).toBe(true);
+  }, 30_000);
+
   test('interactive add block validates the missing name before prompting', async () => {
     const projectDir = path.join(tempRoot, 'demo-add-interactive-missing-name');
     const selectedPrompts: string[] = [];

--- a/packages/wp-typia/tests/node-cli-core.test.ts
+++ b/packages/wp-typia/tests/node-cli-core.test.ts
@@ -326,8 +326,9 @@ describe('Gunshi CLI core routing', () => {
     expect(addDispatcherSource).toContain(
       'export async function dispatchPortableCliAdd',
     );
-    expect(addDispatcherSource).toContain('buildMissingAddKindDetailLines');
-    expect(addDispatcherSource).toContain('shouldPrintMissingAddKindHelp');
+    expect(addDispatcherSource).toContain('executeAddCommand');
+    expect(addDispatcherSource).not.toContain('buildMissingAddKindDetailLines');
+    expect(addDispatcherSource).not.toContain('shouldPrintMissingAddKindHelp');
     expect(addDispatcherSource).not.toContain('formatAddKindUsagePlaceholder');
     expect(createDispatcherSource).toContain(
       'export async function dispatchPortableCliCreate',
@@ -336,6 +337,7 @@ describe('Gunshi CLI core routing', () => {
       'buildMissingCreateProjectDirDetailLines',
     );
     expect(runtimeBridgeSource).toContain("from './runtime-bridge-add'");
+    expect(runtimeBridgeAddSource).toContain('getAddKindOptions');
     expect(runtimeBridgeAddSource).toContain('formatMissingAddKindDetailLine');
     expect(runtimeBridgeAddSource).toContain('shouldPrintMissingAddKindHelp');
     expect(cliErrorMessagesSource).toContain(


### PR DESCRIPTION
## Summary
- prompt for an add kind when `wp-typia add` runs interactively without a kind
- prompt for the selected kind name only when the kind was selected interactively
- keep non-interactive and JSON missing-kind diagnostics unchanged

## Validation
- bun test packages/wp-typia/tests/add-command.test.ts packages/wp-typia/tests/node-cli-core.test.ts packages/wp-typia/tests/add-command-package.test.ts
- bun run --filter wp-typia test
- bun run --filter wp-typia build
- node packages/wp-typia/bin/wp-typia.js add --help
- node packages/wp-typia/bin/wp-typia.js add --format json (expected exit 1, verified missing-argument JSON)
- bun run format:check
- bun run typecheck
- bun run lint:repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `wp-typia add` command now prompts for type selection when run interactively without a kind argument.
  * Added interactive name prompting when required during the add workflow.

* **Tests**
  * Added test coverage for interactive prompting behavior in the add command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->