### PR TITLE
feat(cli): ignore generated local skills

### DIFF
--- a/.sampo/changesets/cli-local-skills-gitignore.md
+++ b/.sampo/changesets/cli-local-skills-gitignore.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Ignore generated local universal skills when running `wp-typia skills sync --local`.

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -245,11 +245,20 @@ async function dispatchPortableCliSkills({
       printLine('Skills are up to date.');
       return;
     }
-    printLine(`Synced skills to ${result.paths.length} location(s).`);
+    if (result.paths.length > 0) {
+      printLine(`Synced skills to ${result.paths.length} location(s).`);
+    }
     for (const install of result.agents) {
       const reason = install.reason ? ` (${install.reason})` : '';
       printLine(
         `  ${install.agent}: ${install.mode} -> ${install.path}${reason}`,
+      );
+    }
+    if (result.gitignore?.updated) {
+      printLine(
+        `Updated .gitignore for generated local skills: ${result.gitignore.entries.join(
+          ', ',
+        )}`,
       );
     }
     return;

--- a/packages/wp-typia/src/skills.ts
+++ b/packages/wp-typia/src/skills.ts
@@ -44,8 +44,15 @@ export type SkillInstall = {
   reason?: string;
 };
 
+export type SkillsGitignoreUpdate = {
+  entries: string[];
+  path: string;
+  updated: boolean;
+};
+
 export type SkillsSyncResult = {
   agents: SkillInstall[];
+  gitignore?: SkillsGitignoreUpdate;
   paths: string[];
   updated: boolean;
 };
@@ -61,6 +68,7 @@ const defaultSkillRuntime: SkillRuntime = {
   homeDir: () => os.homedir(),
 };
 const GENERATED_SKILL_MARKER = '.wp-typia-skill.json';
+const LOCAL_SKILL_GITIGNORE_ENTRY = '.agents/skills/wp-typia/';
 const SKILL_FILE = 'SKILL.md';
 
 function configHome(home: string): string {
@@ -458,6 +466,45 @@ function resolveParent(dir: string): string {
   }
 }
 
+function detectLineEnding(content: string): string {
+  return content.includes('\r\n') ? '\r\n' : '\n';
+}
+
+async function ensureLocalSkillsGitignore(
+  cwd: string,
+): Promise<SkillsGitignoreUpdate> {
+  const gitignorePath = path.join(cwd, '.gitignore');
+  const entries = [LOCAL_SKILL_GITIGNORE_ENTRY];
+  let content = '';
+  let exists = true;
+
+  try {
+    content = await fsp.readFile(gitignorePath, 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error;
+    }
+    exists = false;
+  }
+
+  const lines = content.split(/\r?\n/u).map((line) => line.trim());
+  const missingEntries = entries.filter((entry) => !lines.includes(entry));
+  if (missingEntries.length === 0) {
+    return { entries, path: gitignorePath, updated: false };
+  }
+
+  const lineEnding = exists ? detectLineEnding(content) : '\n';
+  let nextContent = content;
+  if (nextContent.length > 0 && !nextContent.endsWith('\n')) {
+    nextContent += lineEnding;
+  }
+  nextContent += missingEntries.map((entry) => `${entry}${lineEnding}`).join('');
+
+  await fsp.writeFile(gitignorePath, nextContent, 'utf8');
+
+  return { entries, path: gitignorePath, updated: true };
+}
+
 export async function syncSkills(
   options: {
     cwd?: string;
@@ -489,6 +536,7 @@ export async function syncSkills(
   const hash = createHash('sha256').update(content).digest('hex').slice(0, 16);
   const cacheKey = stalenessCacheKey(skillName, isGlobal, cwd, canonicalBase);
   const previousState = readState(cacheKey, runtime);
+  const gitignore = isGlobal ? undefined : await ensureLocalSkillsGitignore(cwd);
 
   if (
     !options.force &&
@@ -496,7 +544,12 @@ export async function syncSkills(
     previousState.agentKey === agentKey &&
     skillTargetsAreCurrent(canonicalDir, agentDirs, content)
   ) {
-    return { agents: [], paths: [], updated: false };
+    return {
+      agents: [],
+      gitignore,
+      paths: [],
+      updated: Boolean(gitignore?.updated),
+    };
   }
 
   await fsp.mkdir(canonicalDir, { recursive: true });
@@ -541,6 +594,7 @@ export async function syncSkills(
 
   return {
     agents: installs,
+    gitignore,
     paths: [canonicalDir],
     updated: true,
   };

--- a/packages/wp-typia/tests/gunshi-public-surfaces.test.ts
+++ b/packages/wp-typia/tests/gunshi-public-surfaces.test.ts
@@ -264,6 +264,73 @@ describe('Gunshi public CLI surfaces', () => {
     }
   });
 
+  test('syncs local skills and maintains the generated skill gitignore entry', async () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wp-typia-skills-'));
+    const home = path.join(tempRoot, 'home');
+    const cwd = path.join(tempRoot, 'project');
+    const dataHome = path.join(tempRoot, 'data');
+    const gitignorePath = path.join(cwd, '.gitignore');
+
+    try {
+      fs.mkdirSync(path.join(home, '.codex'), { recursive: true });
+      fs.mkdirSync(path.join(home, '.claude'), { recursive: true });
+      fs.mkdirSync(path.join(home, '.continue'), { recursive: true });
+      fs.mkdirSync(path.join(home, '.codeium', 'windsurf'), {
+        recursive: true,
+      });
+      fs.mkdirSync(cwd, { recursive: true });
+      fs.writeFileSync(gitignorePath, 'node_modules\r\n', 'utf8');
+
+      const env = {
+        CLAUDE_CONFIG_DIR: path.join(home, '.claude'),
+        CODEX_HOME: path.join(home, '.codex'),
+        XDG_CONFIG_HOME: path.join(home, '.config'),
+        XDG_DATA_HOME: dataHome,
+      };
+      const runtime = {
+        dataHome: () => dataHome,
+        homeDir: () => home,
+      };
+      const result = await withProcessEnv(env, () =>
+        syncSkills({ cwd, global: false, runtime }),
+      );
+      const gitignore = fs.readFileSync(gitignorePath, 'utf8');
+
+      expect(result.updated).toBe(true);
+      expect(result.gitignore).toEqual({
+        entries: ['.agents/skills/wp-typia/'],
+        path: gitignorePath,
+        updated: true,
+      });
+      expect(gitignore).toBe('node_modules\r\n.agents/skills/wp-typia/\r\n');
+      expect(gitignore).not.toContain('.claude/skills');
+      expect(gitignore).not.toContain('.continue/skills');
+      expect(gitignore).not.toContain('.windsurf/skills');
+
+      const resync = await withProcessEnv(env, () =>
+        syncSkills({ cwd, global: false, runtime }),
+      );
+      const idempotentGitignore = fs.readFileSync(gitignorePath, 'utf8');
+
+      expect(resync.updated).toBe(false);
+      expect(resync.gitignore).toEqual({
+        entries: ['.agents/skills/wp-typia/'],
+        path: gitignorePath,
+        updated: false,
+      });
+      expect(idempotentGitignore).toBe(gitignore);
+
+      const globalSync = await withProcessEnv(env, () =>
+        syncSkills({ cwd, global: true, runtime }),
+      );
+
+      expect(globalSync.gitignore).toBeUndefined();
+      expect(fs.readFileSync(gitignorePath, 'utf8')).toBe(gitignore);
+    } finally {
+      fs.rmSync(tempRoot, { force: true, recursive: true });
+    }
+  });
+
   test('syncs MCP schemas to the new default directory and custom output directory', async () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wp-typia-mcp-'));
     const schemaPath = path.join(tempRoot, 'tools.json');

--- a/packages/wp-typia/tests/node-cli-core.test.ts
+++ b/packages/wp-typia/tests/node-cli-core.test.ts
@@ -114,6 +114,36 @@ async function captureNodeCli(
   }
 }
 
+async function withProcessEnv<T>(
+  overrides: Partial<NodeJS.ProcessEnv>,
+  callback: () => Promise<T>,
+): Promise<T> {
+  const previous = new Map<string, string | undefined>();
+
+  for (const key of Object.keys(overrides)) {
+    previous.set(key, process.env[key]);
+  }
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  try {
+    return await callback();
+  } finally {
+    for (const [key, value] of previous) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
 function createTempRoot(prefix: string): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
 }
@@ -1035,5 +1065,65 @@ describe('Gunshi CLI core routing', () => {
     expect(parsed.ok).toBe(false);
     expect(parsed.error?.code).toBe(CLI_DIAGNOSTIC_CODES.INVALID_COMMAND);
     expect(parsed.error?.command).toBe('skills');
+  });
+
+  test('reports generated local skill gitignore updates in text and json output', async () => {
+    const tempRoot = createTempRoot('wp-typia-skills-cli-');
+    const home = path.join(tempRoot, 'home');
+    const textCwd = path.join(tempRoot, 'text-project');
+    const jsonCwd = path.join(tempRoot, 'json-project');
+    const dataHome = path.join(tempRoot, 'data');
+
+    try {
+      fs.mkdirSync(path.join(home, '.codex'), { recursive: true });
+      fs.mkdirSync(textCwd, { recursive: true });
+      fs.mkdirSync(jsonCwd, { recursive: true });
+
+      const env = {
+        CODEX_HOME: path.join(home, '.codex'),
+        XDG_CONFIG_HOME: path.join(home, '.config'),
+        XDG_DATA_HOME: dataHome,
+      };
+      const textResult = await withProcessEnv(env, () =>
+        captureNodeCli(['skills', 'sync', '--local'], { cwd: textCwd }),
+      );
+
+      expect(textResult.error).toBeUndefined();
+      expect(textResult.exitCode).toBe(0);
+      expect(textResult.stderr).toBe('');
+      expect(textResult.stdout).toContain(
+        'Updated .gitignore for generated local skills: .agents/skills/wp-typia/',
+      );
+      expect(
+        fs.readFileSync(path.join(textCwd, '.gitignore'), 'utf8'),
+      ).toContain('.agents/skills/wp-typia/');
+
+      const jsonResult = await withProcessEnv(env, () =>
+        captureNodeCli(['skills', 'sync', '--local', '--format', 'json'], {
+          cwd: jsonCwd,
+        }),
+      );
+      const parsed = JSON.parse(jsonResult.stdout) as {
+        gitignore?: { entries?: string[]; path?: string; updated?: boolean };
+        paths?: string[];
+        updated?: boolean;
+      };
+
+      expect(jsonResult.error).toBeUndefined();
+      expect(jsonResult.exitCode).toBe(0);
+      expect(jsonResult.stderr).toBe('');
+      expect(parsed.updated).toBe(true);
+      const resolvedJsonCwd = fs.realpathSync(jsonCwd);
+      expect(parsed.paths).toContain(
+        path.join(resolvedJsonCwd, '.agents', 'skills', 'wp-typia'),
+      );
+      expect(parsed.gitignore).toEqual({
+        entries: ['.agents/skills/wp-typia/'],
+        path: path.join(resolvedJsonCwd, '.gitignore'),
+        updated: true,
+      });
+    } finally {
+      removeTempRoot(tempRoot);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- ensure `wp-typia skills sync --local` adds `.agents/skills/wp-typia/` to the project `.gitignore`
- report `.gitignore` updates in text output and the structured JSON sync result
- keep global sync and agent-specific local skill paths out of automatic ignore management

## Validation
- `bun test packages/wp-typia/tests/gunshi-public-surfaces.test.ts packages/wp-typia/tests/node-cli-core.test.ts`
- `bun run format:check`
- `bun run typecheck`
- `bun run lint:repo`
- `bun run --filter wp-typia build`
- `bun run --filter wp-typia test`
- built CLI smoke for `add --help`, expected-error `add --format json`, and `skills sync --local --format json`
- `bun run test:publish-install-smoke`
