### PR TITLE
docs(cli): document local skills gitignore handling

### DIFF
--- a/.sampo/changesets/cli-local-skills-gitignore-docs.md
+++ b/.sampo/changesets/cli-local-skills-gitignore-docs.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Document local skills sync gitignore handling in CLI help and reference docs.

--- a/apps/docs/src/content/docs/reference/cli.md
+++ b/apps/docs/src/content/docs/reference/cli.md
@@ -480,6 +480,7 @@ wp-typia mcp list
 wp-typia mcp sync
 wp-typia skills list
 wp-typia skills sync
+wp-typia skills sync --local
 wp-typia complete zsh
 ```
 
@@ -487,3 +488,9 @@ wp-typia complete zsh
 downstream tooling. `mcp sync` writes to `.wp-typia/mcp` by default, and
 `skills` plus `complete` are first-party CLI surfaces. `completions` remains
 available as a legacy alias for `complete`.
+
+`skills sync` installs global skills by default. `skills sync --local` writes
+project-local skill files, adds the generated universal skill path
+`.agents/skills/wp-typia/` to the project `.gitignore` when missing, and leaves
+agent-specific local skill directories such as `.claude/skills` or
+`.continue/skills` under user control.

--- a/packages/wp-typia/src/portable-cli/help.ts
+++ b/packages/wp-typia/src/portable-cli/help.ts
@@ -136,6 +136,7 @@ const PORTABLE_CLI_COMMAND_HELP_CONFIG = {
   skills: {
     bodyLines: [
       'List detected coding agents or generate a compact wp-typia SKILL.md from command metadata.',
+      'Use --local to install project-local skills; generated universal skills under .agents/skills/wp-typia/ are added to .gitignore.',
     ],
     heading: 'Usage: wp-typia skills <list|sync>',
     optionMetadata: SKILLS_OPTION_METADATA,

--- a/packages/wp-typia/tests/node-cli-core.test.ts
+++ b/packages/wp-typia/tests/node-cli-core.test.ts
@@ -222,6 +222,7 @@ describe('Gunshi CLI core routing', () => {
     const addHelp = await captureNodeCli(['help', 'add']);
     const createHelp = await captureNodeCli(['--help', 'create']);
     const commandHelp = await captureNodeCli(['help', 'templates']);
+    const skillsHelp = await captureNodeCli(['skills', '--help']);
 
     expect(generalHelp.error).toBeUndefined();
     expect(generalHelp.exitCode).toBe(0);
@@ -249,6 +250,12 @@ describe('Gunshi CLI core routing', () => {
     expect(commandHelp.stdout).toContain('Runtime: Node-first wp-typia CLI');
     expect(commandHelp.stdout).toContain('Supported flags:');
     expect(commandHelp.stdout).toContain('--id');
+
+    expect(skillsHelp.error).toBeUndefined();
+    expect(skillsHelp.exitCode).toBe(0);
+    expect(skillsHelp.stdout).toContain('Usage: wp-typia skills <list|sync>');
+    expect(skillsHelp.stdout).toContain('.agents/skills/wp-typia/');
+    expect(skillsHelp.stdout).toContain('.gitignore');
   });
 
   test('renders focused guidance for unknown help targets without dispatching commands', async () => {


### PR DESCRIPTION
## Summary
- document `skills sync --local` adding `.agents/skills/wp-typia/` to `.gitignore`
- add the same local-sync note to `wp-typia skills --help`
- cover the help text with a CLI routing assertion

## Validation
- `bun test packages/wp-typia/tests/command-option-metadata.test.ts packages/wp-typia/tests/add-command.test.ts packages/wp-typia/tests/add-kind-registry.test.ts packages/wp-typia/tests/gunshi-public-surfaces.test.ts packages/wp-typia/tests/node-cli-core.test.ts`
- `bun test packages/wp-typia/tests/node-cli-core.test.ts`
- `bun run format:check`
- `bun run typecheck`
- `bun run lint:repo`
- `bun run docs:build`
- `bun run --filter wp-typia build`
- `node packages/wp-typia/bin/wp-typia.js skills --help`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI reference documentation for `skills sync --local` command, explaining local skill installation and `.gitignore` handling.
  * Enhanced CLI help text to clarify the `--local` flag functionality and default skill directory behavior.

* **Tests**
  * Added test coverage for CLI skills command help output verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->