### PR TITLE
fix(cli): suggest help target typos

### DIFF
--- a/.sampo/changesets/cli-help-typo-suggestions.md
+++ b/.sampo/changesets/cli-help-typo-suggestions.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Suggest close command names for unknown `wp-typia help <target>` requests.

--- a/packages/wp-typia/src/command-contract.ts
+++ b/packages/wp-typia/src/command-contract.ts
@@ -166,7 +166,7 @@ function isEdgeInsertionOrDeletionTypo(left: string, right: string): boolean {
   return longer.startsWith(shorter) || longer.endsWith(shorter);
 }
 
-function suggestTopLevelCommandTypo(
+export function suggestTopLevelCommandTypo(
   value: string,
 ): WpTypiaReservedTopLevelCommandName | null {
   const normalizedValue = value.trim().toLowerCase();

--- a/packages/wp-typia/src/portable-cli/help.ts
+++ b/packages/wp-typia/src/portable-cli/help.ts
@@ -19,6 +19,7 @@ import {
   WP_TYPIA_FUTURE_COMMAND_TREE,
   WP_TYPIA_PORTABLE_CLI_TOP_LEVEL_COMMAND_NAMES,
   WP_TYPIA_POSITIONAL_ALIAS_USAGE,
+  suggestTopLevelCommandTypo,
 } from '../command-contract';
 import type { PrintLine } from '../print-line';
 import { printBlock } from '../print-block';
@@ -74,8 +75,13 @@ export function renderUnknownHelpTarget(
   printLine: PrintLine,
   target: string,
 ) {
+  const suggestion = suggestTopLevelCommandTypo(target);
+
   printBlock(printLine, [
     `Unknown help target "${target}".`,
+    ...(suggestion
+      ? [`Did you mean "${suggestion}"? Run wp-typia ${suggestion} --help.`]
+      : []),
     `Supported commands: ${WP_TYPIA_PORTABLE_CLI_TOP_LEVEL_COMMAND_NAMES.join(
       ', ',
     )}.`,

--- a/packages/wp-typia/tests/node-cli-core.test.ts
+++ b/packages/wp-typia/tests/node-cli-core.test.ts
@@ -260,6 +260,7 @@ describe('Gunshi CLI core routing', () => {
 
   test('renders focused guidance for unknown help targets without dispatching commands', async () => {
     const result = await captureNodeCli(['help', 'definitely-not-a-command']);
+    const typoResult = await captureNodeCli(['help', 'docotr']);
     const structuredResult = await captureNodeCli([
       '--format',
       'json',
@@ -275,6 +276,14 @@ describe('Gunshi CLI core routing', () => {
     expect(result.stdout).toContain('Supported commands: create, init, sync');
     expect(result.stdout).toContain('wp-typia --help');
     expect(result.stdout).not.toContain('Usage: wp-typia create <project-dir>');
+
+    expect(typoResult.error).toBeUndefined();
+    expect(typoResult.exitCode).toBe(0);
+    expect(typoResult.stdout).toContain('Unknown help target "docotr".');
+    expect(typoResult.stdout).toContain(
+      'Did you mean "doctor"? Run wp-typia doctor --help.',
+    );
+    expect(typoResult.stdout).toContain('Supported commands: create, init, sync');
 
     expect(structuredResult.error).toBeUndefined();
     expect(structuredResult.exitCode).toBe(0);


### PR DESCRIPTION
## Summary
- reuse the existing top-level command typo suggester for unknown `wp-typia help <target>` requests
- show a focused `Did you mean` line with the suggested command help invocation
- add node CLI coverage plus a Sampo patch changeset for the public help output polish

## Validation
- bun test packages/wp-typia/tests/node-cli-core.test.ts
- bun run format:check
- bun run typecheck
- bun run lint:repo
- bun run --filter wp-typia build
- bun run --filter wp-typia test
- node packages/wp-typia/bin/wp-typia.js help docotr
- node packages/wp-typia/bin/wp-typia.js --help | sed -n '1,25p'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI now suggests close command names when users request help for unknown targets, providing helpful corrections for common typos.

* **Tests**
  * Added test coverage to verify typo suggestion behavior, ensuring users receive accurate recommendations when entering mistyped help commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->