### PR TITLE
feat(cli): prompt for required add fields

### DIFF
--- a/.sampo/changesets/cli-add-required-field-prompts.md
+++ b/.sampo/changesets/cli-add-required-field-prompts.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Prompt for required add fields when interactive `wp-typia add` users select kinds such as style, variation, transform, hooked-block, core-variation, or post-meta.

--- a/packages/wp-typia/src/runtime-bridge-add.ts
+++ b/packages/wp-typia/src/runtime-bridge-add.ts
@@ -4,6 +4,7 @@ import {
   createCliDiagnosticCodeError,
 } from '@wp-typia/project-tools/cli-diagnostics';
 import {
+  type AddFieldName,
   type AddKindExecutionPlan,
   type AddKindExecutionPlanFor,
   type AddKindExecutionContext,
@@ -50,6 +51,31 @@ const loadCliAddRuntime = () => import('@wp-typia/project-tools/cli-add');
 const loadCliPromptRuntime = () => import('@wp-typia/project-tools/cli-prompt');
 const loadWorkspaceProjectRuntime = () =>
   import('@wp-typia/project-tools/workspace-project');
+
+type RequiredPromptableAddFieldName = Extract<
+  AddFieldName,
+  'anchor' | 'block' | 'from' | 'position' | 'post-type' | 'to'
+>;
+
+const REQUIRED_FIELD_PROMPTS_BY_ADD_KIND: Partial<
+  Record<AddKindId, readonly RequiredPromptableAddFieldName[]>
+> = {
+  'core-variation': ['block'],
+  'hooked-block': ['anchor', 'position'],
+  'post-meta': ['post-type'],
+  style: ['block'],
+  transform: ['from', 'to'],
+  variation: ['block'],
+};
+
+const REQUIRED_FIELD_PROMPT_LABELS = {
+  anchor: 'Anchor block',
+  block: 'Target block',
+  from: 'Source block',
+  position: 'Hook position',
+  'post-type': 'Post type',
+  to: 'Target block',
+} as const satisfies Record<RequiredPromptableAddFieldName, string>;
 
 async function executeWorkspaceAddWithOptionalDryRun<TResult>(options: {
   buildCompletion: (
@@ -144,6 +170,37 @@ function contextAllowsInteractivePrompts(flags: Record<string, unknown>): boolea
   return flags.format !== 'json';
 }
 
+function shouldPromptForRequiredAddField(
+  flags: Record<string, unknown>,
+  fieldName: RequiredPromptableAddFieldName,
+): boolean {
+  const value = flags[fieldName];
+  return (
+    value === undefined ||
+    value === null ||
+    (typeof value === 'string' && value.trim().length === 0)
+  );
+}
+
+async function promptForRequiredAddFields(options: {
+  flags: Record<string, unknown>;
+  getOrCreatePrompt: () => Promise<ReadlinePrompt>;
+  kind: AddKindId;
+}): Promise<void> {
+  const requiredFields = REQUIRED_FIELD_PROMPTS_BY_ADD_KIND[options.kind] ?? [];
+  for (const fieldName of requiredFields) {
+    if (!shouldPromptForRequiredAddField(options.flags, fieldName)) {
+      continue;
+    }
+
+    const label = REQUIRED_FIELD_PROMPT_LABELS[fieldName];
+    const fieldPrompt = await options.getOrCreatePrompt();
+    options.flags[fieldName] = await fieldPrompt.text(label, '', (value) =>
+      value.trim().length > 0 ? true : `${label} is required.`,
+    );
+  }
+}
+
 export async function executeAddCommand({
   cwd,
   emitOutput = true,
@@ -157,7 +214,8 @@ export async function executeAddCommand({
   warnLine = console.warn as PrintLine,
 }: AddExecutionInput): Promise<RuntimeCompletionPayload | void> {
   let activePrompt: ReadlinePrompt | undefined;
-  const dryRun = Boolean(flags['dry-run']);
+  const resolvedFlags = { ...flags };
+  const dryRun = Boolean(resolvedFlags['dry-run']);
 
   try {
     const addRuntime = await loadCliAddRuntime();
@@ -178,7 +236,7 @@ export async function executeAddCommand({
     if (
       !resolvedKind &&
       isInteractiveSession &&
-      contextAllowsInteractivePrompts(flags)
+      contextAllowsInteractivePrompts(resolvedFlags)
     ) {
       const kindPrompt = await getOrCreatePrompt();
       resolvedKind = await kindPrompt.select(
@@ -216,6 +274,13 @@ export async function executeAddCommand({
           : `${getAddNameLabel(resolvedKind)} is required.`,
       );
     }
+    if (promptedForKind) {
+      await promptForRequiredAddFields({
+        flags: resolvedFlags,
+        getOrCreatePrompt,
+        kind: resolvedKind,
+      });
+    }
     if (dryRun && !supportsAddKindDryRun(resolvedKind)) {
       throw createCliDiagnosticCodeError(
         CLI_DIAGNOSTIC_CODES.INVALID_ARGUMENT,
@@ -226,7 +291,7 @@ export async function executeAddCommand({
     const executionContext: AddKindExecutionContext = {
       addRuntime,
       cwd,
-      flags,
+      flags: resolvedFlags,
       getOrCreatePrompt,
       isInteractiveSession,
       name: resolvedName,

--- a/packages/wp-typia/tests/add-command.test.ts
+++ b/packages/wp-typia/tests/add-command.test.ts
@@ -566,6 +566,86 @@ describe('wp-typia add command bridge', () => {
     ).toBe(true);
   }, 30_000);
 
+  test('interactive plain add prompts for required fields after kind selection', async () => {
+    const projectDir = path.join(
+      tempRoot,
+      'demo-add-interactive-required-fields',
+    );
+    const selectedPrompts: string[] = [];
+    const textPrompts: string[] = [];
+    const promptValues = new Map([
+      ['Style name', 'callout-emphasis'],
+      ['Target block', 'counter-card'],
+    ]);
+    const prompt: ReadlinePrompt = {
+      close() {},
+      async select<T extends string>(
+        message: string,
+        options: Array<{ value: T }>,
+      ) {
+        selectedPrompts.push(message);
+        if (message === 'Select what to add') {
+          expect(options.map((option) => String(option.value))).toEqual([
+            ...ADD_KIND_IDS,
+          ]);
+          return 'style' as T;
+        }
+        throw new Error(`Unexpected select prompt: ${message}`);
+      },
+      async text(message, defaultValue, validate) {
+        textPrompts.push(message);
+        expect(defaultValue).toBe('');
+        expect(validate?.('')).toBe(`${message} is required.`);
+        const value = promptValues.get(message);
+        if (!value) {
+          throw new Error(`Unexpected text prompt: ${message}`);
+        }
+        expect(validate?.(value)).toBe(true);
+        return value;
+      },
+    };
+
+    await scaffoldOfficialWorkspace(projectDir);
+    linkWorkspaceNodeModules(projectDir);
+    await executeAddCommand({
+      cwd: projectDir,
+      emitOutput: false,
+      flags: {
+        template: 'basic',
+      },
+      interactive: false,
+      kind: 'block',
+      name: 'counter-card',
+    });
+
+    const payload = await executeAddCommand({
+      cwd: projectDir,
+      emitOutput: false,
+      flags: {},
+      interactive: true,
+      prompt,
+    });
+
+    expect(selectedPrompts).toEqual(['Select what to add']);
+    expect(textPrompts).toEqual(['Style name', 'Target block']);
+    expect(payload?.summaryLines).toContain(
+      'Block style: callout-emphasis',
+    );
+    expect(payload?.summaryLines).toContain('Target block: counter-card');
+    expect(
+      fs.existsSync(
+        path.join(
+          projectDir,
+          'src',
+          'blocks',
+          'counter-card',
+          'styles',
+          'callout-emphasis.ts',
+        ),
+      ),
+    ).toBe(true);
+  }, 30_000);
+
   test('interactive add block validates the missing name before prompting', async () => {
     const projectDir = path.join(tempRoot, 'demo-add-interactive-missing-name');
     const selectedPrompts: string[] = [];


### PR DESCRIPTION
## Summary
- prompt for known required string fields after interactive plain `wp-typia add` users select a kind
- keep explicit-kind, non-interactive, and `--format json` missing-argument behavior unchanged
- add coverage for the style flow plus a Sampo patch changeset

## Validation
- bun test packages/wp-typia/tests/add-command.test.ts
- bun run format:check
- bun run typecheck
- bun run lint:repo
- bun run --filter wp-typia build
- bun run --filter wp-typia test
- node packages/wp-typia/bin/wp-typia.js add --help | sed -n '1,35p'\n- node packages/wp-typia/bin/wp-typia.js add --format json # exits 1 with the existing missing-kind diagnostic\n\n## Notes\nThis only applies to plain interactive `wp-typia add` after the kind prompt. It intentionally does not turn optional or paired add inputs into a full wizard.