### PR TITLE
fix(cli): polish interactive add prompts and structured warnings

### DIFF
--- a/.sampo/changesets/cli-add-interactive-polish.md
+++ b/.sampo/changesets/cli-add-interactive-polish.md
@@ -1,0 +1,5 @@
+---
+npm/wp-typia: patch
+---
+
+Polish interactive add prompts and expose legacy pattern tag warnings in structured CLI output.

--- a/packages/wp-typia/src/add-kinds/pattern.ts
+++ b/packages/wp-typia/src/add-kinds/pattern.ts
@@ -56,7 +56,9 @@ export const patternAddKindEntry =
       const tags =
         normalizePatternTagFlags(context.flags.tags, context.flags.tag);
       const thumbnailUrl = rawThumbnailUrl;
-      if (context.flags.tag !== undefined && context.flags.format !== 'json') {
+      const legacyTagWarning =
+        context.flags.tag !== undefined ? LEGACY_TAG_FLAG_WARNING : undefined;
+      if (legacyTagWarning && context.flags.format !== 'json') {
         context.warnLine(LEGACY_TAG_FLAG_WARNING);
       }
 
@@ -85,6 +87,10 @@ export const patternAddKindEntry =
           patternScope: result.patternScope,
           ...(result.sectionRole ? { sectionRole: result.sectionRole } : {}),
         }),
+        getWarnings: () =>
+          context.flags.format === 'json' && legacyTagWarning
+            ? [legacyTagWarning]
+            : undefined,
         warnLine: context.warnLine,
       };
     },

--- a/packages/wp-typia/src/runtime-bridge-add.ts
+++ b/packages/wp-typia/src/runtime-bridge-add.ts
@@ -1,4 +1,5 @@
 import type { ReadlinePrompt } from '@wp-typia/project-tools/cli-prompt';
+import { HOOKED_BLOCK_POSITION_IDS } from '@wp-typia/project-tools/hooked-blocks';
 import {
   CLI_DIAGNOSTIC_CODES,
   createCliDiagnosticCodeError,
@@ -195,6 +196,19 @@ async function promptForRequiredAddFields(options: {
 
     const label = REQUIRED_FIELD_PROMPT_LABELS[fieldName];
     const fieldPrompt = await options.getOrCreatePrompt();
+    if (fieldName === 'position') {
+      options.flags[fieldName] = await fieldPrompt.select(
+        label,
+        HOOKED_BLOCK_POSITION_IDS.map((position) => ({
+          hint: `Insert relative to the anchor block as ${position}`,
+          label: position,
+          value: position,
+        })),
+        2,
+      );
+      continue;
+    }
+
     options.flags[fieldName] = await fieldPrompt.text(label, '', (value) =>
       value.trim().length > 0 ? true : `${label} is required.`,
     );
@@ -231,7 +245,6 @@ export async function executeAddCommand({
     };
     let resolvedKind = kind;
     let resolvedName = name;
-    let promptedForKind = false;
 
     if (
       !resolvedKind &&
@@ -248,7 +261,6 @@ export async function executeAddCommand({
         })),
         1,
       );
-      promptedForKind = true;
     }
 
     if (!resolvedKind) {
@@ -266,7 +278,11 @@ export async function executeAddCommand({
         `Unknown add kind "${resolvedKind}". Expected one of: ${formatAddKindList()}.`,
       );
     }
-    if (!resolvedName && promptedForKind) {
+    if (
+      !resolvedName &&
+      isInteractiveSession &&
+      contextAllowsInteractivePrompts(resolvedFlags)
+    ) {
       const namePrompt = await getOrCreatePrompt();
       resolvedName = await namePrompt.text(getAddNameLabel(resolvedKind), '', (value) =>
         value.trim().length > 0
@@ -274,7 +290,10 @@ export async function executeAddCommand({
           : `${getAddNameLabel(resolvedKind)} is required.`,
       );
     }
-    if (promptedForKind) {
+    if (
+      isInteractiveSession &&
+      contextAllowsInteractivePrompts(resolvedFlags)
+    ) {
       await promptForRequiredAddFields({
         flags: resolvedFlags,
         getOrCreatePrompt,

--- a/packages/wp-typia/tests/add-command-package.test.ts
+++ b/packages/wp-typia/tests/add-command-package.test.ts
@@ -179,6 +179,52 @@ test('emits structured add completion output in portable CLI JSON mode', async (
   }
 });
 
+test('emits legacy pattern tag warnings in portable CLI JSON completion output', async () => {
+  const projectDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'wp-typia-add-pattern-json-'),
+  );
+
+  try {
+    await scaffoldOfficialWorkspace(projectDir);
+    linkWorkspaceNodeModules(projectDir);
+
+    const result = runCapturedCommand(
+      process.execPath,
+      [
+        entryPath,
+        'add',
+        'pattern',
+        'hero-photo',
+        '--tag',
+        'featured',
+        '--format',
+        'json',
+      ],
+      {
+        cwd: projectDir,
+        env: withoutLocalBunEnv(),
+      },
+    );
+    const parsed = parseJsonObjectFromOutput<{
+      data?: {
+        completion?: {
+          warningLines?: string[];
+        };
+      };
+      ok?: boolean;
+    }>(result.stdout);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(parsed.ok).toBe(true);
+    expect(parsed.data?.completion?.warningLines).toEqual([
+      '--tag is deprecated; use repeatable --tags instead.',
+    ]);
+  } finally {
+    fs.rmSync(projectDir, { force: true, recursive: true });
+  }
+});
+
 test('preserves add diagnostic metadata in portable CLI JSON mode on failure', () => {
   const result = runCapturedCommand(
     process.execPath,

--- a/packages/wp-typia/tests/add-command.test.ts
+++ b/packages/wp-typia/tests/add-command.test.ts
@@ -646,37 +646,115 @@ describe('wp-typia add command bridge', () => {
     ).toBe(true);
   }, 30_000);
 
-  test('interactive add block validates the missing name before prompting', async () => {
+  test('interactive explicit add block prompts for a missing name', async () => {
     const projectDir = path.join(tempRoot, 'demo-add-interactive-missing-name');
     const selectedPrompts: string[] = [];
+    const textPrompts: string[] = [];
     const prompt: ReadlinePrompt = {
       close() {},
-      async select(message: string) {
+      async select<T extends string>(
+        message: string,
+        options: Array<{ value: T }>,
+      ) {
         selectedPrompts.push(message);
-        throw new Error('select() should not be called before name validation');
+        expect(message).toBe('Select a block template');
+        expect(options.map((option) => String(option.value))).toEqual([
+          'basic',
+          'interactivity',
+          'persistence',
+          'compound',
+        ]);
+        return 'basic' as T;
       },
-      async text() {
-        throw new Error('text() should not be called before name validation');
+      async text(message, defaultValue, validate) {
+        textPrompts.push(message);
+        expect(defaultValue).toBe('');
+        expect(validate?.('')).toBe('Block name is required.');
+        expect(validate?.('prompted-explicit-card')).toBe(true);
+        return 'prompted-explicit-card';
       },
     };
 
     await scaffoldOfficialWorkspace(projectDir);
     linkWorkspaceNodeModules(projectDir);
 
-    await expect(
-      executeAddCommand({
-        cwd: projectDir,
-        emitOutput: false,
-        flags: {},
-        interactive: true,
-        kind: 'block',
-        prompt,
-      }),
-    ).rejects.toThrow(
-      '`wp-typia add block` requires <name>. Usage: wp-typia add block <name> [--template <basic|interactivity|persistence|compound>]',
-    );
-    expect(selectedPrompts).toEqual([]);
-  }, 15_000);
+    const payload = await executeAddCommand({
+      cwd: projectDir,
+      emitOutput: false,
+      flags: {},
+      interactive: true,
+      kind: 'block',
+      prompt,
+    });
+
+    expect(selectedPrompts).toEqual(['Select a block template']);
+    expect(textPrompts).toEqual(['Block name']);
+    expect(payload?.summaryLines).toContain('Template family: basic');
+    expect(
+      fs.existsSync(
+        path.join(
+          projectDir,
+          'src',
+          'blocks',
+          'prompted-explicit-card',
+          'block.json',
+        ),
+      ),
+    ).toBe(true);
+  }, 30_000);
+
+  test('interactive hooked-block prompts for position with select options', async () => {
+    const projectDir = path.join(tempRoot, 'demo-add-hooked-position-select');
+    const selectedPrompts: string[] = [];
+    const prompt: ReadlinePrompt = {
+      close() {},
+      async select<T extends string>(
+        message: string,
+        options: Array<{ value: T }>,
+      ) {
+        selectedPrompts.push(message);
+        expect(message).toBe('Hook position');
+        expect(options.map((option) => String(option.value))).toEqual([
+          'before',
+          'after',
+          'firstChild',
+          'lastChild',
+        ]);
+        return 'before' as T;
+      },
+      async text() {
+        throw new Error('text() should not be used for hook position');
+      },
+    };
+
+    await scaffoldOfficialWorkspace(projectDir);
+    linkWorkspaceNodeModules(projectDir);
+    await executeAddCommand({
+      cwd: projectDir,
+      emitOutput: false,
+      flags: {
+        template: 'basic',
+      },
+      interactive: false,
+      kind: 'block',
+      name: 'counter-card',
+    });
+
+    const payload = await executeAddCommand({
+      cwd: projectDir,
+      emitOutput: false,
+      flags: {
+        anchor: 'core/post-content',
+      },
+      interactive: true,
+      kind: 'hooked-block',
+      name: 'counter-card',
+      prompt,
+    });
+
+    expect(selectedPrompts).toEqual(['Hook position']);
+    expect(payload?.summaryLines).toContain('Position: before');
+  }, 30_000);
 
   test('aligns missing kind help output with the bridge emitOutput context', async () => {
     const printedHumanLines: string[] = [];

--- a/packages/wp-typia/tests/add-kind-registry.test.ts
+++ b/packages/wp-typia/tests/add-kind-registry.test.ts
@@ -337,7 +337,7 @@ test('passes repeatable pattern tag flags to the runtime', async () => {
   ]);
 });
 
-test('does not warn for legacy pattern tag flags in structured output', async () => {
+test('surfaces legacy pattern tag flags through structured output warnings', async () => {
   const warnings: string[] = [];
   const plan = await ADD_KIND_REGISTRY.pattern.prepareExecution({
     addRuntime: {
@@ -368,9 +368,12 @@ test('does not warn for legacy pattern tag flags in structured output', async ()
     },
   });
 
-  await plan.execute('/tmp/wp-typia-pattern-json-repeatable-test');
+  const result = await plan.execute('/tmp/wp-typia-pattern-json-repeatable-test');
 
   expect(warnings).toEqual([]);
+  expect(plan.getWarnings?.(result)).toEqual([
+    '--tag is deprecated; use repeatable --tags instead.',
+  ]);
 });
 
 test('surfaces core-variation runtime warnings through the add plan', async () => {


### PR DESCRIPTION
## Summary
- surface legacy `--tag` deprecation warnings in JSON add completion payloads without duplicating text-mode warnings
- prompt for a missing add name in interactive explicit-kind runs
- use a select prompt for interactive hooked-block position choices

## Validation
- bun test packages/wp-typia/tests/add-kind-registry.test.ts packages/wp-typia/tests/add-command.test.ts packages/wp-typia/tests/add-command-package.test.ts
- bun run --filter wp-typia build
- bun run --filter wp-typia test
- bun run format:check
- bun run typecheck
- bun run lint:repo
- node packages/wp-typia/bin/wp-typia.js add --help
- node packages/wp-typia/bin/wp-typia.js add --format json

## Notes
- `bun run --filter @wp-typia/project-tools test` was also attempted locally. It exited with unrelated existing project-tools failures: one scaffold query-loop failure plus two binding-source timeout cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Position selection for hooked blocks now uses dropdown menu with available options.
  * Legacy pattern tag deprecation warnings now exposed in JSON format output.

* **Improvements**
  * Enhanced interactive prompting flow for block template and name selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->