### PR TITLE
feat(block-types): add WordPress 7 compatibility entries

### DIFF
--- a/.sampo/changesets/wp70-block-compatibility-matrix.md
+++ b/.sampo/changesets/wp70-block-compatibility-matrix.md
@@ -1,0 +1,5 @@
+---
+npm/@wp-typia/block-types: patch
+---
+
+Add WordPress compatibility metadata for interactivity, splitting, and blockHooks features.

--- a/packages/wp-typia-block-types/src/blocks/compatibility.ts
+++ b/packages/wp-typia-block-types/src/blocks/compatibility.ts
@@ -3,6 +3,7 @@ export type WordPressVersion =
   | `${number}.${number}.${number}`;
 
 export type WordPressBlockApiCompatibilityArea =
+  | 'blockMetadata'
   | 'blockSupports'
   | 'blockVariations'
   | 'blockBindings';
@@ -88,6 +89,8 @@ export const WORDPRESS_BLOCK_API_COMPATIBILITY_SOURCES = {
     'https://developer.wordpress.org/reference/functions/register_block_bindings_source/',
   blockBindingsSupportedAttributes:
     'https://developer.wordpress.org/reference/functions/get_block_bindings_supported_attributes/',
+  blockMetadataReference:
+    'https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/',
   blockSupportsHandbook:
     'https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/',
   blockVariationsDevNote:
@@ -101,6 +104,14 @@ export const WORDPRESS_BLOCK_API_COMPATIBILITY_SOURCES = {
 } as const;
 
 export const WORDPRESS_BLOCK_API_COMPATIBILITY = {
+  blockMetadata: {
+    blockHooks: {
+      label: 'blockHooks metadata',
+      runtime: ['block-json', 'php'],
+      since: '6.4',
+      source: 'blockMetadataReference',
+    },
+  },
   blockBindings: {
     'metadata.bindings': {
       derivedAttributes: ['metadata'],
@@ -200,6 +211,12 @@ export const WORDPRESS_BLOCK_API_COMPATIBILITY = {
       since: '5.9',
       source: 'themeJsonStyleVersions',
     },
+    interactivity: {
+      label: 'supports.interactivity',
+      runtime: ['block-json', 'editor-js'],
+      since: '6.5',
+      source: 'blockSupportsHandbook',
+    },
     listView: {
       label: 'supports.listView',
       runtime: ['block-json', 'editor-js'],
@@ -222,6 +239,12 @@ export const WORDPRESS_BLOCK_API_COMPATIBILITY = {
     shadow: {
       derivedAttributes: ['style'],
       label: 'supports.shadow',
+      runtime: ['block-json', 'editor-js'],
+      since: '6.5',
+      source: 'blockSupportsHandbook',
+    },
+    splitting: {
+      label: 'supports.splitting',
       runtime: ['block-json', 'editor-js'],
       since: '6.5',
       source: 'blockSupportsHandbook',
@@ -332,6 +355,9 @@ export const WORDPRESS_BLOCK_API_COMPATIBILITY = {
 
 export type WordPressBlockSupportCompatibilityFeature =
   keyof typeof WORDPRESS_BLOCK_API_COMPATIBILITY.blockSupports;
+
+export type WordPressBlockMetadataCompatibilityFeature =
+  keyof typeof WORDPRESS_BLOCK_API_COMPATIBILITY.blockMetadata;
 
 export type WordPressBlockVariationCompatibilityFeature =
   keyof typeof WORDPRESS_BLOCK_API_COMPATIBILITY.blockVariations;

--- a/packages/wp-typia-block-types/src/blocks/supports-manifest.ts
+++ b/packages/wp-typia-block-types/src/blocks/supports-manifest.ts
@@ -38,10 +38,12 @@ const TOP_LEVEL_COMPATIBILITY_SUPPORT_KEYS = [
   "background",
   "contentRole",
   "dimensions",
+  "interactivity",
   "listView",
   "position",
   "renaming",
   "shadow",
+  "splitting",
   "visibility",
 ] as const satisfies readonly BlockSupportFeature[];
 

--- a/packages/wp-typia-block-types/tests/compatibility.test.ts
+++ b/packages/wp-typia-block-types/tests/compatibility.test.ts
@@ -33,6 +33,21 @@ describe("WordPress block API compatibility matrix", () => {
 			since: "6.6",
 			source: "blockSupportsHandbook",
 		});
+		expect(WORDPRESS_BLOCK_API_COMPATIBILITY.blockSupports.interactivity).toMatchObject({
+			runtime: ["block-json", "editor-js"],
+			since: "6.5",
+			source: "blockSupportsHandbook",
+		});
+		expect(WORDPRESS_BLOCK_API_COMPATIBILITY.blockSupports.splitting).toMatchObject({
+			runtime: ["block-json", "editor-js"],
+			since: "6.5",
+			source: "blockSupportsHandbook",
+		});
+		expect(WORDPRESS_BLOCK_API_COMPATIBILITY.blockMetadata.blockHooks).toMatchObject({
+			runtime: ["block-json", "php"],
+			since: "6.4",
+			source: "blockMetadataReference",
+		});
 		expect(
 			WORDPRESS_BLOCK_API_COMPATIBILITY.blockVariations.editorRegistration,
 		).toMatchObject({
@@ -63,6 +78,9 @@ describe("WordPress block API compatibility matrix", () => {
 		expect(WORDPRESS_BLOCK_API_COMPATIBILITY_SOURCES.blockSupportsHandbook).toContain(
 			"developer.wordpress.org",
 		);
+		expect(
+			WORDPRESS_BLOCK_API_COMPATIBILITY_SOURCES.blockMetadataReference,
+		).toContain("developer.wordpress.org");
 	});
 
 	test("compares dotted WordPress versions with missing patch parts as zero", () => {
@@ -160,6 +178,10 @@ describe("WordPress block API compatibility matrix", () => {
 					area: "blockBindings",
 					feature: "futureEditorFieldList",
 				},
+				{
+					area: "blockMetadata",
+					feature: "blockHooks",
+				},
 			],
 			{
 				minVersion: "6.8",
@@ -169,6 +191,7 @@ describe("WordPress block API compatibility matrix", () => {
 
 		expect(manifest.supported.map((feature) => feature.feature)).toEqual([
 			"typography.fontSize",
+			"blockHooks",
 		]);
 		expect(manifest.unsupported.map((feature) => feature.feature)).toEqual([
 			"visibility",

--- a/packages/wp-typia-block-types/tests/fixtures/public-type-contracts.ts
+++ b/packages/wp-typia-block-types/tests/fixtures/public-type-contracts.ts
@@ -57,6 +57,7 @@ import {
 	createWordPressBlockApiCompatibilityManifest,
 	type WordPressBlockBindingCompatibilityFeature,
 	type WordPressBlockApiCompatibilityFeature,
+	type WordPressBlockMetadataCompatibilityFeature,
 	type WordPressBlockSupportCompatibilityFeature,
 	type WordPressCompatibilitySettings,
 	type WordPressVersion,
@@ -151,6 +152,8 @@ const compatibilityFeature: WordPressBlockApiCompatibilityFeature = {
 };
 const supportCompatibilityFeature: WordPressBlockSupportCompatibilityFeature =
 	"typography.textAlign";
+const metadataCompatibilityFeature: WordPressBlockMetadataCompatibilityFeature =
+	"blockHooks";
 const bindingCompatibilityFeature: WordPressBlockBindingCompatibilityFeature =
 	"editorFieldsList";
 const compatibilityManifest = createWordPressBlockApiCompatibilityManifest(
@@ -504,6 +507,7 @@ void spacingSupportKeys;
 void typographySupportKeys;
 void compatibilityManifest;
 void supportCompatibilityFeature;
+void metadataCompatibilityFeature;
 void bindingCompatibilityFeature;
 void supportsTextAlignSince;
 void proseSupports;

--- a/packages/wp-typia-block-types/tests/supports.test.ts
+++ b/packages/wp-typia-block-types/tests/supports.test.ts
@@ -183,10 +183,29 @@ describe("defineSupports", () => {
 	test("checks version gates for newer top-level supports", () => {
 		const features = collectBlockSupportsCompatibilityFeatures({
 			contentRole: true,
+			interactivity: true,
 			listView: true,
+			splitting: true,
 		}).map((feature) => feature.feature);
 
-		expect(features).toEqual(["contentRole", "listView"]);
+		expect(features).toEqual([
+			"contentRole",
+			"interactivity",
+			"listView",
+			"splitting",
+		]);
+		expect(() =>
+			defineSupports({
+				minWordPress: "6.4",
+				interactivity: true,
+			}),
+		).toThrow("supports.interactivity requires WordPress 6.5+");
+		expect(() =>
+			defineSupports({
+				minWordPress: "6.4",
+				splitting: true,
+			}),
+		).toThrow("supports.splitting requires WordPress 6.5+");
 		expect(() =>
 			defineSupports({
 				minWordPress: "6.8",


### PR DESCRIPTION
## Summary
- add block metadata compatibility area with `blockHooks` at WordPress 6.4
- add `supports.interactivity` and `supports.splitting` compatibility entries at WordPress 6.5
- include enabled interactivity/splitting supports in compatibility diagnostics

## Validation
- bun test packages/wp-typia-block-types/tests/compatibility.test.ts packages/wp-typia-block-types/tests/supports.test.ts
- bun test packages/wp-typia-block-types/tests/type-contracts.test.ts packages/wp-typia-block-types/tests/package-contracts.test.ts
- bun run --filter @wp-typia/block-types test
- bun run format:check
- bun run typecheck
- bun run lint:repo

## Reference
- WordPress Block Supports reference
- WordPress Interactivity API reference
- WordPress block.json metadata reference