### PR TITLE
feat(cli): check WordPress feature compatibility in doctor

### DIFF
--- a/.sampo/changesets/doctor-wp-version-check.md
+++ b/.sampo/changesets/doctor-wp-version-check.md
@@ -1,0 +1,6 @@
+---
+npm/wp-typia: patch
+npm/@wp-typia/project-tools: patch
+---
+
+Add `wp-typia doctor --wp-version-check` to validate generated WordPress feature floors against plugin bootstrap headers.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ package-runner convenience, not as a runtime requirement for `wp-typia`.
 New scaffolds target WordPress 7.0 for generated `Tested up to` plugin headers
 by default. Use `--wp-version 6.9` when you need the legacy 6.9 target. The
 generated `Requires at least` header still follows the selected features' hard
-floor instead of being raised only because the target is 7.0.
+floor instead of being raised only because the target is 7.0. Run
+`wp-typia doctor --wp-version-check` in a workspace when you want an explicit
+header check against generated block, ability, and AI feature metadata.
 
 For an install outside package runners, use the standalone installers published
 with each GitHub Release:

--- a/apps/docs/src/content/docs/reference/cli.md
+++ b/apps/docs/src/content/docs/reference/cli.md
@@ -411,6 +411,7 @@ Run read-only diagnostics.
 ```bash
 wp-typia doctor
 wp-typia doctor --format json
+wp-typia doctor --wp-version-check
 wp-typia doctor --help
 ```
 
@@ -418,6 +419,12 @@ wp-typia doctor --help
 also get inventory, source-tree drift, and shared convention checks. Use
 `--format json` for CI, IDE, and wrapper integrations that need stable
 machine-readable check results.
+
+Use `--wp-version-check` when you want doctor to compare generated feature
+floors, including block supports, `blockHooks`, abilities, and AI feature
+compatibility metadata, against the plugin bootstrap `Requires at least` and
+`Tested up to` headers. The check is opt-in so existing JSON doctor payloads stay
+stable unless the flag is passed.
 
 Workspace block diagnostics also include iframe/API v3 readiness rows. `WARN`
 rows do not fail `doctor`; treat them as compatibility follow-up before relying

--- a/packages/wp-typia-project-tools/src/runtime/cli/cli-core.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli/cli-core.ts
@@ -41,6 +41,7 @@ export {
 	type DoctorExitPolicy,
 	type DoctorFailureSummary,
 	type DoctorRunSummary,
+	type GetDoctorChecksOptions,
 } from "../doctor/cli-doctor.js";
 export {
 	createCliCommandError,

--- a/packages/wp-typia-project-tools/src/runtime/cli/cli-help.ts
+++ b/packages/wp-typia-project-tools/src/runtime/cli/cli-help.ts
@@ -40,7 +40,7 @@ export function formatHelpText(): string {
   wp-typia migrate <init|snapshot|diff|scaffold|verify|doctor|fixtures|fuzz> [...]
   wp-typia templates list
   wp-typia templates inspect <id>
-  wp-typia doctor
+  wp-typia doctor [--wp-version-check]
   wp-typia mcp <list|sync>
   wp-typia skills <list|sync>
   wp-typia completions <bash|zsh|fish|powershell>
@@ -79,7 +79,7 @@ Notes:
   \`add ai-feature\` scaffolds server-owned AI feature endpoints under \`src/ai-features/\` and PHP route glue under \`inc/ai-features/\`.
   \`add editor-plugin\` scaffolds a document-level editor extension under \`src/editor-plugins/\`; legacy aliases \`PluginSidebar\` and \`PluginDocumentSettingPanel\` resolve to \`sidebar\` and \`document-setting-panel\`.
   \`add hooked-block\` patches an existing workspace block's \`block.json\` \`blockHooks\` metadata.
-  \`wp-typia doctor\` always checks environment readiness and reports when it only ran environment-level diagnostics; official workspace roots also get inventory, source-tree drift, shared convention checks, and iframe/API v3 compatibility checks.
+  \`wp-typia doctor\` always checks environment readiness and reports when it only ran environment-level diagnostics; official workspace roots also get inventory, source-tree drift, shared convention checks, and iframe/API v3 compatibility checks. Pass \`--wp-version-check\` to compare generated feature floors such as block supports, blockHooks, abilities, and AI feature metadata with plugin bootstrap compatibility headers.
   \`wp-typia init\` previews or applies the minimum sync/doctor/migration adoption layer for supported existing layouts; pass \`--package-manager <id>\` to pin emitted scripts and next steps.
   \`wp-typia migrate doctor --all\` checks migration target alignment, snapshots, fixtures, and generated migration artifacts.
   \`migrate\` is the canonical migration command; \`migrations\` is no longer supported.`;

--- a/packages/wp-typia-project-tools/src/runtime/doctor/cli-doctor-wordpress-version.ts
+++ b/packages/wp-typia-project-tools/src/runtime/doctor/cli-doctor-wordpress-version.ts
@@ -1,0 +1,467 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { parseScaffoldBlockMetadata } from "@wp-typia/block-runtime/blocks";
+import ts from "typescript";
+
+import {
+	createDoctorCheck,
+	resolveWorkspaceBootstrapPath,
+} from "./cli-doctor-workspace-shared.js";
+import { readJsonFileSync } from "../shared/json-utils.js";
+import { getPropertyNameText } from "../shared/ts-property-names.js";
+import {
+	compareVersionFloors,
+	pickHigherVersionFloor,
+} from "../shared/version-floor.js";
+import { DEFAULT_SCAFFOLD_WORDPRESS_TARGET_VERSION } from "../templates/scaffold-compatibility.js";
+
+import type { DoctorCheck } from "./cli-doctor.js";
+import type { WorkspaceInventory } from "../workspace/workspace-inventory.js";
+import type { WorkspaceProject } from "../workspace/workspace-project.js";
+
+/** Options for opt-in WordPress version compatibility doctor checks. */
+export interface WorkspaceWordPressVersionDoctorCheckOptions {
+	/** WordPress target used for `Tested up to` warnings. Defaults to the scaffold target. */
+	targetVersion?: string;
+}
+
+interface WordPressVersionRequirement {
+	label: string;
+	version: string;
+}
+
+interface WordPressVersionRequirementCollection {
+	issues: string[];
+	requirements: WordPressVersionRequirement[];
+}
+
+interface BootstrapHeaderVersionSnapshot {
+	requiresAtLeast?: string;
+	testedUpTo?: string;
+}
+
+const WORDPRESS_VERSION_CHECK_CODES = {
+	featureMinimum: "wp-typia.workspace.wordpress.feature-minimum",
+	testedTarget: "wp-typia.workspace.wordpress.tested-target",
+} as const;
+
+const BLOCK_METADATA_WORDPRESS_FLOORS = {
+	blockHooks: "6.4",
+	supportsInteractivity: "6.5",
+	supportsSplitting: "6.5",
+} as const;
+
+function isEnabledMetadataValue(value: unknown): boolean {
+	return value !== undefined && value !== false && value !== null;
+}
+
+function getBootstrapHeaderValue(
+	source: string,
+	headerName: "Requires at least" | "Tested up to",
+): string | undefined {
+	const escapedHeaderName = headerName.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+	const pattern = new RegExp(
+		`^\\s*\\*\\s*${escapedHeaderName}:\\s*([^\\r\\n]*)`,
+		"mu",
+	);
+	const match = pattern.exec(source);
+	return match?.[1]?.trim();
+}
+
+function readBootstrapHeaderVersions(
+	workspace: WorkspaceProject,
+): BootstrapHeaderVersionSnapshot {
+	const bootstrapPath = resolveWorkspaceBootstrapPath(
+		workspace.projectDir,
+		workspace.packageName,
+	);
+	if (!fs.existsSync(bootstrapPath)) {
+		return {};
+	}
+
+	const source = fs.readFileSync(bootstrapPath, "utf8");
+	return {
+		requiresAtLeast: getBootstrapHeaderValue(source, "Requires at least"),
+		testedUpTo: getBootstrapHeaderValue(source, "Tested up to"),
+	};
+}
+
+function pushRequirement(
+	requirements: WordPressVersionRequirement[],
+	label: string,
+	version: string,
+): void {
+	requirements.push({
+		label,
+		version,
+	});
+}
+
+function collectBlockMetadataRequirements(
+	workspace: WorkspaceProject,
+	inventory: WorkspaceInventory,
+): WordPressVersionRequirementCollection {
+	const issues: string[] = [];
+	const requirements: WordPressVersionRequirement[] = [];
+
+	for (const block of inventory.blocks) {
+		const blockJsonRelativePath = path.join(
+			"src",
+			"blocks",
+			block.slug,
+			"block.json",
+		);
+		const blockJsonPath = path.join(workspace.projectDir, blockJsonRelativePath);
+		if (!fs.existsSync(blockJsonPath)) {
+			continue;
+		}
+
+		let blockJson: Record<string, unknown> & {
+			blockHooks?: unknown;
+			supports?: Record<string, unknown>;
+		};
+		try {
+			blockJson = parseScaffoldBlockMetadata<
+				Record<string, unknown> & {
+					blockHooks?: unknown;
+					supports?: Record<string, unknown>;
+				}
+			>(
+				readJsonFileSync(blockJsonPath, {
+					context: "workspace block metadata",
+				}),
+			);
+		} catch (error) {
+			issues.push(
+				`${blockJsonRelativePath}: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			);
+			continue;
+		}
+
+		if (isEnabledMetadataValue(blockJson.supports?.interactivity)) {
+			pushRequirement(
+				requirements,
+				`Block ${block.slug} supports.interactivity`,
+				BLOCK_METADATA_WORDPRESS_FLOORS.supportsInteractivity,
+			);
+		}
+		if (isEnabledMetadataValue(blockJson.supports?.splitting)) {
+			pushRequirement(
+				requirements,
+				`Block ${block.slug} supports.splitting`,
+				BLOCK_METADATA_WORDPRESS_FLOORS.supportsSplitting,
+			);
+		}
+		if (blockJson.blockHooks !== undefined) {
+			pushRequirement(
+				requirements,
+				`Block ${block.slug} blockHooks`,
+				BLOCK_METADATA_WORDPRESS_FLOORS.blockHooks,
+			);
+		}
+	}
+
+	return {
+		issues,
+		requirements,
+	};
+}
+
+function findExportedArrayLiteral(
+	sourceFile: ts.SourceFile,
+	exportName: string,
+): ts.ArrayLiteralExpression | null {
+	for (const statement of sourceFile.statements) {
+		if (
+			!ts.isVariableStatement(statement) ||
+			!statement.modifiers?.some(
+				(modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword,
+			)
+		) {
+			continue;
+		}
+
+		for (const declaration of statement.declarationList.declarations) {
+			if (
+				ts.isIdentifier(declaration.name) &&
+				declaration.name.text === exportName &&
+				declaration.initializer &&
+				ts.isArrayLiteralExpression(declaration.initializer)
+			) {
+				return declaration.initializer;
+			}
+		}
+	}
+
+	return null;
+}
+
+function getObjectProperty(
+	objectLiteral: ts.ObjectLiteralExpression,
+	key: string,
+): ts.Expression | undefined {
+	for (const property of objectLiteral.properties) {
+		if (!ts.isPropertyAssignment(property)) {
+			continue;
+		}
+		if (getPropertyNameText(property.name) === key) {
+			return property.initializer;
+		}
+	}
+
+	return undefined;
+}
+
+function getObjectLiteralProperty(
+	objectLiteral: ts.ObjectLiteralExpression | undefined,
+	key: string,
+): ts.ObjectLiteralExpression | undefined {
+	const property = objectLiteral ? getObjectProperty(objectLiteral, key) : undefined;
+	return property && ts.isObjectLiteralExpression(property) ? property : undefined;
+}
+
+function getStringLiteralProperty(
+	objectLiteral: ts.ObjectLiteralExpression,
+	key: string,
+): string | undefined {
+	const property = getObjectProperty(objectLiteral, key);
+	return property && ts.isStringLiteralLike(property) ? property.text : undefined;
+}
+
+function collectInventoryCompatibilityRequirements(
+	inventory: WorkspaceInventory,
+): WordPressVersionRequirementCollection {
+	const issues: string[] = [];
+	const requirements: WordPressVersionRequirement[] = [];
+	const sourceFile = ts.createSourceFile(
+		"scripts/block-config.ts",
+		inventory.source,
+		ts.ScriptTarget.Latest,
+		true,
+		ts.ScriptKind.TS,
+	);
+
+	for (const section of [
+		{ exportName: "ABILITIES", label: "Ability" },
+		{ exportName: "AI_FEATURES", label: "AI feature" },
+	] as const) {
+		const arrayLiteral = findExportedArrayLiteral(sourceFile, section.exportName);
+		if (!arrayLiteral) {
+			continue;
+		}
+
+		arrayLiteral.elements.forEach((element, elementIndex) => {
+			if (!ts.isObjectLiteralExpression(element)) {
+				return;
+			}
+			const slug =
+				getStringLiteralProperty(element, "slug") ?? `entry ${elementIndex + 1}`;
+			const compatibility = getObjectLiteralProperty(element, "compatibility");
+			const hardMinimums = getObjectLiteralProperty(
+				compatibility,
+				"hardMinimums",
+			);
+			const wordpressMinimum = hardMinimums
+				? getObjectProperty(hardMinimums, "wordpress")
+				: undefined;
+			if (wordpressMinimum === undefined) {
+				return;
+			}
+			if (!ts.isStringLiteralLike(wordpressMinimum)) {
+				issues.push(
+					`${section.exportName}[${elementIndex}].compatibility.hardMinimums.wordpress must be a string literal.`,
+				);
+				return;
+			}
+
+			requirements.push({
+				label: `${section.label} ${slug} compatibility metadata`,
+				version: wordpressMinimum.text,
+			});
+		});
+	}
+
+	return {
+		issues,
+		requirements,
+	};
+}
+
+function collectWordPressVersionRequirements(
+	workspace: WorkspaceProject,
+	inventory: WorkspaceInventory,
+): WordPressVersionRequirementCollection {
+	const blockRequirements = collectBlockMetadataRequirements(workspace, inventory);
+	const inventoryRequirements =
+		collectInventoryCompatibilityRequirements(inventory);
+
+	return {
+		issues: [...blockRequirements.issues, ...inventoryRequirements.issues],
+		requirements: [
+			...blockRequirements.requirements,
+			...inventoryRequirements.requirements,
+		],
+	};
+}
+
+function pickHighestRequirementFloor(
+	requirements: readonly WordPressVersionRequirement[],
+	issues: string[],
+): string | undefined {
+	let highest: string | undefined;
+	for (const requirement of requirements) {
+		try {
+			highest = pickHigherVersionFloor(highest, requirement.version);
+		} catch {
+			issues.push(
+				`${requirement.label} declares invalid WordPress version floor "${requirement.version}".`,
+			);
+		}
+	}
+
+	return highest;
+}
+
+function formatRequirementSummary(
+	requirements: readonly WordPressVersionRequirement[],
+	floor: string,
+): string {
+	const labels = requirements
+		.filter((requirement) => requirement.version === floor)
+		.map((requirement) => requirement.label);
+
+	return labels.length > 0 ? labels.join(", ") : "generated workspace features";
+}
+
+function createFeatureMinimumCheck(
+	workspace: WorkspaceProject,
+	inventory: WorkspaceInventory,
+	headers: BootstrapHeaderVersionSnapshot,
+): DoctorCheck {
+	const { issues, requirements } = collectWordPressVersionRequirements(
+		workspace,
+		inventory,
+	);
+	const highestFloor = pickHighestRequirementFloor(requirements, issues);
+
+	if (issues.length > 0) {
+		return createDoctorCheck(
+			"WordPress feature minimum",
+			"fail",
+			issues.join("; "),
+			WORDPRESS_VERSION_CHECK_CODES.featureMinimum,
+		);
+	}
+
+	if (!highestFloor) {
+		return createDoctorCheck(
+			"WordPress feature minimum",
+			"pass",
+			"No generated workspace features declare an additional WordPress hard floor.",
+			WORDPRESS_VERSION_CHECK_CODES.featureMinimum,
+		);
+	}
+
+	if (!headers.requiresAtLeast) {
+		return createDoctorCheck(
+			"WordPress feature minimum",
+			"fail",
+			`Plugin bootstrap is missing a Requires at least header but generated features require WordPress ${highestFloor}.`,
+			WORDPRESS_VERSION_CHECK_CODES.featureMinimum,
+		);
+	}
+
+	try {
+		if (compareVersionFloors(headers.requiresAtLeast, highestFloor) < 0) {
+			return createDoctorCheck(
+				"WordPress feature minimum",
+				"fail",
+				`Requires at least ${headers.requiresAtLeast} is below generated feature floor ${highestFloor} (${formatRequirementSummary(
+					requirements,
+					highestFloor,
+				)}).`,
+				WORDPRESS_VERSION_CHECK_CODES.featureMinimum,
+			);
+		}
+	} catch {
+		return createDoctorCheck(
+			"WordPress feature minimum",
+			"fail",
+			`Plugin bootstrap Requires at least header "${headers.requiresAtLeast}" is not a dotted numeric version.`,
+			WORDPRESS_VERSION_CHECK_CODES.featureMinimum,
+		);
+	}
+
+	return createDoctorCheck(
+		"WordPress feature minimum",
+		"pass",
+		`Requires at least ${headers.requiresAtLeast} covers generated feature floor ${highestFloor} (${formatRequirementSummary(
+			requirements,
+			highestFloor,
+		)}).`,
+		WORDPRESS_VERSION_CHECK_CODES.featureMinimum,
+	);
+}
+
+function createTestedTargetCheck(
+	headers: BootstrapHeaderVersionSnapshot,
+	targetVersion: string,
+): DoctorCheck {
+	if (!headers.testedUpTo) {
+		return createDoctorCheck(
+			"WordPress tested target",
+			"fail",
+			`Plugin bootstrap is missing a Tested up to header; expected ${targetVersion} or newer.`,
+			WORDPRESS_VERSION_CHECK_CODES.testedTarget,
+		);
+	}
+
+	try {
+		if (compareVersionFloors(headers.testedUpTo, targetVersion) < 0) {
+			return createDoctorCheck(
+				"WordPress tested target",
+				"warn",
+				`Tested up to ${headers.testedUpTo} is below the selected WordPress target ${targetVersion}.`,
+				WORDPRESS_VERSION_CHECK_CODES.testedTarget,
+			);
+		}
+	} catch {
+		return createDoctorCheck(
+			"WordPress tested target",
+			"fail",
+			`Plugin bootstrap Tested up to header "${headers.testedUpTo}" is not a dotted numeric version.`,
+			WORDPRESS_VERSION_CHECK_CODES.testedTarget,
+		);
+	}
+
+	return createDoctorCheck(
+		"WordPress tested target",
+		"pass",
+		`Tested up to ${headers.testedUpTo} covers the selected WordPress target ${targetVersion}.`,
+		WORDPRESS_VERSION_CHECK_CODES.testedTarget,
+	);
+}
+
+/**
+ * Collect opt-in WordPress feature floor checks for an official workspace.
+ *
+ * These checks compare generated feature metadata against plugin bootstrap
+ * headers without changing the default doctor output shape.
+ */
+export function getWorkspaceWordPressVersionDoctorChecks(
+	workspace: WorkspaceProject,
+	inventory: WorkspaceInventory,
+	options: WorkspaceWordPressVersionDoctorCheckOptions = {},
+): DoctorCheck[] {
+	const targetVersion =
+		options.targetVersion ?? DEFAULT_SCAFFOLD_WORDPRESS_TARGET_VERSION;
+	const headers = readBootstrapHeaderVersions(workspace);
+
+	return [
+		createFeatureMinimumCheck(workspace, inventory, headers),
+		createTestedTargetCheck(headers, targetVersion),
+	];
+}

--- a/packages/wp-typia-project-tools/src/runtime/doctor/cli-doctor-workspace.ts
+++ b/packages/wp-typia-project-tools/src/runtime/doctor/cli-doctor-workspace.ts
@@ -8,6 +8,9 @@ import {
 	getWorkspaceFeatureDoctorChecks,
 } from "./cli-doctor-workspace-features.js";
 import {
+	getWorkspaceWordPressVersionDoctorChecks,
+} from "./cli-doctor-wordpress-version.js";
+import {
 	getMigrationWorkspaceHintCheck,
 	getWorkspacePackageMetadataCheck,
 	prepareWorkspacePackageDoctorSnapshot,
@@ -29,6 +32,12 @@ import {
 } from "../workspace/workspace-project.js";
 
 import type { DoctorCheck } from "./cli-doctor.js";
+
+/** Options used when collecting workspace-scoped doctor rows. */
+export interface WorkspaceDoctorChecksOptions {
+	/** Include opt-in WordPress feature floor and plugin header checks. */
+	wordpressVersionCheck?: boolean;
+}
 
 function formatWorkspaceInventorySummary(inventory: WorkspaceInventory): string {
 	return [
@@ -57,13 +66,18 @@ function formatWorkspaceInventorySummary(inventory: WorkspaceInventory): string 
  * failing rows are returned early and the remaining checks are skipped.
  * When an official workspace is detected, a passing "Doctor scope" row is
  * emitted first so the remaining package metadata, inventory, source-tree
- * drift, and optional migration hint rows are clearly framed as workspace
- * diagnostics for that run.
+ * drift, optional WordPress version checks, and optional migration hint rows
+ * are clearly framed as workspace diagnostics for that run.
  *
  * @param cwd Working directory expected to host an official workspace.
+ * @param options Optional feature gates for additional workspace doctor rows.
+ * @param options.wordpressVersionCheck Include WordPress feature floor and plugin header checks.
  * @returns Ordered workspace check rows ready for CLI rendering.
  */
-export async function getWorkspaceDoctorChecks(cwd: string): Promise<DoctorCheck[]> {
+export async function getWorkspaceDoctorChecks(
+	cwd: string,
+	options: WorkspaceDoctorChecksOptions = {},
+): Promise<DoctorCheck[]> {
 	const checks: DoctorCheck[] = [];
 
 	let workspace: WorkspaceProject | null = null;
@@ -167,6 +181,11 @@ export async function getWorkspaceDoctorChecks(cwd: string): Promise<DoctorCheck
 		checks.push(...getWorkspaceBlockDoctorChecks(workspace, inventory));
 		checks.push(...getWorkspaceBindingDoctorChecks(workspace, inventory));
 		checks.push(...getWorkspaceFeatureDoctorChecks(workspace, inventory));
+		if (options.wordpressVersionCheck) {
+			checks.push(
+				...getWorkspaceWordPressVersionDoctorChecks(workspace, inventory),
+			);
+		}
 
 		const migrationWorkspaceCheck = getMigrationWorkspaceHintCheck(
 			workspacePackageJson,

--- a/packages/wp-typia-project-tools/src/runtime/doctor/cli-doctor.ts
+++ b/packages/wp-typia-project-tools/src/runtime/doctor/cli-doctor.ts
@@ -55,10 +55,17 @@ interface RunDoctorOptions {
 	exitPolicy?: DoctorExitPolicy;
 	renderLine?: (check: DoctorCheck) => void;
 	renderSummaryLine?: (summaryLine: string) => void;
+	wordpressVersionCheck?: boolean;
 }
 
 interface DoctorSummaryOptions {
 	exitPolicy?: DoctorExitPolicy;
+}
+
+/** Options used when collecting doctor checks before rendering. */
+export interface GetDoctorChecksOptions {
+	/** Include opt-in WordPress feature floor and plugin header checks. */
+	wordpressVersionCheck?: boolean;
 }
 
 type DoctorLinePrinter = (line: string) => void;
@@ -125,12 +132,22 @@ function toFailureSummary(
  * patterns, bindings, and optional migration hints) in display order.
  *
  * @param cwd Working directory to validate for writability.
+ * @param options Optional feature gates for additional doctor rows.
+ * @param options.wordpressVersionCheck Include WordPress feature floor and plugin header checks.
  * @returns Ordered doctor check rows ready for CLI rendering.
  */
-export async function getDoctorChecks(cwd: string): Promise<DoctorCheck[]> {
+export async function getDoctorChecks(
+	cwd: string,
+	options: GetDoctorChecksOptions = {},
+): Promise<DoctorCheck[]> {
 	return [
 		...annotateDoctorChecks(await getEnvironmentDoctorChecks(cwd), "environment"),
-		...annotateDoctorChecks(await getWorkspaceDoctorChecks(cwd), "workspace"),
+		...annotateDoctorChecks(
+			await getWorkspaceDoctorChecks(cwd, {
+				wordpressVersionCheck: options.wordpressVersionCheck,
+			}),
+			"workspace",
+		),
 	];
 }
 
@@ -204,6 +221,7 @@ export function createDoctorRunSummary(
  * @param options.exitPolicy Policy deciding which failed checks contribute to the process exit code.
  * @param options.renderLine Optional renderer for each check row. Defaults to the stdout line printer.
  * @param options.renderSummaryLine Optional renderer for the summary row. Defaults to the stdout line printer unless a custom `renderLine` suppresses implicit summary output.
+ * @param options.wordpressVersionCheck Include WordPress feature floor and plugin header checks.
  * @returns The completed list of doctor checks.
  * @throws {Error} When one or more failed checks contribute to the exit code under the active policy.
  */
@@ -216,7 +234,9 @@ export async function runDoctor(
 	const renderSummaryLine =
 		options.renderSummaryLine ??
 		(options.renderLine ? () => undefined : renderDefaultDoctorSummaryLine);
-	const checks = await getDoctorChecks(cwd);
+	const checks = await getDoctorChecks(cwd, {
+		wordpressVersionCheck: options.wordpressVersionCheck,
+	});
 
 	for (const check of checks) {
 		renderLine(check);

--- a/packages/wp-typia-project-tools/src/runtime/index.ts
+++ b/packages/wp-typia-project-tools/src/runtime/index.ts
@@ -235,6 +235,7 @@ export type {
 	DoctorExitPolicy,
 	DoctorFailureSummary,
 	DoctorRunSummary,
+	GetDoctorChecksOptions,
 	EditorPluginSlotId,
 	HookedBlockPositionId,
 	ReadlinePrompt,

--- a/packages/wp-typia-project-tools/tests/cli-doctor-boundaries.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-doctor-boundaries.test.ts
@@ -71,6 +71,10 @@ test("cli-doctor keeps environment and workspace checks in dedicated modules", (
 		resolve(sourceRoot, "cli-doctor-workspace-package.ts"),
 		"utf8",
 	);
+	const workspaceWordPressVersionSource = readFileSync(
+		resolve(sourceRoot, "cli-doctor-wordpress-version.ts"),
+		"utf8",
+	);
 	const workspaceSharedSource = readFileSync(
 		resolve(sourceRoot, "cli-doctor-workspace-shared.ts"),
 		"utf8",
@@ -82,8 +86,9 @@ test("cli-doctor keeps environment and workspace checks in dedicated modules", (
 
 	expect(cliDoctorSource).toContain('from "./cli-doctor-environment.js"');
 	expect(cliDoctorSource).toContain('from "./cli-doctor-workspace.js"');
+	expect(cliDoctorSource).toContain("await getWorkspaceDoctorChecks(cwd, {");
 	expect(cliDoctorSource).toContain(
-		'...annotateDoctorChecks(await getWorkspaceDoctorChecks(cwd), "workspace"),',
+		"wordpressVersionCheck: options.wordpressVersionCheck,",
 	);
 	expect(cliDoctorSource).toContain("const defaultDoctorLinePrinter");
 	expect(cliDoctorSource).toContain("process.stdout.write(`${line}\\n`)");
@@ -102,6 +107,7 @@ test("cli-doctor keeps environment and workspace checks in dedicated modules", (
 	expect(workspaceSource).toContain('from "./cli-doctor-workspace-blocks.js"');
 	expect(workspaceSource).toContain('from "./cli-doctor-workspace-features.js"');
 	expect(workspaceSource).toContain('from "./cli-doctor-workspace-package.js"');
+	expect(workspaceSource).toContain('from "./cli-doctor-wordpress-version.js"');
 	expect(workspaceSource).toContain("intentionally stay synchronous");
 	expect(workspaceSharedSource).toContain("category collectors remain synchronous");
 	expect(migrationDoctorSource).toContain("synchronous maintenance command");
@@ -114,6 +120,10 @@ test("cli-doctor keeps environment and workspace checks in dedicated modules", (
 	);
 	expect(workspaceSource).toContain(
 		"getWorkspaceFeatureDoctorChecks(workspace, inventory)",
+	);
+	expect(workspaceSource).toContain("getWorkspaceWordPressVersionDoctorChecks(");
+	expect(workspaceWordPressVersionSource).toContain(
+		"export function getWorkspaceWordPressVersionDoctorChecks(",
 	);
 	expect(workspaceBlocksSource).toContain("export function getWorkspaceBlockDoctorChecks(");
 	expect(workspaceBlocksSource).toContain("getWorkspaceBlockCoreDoctorChecks(");

--- a/packages/wp-typia-project-tools/tests/cli-entry.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-entry.test.ts
@@ -1371,14 +1371,15 @@ test("node entry exposes portable CLI help and rejects the removed migrations al
     "Inspect or sync schema-driven MCP metadata."
   );
   expect(doctorHelpOutput).toContain(
-    "Usage: wp-typia doctor [--format json] [--workspace-only]"
+    "Usage: wp-typia doctor [--format json] [--workspace-only] [--wp-version-check]"
   );
   expect(doctorHelpOutput).toContain("Supported flags:");
   expect(doctorHelpOutput).toContain("--format");
   expect(doctorHelpOutput).toContain("--workspace-only");
+  expect(doctorHelpOutput).toContain("--wp-version-check");
   expect(doctorHelpOutput).toContain("machine-readable doctor check output");
   expect(doctorHelpAliasOutput).toContain(
-    "Usage: wp-typia doctor [--format json] [--workspace-only]"
+    "Usage: wp-typia doctor [--format json] [--workspace-only] [--wp-version-check]"
   );
   expect(errorMessage).toContain(
     "`wp-typia migrations` was removed in favor of `wp-typia migrate`."
@@ -1421,11 +1422,12 @@ test("bun entry exposes portable CLI help and rejects the removed migrations ali
     "Inspect or sync schema-driven MCP metadata."
   );
   expect(doctorHelpOutput).toContain(
-    "Usage: wp-typia doctor [--format json] [--workspace-only]"
+    "Usage: wp-typia doctor [--format json] [--workspace-only] [--wp-version-check]"
   );
   expect(doctorHelpOutput).toContain("Supported flags:");
   expect(doctorHelpOutput).toContain("--format");
   expect(doctorHelpOutput).toContain("--workspace-only");
+  expect(doctorHelpOutput).toContain("--wp-version-check");
   expect(doctorHelpOutput).toContain("machine-readable doctor check output");
   expect(errorMessage).toContain(
     "`wp-typia migrations` was removed in favor of `wp-typia migrate`."

--- a/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, describe, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { cleanupScaffoldTempRoot, createScaffoldTempRoot, entryPath, getCommandErrorMessage, linkWorkspaceNodeModules, parseJsonObjectFromOutput, runCli, scaffoldOfficialWorkspace, stripPhpFunction, workspaceTemplatePackageManifest } from "./helpers/scaffold-test-harness.js";
+import { cleanupScaffoldTempRoot, createScaffoldTempRoot, entryPath, getCommandErrorMessage, linkWorkspaceNodeModules, parseJsonObjectFromOutput, runCapturedCli, runCli, scaffoldOfficialWorkspace, stripPhpFunction, workspaceTemplatePackageManifest } from "./helpers/scaffold-test-harness.js";
 import { scaffoldProject } from "../src/runtime/index.js";
 import {
   createDoctorRunSummary,
@@ -33,6 +33,37 @@ describe("@wp-typia/project-tools workspace doctor", () => {
     GEMINI_CLI: "",
     OPENCODE: "",
   } satisfies NodeJS.ProcessEnv;
+
+  function getGeneratedBootstrapPath(projectDir: string): string {
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(projectDir, "package.json"), "utf8")
+    ) as { name?: string };
+    const packageBaseName =
+      typeof packageJson.name === "string"
+        ? packageJson.name.split("/").pop()
+        : path.basename(projectDir);
+
+    return path.join(projectDir, `${packageBaseName ?? path.basename(projectDir)}.php`);
+  }
+
+  function replaceBootstrapHeader(
+    projectDir: string,
+    headerName: "Requires at least" | "Tested up to",
+    value: string
+  ): void {
+    const bootstrapPath = getGeneratedBootstrapPath(projectDir);
+    const source = fs.readFileSync(bootstrapPath, "utf8");
+    const escapedHeaderName = headerName.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+    const pattern = new RegExp(
+      `(\\* ${escapedHeaderName}:\\s*)[^\\r\\n]*`,
+      "u"
+    );
+    fs.writeFileSync(
+      bootstrapPath,
+      source.replace(pattern, `$1${value}`),
+      "utf8"
+    );
+  }
 
   afterAll(() => {
     cleanupScaffoldTempRoot(tempRoot);
@@ -231,6 +262,160 @@ test("doctor reports iframe/API v3 compatibility warnings without failing", asyn
     "warn"
   );
 }, 15_000);
+
+test("doctor WordPress version checks stay opt-in and warn on target drift", async () => {
+  const targetDir = path.join(
+    tempRoot,
+    "demo-workspace-wp-version-target-warning"
+  );
+
+  await scaffoldOfficialWorkspace(targetDir, {
+    description: "Demo workspace WordPress version target warning",
+    slug: "demo-workspace-wp-version-target-warning",
+    title: "Demo Workspace WordPress Version Target Warning",
+  });
+
+  linkWorkspaceNodeModules(targetDir);
+  replaceBootstrapHeader(targetDir, "Tested up to", "6.9");
+
+  const defaultDoctorOutput = runCli(
+    "node",
+    [entryPath, "doctor", "--format", "json"],
+    {
+      cwd: targetDir,
+    }
+  );
+  const defaultDoctorChecks = parseJsonObjectFromOutput<{
+    checks: Array<{ code?: string; label: string; status: string }>;
+  }>(defaultDoctorOutput);
+  expect(
+    defaultDoctorChecks.checks.some((check) =>
+      check.code?.startsWith("wp-typia.workspace.wordpress.")
+    )
+  ).toBe(false);
+
+  const flaggedDoctorOutput = runCli(
+    "node",
+    [entryPath, "doctor", "--wp-version-check", "--format", "json"],
+    {
+      cwd: targetDir,
+    }
+  );
+  const flaggedDoctorChecks = parseJsonObjectFromOutput<{
+    checks: Array<{ code?: string; detail: string; label: string; status: string }>;
+    summary: { exitCode: 0 | 1; warnings: number };
+  }>(flaggedDoctorOutput);
+  const testedTargetCheck = flaggedDoctorChecks.checks.find(
+    (check) => check.code === "wp-typia.workspace.wordpress.tested-target"
+  );
+
+  expect(flaggedDoctorChecks.summary.exitCode).toBe(0);
+  expect(flaggedDoctorChecks.summary.warnings).toBeGreaterThan(0);
+  expect(testedTargetCheck?.status).toBe("warn");
+  expect(testedTargetCheck?.detail).toContain("Tested up to 6.9");
+  expect(testedTargetCheck?.detail).toContain("WordPress target 7.0");
+}, 15_000);
+
+test("doctor WordPress version check fails when block feature floors exceed headers", async () => {
+  const targetDir = path.join(
+    tempRoot,
+    "demo-workspace-wp-version-block-floor"
+  );
+
+  await scaffoldOfficialWorkspace(targetDir, {
+    description: "Demo workspace WordPress version block floor",
+    slug: "demo-workspace-wp-version-block-floor",
+    title: "Demo Workspace WordPress Version Block Floor",
+  });
+
+  linkWorkspaceNodeModules(targetDir);
+  runCli("node", [entryPath, "add", "block", "counter-card"], {
+    cwd: targetDir,
+  });
+
+  const blockJsonPath = path.join(
+    targetDir,
+    "src",
+    "blocks",
+    "counter-card",
+    "block.json"
+  );
+  const blockJson = JSON.parse(fs.readFileSync(blockJsonPath, "utf8")) as {
+    supports?: Record<string, unknown>;
+  };
+  blockJson.supports = {
+    ...blockJson.supports,
+    interactivity: true,
+    splitting: true,
+  };
+  fs.writeFileSync(blockJsonPath, JSON.stringify(blockJson, null, 2), "utf8");
+  replaceBootstrapHeader(targetDir, "Requires at least", "6.4");
+
+  const result = runCapturedCli(
+    "node",
+    [entryPath, "doctor", "--wp-version-check", "--format", "json"],
+    {
+      cwd: targetDir,
+    }
+  );
+  const doctorChecks = parseJsonObjectFromOutput<{
+    checks: Array<{ code?: string; detail: string; label: string; status: string }>;
+    summary: { exitCode: 0 | 1; exitFailureCount: number };
+  }>(result.stdout);
+  const featureMinimumCheck = doctorChecks.checks.find(
+    (check) => check.code === "wp-typia.workspace.wordpress.feature-minimum"
+  );
+
+  expect(result.status).toBe(1);
+  expect(doctorChecks.summary.exitCode).toBe(1);
+  expect(doctorChecks.summary.exitFailureCount).toBeGreaterThan(0);
+  expect(featureMinimumCheck?.status).toBe("fail");
+  expect(featureMinimumCheck?.detail).toContain("Requires at least 6.4");
+  expect(featureMinimumCheck?.detail).toContain("feature floor 6.5");
+  expect(featureMinimumCheck?.detail).toContain("supports.interactivity");
+  expect(featureMinimumCheck?.detail).toContain("supports.splitting");
+}, 15_000);
+
+test("doctor WordPress version check reads ability inventory compatibility floors", async () => {
+  const targetDir = path.join(
+    tempRoot,
+    "demo-workspace-wp-version-ability-floor"
+  );
+
+  await scaffoldOfficialWorkspace(targetDir, {
+    description: "Demo workspace WordPress version ability floor",
+    slug: "demo-workspace-wp-version-ability-floor",
+    title: "Demo Workspace WordPress Version Ability Floor",
+  });
+
+  linkWorkspaceNodeModules(targetDir);
+  runCli("node", [entryPath, "add", "ability", "summarize-post"], {
+    cwd: targetDir,
+  });
+  replaceBootstrapHeader(targetDir, "Requires at least", "6.9");
+
+  const result = runCapturedCli(
+    "node",
+    [entryPath, "doctor", "--wp-version-check", "--format", "json"],
+    {
+      cwd: targetDir,
+    }
+  );
+  const doctorChecks = parseJsonObjectFromOutput<{
+    checks: Array<{ code?: string; detail: string; label: string; status: string }>;
+  }>(result.stdout);
+  const featureMinimumCheck = doctorChecks.checks.find(
+    (check) => check.code === "wp-typia.workspace.wordpress.feature-minimum"
+  );
+
+  expect(result.status).toBe(1);
+  expect(featureMinimumCheck?.status).toBe("fail");
+  expect(featureMinimumCheck?.detail).toContain("Requires at least 6.9");
+  expect(featureMinimumCheck?.detail).toContain("feature floor 7.0");
+  expect(featureMinimumCheck?.detail).toContain(
+    "Ability summarize-post compatibility metadata"
+  );
+}, 20_000);
 
 test("doctor accepts workspaces that keep binding registries in src/bindings/index.js", async () => {
   const targetDir = path.join(

--- a/packages/wp-typia/README.md
+++ b/packages/wp-typia/README.md
@@ -17,7 +17,9 @@ commands.
 
 Generated scaffolds target WordPress 7.0 for `Tested up to` plugin headers by
 default. Pass `--wp-version 6.9` to restore the legacy 6.9 scaffold target; the
-`Requires at least` header remains tied to the selected feature hard floor.
+`Requires at least` header remains tied to the selected feature hard floor. Use
+`wp-typia doctor --wp-version-check` to validate workspace headers against
+generated block, ability, and AI feature metadata.
 
 Extend an existing workspace with:
 

--- a/packages/wp-typia/src/command-options/doctor.ts
+++ b/packages/wp-typia/src/command-options/doctor.ts
@@ -15,4 +15,10 @@ export const DOCTOR_OPTION_METADATA = {
       'Fail only on workspace-scoped doctor checks; environment/runtime failures remain advisory in JSON summaries.',
     type: 'boolean',
   },
+  'wp-version-check': {
+    argumentKind: 'flag',
+    description:
+      'Check generated WordPress feature floors against plugin bootstrap headers and the current scaffold target.',
+    type: 'boolean',
+  },
 } as const satisfies CommandOptionMetadataMap;

--- a/packages/wp-typia/src/portable-cli/doctor.ts
+++ b/packages/wp-typia/src/portable-cli/doctor.ts
@@ -10,6 +10,7 @@ import type { PortableCliDispatchContext } from './types';
 async function renderPortableCliDoctorJson(
   cwd: string,
   exitPolicy: DoctorExitPolicy,
+  wordpressVersionCheck: boolean,
   printLine: PrintLine,
 ): Promise<void> {
   const {
@@ -17,7 +18,7 @@ async function renderPortableCliDoctorJson(
     getDoctorChecks,
     getDoctorExitFailureDetailLines,
   } = await import('@wp-typia/project-tools/cli-doctor');
-  const checks = await getDoctorChecks(cwd);
+  const checks = await getDoctorChecks(cwd, { wordpressVersionCheck });
   const summary = createDoctorRunSummary(checks, { exitPolicy });
   printLine(
     JSON.stringify(
@@ -45,9 +46,15 @@ export async function dispatchPortableCliDoctor({
   printLine,
 }: PortableCliDispatchContext): Promise<void> {
   const exitPolicy = mergedFlags['workspace-only'] ? 'workspace-only' : 'strict';
+  const wordpressVersionCheck = Boolean(mergedFlags['wp-version-check']);
   if (mergedFlags.format === 'json') {
-    await renderPortableCliDoctorJson(cwd, exitPolicy, printLine);
+    await renderPortableCliDoctorJson(
+      cwd,
+      exitPolicy,
+      wordpressVersionCheck,
+      printLine,
+    );
     return;
   }
-  await executeDoctorCommand(cwd, { exitPolicy });
+  await executeDoctorCommand(cwd, { exitPolicy, wordpressVersionCheck });
 }

--- a/packages/wp-typia/src/portable-cli/help.ts
+++ b/packages/wp-typia/src/portable-cli/help.ts
@@ -116,9 +116,10 @@ const PORTABLE_CLI_COMMAND_HELP_CONFIG = {
   },
   doctor: {
     bodyLines: [
-      'Runs read-only environment readiness checks. Official wp-typia workspace roots also get inventory, source-tree drift, iframe/API v3 compatibility, and shared convention checks. Use --workspace-only for CI gates that should fail only on workspace-scoped checks while keeping environment failures advisory.',
+      'Runs read-only environment readiness checks. Official wp-typia workspace roots also get inventory, source-tree drift, iframe/API v3 compatibility, and shared convention checks. Use --workspace-only for CI gates that should fail only on workspace-scoped checks while keeping environment failures advisory. Use --wp-version-check to compare generated feature floors with plugin bootstrap headers.',
     ],
-    heading: 'Usage: wp-typia doctor [--format json] [--workspace-only]',
+    heading:
+      'Usage: wp-typia doctor [--format json] [--workspace-only] [--wp-version-check]',
     optionMetadata: DOCTOR_OPTION_METADATA,
   },
   mcp: {

--- a/packages/wp-typia/src/runtime-bridge-doctor.ts
+++ b/packages/wp-typia/src/runtime-bridge-doctor.ts
@@ -5,6 +5,7 @@ const loadCliDoctorRuntime = () => import('@wp-typia/project-tools/cli-doctor');
 
 type ExecuteDoctorCommandOptions = {
   exitPolicy?: DoctorExitPolicy;
+  wordpressVersionCheck?: boolean;
 };
 
 export async function executeDoctorCommand(
@@ -13,7 +14,10 @@ export async function executeDoctorCommand(
 ): Promise<void> {
   try {
     const { runDoctor } = await loadCliDoctorRuntime();
-    await runDoctor(cwd, { exitPolicy: options.exitPolicy });
+    await runDoctor(cwd, {
+      exitPolicy: options.exitPolicy,
+      wordpressVersionCheck: options.wordpressVersionCheck,
+    });
   } catch (error) {
     throw await wrapCliCommandError('doctor', error);
   }

--- a/packages/wp-typia/tests/command-option-metadata.test.ts
+++ b/packages/wp-typia/tests/command-option-metadata.test.ts
@@ -482,7 +482,7 @@ describe('command option metadata helpers', () => {
 
   test('parses doctor structured output flags from shared metadata', () => {
     const parsed = parseCommandArgvWithMetadata(
-      ['doctor', '--format', 'json', '--workspace-only'],
+      ['doctor', '--format', 'json', '--workspace-only', '--wp-version-check'],
       {
         extraBooleanOptionNames: ['help', 'version'],
         parser: buildCommandOptionParser(
@@ -495,6 +495,7 @@ describe('command option metadata helpers', () => {
     expect(parsed.flags).toEqual({
       format: 'json',
       'workspace-only': true,
+      'wp-version-check': true,
     });
     expect(parsed.positionals).toEqual(['doctor']);
   });

--- a/scripts/lib/typescript-runtime-policy.mjs
+++ b/scripts/lib/typescript-runtime-policy.mjs
@@ -31,6 +31,7 @@ export const TYPESCRIPT_RUNTIME_PACKAGE_POLICIES = [
 		requiredTypeScriptImportFiles: [
 			"src/runtime/add/cli-add-workspace-binding-source.ts",
 			"src/runtime/cli/cli-init-plan.ts",
+			"src/runtime/doctor/cli-doctor-wordpress-version.ts",
 			"src/runtime/shared/ts-property-names.ts",
 			"src/runtime/workspace/workspace-inventory-parser-entries.ts",
 			"src/runtime/workspace/workspace-inventory-parser.ts",


### PR DESCRIPTION
## Summary
- add opt-in `wp-typia doctor --wp-version-check` support
- check generated WordPress feature floors from block metadata and ability/AI inventory compatibility against plugin bootstrap headers
- warn when `Tested up to` is below the current scaffold target
- document the new flag and add patch changesets for `wp-typia` and `@wp-typia/project-tools`

## Validation
- `bun run format:check`
- `bun run typecheck`
- `bun run lint:repo`
- `bun test packages/wp-typia-project-tools/tests/cli-doctor-boundaries.test.ts`
- `bun run --filter @wp-typia/project-tools test`
- `bun run --filter wp-typia build`
- `bun run docs:build`
- `node packages/wp-typia/bin/wp-typia.js create demo --dry-run --wp-version 7.0 --format json`
- `node packages/wp-typia/bin/wp-typia.js doctor --wp-version-check --format json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--wp-version-check` flag to the `wp-typia doctor` command, enabling opt-in validation to verify generated WordPress feature requirements align with plugin bootstrap headers.

* **Documentation**
  * Updated CLI reference documentation and README with details about the new validation feature and instructions for running the check in your workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->