### PR TITLE
fix(cli): align ability scaffold with WordPress 7 target checks

### DIFF
--- a/.sampo/changesets/ability-wp70-contract.md
+++ b/.sampo/changesets/ability-wp70-contract.md
@@ -1,0 +1,6 @@
+---
+npm/wp-typia: patch
+npm/@wp-typia/project-tools: patch
+---
+
+Preserve generated ability compatibility metadata in workspace inventory and verify `wp-typia add ability` passes WordPress 7 doctor checks.

--- a/.sampo/changesets/ability-wp70-contract.md
+++ b/.sampo/changesets/ability-wp70-contract.md
@@ -3,4 +3,4 @@ npm/wp-typia: patch
 npm/@wp-typia/project-tools: patch
 ---
 
-Preserve generated ability compatibility metadata in workspace inventory and verify `wp-typia add ability` passes WordPress 7 doctor checks.
+Preserve generated ability and AI feature compatibility metadata in workspace inventory and verify `wp-typia add ability` passes WordPress 7 doctor checks.

--- a/packages/wp-typia-project-tools/src/runtime/workspace/workspace-inventory-parser-entries.ts
+++ b/packages/wp-typia-project-tools/src/runtime/workspace/workspace-inventory-parser-entries.ts
@@ -7,6 +7,7 @@ import {
 	type InventoryEntryParserDescriptor,
 	type InventorySectionDescriptor,
 } from "./workspace-inventory-parser-validation.js";
+import type { ScaffoldCompatibilityConfig } from "../templates/scaffold-compatibility.js";
 
 function findExportedArrayLiteral(
 	sourceFile: ts.SourceFile,
@@ -142,6 +143,179 @@ function getOptionalBooleanProperty(
 	return undefined;
 }
 
+function findObjectPropertyExpression(
+	objectLiteral: ts.ObjectLiteralExpression,
+	key: string,
+): ts.Expression | undefined {
+	for (const property of objectLiteral.properties) {
+		if (!ts.isPropertyAssignment(property)) {
+			continue;
+		}
+		if (getPropertyNameText(property.name) === key) {
+			return property.initializer;
+		}
+	}
+
+	return undefined;
+}
+
+function getRequiredObjectLiteralProperty(
+	objectLiteral: ts.ObjectLiteralExpression,
+	key: string,
+	context: string,
+): ts.ObjectLiteralExpression {
+	const expression = findObjectPropertyExpression(objectLiteral, key);
+	if (!expression) {
+		throw new Error(`${context}.${key} is required in scripts/block-config.ts.`);
+	}
+	if (!ts.isObjectLiteralExpression(expression)) {
+		throw new Error(
+			`${context}.${key} must be an object literal in scripts/block-config.ts.`,
+		);
+	}
+	return expression;
+}
+
+function getRequiredStringProperty(
+	objectLiteral: ts.ObjectLiteralExpression,
+	key: string,
+	context: string,
+): string {
+	const expression = findObjectPropertyExpression(objectLiteral, key);
+	if (!expression) {
+		throw new Error(`${context}.${key} is required in scripts/block-config.ts.`);
+	}
+	if (!ts.isStringLiteralLike(expression)) {
+		throw new Error(
+			`${context}.${key} must be a string literal in scripts/block-config.ts.`,
+		);
+	}
+	return expression.text;
+}
+
+function getOptionalNestedStringProperty(
+	objectLiteral: ts.ObjectLiteralExpression,
+	key: string,
+	context: string,
+): string | undefined {
+	const expression = findObjectPropertyExpression(objectLiteral, key);
+	if (!expression) {
+		return undefined;
+	}
+	if (!ts.isStringLiteralLike(expression)) {
+		throw new Error(
+			`${context}.${key} must be a string literal in scripts/block-config.ts.`,
+		);
+	}
+	return expression.text;
+}
+
+function getRequiredStringArrayProperty(
+	objectLiteral: ts.ObjectLiteralExpression,
+	key: string,
+	context: string,
+): string[] {
+	const expression = findObjectPropertyExpression(objectLiteral, key);
+	if (!expression) {
+		throw new Error(`${context}.${key} is required in scripts/block-config.ts.`);
+	}
+	if (!ts.isArrayLiteralExpression(expression)) {
+		throw new Error(
+			`${context}.${key} must be an array literal in scripts/block-config.ts.`,
+		);
+	}
+	return expression.elements.map((element, itemIndex) => {
+		if (!ts.isStringLiteralLike(element)) {
+			throw new Error(
+				`${context}.${key}[${itemIndex}] must be a string literal in scripts/block-config.ts.`,
+			);
+		}
+		return element.text;
+	});
+}
+
+function parseCompatibilityConfigLiteral(
+	objectLiteral: ts.ObjectLiteralExpression,
+	context: string,
+): ScaffoldCompatibilityConfig {
+	const hardMinimumsObject = getRequiredObjectLiteralProperty(
+		objectLiteral,
+		"hardMinimums",
+		context,
+	);
+	const mode = getRequiredStringProperty(objectLiteral, "mode", context);
+	if (mode !== "baseline" && mode !== "optional" && mode !== "required") {
+		throw new Error(
+			`${context}.mode must be baseline, optional, or required in scripts/block-config.ts.`,
+		);
+	}
+
+	const php = getOptionalNestedStringProperty(
+		hardMinimumsObject,
+		"php",
+		`${context}.hardMinimums`,
+	);
+	const wordpress = getOptionalNestedStringProperty(
+		hardMinimumsObject,
+		"wordpress",
+		`${context}.hardMinimums`,
+	);
+
+	return {
+		hardMinimums: {
+			...(php ? { php } : {}),
+			...(wordpress ? { wordpress } : {}),
+		},
+		mode,
+		optionalFeatureIds: getRequiredStringArrayProperty(
+			objectLiteral,
+			"optionalFeatureIds",
+			context,
+		),
+		optionalFeatures: getRequiredStringArrayProperty(
+			objectLiteral,
+			"optionalFeatures",
+			context,
+		),
+		requiredFeatureIds: getRequiredStringArrayProperty(
+			objectLiteral,
+			"requiredFeatureIds",
+			context,
+		),
+		requiredFeatures: getRequiredStringArrayProperty(
+			objectLiteral,
+			"requiredFeatures",
+			context,
+		),
+		runtimeGates: getRequiredStringArrayProperty(
+			objectLiteral,
+			"runtimeGates",
+			context,
+		),
+	};
+}
+
+function getOptionalCompatibilityConfigProperty(
+	entryName: string,
+	elementIndex: number,
+	objectLiteral: ts.ObjectLiteralExpression,
+	key: string,
+): ScaffoldCompatibilityConfig | undefined {
+	const expression = findObjectPropertyExpression(objectLiteral, key);
+	if (!expression) {
+		return undefined;
+	}
+	if (!ts.isObjectLiteralExpression(expression)) {
+		throw new Error(
+			`${entryName}[${elementIndex}].${key} must be an object literal in scripts/block-config.ts.`,
+		);
+	}
+	return parseCompatibilityConfigLiteral(
+		expression,
+		`${entryName}[${elementIndex}].${key}`,
+	);
+}
+
 function parseInventoryEntries<T extends object>(
 	arrayLiteral: ts.ArrayLiteralExpression,
 	descriptor: InventoryEntryParserDescriptor,
@@ -164,6 +338,13 @@ function parseInventoryEntries<T extends object>(
 							element,
 							field.key,
 						)
+					: kind === "compatibilityConfig"
+						? getOptionalCompatibilityConfigProperty(
+								descriptor.entryName,
+								elementIndex,
+								element,
+								field.key,
+							)
 					: kind === "boolean"
 						? getOptionalBooleanProperty(
 								descriptor.entryName,

--- a/packages/wp-typia-project-tools/src/runtime/workspace/workspace-inventory-parser-validation.ts
+++ b/packages/wp-typia-project-tools/src/runtime/workspace/workspace-inventory-parser-validation.ts
@@ -3,11 +3,17 @@ import type {
 	WorkspaceInventoryEntriesKey,
 	WorkspaceInventorySectionFlagKey,
 } from "./workspace-inventory-types.js";
+import type { ScaffoldCompatibilityConfig } from "../templates/scaffold-compatibility.js";
 
 /**
  * Literal value shape accepted by descriptor-driven inventory entry fields.
  */
-export type InventoryEntryFieldValue = string | string[] | boolean | undefined;
+export type InventoryEntryFieldValue =
+	| string
+	| string[]
+	| boolean
+	| ScaffoldCompatibilityConfig
+	| undefined;
 
 /**
  * Context passed to custom field validators while parsing one inventory entry.
@@ -20,7 +26,7 @@ export type InventoryEntryFieldValidationContext = {
 
 type InventoryEntryFieldDescriptor = {
 	key: string;
-	kind?: "boolean" | "string" | "stringArray";
+	kind?: "boolean" | "compatibilityConfig" | "string" | "stringArray";
 	required?: boolean;
 	validate?: (
 		value: InventoryEntryFieldValue,

--- a/packages/wp-typia-project-tools/src/runtime/workspace/workspace-inventory-section-descriptors.ts
+++ b/packages/wp-typia-project-tools/src/runtime/workspace/workspace-inventory-section-descriptors.ts
@@ -424,6 +424,7 @@ export const INVENTORY_SECTIONS: readonly InventorySectionDescriptor[] = [
 				entryName: "ABILITIES",
 				fields: [
 					{ key: "clientFile", required: true },
+					{ key: "compatibility", kind: "compatibilityConfig" },
 					{ key: "configFile", required: true },
 					{ key: "dataFile", required: true },
 					{ key: "inputSchemaFile", required: true },
@@ -459,6 +460,7 @@ export const INVENTORY_SECTIONS: readonly InventorySectionDescriptor[] = [
 					{ key: "aiSchemaFile", required: true },
 					{ key: "apiFile", required: true },
 					{ key: "clientFile", required: true },
+					{ key: "compatibility", kind: "compatibilityConfig" },
 					{ key: "dataFile", required: true },
 					{ key: "namespace", required: true },
 					{ key: "openApiFile", required: true },

--- a/packages/wp-typia-project-tools/src/runtime/workspace/workspace-inventory-types.ts
+++ b/packages/wp-typia-project-tools/src/runtime/workspace/workspace-inventory-types.ts
@@ -1,3 +1,5 @@
+import type { ScaffoldCompatibilityConfig } from "../templates/scaffold-compatibility.js";
+
 export interface WorkspaceBlockInventoryEntry {
 	apiTypesFile?: string;
 	attributeTypeName?: string;
@@ -122,6 +124,7 @@ export interface WorkspacePostMetaInventoryEntry {
  */
 export interface WorkspaceAbilityInventoryEntry {
 	clientFile: string;
+	compatibility?: ScaffoldCompatibilityConfig;
 	configFile: string;
 	dataFile: string;
 	inputSchemaFile: string;
@@ -144,6 +147,7 @@ export interface WorkspaceAiFeatureInventoryEntry {
 	aiSchemaFile: string;
 	apiFile: string;
 	clientFile: string;
+	compatibility?: ScaffoldCompatibilityConfig;
 	dataFile: string;
 	namespace: string;
 	openApiFile: string;

--- a/packages/wp-typia-project-tools/tests/cli-add-workspace-ability.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-add-workspace-ability.test.ts
@@ -243,6 +243,8 @@ function demo_space_enqueue_workflow_abilities() {
 			'outputTypeName: "ReviewWorkflowAbilityOutput"',
 		);
 		expect(blockConfigSource).toContain('"mode": "required"');
+		expect(blockConfigSource).toContain('"hardMinimums": {');
+		expect(blockConfigSource).toContain('"wordpress": "7.0"');
 		expect(blockConfigSource).toContain("WordPress Abilities API");
 		expect(blockConfigSource).toContain("@wordpress/core-abilities");
 		expect(bootstrapSource).toContain("Requires at least: 7.0");
@@ -290,6 +292,27 @@ function demo_space_enqueue_workflow_abilities() {
 		expect(phpSource).toContain("output.schema.json");
 		expect(abilityEntry).toEqual({
 			clientFile: "src/abilities/review-workflow/client.ts",
+			compatibility: {
+				hardMinimums: {
+					wordpress: "7.0",
+				},
+				mode: "required",
+				optionalFeatureIds: [],
+				optionalFeatures: [],
+				requiredFeatureIds: [
+					"wordpress-server-abilities",
+					"wordpress-core-abilities",
+				],
+				requiredFeatures: [
+					"WordPress Abilities API",
+					"@wordpress/core-abilities",
+				],
+				runtimeGates: [
+					"WordPress Abilities API: php-function wp_register_ability",
+					"WordPress Abilities API: php-function wp_register_ability_category",
+					"@wordpress/core-abilities: script-package @wordpress/core-abilities",
+				],
+			},
 			configFile: "src/abilities/review-workflow/ability.config.json",
 			dataFile: "src/abilities/review-workflow/data.ts",
 			inputSchemaFile: "src/abilities/review-workflow/input.schema.json",
@@ -352,6 +375,34 @@ function demo_space_enqueue_workflow_abilities() {
 				(check) => check.label === "Ability review-workflow",
 			)?.status,
 		).toBe("pass");
+
+		const wordpressVersionDoctorOutput = runCli(
+			"node",
+			[entryPath, "doctor", "--wp-version-check", "--format", "json"],
+			{
+				cwd: targetDir,
+			},
+		);
+		const wordpressVersionDoctorChecks = parseJsonObjectFromOutput<{
+			checks: Array<{ code?: string; detail: string; status: string }>;
+			summary: { exitCode: 0 | 1; exitFailureCount: number };
+		}>(wordpressVersionDoctorOutput);
+		const featureMinimumCheck = wordpressVersionDoctorChecks.checks.find(
+			(check) => check.code === "wp-typia.workspace.wordpress.feature-minimum",
+		);
+		const testedTargetCheck = wordpressVersionDoctorChecks.checks.find(
+			(check) => check.code === "wp-typia.workspace.wordpress.tested-target",
+		);
+		expect(wordpressVersionDoctorChecks.summary.exitCode).toBe(0);
+		expect(wordpressVersionDoctorChecks.summary.exitFailureCount).toBe(0);
+		expect(featureMinimumCheck?.status).toBe("pass");
+		expect(featureMinimumCheck?.detail).toContain("Requires at least 7.0");
+		expect(featureMinimumCheck?.detail).toContain("feature floor 7.0");
+		expect(featureMinimumCheck?.detail).toContain(
+			"Ability review-workflow compatibility metadata",
+		);
+		expect(testedTargetCheck?.status).toBe("pass");
+		expect(testedTargetCheck?.detail).toContain("Tested up to 7.0");
 
 		runGeneratedScript(targetDir, "scripts/sync-abilities.ts", ["--check"]);
 		typecheckGeneratedProject(targetDir);

--- a/packages/wp-typia-project-tools/tests/cli-add-workspace-ai.test.ts
+++ b/packages/wp-typia-project-tools/tests/cli-add-workspace-ai.test.ts
@@ -288,6 +288,17 @@ describe("@wp-typia/project-tools cli-add-workspace ai-feature", () => {
 				"src/ai-features/brief-suggestions/ai-schemas/feature-result.ai.schema.json",
 			apiFile: "src/ai-features/brief-suggestions/api.ts",
 			clientFile: "src/ai-features/brief-suggestions/api-client.ts",
+			compatibility: {
+				hardMinimums: {},
+				mode: "optional",
+				optionalFeatureIds: ["wordpress-ai-client"],
+				optionalFeatures: ["WordPress AI Client"],
+				requiredFeatureIds: [],
+				requiredFeatures: [],
+				runtimeGates: [
+					"WordPress AI Client: wordpress-core-feature WordPress AI Client",
+				],
+			},
 			dataFile: "src/ai-features/brief-suggestions/data.ts",
 			namespace: "demo-space/v1",
 			openApiFile: "src/ai-features/brief-suggestions/api.openapi.json",


### PR DESCRIPTION
## Summary
- preserve generated `compatibility` metadata when reading workspace ability and AI feature inventory entries
- keep `wp-typia add ability` aligned with the WordPress 7 floor required by `@wordpress/core-abilities`
- add coverage proving generated ability scaffolds raise headers to 7.0 and pass `doctor --wp-version-check`

## Validation
- `bun test packages/wp-typia-project-tools/tests/cli-add-workspace-ability.test.ts packages/wp-typia-project-tools/tests/cli-add-workspace-ai.test.ts packages/wp-typia-project-tools/tests/workspace-doctor.test.ts`
- `bun run format:check`
- `bun run typecheck`
- `bun run lint:repo`
- `bun run --filter wp-typia build`
- `bun run --filter wp-typia test`
- `bun run --filter @wp-typia/project-tools test`
- `node packages/wp-typia/bin/wp-typia.js create demo --dry-run --wp-version 7.0 --format json`
- `node packages/wp-typia/bin/wp-typia.js doctor --wp-version-check --format json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WordPress 7 compatibility support for ability and AI feature scaffolding.
  * Workspace inventory now preserves compatibility metadata for abilities and AI features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->