### PR TITLE
fix(cli): complete WordPress feature floor checks

### DIFF
--- a/.sampo/changesets/doctor-wp-feature-floor-coverage.md
+++ b/.sampo/changesets/doctor-wp-feature-floor-coverage.md
@@ -1,0 +1,6 @@
+---
+npm/wp-typia: patch
+npm/@wp-typia/project-tools: patch
+---
+
+Expand `doctor --wp-version-check` coverage to reuse the shared WordPress block API compatibility matrix for block supports, metadata, and generated binding source feature floors.

--- a/packages/wp-typia-project-tools/package.json
+++ b/packages/wp-typia-project-tools/package.json
@@ -121,7 +121,7 @@
     "package.json"
   ],
   "scripts": {
-    "build": "bun run --filter @wp-typia/api-client build && bun run --filter @wp-typia/block-runtime build && rm -rf dist && tsc -p tsconfig.runtime.json",
+    "build": "bun run --filter @wp-typia/block-types build && bun run --filter @wp-typia/api-client build && bun run --filter @wp-typia/block-runtime build && rm -rf dist && tsc -p tsconfig.runtime.json",
     "prepack": "bun run build && node ./scripts/publish-manifest.mjs prepare",
     "postpack": "node ./scripts/publish-manifest.mjs restore",
     "test": "bun run build && bun test tests/*.test.ts",

--- a/packages/wp-typia-project-tools/src/runtime/doctor/cli-doctor-wordpress-version.ts
+++ b/packages/wp-typia-project-tools/src/runtime/doctor/cli-doctor-wordpress-version.ts
@@ -2,14 +2,13 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { parseScaffoldBlockMetadata } from "@wp-typia/block-runtime/blocks";
-import ts from "typescript";
+import { WORDPRESS_BLOCK_API_COMPATIBILITY } from "@wp-typia/block-types/blocks/compatibility";
 
 import {
 	createDoctorCheck,
 	resolveWorkspaceBootstrapPath,
 } from "./cli-doctor-workspace-shared.js";
 import { readJsonFileSync } from "../shared/json-utils.js";
-import { getPropertyNameText } from "../shared/ts-property-names.js";
 import {
 	compareVersionFloors,
 	pickHigherVersionFloor,
@@ -46,14 +45,37 @@ const WORDPRESS_VERSION_CHECK_CODES = {
 	testedTarget: "wp-typia.workspace.wordpress.tested-target",
 } as const;
 
-const BLOCK_METADATA_WORDPRESS_FLOORS = {
-	blockHooks: "6.4",
-	supportsInteractivity: "6.5",
-	supportsSplitting: "6.5",
-} as const;
-
 function isEnabledMetadataValue(value: unknown): boolean {
 	return value !== undefined && value !== false && value !== null;
+}
+
+function getNestedMetadataValue(
+	object: Record<string, unknown> | undefined,
+	key: string,
+): unknown {
+	if (!object) {
+		return undefined;
+	}
+	if (Object.prototype.hasOwnProperty.call(object, key)) {
+		return object[key];
+	}
+
+	return key
+		.split(".")
+		.reduce<unknown>((current, segment) => {
+			if (
+				current === null ||
+				typeof current !== "object" ||
+				Array.isArray(current)
+			) {
+				return undefined;
+			}
+
+			const record = current as Record<string, unknown>;
+			return Object.prototype.hasOwnProperty.call(record, segment)
+				? record[segment]
+				: undefined;
+		}, object);
 }
 
 function getBootstrapHeaderValue(
@@ -96,6 +118,22 @@ function pushRequirement(
 		label,
 		version,
 	});
+}
+
+function pushBlockApiRequirement(
+	requirements: WordPressVersionRequirement[],
+	labelPrefix: string,
+	entry: { label: string; since: string },
+): void {
+	pushRequirement(requirements, `${labelPrefix} ${entry.label}`, entry.since);
+}
+
+function readExistingTextFile(filePath: string): string | undefined {
+	if (!fs.existsSync(filePath)) {
+		return undefined;
+	}
+
+	return fs.readFileSync(filePath, "utf8");
 }
 
 function collectBlockMetadataRequirements(
@@ -141,26 +179,31 @@ function collectBlockMetadataRequirements(
 			continue;
 		}
 
-		if (isEnabledMetadataValue(blockJson.supports?.interactivity)) {
-			pushRequirement(
-				requirements,
-				`Block ${block.slug} supports.interactivity`,
-				BLOCK_METADATA_WORDPRESS_FLOORS.supportsInteractivity,
-			);
+		for (const [feature, entry] of Object.entries(
+			WORDPRESS_BLOCK_API_COMPATIBILITY.blockSupports,
+		)) {
+			if (isEnabledMetadataValue(getNestedMetadataValue(blockJson.supports, feature))) {
+				pushBlockApiRequirement(requirements, `Block ${block.slug}`, entry);
+			}
 		}
-		if (isEnabledMetadataValue(blockJson.supports?.splitting)) {
-			pushRequirement(
-				requirements,
-				`Block ${block.slug} supports.splitting`,
-				BLOCK_METADATA_WORDPRESS_FLOORS.supportsSplitting,
-			);
+
+		for (const [feature, entry] of Object.entries(
+			WORDPRESS_BLOCK_API_COMPATIBILITY.blockMetadata,
+		)) {
+			if (isEnabledMetadataValue(getNestedMetadataValue(blockJson, feature))) {
+				pushBlockApiRequirement(requirements, `Block ${block.slug}`, entry);
+			}
 		}
-		if (blockJson.blockHooks !== undefined) {
-			pushRequirement(
-				requirements,
-				`Block ${block.slug} blockHooks`,
-				BLOCK_METADATA_WORDPRESS_FLOORS.blockHooks,
-			);
+
+		for (const [feature, entry] of Object.entries(
+			WORDPRESS_BLOCK_API_COMPATIBILITY.blockBindings,
+		)) {
+			if (
+				(entry.runtime as readonly string[]).includes("block-json") &&
+				isEnabledMetadataValue(getNestedMetadataValue(blockJson, feature))
+			) {
+				pushBlockApiRequirement(requirements, `Block ${block.slug}`, entry);
+			}
 		}
 	}
 
@@ -170,122 +213,87 @@ function collectBlockMetadataRequirements(
 	};
 }
 
-function findExportedArrayLiteral(
-	sourceFile: ts.SourceFile,
-	exportName: string,
-): ts.ArrayLiteralExpression | null {
-	for (const statement of sourceFile.statements) {
-		if (
-			!ts.isVariableStatement(statement) ||
-			!statement.modifiers?.some(
-				(modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword,
-			)
-		) {
-			continue;
-		}
-
-		for (const declaration of statement.declarationList.declarations) {
-			if (
-				ts.isIdentifier(declaration.name) &&
-				declaration.name.text === exportName &&
-				declaration.initializer &&
-				ts.isArrayLiteralExpression(declaration.initializer)
-			) {
-				return declaration.initializer;
-			}
-		}
-	}
-
-	return null;
-}
-
-function getObjectProperty(
-	objectLiteral: ts.ObjectLiteralExpression,
-	key: string,
-): ts.Expression | undefined {
-	for (const property of objectLiteral.properties) {
-		if (!ts.isPropertyAssignment(property)) {
-			continue;
-		}
-		if (getPropertyNameText(property.name) === key) {
-			return property.initializer;
-		}
-	}
-
-	return undefined;
-}
-
-function getObjectLiteralProperty(
-	objectLiteral: ts.ObjectLiteralExpression | undefined,
-	key: string,
-): ts.ObjectLiteralExpression | undefined {
-	const property = objectLiteral ? getObjectProperty(objectLiteral, key) : undefined;
-	return property && ts.isObjectLiteralExpression(property) ? property : undefined;
-}
-
-function getStringLiteralProperty(
-	objectLiteral: ts.ObjectLiteralExpression,
-	key: string,
-): string | undefined {
-	const property = getObjectProperty(objectLiteral, key);
-	return property && ts.isStringLiteralLike(property) ? property.text : undefined;
-}
-
 function collectInventoryCompatibilityRequirements(
 	inventory: WorkspaceInventory,
 ): WordPressVersionRequirementCollection {
-	const issues: string[] = [];
 	const requirements: WordPressVersionRequirement[] = [];
-	const sourceFile = ts.createSourceFile(
-		"scripts/block-config.ts",
-		inventory.source,
-		ts.ScriptTarget.Latest,
-		true,
-		ts.ScriptKind.TS,
-	);
 
-	for (const section of [
-		{ exportName: "ABILITIES", label: "Ability" },
-		{ exportName: "AI_FEATURES", label: "AI feature" },
-	] as const) {
-		const arrayLiteral = findExportedArrayLiteral(sourceFile, section.exportName);
-		if (!arrayLiteral) {
-			continue;
-		}
-
-		arrayLiteral.elements.forEach((element, elementIndex) => {
-			if (!ts.isObjectLiteralExpression(element)) {
-				return;
-			}
-			const slug =
-				getStringLiteralProperty(element, "slug") ?? `entry ${elementIndex + 1}`;
-			const compatibility = getObjectLiteralProperty(element, "compatibility");
-			const hardMinimums = getObjectLiteralProperty(
-				compatibility,
-				"hardMinimums",
-			);
-			const wordpressMinimum = hardMinimums
-				? getObjectProperty(hardMinimums, "wordpress")
-				: undefined;
-			if (wordpressMinimum === undefined) {
-				return;
-			}
-			if (!ts.isStringLiteralLike(wordpressMinimum)) {
-				issues.push(
-					`${section.exportName}[${elementIndex}].compatibility.hardMinimums.wordpress must be a string literal.`,
-				);
-				return;
-			}
-
+	for (const ability of inventory.abilities) {
+		const wordpressMinimum = ability.compatibility?.hardMinimums.wordpress;
+		if (wordpressMinimum) {
 			requirements.push({
-				label: `${section.label} ${slug} compatibility metadata`,
-				version: wordpressMinimum.text,
+				label: `Ability ${ability.slug} compatibility metadata`,
+				version: wordpressMinimum,
 			});
-		});
+		}
+	}
+
+	for (const aiFeature of inventory.aiFeatures) {
+		const wordpressMinimum = aiFeature.compatibility?.hardMinimums.wordpress;
+		if (wordpressMinimum) {
+			requirements.push({
+				label: `AI feature ${aiFeature.slug} compatibility metadata`,
+				version: wordpressMinimum,
+			});
+		}
 	}
 
 	return {
-		issues,
+		issues: [],
+		requirements,
+	};
+}
+
+function collectBindingSourceRequirements(
+	workspace: WorkspaceProject,
+	inventory: WorkspaceInventory,
+): WordPressVersionRequirementCollection {
+	const requirements: WordPressVersionRequirement[] = [];
+	const bindingEntries = WORDPRESS_BLOCK_API_COMPATIBILITY.blockBindings;
+
+	for (const bindingSource of inventory.bindingSources) {
+		pushBlockApiRequirement(
+			requirements,
+			`Binding source ${bindingSource.slug}`,
+			bindingEntries.serverRegistration,
+		);
+		pushBlockApiRequirement(
+			requirements,
+			`Binding source ${bindingSource.slug}`,
+			bindingEntries.editorRegistration,
+		);
+
+		const editorFilePath = path.join(
+			workspace.projectDir,
+			bindingSource.editorFile,
+		);
+		if (readExistingTextFile(editorFilePath)?.includes("getFieldsList")) {
+			pushBlockApiRequirement(
+				requirements,
+				`Binding source ${bindingSource.slug}`,
+				bindingEntries.editorFieldsList,
+			);
+		}
+
+		const serverFilePath = path.join(
+			workspace.projectDir,
+			bindingSource.serverFile,
+		);
+		if (
+			readExistingTextFile(serverFilePath)?.includes(
+				"block_bindings_supported_attributes_",
+			)
+		) {
+			pushBlockApiRequirement(
+				requirements,
+				`Binding source ${bindingSource.slug}`,
+				bindingEntries.supportedAttributesFilter,
+			);
+		}
+	}
+
+	return {
+		issues: [],
 		requirements,
 	};
 }
@@ -295,13 +303,22 @@ function collectWordPressVersionRequirements(
 	inventory: WorkspaceInventory,
 ): WordPressVersionRequirementCollection {
 	const blockRequirements = collectBlockMetadataRequirements(workspace, inventory);
+	const bindingRequirements = collectBindingSourceRequirements(
+		workspace,
+		inventory,
+	);
 	const inventoryRequirements =
 		collectInventoryCompatibilityRequirements(inventory);
 
 	return {
-		issues: [...blockRequirements.issues, ...inventoryRequirements.issues],
+		issues: [
+			...blockRequirements.issues,
+			...bindingRequirements.issues,
+			...inventoryRequirements.issues,
+		],
 		requirements: [
 			...blockRequirements.requirements,
+			...bindingRequirements.requirements,
 			...inventoryRequirements.requirements,
 		],
 	};

--- a/packages/wp-typia-project-tools/src/runtime/workspace/workspace-inventory-parser-entries.ts
+++ b/packages/wp-typia-project-tools/src/runtime/workspace/workspace-inventory-parser-entries.ts
@@ -1,6 +1,7 @@
 import ts from "typescript";
 
 import { getPropertyNameText } from "../shared/ts-property-names.js";
+import { parseVersionFloorParts } from "../shared/version-floor.js";
 import {
 	assertParsedInventoryEntry,
 	type InventoryEntryFieldValue,
@@ -210,6 +211,27 @@ function getOptionalNestedStringProperty(
 	return expression.text;
 }
 
+function getOptionalVersionFloorProperty(
+	objectLiteral: ts.ObjectLiteralExpression,
+	key: string,
+	context: string,
+): string | undefined {
+	const value = getOptionalNestedStringProperty(objectLiteral, key, context);
+	if (value === undefined) {
+		return undefined;
+	}
+
+	try {
+		parseVersionFloorParts(value);
+	} catch {
+		throw new Error(
+			`${context}.${key} must be a dotted numeric version such as "6.7" or "8.1.2" in scripts/block-config.ts.`,
+		);
+	}
+
+	return value;
+}
+
 function getRequiredStringArrayProperty(
 	objectLiteral: ts.ObjectLiteralExpression,
 	key: string,
@@ -250,12 +272,12 @@ function parseCompatibilityConfigLiteral(
 		);
 	}
 
-	const php = getOptionalNestedStringProperty(
+	const php = getOptionalVersionFloorProperty(
 		hardMinimumsObject,
 		"php",
 		`${context}.hardMinimums`,
 	);
-	const wordpress = getOptionalNestedStringProperty(
+	const wordpress = getOptionalVersionFloorProperty(
 		hardMinimumsObject,
 		"wordpress",
 		`${context}.hardMinimums`,

--- a/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
@@ -341,7 +341,17 @@ test("doctor WordPress version check fails when block feature floors exceed head
     "block.json"
   );
   const blockJson = JSON.parse(fs.readFileSync(blockJsonPath, "utf8")) as {
+    metadata?: Record<string, unknown>;
     supports?: Record<string, unknown>;
+  };
+  blockJson.metadata = {
+    ...blockJson.metadata,
+    bindings: {
+      headline: {
+        args: { key: "_demo_headline" },
+        source: "core/post-meta",
+      },
+    },
   };
   blockJson.supports = {
     ...blockJson.supports,
@@ -372,9 +382,94 @@ test("doctor WordPress version check fails when block feature floors exceed head
   expect(featureMinimumCheck?.status).toBe("fail");
   expect(featureMinimumCheck?.detail).toContain("Requires at least 6.4");
   expect(featureMinimumCheck?.detail).toContain("feature floor 6.5");
+  expect(featureMinimumCheck?.detail).toContain("block metadata.bindings");
   expect(featureMinimumCheck?.detail).toContain("supports.interactivity");
   expect(featureMinimumCheck?.detail).toContain("supports.splitting");
 }, 15_000);
+
+test("doctor WordPress version check covers shared block API feature floors", async () => {
+  const targetDir = path.join(
+    tempRoot,
+    "demo-workspace-wp-version-shared-block-floors"
+  );
+
+  await scaffoldOfficialWorkspace(targetDir, {
+    description: "Demo workspace WordPress version shared block floors",
+    slug: "demo-workspace-wp-version-shared-block-floors",
+    title: "Demo Workspace WordPress Version Shared Block Floors",
+  });
+
+  linkWorkspaceNodeModules(targetDir);
+  runCli("node", [entryPath, "add", "block", "feature-card"], {
+    cwd: targetDir,
+  });
+
+  const blockJsonPath = path.join(
+    targetDir,
+    "src",
+    "blocks",
+    "feature-card",
+    "block.json"
+  );
+  const blockJson = JSON.parse(fs.readFileSync(blockJsonPath, "utf8")) as {
+    supports?: Record<string, unknown>;
+  };
+  blockJson.supports = {
+    ...blockJson.supports,
+    allowedBlocks: true,
+    contentRole: true,
+    visibility: true,
+  };
+  fs.writeFileSync(blockJsonPath, JSON.stringify(blockJson, null, 2), "utf8");
+  replaceBootstrapHeader(targetDir, "Requires at least", "6.8");
+
+  const sixNineResult = runCapturedCli(
+    "node",
+    [entryPath, "doctor", "--wp-version-check", "--format", "json"],
+    {
+      cwd: targetDir,
+    }
+  );
+  const sixNineChecks = parseJsonObjectFromOutput<{
+    checks: Array<{ code?: string; detail: string; label: string; status: string }>;
+  }>(sixNineResult.stdout);
+  const sixNineFeatureMinimumCheck = sixNineChecks.checks.find(
+    (check) => check.code === "wp-typia.workspace.wordpress.feature-minimum"
+  );
+
+  expect(sixNineResult.status).toBe(1);
+  expect(sixNineFeatureMinimumCheck?.status).toBe("fail");
+  expect(sixNineFeatureMinimumCheck?.detail).toContain("feature floor 6.9");
+  expect(sixNineFeatureMinimumCheck?.detail).toContain("supports.allowedBlocks");
+  expect(sixNineFeatureMinimumCheck?.detail).toContain("supports.contentRole");
+  expect(sixNineFeatureMinimumCheck?.detail).toContain("supports.visibility");
+
+  blockJson.supports = {
+    ...blockJson.supports,
+    listView: true,
+  };
+  fs.writeFileSync(blockJsonPath, JSON.stringify(blockJson, null, 2), "utf8");
+  replaceBootstrapHeader(targetDir, "Requires at least", "6.9");
+
+  const sevenResult = runCapturedCli(
+    "node",
+    [entryPath, "doctor", "--wp-version-check", "--format", "json"],
+    {
+      cwd: targetDir,
+    }
+  );
+  const sevenChecks = parseJsonObjectFromOutput<{
+    checks: Array<{ code?: string; detail: string; label: string; status: string }>;
+  }>(sevenResult.stdout);
+  const sevenFeatureMinimumCheck = sevenChecks.checks.find(
+    (check) => check.code === "wp-typia.workspace.wordpress.feature-minimum"
+  );
+
+  expect(sevenResult.status).toBe(1);
+  expect(sevenFeatureMinimumCheck?.status).toBe("fail");
+  expect(sevenFeatureMinimumCheck?.detail).toContain("feature floor 7.0");
+  expect(sevenFeatureMinimumCheck?.detail).toContain("supports.listView");
+}, 20_000);
 
 test("doctor WordPress version check reads ability inventory compatibility floors", async () => {
   const targetDir = path.join(
@@ -414,6 +509,69 @@ test("doctor WordPress version check reads ability inventory compatibility floor
   expect(featureMinimumCheck?.detail).toContain("feature floor 7.0");
   expect(featureMinimumCheck?.detail).toContain(
     "Ability summarize-post compatibility metadata"
+  );
+}, 20_000);
+
+test("doctor WordPress version check covers binding source API floors", async () => {
+  const targetDir = path.join(
+    tempRoot,
+    "demo-workspace-wp-version-binding-floor"
+  );
+
+  await scaffoldOfficialWorkspace(targetDir, {
+    description: "Demo workspace WordPress version binding floor",
+    slug: "demo-workspace-wp-version-binding-floor",
+    title: "Demo Workspace WordPress Version Binding Floor",
+  });
+
+  linkWorkspaceNodeModules(targetDir);
+  runCli(
+    "node",
+    [entryPath, "add", "block", "counter-card", "--template", "basic"],
+    {
+      cwd: targetDir,
+    }
+  );
+  runCli(
+    "node",
+    [
+      entryPath,
+      "add",
+      "binding-source",
+      "hero-data",
+      "--block",
+      "counter-card",
+      "--attribute",
+      "headline",
+    ],
+    {
+      cwd: targetDir,
+    }
+  );
+  replaceBootstrapHeader(targetDir, "Requires at least", "6.8");
+
+  const result = runCapturedCli(
+    "node",
+    [entryPath, "doctor", "--wp-version-check", "--format", "json"],
+    {
+      cwd: targetDir,
+    }
+  );
+  const doctorChecks = parseJsonObjectFromOutput<{
+    checks: Array<{ code?: string; detail: string; label: string; status: string }>;
+  }>(result.stdout);
+  const featureMinimumCheck = doctorChecks.checks.find(
+    (check) => check.code === "wp-typia.workspace.wordpress.feature-minimum"
+  );
+
+  expect(result.status).toBe(1);
+  expect(featureMinimumCheck?.status).toBe("fail");
+  expect(featureMinimumCheck?.detail).toContain("feature floor 6.9");
+  expect(featureMinimumCheck?.detail).toContain(
+    "registerBlockBindingsSource() getFieldsList()"
+  );
+  expect(featureMinimumCheck?.detail).toContain(
+    "block_bindings_supported_attributes filters"
   );
 }, 20_000);
 
@@ -1081,6 +1239,39 @@ export const REST_RESOURCES = [
 ];
 `)
   ).toThrow("REST_RESOURCES[0].methods includes unsupported values: publish.");
+
+  expect(() =>
+    parseWorkspaceInventorySource(`
+export const BLOCKS = [
+  { slug: "counter-card", typesFile: "src/blocks/counter-card/types.ts" },
+];
+export const ABILITIES = [
+  {
+    clientFile: "src/abilities/review-workflow/client.ts",
+    compatibility: {
+      hardMinimums: { wordpress: "7.x" },
+      mode: "required",
+      optionalFeatureIds: [],
+      optionalFeatures: [],
+      requiredFeatureIds: [],
+      requiredFeatures: [],
+      runtimeGates: [],
+    },
+    configFile: "src/abilities/review-workflow/config.ts",
+    dataFile: "src/abilities/review-workflow/data.ts",
+    inputSchemaFile: "src/abilities/review-workflow/input.schema.json",
+    inputTypeName: "ReviewInput",
+    outputSchemaFile: "src/abilities/review-workflow/output.schema.json",
+    outputTypeName: "ReviewOutput",
+    phpFile: "inc/abilities/review-workflow.php",
+    slug: "review-workflow",
+    typesFile: "src/abilities/review-workflow/types.ts",
+  },
+];
+`)
+  ).toThrow(
+    'ABILITIES[0].compatibility.hardMinimums.wordpress must be a dotted numeric version such as "6.7" or "8.1.2" in scripts/block-config.ts.'
+  );
 });
 
 test("async workspace inventory reader matches the sync compatibility reader", async () => {

--- a/scripts/lib/typescript-runtime-policy.mjs
+++ b/scripts/lib/typescript-runtime-policy.mjs
@@ -31,7 +31,6 @@ export const TYPESCRIPT_RUNTIME_PACKAGE_POLICIES = [
 		requiredTypeScriptImportFiles: [
 			"src/runtime/add/cli-add-workspace-binding-source.ts",
 			"src/runtime/cli/cli-init-plan.ts",
-			"src/runtime/doctor/cli-doctor-wordpress-version.ts",
 			"src/runtime/shared/ts-property-names.ts",
 			"src/runtime/workspace/workspace-inventory-parser-entries.ts",
 			"src/runtime/workspace/workspace-inventory-parser.ts",


### PR DESCRIPTION
## Summary
- Reuse the shared WordPress block API compatibility matrix for doctor feature-floor checks.
- Cover newer block supports, block metadata bindings, and generated binding source 6.9 surfaces.
- Reuse parsed ability/AI inventory compatibility metadata and validate dotted compatibility floor strings.

## Validation
- bun run format:check
- bun run typecheck
- bun run lint:repo
- bun run changesets:validate
- bun run --filter wp-typia build
- bun run --filter wp-typia test
- bun run --filter @wp-typia/project-tools test:workspace
- bun test packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
- node packages/wp-typia/bin/wp-typia.js --help
- node packages/wp-typia/bin/wp-typia.js complete bash
- node packages/wp-typia/bin/wp-typia.js doctor --wp-version-check --format json
- node packages/wp-typia/bin/wp-typia.js create demo --dry-run --wp-version 7.0 --format json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded `doctor --wp-version-check` command to cover WordPress version requirements for block supports, metadata, and binding sources with enhanced compatibility validation.

* **Tests**
  * Added test coverage for block API and binding source feature floor validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->