### PR TITLE
fix(cli): cover block variation WordPress floors

### DIFF
--- a/.sampo/changesets/doctor-block-variation-floor-coverage.md
+++ b/.sampo/changesets/doctor-block-variation-floor-coverage.md
@@ -1,0 +1,9 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/@wp-typia/block-types: patch
+npm/wp-typia: patch
+---
+
+Cover block variation metadata and generated variation registrations in
+`doctor --wp-version-check` by deriving floors from the shared WordPress block
+API compatibility matrix.

--- a/packages/wp-typia-block-types/src/blocks/compatibility.ts
+++ b/packages/wp-typia-block-types/src/blocks/compatibility.ts
@@ -343,9 +343,22 @@ export const WORDPRESS_BLOCK_API_COMPATIBILITY = {
     },
     registrationMetadata: {
       label: 'block registration variations metadata',
-      runtime: ['block-json', 'editor-js'],
+      runtime: ['editor-js'],
       since: '5.4',
       source: 'blockVariationsDevNote',
+    },
+    registrationBlockJsonMetadata: {
+      label: 'block.json variations metadata',
+      runtime: ['block-json'],
+      since: '5.9',
+      source: 'blockMetadataReference',
+    },
+    registrationMetadataFile: {
+      fallback: 'Use inline block.json variations or register variations in editor JavaScript.',
+      label: 'block.json variations file metadata',
+      runtime: ['block-json', 'php'],
+      since: '6.7',
+      source: 'blockMetadataReference',
     },
   },
 } as const satisfies Record<

--- a/packages/wp-typia-block-types/tests/compatibility.test.ts
+++ b/packages/wp-typia-block-types/tests/compatibility.test.ts
@@ -56,6 +56,28 @@ describe("WordPress block API compatibility matrix", () => {
 			source: "blockVariationsDevNote",
 		});
 		expect(
+			WORDPRESS_BLOCK_API_COMPATIBILITY.blockVariations.registrationMetadata,
+		).toMatchObject({
+			runtime: ["editor-js"],
+			since: "5.4",
+			source: "blockVariationsDevNote",
+		});
+		expect(
+			WORDPRESS_BLOCK_API_COMPATIBILITY.blockVariations
+				.registrationBlockJsonMetadata,
+		).toMatchObject({
+			runtime: ["block-json"],
+			since: "5.9",
+			source: "blockMetadataReference",
+		});
+		expect(
+			WORDPRESS_BLOCK_API_COMPATIBILITY.blockVariations.registrationMetadataFile,
+		).toMatchObject({
+			runtime: ["block-json", "php"],
+			since: "6.7",
+			source: "blockMetadataReference",
+		});
+		expect(
 			WORDPRESS_BLOCK_API_COMPATIBILITY.blockBindings.serverRegistration,
 		).toMatchObject({
 			runtime: ["php"],

--- a/packages/wp-typia-project-tools/src/runtime/doctor/cli-doctor-wordpress-version.ts
+++ b/packages/wp-typia-project-tools/src/runtime/doctor/cli-doctor-wordpress-version.ts
@@ -45,8 +45,37 @@ const WORDPRESS_VERSION_CHECK_CODES = {
 	testedTarget: "wp-typia.workspace.wordpress.tested-target",
 } as const;
 
+type BlockVariationCompatibilityMatrix =
+	typeof WORDPRESS_BLOCK_API_COMPATIBILITY.blockVariations;
+
+type BlockVariationBlockJsonFeature = {
+	[Feature in keyof BlockVariationCompatibilityMatrix]: "block-json" extends BlockVariationCompatibilityMatrix[Feature]["runtime"][number]
+		? Feature
+		: never;
+}[keyof BlockVariationCompatibilityMatrix];
+
+// Both entries read the same `variations` field and are distinguished by value type.
+const BLOCK_VARIATION_BLOCK_JSON_KEYS = {
+	registrationBlockJsonMetadata: "variations",
+	registrationMetadataFile: "variations",
+} as const satisfies Record<BlockVariationBlockJsonFeature, string>;
+
 function isEnabledMetadataValue(value: unknown): boolean {
 	return value !== undefined && value !== false && value !== null;
+}
+
+function isEnabledBlockVariationMetadataFeature(
+	feature: BlockVariationBlockJsonFeature,
+	value: unknown,
+): boolean {
+	if (feature === "registrationBlockJsonMetadata") {
+		return Array.isArray(value) && value.length > 0;
+	}
+	if (feature === "registrationMetadataFile") {
+		return typeof value === "string" && value.trim().length > 0;
+	}
+
+	return isEnabledMetadataValue(value);
 }
 
 function getNestedMetadataValue(
@@ -205,10 +234,90 @@ function collectBlockMetadataRequirements(
 				pushBlockApiRequirement(requirements, `Block ${block.slug}`, entry);
 			}
 		}
+
+		for (const [feature, entry] of Object.entries(
+			WORDPRESS_BLOCK_API_COMPATIBILITY.blockVariations,
+		)) {
+			if (!(entry.runtime as readonly string[]).includes("block-json")) {
+				continue;
+			}
+
+			const blockJsonFeature = feature as BlockVariationBlockJsonFeature;
+			const blockJsonKey = BLOCK_VARIATION_BLOCK_JSON_KEYS[blockJsonFeature];
+			if (
+				isEnabledBlockVariationMetadataFeature(
+					blockJsonFeature,
+					getNestedMetadataValue(blockJson, blockJsonKey),
+				)
+			) {
+				pushBlockApiRequirement(requirements, `Block ${block.slug}`, entry);
+			}
+		}
 	}
 
 	return {
 		issues,
+		requirements,
+	};
+}
+
+function hasGeneratedCoreVariationModule(
+	directoryPath: string,
+	isRootDirectory = true,
+): boolean {
+	if (!fs.existsSync(directoryPath)) {
+		return false;
+	}
+
+	for (const entry of fs.readdirSync(directoryPath, { withFileTypes: true })) {
+		const entryPath = path.join(directoryPath, entry.name);
+		if (entry.isDirectory() && hasGeneratedCoreVariationModule(entryPath, false)) {
+			return true;
+		}
+		if (
+			!isRootDirectory &&
+			entry.isFile() &&
+			entry.name.endsWith(".ts") &&
+			entry.name !== "index.ts"
+		) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+function collectVariationRequirements(
+	workspace: WorkspaceProject,
+	inventory: WorkspaceInventory,
+): WordPressVersionRequirementCollection {
+	const requirements: WordPressVersionRequirement[] = [];
+	const variationEntries = WORDPRESS_BLOCK_API_COMPATIBILITY.blockVariations;
+
+	for (const variation of inventory.variations) {
+		pushBlockApiRequirement(
+			requirements,
+			`Variation ${variation.block}/${variation.slug}`,
+			variationEntries.editorRegistration,
+		);
+	}
+
+	const coreVariationsDir = path.join(
+		workspace.projectDir,
+		"src",
+		"editor-plugins",
+		"core-variations",
+	);
+	if (hasGeneratedCoreVariationModule(coreVariationsDir)) {
+		pushBlockApiRequirement(
+			requirements,
+			"Core variations editor plugin",
+			variationEntries.editorRegistration,
+		);
+	}
+
+	return {
+		issues: [],
 		requirements,
 	};
 }
@@ -303,6 +412,7 @@ function collectWordPressVersionRequirements(
 	inventory: WorkspaceInventory,
 ): WordPressVersionRequirementCollection {
 	const blockRequirements = collectBlockMetadataRequirements(workspace, inventory);
+	const variationRequirements = collectVariationRequirements(workspace, inventory);
 	const bindingRequirements = collectBindingSourceRequirements(
 		workspace,
 		inventory,
@@ -313,11 +423,13 @@ function collectWordPressVersionRequirements(
 	return {
 		issues: [
 			...blockRequirements.issues,
+			...variationRequirements.issues,
 			...bindingRequirements.issues,
 			...inventoryRequirements.issues,
 		],
 		requirements: [
 			...blockRequirements.requirements,
+			...variationRequirements.requirements,
 			...bindingRequirements.requirements,
 			...inventoryRequirements.requirements,
 		],

--- a/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
@@ -471,6 +471,228 @@ test("doctor WordPress version check covers shared block API feature floors", as
   expect(sevenFeatureMinimumCheck?.detail).toContain("supports.listView");
 }, 20_000);
 
+test("doctor WordPress version check covers block variation metadata floors", async () => {
+  const targetDir = path.join(
+    tempRoot,
+    "demo-workspace-wp-version-variation-floor"
+  );
+
+  await scaffoldOfficialWorkspace(targetDir, {
+    description: "Demo workspace WordPress version variation floor",
+    slug: "demo-workspace-wp-version-variation-floor",
+    title: "Demo Workspace WordPress Version Variation Floor",
+  });
+
+  linkWorkspaceNodeModules(targetDir);
+  runCli("node", [entryPath, "add", "block", "feature-card"], {
+    cwd: targetDir,
+  });
+
+  const blockJsonPath = path.join(
+    targetDir,
+    "src",
+    "blocks",
+    "feature-card",
+    "block.json"
+  );
+  const blockJson = JSON.parse(fs.readFileSync(blockJsonPath, "utf8")) as {
+    supports?: Record<string, unknown>;
+    variations?: unknown;
+  };
+  blockJson.supports = {};
+
+  blockJson.variations = [];
+  fs.writeFileSync(blockJsonPath, JSON.stringify(blockJson, null, 2), "utf8");
+  replaceBootstrapHeader(targetDir, "Requires at least", "5.8");
+
+  const emptyArrayResult = runCapturedCli(
+    "node",
+    [entryPath, "doctor", "--wp-version-check", "--format", "json"],
+    {
+      cwd: targetDir,
+    }
+  );
+  const emptyArrayChecks = parseJsonObjectFromOutput<{
+    checks: Array<{ code?: string; status: string }>;
+  }>(emptyArrayResult.stdout);
+
+  expect(emptyArrayResult.status).toBe(0);
+  expect(
+    emptyArrayChecks.checks.find(
+      (check) => check.code === "wp-typia.workspace.wordpress.feature-minimum"
+    )?.status
+  ).toBe("pass");
+
+  blockJson.variations = "";
+  fs.writeFileSync(blockJsonPath, JSON.stringify(blockJson, null, 2), "utf8");
+
+  const emptyStringResult = runCapturedCli(
+    "node",
+    [entryPath, "doctor", "--wp-version-check", "--format", "json"],
+    {
+      cwd: targetDir,
+    }
+  );
+  const emptyStringChecks = parseJsonObjectFromOutput<{
+    checks: Array<{ code?: string; status: string }>;
+  }>(emptyStringResult.stdout);
+
+  expect(emptyStringResult.status).toBe(0);
+  expect(
+    emptyStringChecks.checks.find(
+      (check) => check.code === "wp-typia.workspace.wordpress.feature-minimum"
+    )?.status
+  ).toBe("pass");
+
+  blockJson.variations = [
+    {
+      attributes: { className: "is-style-featured" },
+      name: "featured",
+      title: "Featured",
+    },
+  ];
+  fs.writeFileSync(blockJsonPath, JSON.stringify(blockJson, null, 2), "utf8");
+  replaceBootstrapHeader(targetDir, "Requires at least", "5.8");
+
+  const result = runCapturedCli(
+    "node",
+    [entryPath, "doctor", "--wp-version-check", "--format", "json"],
+    {
+      cwd: targetDir,
+    }
+  );
+  const doctorChecks = parseJsonObjectFromOutput<{
+    checks: Array<{ code?: string; detail: string; label: string; status: string }>;
+  }>(result.stdout);
+  const featureMinimumCheck = doctorChecks.checks.find(
+    (check) => check.code === "wp-typia.workspace.wordpress.feature-minimum"
+  );
+
+  expect(result.status).toBe(1);
+  expect(featureMinimumCheck?.status).toBe("fail");
+  expect(featureMinimumCheck?.detail).toContain("feature floor 5.9");
+  expect(featureMinimumCheck?.detail).toContain(
+    "block.json variations metadata"
+  );
+
+  blockJson.variations = "file:./variations.php";
+  fs.writeFileSync(blockJsonPath, JSON.stringify(blockJson, null, 2), "utf8");
+  replaceBootstrapHeader(targetDir, "Requires at least", "6.6");
+
+  const fileResult = runCapturedCli(
+    "node",
+    [entryPath, "doctor", "--wp-version-check", "--format", "json"],
+    {
+      cwd: targetDir,
+    }
+  );
+  const fileChecks = parseJsonObjectFromOutput<{
+    checks: Array<{ code?: string; detail: string; label: string; status: string }>;
+  }>(fileResult.stdout);
+  const fileFeatureMinimumCheck = fileChecks.checks.find(
+    (check) => check.code === "wp-typia.workspace.wordpress.feature-minimum"
+  );
+
+  expect(fileResult.status).toBe(1);
+  expect(fileFeatureMinimumCheck?.status).toBe("fail");
+  expect(fileFeatureMinimumCheck?.detail).toContain("feature floor 6.7");
+  expect(fileFeatureMinimumCheck?.detail).toContain(
+    "block.json variations file metadata"
+  );
+}, 20_000);
+
+test("doctor WordPress version check covers generated variation registration floors", async () => {
+  const targetDir = path.join(
+    tempRoot,
+    "demo-workspace-wp-version-generated-variation-floor"
+  );
+
+  await scaffoldOfficialWorkspace(targetDir, {
+    description: "Demo workspace WordPress version generated variation floor",
+    slug: "demo-workspace-wp-version-generated-variation-floor",
+    title: "Demo Workspace WordPress Version Generated Variation Floor",
+  });
+
+  linkWorkspaceNodeModules(targetDir);
+  runCli("node", [entryPath, "add", "block", "feature-card"], {
+    cwd: targetDir,
+  });
+  runCli(
+    "node",
+    [entryPath, "add", "variation", "featured", "--block", "feature-card"],
+    {
+      cwd: targetDir,
+    }
+  );
+  replaceBootstrapHeader(targetDir, "Requires at least", "5.3");
+
+  const result = runCapturedCli(
+    "node",
+    [entryPath, "doctor", "--wp-version-check", "--format", "json"],
+    {
+      cwd: targetDir,
+    }
+  );
+  const doctorChecks = parseJsonObjectFromOutput<{
+    checks: Array<{ code?: string; detail: string; label: string; status: string }>;
+  }>(result.stdout);
+  const featureMinimumCheck = doctorChecks.checks.find(
+    (check) => check.code === "wp-typia.workspace.wordpress.feature-minimum"
+  );
+
+  expect(result.status).toBe(1);
+  expect(featureMinimumCheck?.status).toBe("fail");
+  expect(featureMinimumCheck?.detail).toContain("feature floor 5.4");
+  expect(featureMinimumCheck?.detail).toContain(
+    "registerBlockVariation() editor registration"
+  );
+}, 30_000);
+
+test("doctor WordPress version check covers generated core variation registration floors", async () => {
+  const targetDir = path.join(
+    tempRoot,
+    "demo-workspace-wp-version-generated-core-variation-floor"
+  );
+
+  await scaffoldOfficialWorkspace(targetDir, {
+    description: "Demo workspace WordPress version generated core variation floor",
+    slug: "demo-workspace-wp-version-generated-core-variation-floor",
+    title: "Demo Workspace WordPress Version Generated Core Variation Floor",
+  });
+
+  linkWorkspaceNodeModules(targetDir);
+  runCli(
+    "node",
+    [entryPath, "add", "core-variation", "core/group", "section-hero"],
+    {
+      cwd: targetDir,
+    }
+  );
+  replaceBootstrapHeader(targetDir, "Requires at least", "5.3");
+
+  const result = runCapturedCli(
+    "node",
+    [entryPath, "doctor", "--wp-version-check", "--format", "json"],
+    {
+      cwd: targetDir,
+    }
+  );
+  const doctorChecks = parseJsonObjectFromOutput<{
+    checks: Array<{ code?: string; detail: string; label: string; status: string }>;
+  }>(result.stdout);
+  const featureMinimumCheck = doctorChecks.checks.find(
+    (check) => check.code === "wp-typia.workspace.wordpress.feature-minimum"
+  );
+
+  expect(result.status).toBe(1);
+  expect(featureMinimumCheck?.status).toBe("fail");
+  expect(featureMinimumCheck?.detail).toContain("feature floor 5.4");
+  expect(featureMinimumCheck?.detail).toContain("Core variations editor plugin");
+  expect(featureMinimumCheck?.detail).toContain(
+    "registerBlockVariation() editor registration"
+  );
+}, 30_000);
+
 test("doctor WordPress version check reads ability inventory compatibility floors", async () => {
   const targetDir = path.join(
     tempRoot,


### PR DESCRIPTION
## Summary
- include block variation block.json metadata in doctor --wp-version-check floor collection
- map the shared blockVariations.registrationMetadata compatibility entry to the block.json variations key
- add a workspace doctor regression proving variation metadata floors are reported from the shared matrix

## Notes
- U2 appears already covered in current add --template help text, which states the basic default and allowed template values.
- U3 is deferred because disclosing AI-agent JSON auto-selection would touch the global structured-output contract rather than this doctor-specific follow-up.

## Validation
- bun test packages/wp-typia-project-tools/tests/workspace-doctor.test.ts -t "block variation metadata floors"
- bun run format:check
- bun run changesets:validate
- bun run typecheck
- bun run lint:repo
- bun run --filter @wp-typia/project-tools test:workspace
- bun run --filter wp-typia test
- node packages/wp-typia/bin/wp-typia.js doctor --wp-version-check --format json
- node packages/wp-typia/bin/wp-typia.js --help

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `doctor --wp-version-check` command now validates block variation metadata against WordPress version compatibility requirements.

* **Tests**
  * Added test case to verify block variation metadata version validation works correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->