### PR TITLE
fix(cli): tighten doctor feature floor detection

### DIFF
--- a/.sampo/changesets/doctor-feature-floor-detection.md
+++ b/.sampo/changesets/doctor-feature-floor-detection.md
@@ -1,0 +1,8 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Fixed `doctor --wp-version-check` feature-floor detection so generated core
+variations and binding source APIs are recognized from executable registrations
+instead of comments, string literals, or stray TypeScript files.

--- a/packages/wp-typia-project-tools/src/runtime/doctor/cli-doctor-wordpress-version.ts
+++ b/packages/wp-typia-project-tools/src/runtime/doctor/cli-doctor-wordpress-version.ts
@@ -13,6 +13,7 @@ import { hasPhpFunctionCallWithStringArgumentPrefix } from "../shared/php-utils.
 import {
 	hasExecutablePattern,
 	hasUncommentedPattern,
+	maskTypeScriptCommentsAndLiterals,
 } from "../shared/ts-source-masking.js";
 import {
 	compareVersionFloors,
@@ -70,8 +71,9 @@ const CORE_VARIATION_REGISTRY_IMPORT_PATTERN =
 const REGISTER_BLOCK_VARIATION_CALL_PATTERN = /\bregisterBlockVariation\s*\(/u;
 const REGISTER_WORKSPACE_CORE_VARIATIONS_CALL_PATTERN =
 	/^\s*registerWorkspaceCoreVariations\s*\(\s*\)\s*;?\s*$/mu;
-const GET_FIELDS_LIST_REGISTRATION_PATTERN =
-	/\bgetFieldsList\s*(?:\([^)]*\)\s*\{|:\s*(?:(?:async\s+)?function(?:\s+\w+)?\s*\([^)]*\)|(?:async\s*)?\([^)]*\)\s*=>)\s*\{)/u;
+const REGISTER_BLOCK_BINDINGS_SOURCE_CALL_PATTERN =
+	/\bregisterBlockBindingsSource\s*\(/gu;
+const GET_FIELDS_LIST_PROPERTY_PATTERN = /\bgetFieldsList\s*(?:\([^)]*\)\s*\{|:)/u;
 const SUPPORTED_ATTRIBUTES_FILTER_PREFIX =
 	"block_bindings_supported_attributes_";
 
@@ -182,6 +184,55 @@ function readExistingTextFile(filePath: string): string | undefined {
 	}
 
 	return fs.readFileSync(filePath, "utf8");
+}
+
+function findClosingParenthesis(source: string, openIndex: number): number | null {
+	let depth = 0;
+	for (let cursor = openIndex; cursor < source.length; cursor += 1) {
+		const character = source[cursor];
+		if (character === "(") {
+			depth += 1;
+			continue;
+		}
+		if (character === ")") {
+			depth -= 1;
+			if (depth === 0) {
+				return cursor;
+			}
+		}
+	}
+
+	return null;
+}
+
+function hasRegisterBlockBindingsSourceGetFieldsList(source: string): boolean {
+	const maskedSource = maskTypeScriptCommentsAndLiterals(source);
+	REGISTER_BLOCK_BINDINGS_SOURCE_CALL_PATTERN.lastIndex = 0;
+
+	let match: RegExpExecArray | null;
+	while (
+		(match = REGISTER_BLOCK_BINDINGS_SOURCE_CALL_PATTERN.exec(maskedSource))
+	) {
+		const openIndex = maskedSource.indexOf("(", match.index);
+		if (openIndex === -1) {
+			continue;
+		}
+
+		const closeIndex = findClosingParenthesis(maskedSource, openIndex);
+		if (closeIndex === null) {
+			continue;
+		}
+
+		const callArgumentsSource = maskedSource.slice(openIndex + 1, closeIndex);
+		GET_FIELDS_LIST_PROPERTY_PATTERN.lastIndex = 0;
+		if (GET_FIELDS_LIST_PROPERTY_PATTERN.test(callArgumentsSource)) {
+			return true;
+		}
+
+		REGISTER_BLOCK_BINDINGS_SOURCE_CALL_PATTERN.lastIndex = closeIndex + 1;
+	}
+
+	return false;
 }
 
 function collectBlockMetadataRequirements(
@@ -387,7 +438,7 @@ function collectBindingSourceRequirements(
 		const editorSource = readExistingTextFile(editorFilePath);
 		if (
 			editorSource &&
-			hasExecutablePattern(editorSource, GET_FIELDS_LIST_REGISTRATION_PATTERN)
+			hasRegisterBlockBindingsSourceGetFieldsList(editorSource)
 		) {
 			pushBlockApiRequirement(
 				requirements,

--- a/packages/wp-typia-project-tools/src/runtime/doctor/cli-doctor-wordpress-version.ts
+++ b/packages/wp-typia-project-tools/src/runtime/doctor/cli-doctor-wordpress-version.ts
@@ -71,7 +71,7 @@ const REGISTER_BLOCK_VARIATION_CALL_PATTERN = /\bregisterBlockVariation\s*\(/u;
 const REGISTER_WORKSPACE_CORE_VARIATIONS_CALL_PATTERN =
 	/^\s*registerWorkspaceCoreVariations\s*\(\s*\)\s*;?\s*$/mu;
 const GET_FIELDS_LIST_REGISTRATION_PATTERN =
-	/\bgetFieldsList\s*(?:\(|:\s*(?:async\s*)?\()/u;
+	/\bgetFieldsList\s*(?:\([^)]*\)\s*\{|:\s*(?:async\s*)?\([^)]*\)\s*=>\s*\{)/u;
 const SUPPORTED_ATTRIBUTES_FILTER_PREFIX =
 	"block_bindings_supported_attributes_";
 

--- a/packages/wp-typia-project-tools/src/runtime/doctor/cli-doctor-wordpress-version.ts
+++ b/packages/wp-typia-project-tools/src/runtime/doctor/cli-doctor-wordpress-version.ts
@@ -79,7 +79,7 @@ const REGISTER_WORKSPACE_CORE_VARIATIONS_CALL_PATTERN =
 const REGISTER_BLOCK_BINDINGS_SOURCE_CALL_PATTERN =
 	/\bregisterBlockBindingsSource\s*\(/gu;
 const GET_FIELDS_LIST_PROPERTY_PATTERN =
-	/(?:\bgetFieldsList\s*\([^)]*\)\s*(?::\s*[^{};,]+)?\s*\{|\bgetFieldsList\s*:\s*(?:(?:async\s+)?function(?:\s+\w+)?\s*\([^)]*\)\s*(?::\s*[^{};,]+)?\s*\{|(?:async\s*)?\([^)]*\)\s*=>)|["']getFieldsList["']\s*:\s*(?:(?:async\s+)?function(?:\s+\w+)?\s*\([^)]*\)\s*(?::\s*[^{};,]+)?\s*\{|(?:async\s*)?\([^)]*\)\s*=>))/u;
+	/(?:async\s+)?\bgetFieldsList\s*\([^)]*\)\s*(?::\s*[^{};,]+)?\s*\{|["']getFieldsList["']\s*\([^)]*\)\s*(?::\s*[^{};,]+)?\s*\{|\bgetFieldsList\s*:|["']getFieldsList["']\s*:|\bgetFieldsList\s*(?=,|\})/gu;
 const SUPPORTED_ATTRIBUTES_FILTER_PREFIX =
 	"block_bindings_supported_attributes_";
 
@@ -192,15 +192,36 @@ function readExistingTextFile(filePath: string): string | undefined {
 	return fs.readFileSync(filePath, "utf8");
 }
 
-function findClosingParenthesis(source: string, openIndex: number): number | null {
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
+function isTypeScriptIdentifierPart(character: string | undefined): boolean {
+	return /^[A-Za-z0-9_$]$/u.test(character ?? "");
+}
+
+function skipTypeScriptWhitespace(source: string, index: number): number {
+	let cursor = index;
+	while (/\s/u.test(source[cursor] ?? "")) {
+		cursor += 1;
+	}
+	return cursor;
+}
+
+function findClosingDelimiter(
+	source: string,
+	openIndex: number,
+	openDelimiter: "{" | "(",
+	closeDelimiter: "}" | ")",
+): number | null {
 	let depth = 0;
 	for (let cursor = openIndex; cursor < source.length; cursor += 1) {
 		const character = source[cursor];
-		if (character === "(") {
+		if (character === openDelimiter) {
 			depth += 1;
 			continue;
 		}
-		if (character === ")") {
+		if (character === closeDelimiter) {
 			depth -= 1;
 			if (depth === 0) {
 				return cursor;
@@ -209,6 +230,254 @@ function findClosingParenthesis(source: string, openIndex: number): number | nul
 	}
 
 	return null;
+}
+
+function findTopLevelSatisfiesIndex(source: string): number | null {
+	let braceDepth = 0;
+	let bracketDepth = 0;
+	let parenthesisDepth = 0;
+
+	for (let cursor = 0; cursor < source.length; cursor += 1) {
+		const character = source[cursor];
+		if (character === "{") {
+			braceDepth += 1;
+			continue;
+		}
+		if (character === "}") {
+			braceDepth = Math.max(0, braceDepth - 1);
+			continue;
+		}
+		if (character === "[") {
+			bracketDepth += 1;
+			continue;
+		}
+		if (character === "]") {
+			bracketDepth = Math.max(0, bracketDepth - 1);
+			continue;
+		}
+		if (character === "(") {
+			parenthesisDepth += 1;
+			continue;
+		}
+		if (character === ")") {
+			parenthesisDepth = Math.max(0, parenthesisDepth - 1);
+			continue;
+		}
+		if (
+			braceDepth === 0 &&
+			bracketDepth === 0 &&
+			parenthesisDepth === 0 &&
+			source.startsWith("satisfies", cursor) &&
+			!isTypeScriptIdentifierPart(source[cursor - 1]) &&
+			!isTypeScriptIdentifierPart(source[cursor + "satisfies".length])
+		) {
+			return cursor;
+		}
+	}
+
+	return null;
+}
+
+function isTopLevelObjectPropertyStart(
+	structureMaskedObjectSource: string,
+	index: number,
+): boolean {
+	let braceDepth = 0;
+	let bracketDepth = 0;
+	let parenthesisDepth = 0;
+
+	for (let cursor = 0; cursor < index; cursor += 1) {
+		const character = structureMaskedObjectSource[cursor];
+		if (character === "{") {
+			braceDepth += 1;
+			continue;
+		}
+		if (character === "}") {
+			braceDepth = Math.max(0, braceDepth - 1);
+			continue;
+		}
+		if (character === "[") {
+			bracketDepth += 1;
+			continue;
+		}
+		if (character === "]") {
+			bracketDepth = Math.max(0, bracketDepth - 1);
+			continue;
+		}
+		if (character === "(") {
+			parenthesisDepth += 1;
+			continue;
+		}
+		if (character === ")") {
+			parenthesisDepth = Math.max(0, parenthesisDepth - 1);
+		}
+	}
+
+	if (braceDepth !== 1 || bracketDepth !== 0 || parenthesisDepth !== 0) {
+		return false;
+	}
+
+	let previousCursor = index - 1;
+	while (
+		previousCursor >= 0 &&
+		/\s/u.test(structureMaskedObjectSource[previousCursor] ?? "")
+	) {
+		previousCursor -= 1;
+	}
+	const previousToken = structureMaskedObjectSource[previousCursor];
+	return previousToken === "{" || previousToken === ",";
+}
+
+function objectLiteralHasGetFieldsListProperty(
+	commentMaskedObjectSource: string,
+	structureMaskedObjectSource: string,
+): boolean {
+	GET_FIELDS_LIST_PROPERTY_PATTERN.lastIndex = 0;
+	let match: RegExpExecArray | null;
+	while ((match = GET_FIELDS_LIST_PROPERTY_PATTERN.exec(commentMaskedObjectSource))) {
+		if (isTopLevelObjectPropertyStart(structureMaskedObjectSource, match.index)) {
+			GET_FIELDS_LIST_PROPERTY_PATTERN.lastIndex = 0;
+			return true;
+		}
+	}
+	GET_FIELDS_LIST_PROPERTY_PATTERN.lastIndex = 0;
+	return false;
+}
+
+function getRuntimeArgumentEnd(maskedCallArgumentsSource: string): number {
+	return (
+		findTopLevelSatisfiesIndex(maskedCallArgumentsSource) ??
+		maskedCallArgumentsSource.length
+	);
+}
+
+function getFirstObjectArgumentSpan(
+	structureMaskedRuntimeArgumentsSource: string,
+	absoluteStart: number,
+): { end: number; start: number } | undefined {
+	const objectStartOffset = skipTypeScriptWhitespace(
+		structureMaskedRuntimeArgumentsSource,
+		0,
+	);
+	if (structureMaskedRuntimeArgumentsSource[objectStartOffset] !== "{") {
+		return undefined;
+	}
+
+	const objectEndOffset = findClosingDelimiter(
+		structureMaskedRuntimeArgumentsSource,
+		objectStartOffset,
+		"{",
+		"}",
+	);
+	if (objectEndOffset === null) {
+		return undefined;
+	}
+
+	return {
+		end: absoluteStart + objectEndOffset + 1,
+		start: absoluteStart + objectStartOffset,
+	};
+}
+
+function getSimpleRuntimeArgumentIdentifier(
+	structureMaskedRuntimeArgumentsSource: string,
+): string | undefined {
+	const trimmed = structureMaskedRuntimeArgumentsSource.trim();
+	const match = /^([A-Za-z_$][\w$]*)$/u.exec(trimmed);
+	return match?.[1];
+}
+
+function findObjectInitializerStart(
+	structureMaskedSource: string,
+	index: number,
+): number | null {
+	let braceDepth = 0;
+	let bracketDepth = 0;
+	let parenthesisDepth = 0;
+
+	for (let cursor = index; cursor < structureMaskedSource.length; cursor += 1) {
+		const character = structureMaskedSource[cursor];
+		if (character === "{") {
+			braceDepth += 1;
+			continue;
+		}
+		if (character === "}") {
+			braceDepth = Math.max(0, braceDepth - 1);
+			continue;
+		}
+		if (character === "[") {
+			bracketDepth += 1;
+			continue;
+		}
+		if (character === "]") {
+			bracketDepth = Math.max(0, bracketDepth - 1);
+			continue;
+		}
+		if (character === "(") {
+			parenthesisDepth += 1;
+			continue;
+		}
+		if (character === ")") {
+			parenthesisDepth = Math.max(0, parenthesisDepth - 1);
+			continue;
+		}
+
+		if (braceDepth !== 0 || bracketDepth !== 0 || parenthesisDepth !== 0) {
+			continue;
+		}
+		if (character === ";") {
+			return null;
+		}
+		if (character !== "=" || structureMaskedSource[cursor + 1] === ">") {
+			continue;
+		}
+
+		const valueStart = skipTypeScriptWhitespace(structureMaskedSource, cursor + 1);
+		return structureMaskedSource[valueStart] === "{" ? valueStart : null;
+	}
+
+	return null;
+}
+
+function variableObjectHasGetFieldsListProperty(
+	identifier: string,
+	commentMaskedSource: string,
+	structureMaskedSource: string,
+): boolean {
+	const variablePattern = new RegExp(
+		`\\b(?:export\\s+)?(?:const|let|var)\\s+${escapeRegExp(identifier)}\\b`,
+		"gu",
+	);
+	let match: RegExpExecArray | null;
+	while ((match = variablePattern.exec(structureMaskedSource))) {
+		const objectStart = findObjectInitializerStart(
+			structureMaskedSource,
+			match.index + match[0].length,
+		);
+		if (objectStart === null) {
+			continue;
+		}
+		const objectEnd = findClosingDelimiter(
+			structureMaskedSource,
+			objectStart,
+			"{",
+			"}",
+		);
+		if (objectEnd === null) {
+			continue;
+		}
+
+		if (
+			objectLiteralHasGetFieldsListProperty(
+				commentMaskedSource.slice(objectStart, objectEnd + 1),
+				structureMaskedSource.slice(objectStart, objectEnd + 1),
+			)
+		) {
+			return true;
+		}
+	}
+
+	return false;
 }
 
 function hasRegisterBlockBindingsSourceGetFieldsList(source: string): boolean {
@@ -226,7 +495,12 @@ function hasRegisterBlockBindingsSourceGetFieldsList(source: string): boolean {
 			continue;
 		}
 
-		const closeIndex = findClosingParenthesis(structureMaskedSource, openIndex);
+		const closeIndex = findClosingDelimiter(
+			structureMaskedSource,
+			openIndex,
+			"(",
+			")",
+		);
 		if (closeIndex === null) {
 			continue;
 		}
@@ -235,14 +509,37 @@ function hasRegisterBlockBindingsSourceGetFieldsList(source: string): boolean {
 			openIndex + 1,
 			closeIndex,
 		);
-		const satisfiesMatch = /\bsatisfies\b/u.exec(maskedCallArgumentsSource);
-		const runtimeArgumentEnd = satisfiesMatch?.index ?? maskedCallArgumentsSource.length;
-		const callArgumentsSource = commentMaskedSource.slice(
-			openIndex + 1,
-			openIndex + 1 + runtimeArgumentEnd,
+		const runtimeArgumentEnd = getRuntimeArgumentEnd(maskedCallArgumentsSource);
+		const runtimeArgumentsStart = openIndex + 1;
+		const maskedRuntimeArgumentsSource = structureMaskedSource.slice(
+			runtimeArgumentsStart,
+			runtimeArgumentsStart + runtimeArgumentEnd,
 		);
-		GET_FIELDS_LIST_PROPERTY_PATTERN.lastIndex = 0;
-		if (GET_FIELDS_LIST_PROPERTY_PATTERN.test(callArgumentsSource)) {
+		const objectArgumentSpan = getFirstObjectArgumentSpan(
+			maskedRuntimeArgumentsSource,
+			runtimeArgumentsStart,
+		);
+		if (
+			objectArgumentSpan &&
+			objectLiteralHasGetFieldsListProperty(
+				commentMaskedSource.slice(objectArgumentSpan.start, objectArgumentSpan.end),
+				structureMaskedSource.slice(objectArgumentSpan.start, objectArgumentSpan.end),
+			)
+		) {
+			return true;
+		}
+
+		const runtimeArgumentIdentifier = getSimpleRuntimeArgumentIdentifier(
+			maskedRuntimeArgumentsSource,
+		);
+		if (
+			runtimeArgumentIdentifier &&
+			variableObjectHasGetFieldsListProperty(
+				runtimeArgumentIdentifier,
+				commentMaskedSource,
+				structureMaskedSource,
+			)
+		) {
 			return true;
 		}
 

--- a/packages/wp-typia-project-tools/src/runtime/doctor/cli-doctor-wordpress-version.ts
+++ b/packages/wp-typia-project-tools/src/runtime/doctor/cli-doctor-wordpress-version.ts
@@ -9,6 +9,11 @@ import {
 	resolveWorkspaceBootstrapPath,
 } from "./cli-doctor-workspace-shared.js";
 import { readJsonFileSync } from "../shared/json-utils.js";
+import { hasPhpFunctionCallWithStringArgument } from "../shared/php-utils.js";
+import {
+	hasExecutablePattern,
+	hasUncommentedPattern,
+} from "../shared/ts-source-masking.js";
 import {
 	compareVersionFloors,
 	pickHigherVersionFloor,
@@ -60,8 +65,19 @@ const BLOCK_VARIATION_BLOCK_JSON_KEYS = {
 	registrationMetadataFile: "variations",
 } as const satisfies Record<BlockVariationBlockJsonFeature, string>;
 
+const CORE_VARIATION_REGISTRY_IMPORT_PATTERN =
+	/^\s*import\s*\{[^}]+\}\s*from\s*["']\.\/[^"']+\/[^"']+\/[^"']+["']\s*;?\s*$/mu;
+const REGISTER_BLOCK_VARIATION_CALL_PATTERN = /\bregisterBlockVariation\s*\(/u;
+const REGISTER_WORKSPACE_CORE_VARIATIONS_CALL_PATTERN =
+	/\bregisterWorkspaceCoreVariations\s*\(/u;
+const GET_FIELDS_LIST_CALL_PATTERN = /\bgetFieldsList\s*\(/u;
+
 function isEnabledMetadataValue(value: unknown): boolean {
 	return value !== undefined && value !== false && value !== null;
+}
+
+function assertNeverBlockVariationFeature(feature: never): never {
+	throw new Error(`Unhandled block variation metadata feature "${String(feature)}".`);
 }
 
 function isEnabledBlockVariationMetadataFeature(
@@ -75,7 +91,7 @@ function isEnabledBlockVariationMetadataFeature(
 		return typeof value === "string" && value.trim().length > 0;
 	}
 
-	return isEnabledMetadataValue(value);
+	return assertNeverBlockVariationFeature(feature);
 }
 
 function getNestedMetadataValue(
@@ -261,30 +277,24 @@ function collectBlockMetadataRequirements(
 	};
 }
 
-function hasGeneratedCoreVariationModule(
-	directoryPath: string,
-	isRootDirectory = true,
-): boolean {
-	if (!fs.existsSync(directoryPath)) {
+function hasGeneratedCoreVariationRegistry(projectDir: string): boolean {
+	const registryPath = path.join(
+		projectDir,
+		"src",
+		"editor-plugins",
+		"core-variations",
+		"index.ts",
+	);
+	const source = readExistingTextFile(registryPath);
+	if (!source) {
 		return false;
 	}
 
-	for (const entry of fs.readdirSync(directoryPath, { withFileTypes: true })) {
-		const entryPath = path.join(directoryPath, entry.name);
-		if (entry.isDirectory() && hasGeneratedCoreVariationModule(entryPath, false)) {
-			return true;
-		}
-		if (
-			!isRootDirectory &&
-			entry.isFile() &&
-			entry.name.endsWith(".ts") &&
-			entry.name !== "index.ts"
-		) {
-			return true;
-		}
-	}
-
-	return false;
+	return (
+		hasUncommentedPattern(source, CORE_VARIATION_REGISTRY_IMPORT_PATTERN) &&
+		hasExecutablePattern(source, REGISTER_BLOCK_VARIATION_CALL_PATTERN) &&
+		hasExecutablePattern(source, REGISTER_WORKSPACE_CORE_VARIATIONS_CALL_PATTERN)
+	);
 }
 
 function collectVariationRequirements(
@@ -302,13 +312,7 @@ function collectVariationRequirements(
 		);
 	}
 
-	const coreVariationsDir = path.join(
-		workspace.projectDir,
-		"src",
-		"editor-plugins",
-		"core-variations",
-	);
-	if (hasGeneratedCoreVariationModule(coreVariationsDir)) {
+	if (hasGeneratedCoreVariationRegistry(workspace.projectDir)) {
 		pushBlockApiRequirement(
 			requirements,
 			"Core variations editor plugin",
@@ -376,7 +380,11 @@ function collectBindingSourceRequirements(
 			workspace.projectDir,
 			bindingSource.editorFile,
 		);
-		if (readExistingTextFile(editorFilePath)?.includes("getFieldsList")) {
+		const editorSource = readExistingTextFile(editorFilePath);
+		if (
+			editorSource &&
+			hasExecutablePattern(editorSource, GET_FIELDS_LIST_CALL_PATTERN)
+		) {
 			pushBlockApiRequirement(
 				requirements,
 				`Binding source ${bindingSource.slug}`,
@@ -388,9 +396,14 @@ function collectBindingSourceRequirements(
 			workspace.projectDir,
 			bindingSource.serverFile,
 		);
+		const serverSource = readExistingTextFile(serverFilePath);
+		const supportedAttributesFilter = `block_bindings_supported_attributes_${workspace.workspace.namespace}/${bindingSource.block}`;
 		if (
-			readExistingTextFile(serverFilePath)?.includes(
-				"block_bindings_supported_attributes_",
+			serverSource &&
+			hasPhpFunctionCallWithStringArgument(
+				serverSource,
+				"add_filter",
+				supportedAttributesFilter,
 			)
 		) {
 			pushBlockApiRequirement(

--- a/packages/wp-typia-project-tools/src/runtime/doctor/cli-doctor-wordpress-version.ts
+++ b/packages/wp-typia-project-tools/src/runtime/doctor/cli-doctor-wordpress-version.ts
@@ -9,7 +9,7 @@ import {
 	resolveWorkspaceBootstrapPath,
 } from "./cli-doctor-workspace-shared.js";
 import { readJsonFileSync } from "../shared/json-utils.js";
-import { hasPhpFunctionCallWithStringArgument } from "../shared/php-utils.js";
+import { hasPhpFunctionCallWithStringArgumentPrefix } from "../shared/php-utils.js";
 import {
 	hasExecutablePattern,
 	hasUncommentedPattern,
@@ -70,7 +70,9 @@ const CORE_VARIATION_REGISTRY_IMPORT_PATTERN =
 const REGISTER_BLOCK_VARIATION_CALL_PATTERN = /\bregisterBlockVariation\s*\(/u;
 const REGISTER_WORKSPACE_CORE_VARIATIONS_CALL_PATTERN =
 	/\bregisterWorkspaceCoreVariations\s*\(/u;
-const GET_FIELDS_LIST_CALL_PATTERN = /\bgetFieldsList\s*\(/u;
+const GET_FIELDS_LIST_REGISTRATION_PATTERN = /\bgetFieldsList\s*(?:\(|:)/u;
+const SUPPORTED_ATTRIBUTES_FILTER_PREFIX =
+	"block_bindings_supported_attributes_";
 
 function isEnabledMetadataValue(value: unknown): boolean {
 	return value !== undefined && value !== false && value !== null;
@@ -383,7 +385,7 @@ function collectBindingSourceRequirements(
 		const editorSource = readExistingTextFile(editorFilePath);
 		if (
 			editorSource &&
-			hasExecutablePattern(editorSource, GET_FIELDS_LIST_CALL_PATTERN)
+			hasExecutablePattern(editorSource, GET_FIELDS_LIST_REGISTRATION_PATTERN)
 		) {
 			pushBlockApiRequirement(
 				requirements,
@@ -397,13 +399,12 @@ function collectBindingSourceRequirements(
 			bindingSource.serverFile,
 		);
 		const serverSource = readExistingTextFile(serverFilePath);
-		const supportedAttributesFilter = `block_bindings_supported_attributes_${workspace.workspace.namespace}/${bindingSource.block}`;
 		if (
 			serverSource &&
-			hasPhpFunctionCallWithStringArgument(
+			hasPhpFunctionCallWithStringArgumentPrefix(
 				serverSource,
 				"add_filter",
-				supportedAttributesFilter,
+				SUPPORTED_ATTRIBUTES_FILTER_PREFIX,
 			)
 		) {
 			pushBlockApiRequirement(

--- a/packages/wp-typia-project-tools/src/runtime/doctor/cli-doctor-wordpress-version.ts
+++ b/packages/wp-typia-project-tools/src/runtime/doctor/cli-doctor-wordpress-version.ts
@@ -9,10 +9,15 @@ import {
 	resolveWorkspaceBootstrapPath,
 } from "./cli-doctor-workspace-shared.js";
 import { readJsonFileSync } from "../shared/json-utils.js";
-import { hasPhpFunctionCallWithStringArgumentPrefix } from "../shared/php-utils.js";
+import {
+	hasPhpCodeStringLiteralPrefix,
+	hasPhpFunctionCall,
+	hasPhpFunctionCallWithStringArgumentPrefix,
+} from "../shared/php-utils.js";
 import {
 	hasExecutablePattern,
 	hasUncommentedPattern,
+	maskTypeScriptComments,
 	maskTypeScriptCommentsAndLiterals,
 } from "../shared/ts-source-masking.js";
 import {
@@ -73,7 +78,8 @@ const REGISTER_WORKSPACE_CORE_VARIATIONS_CALL_PATTERN =
 	/^\s*registerWorkspaceCoreVariations\s*\(\s*\)\s*;?\s*$/mu;
 const REGISTER_BLOCK_BINDINGS_SOURCE_CALL_PATTERN =
 	/\bregisterBlockBindingsSource\s*\(/gu;
-const GET_FIELDS_LIST_PROPERTY_PATTERN = /\bgetFieldsList\s*(?:\([^)]*\)\s*\{|:)/u;
+const GET_FIELDS_LIST_PROPERTY_PATTERN =
+	/(?:\bgetFieldsList\s*\([^)]*\)\s*(?::\s*[^{};,]+)?\s*\{|\bgetFieldsList\s*:\s*(?:(?:async\s+)?function(?:\s+\w+)?\s*\([^)]*\)\s*(?::\s*[^{};,]+)?\s*\{|(?:async\s*)?\([^)]*\)\s*=>)|["']getFieldsList["']\s*:\s*(?:(?:async\s+)?function(?:\s+\w+)?\s*\([^)]*\)\s*(?::\s*[^{};,]+)?\s*\{|(?:async\s*)?\([^)]*\)\s*=>))/u;
 const SUPPORTED_ATTRIBUTES_FILTER_PREFIX =
 	"block_bindings_supported_attributes_";
 
@@ -206,24 +212,35 @@ function findClosingParenthesis(source: string, openIndex: number): number | nul
 }
 
 function hasRegisterBlockBindingsSourceGetFieldsList(source: string): boolean {
-	const maskedSource = maskTypeScriptCommentsAndLiterals(source);
+	const structureMaskedSource = maskTypeScriptCommentsAndLiterals(source);
+	const commentMaskedSource = maskTypeScriptComments(source);
 	REGISTER_BLOCK_BINDINGS_SOURCE_CALL_PATTERN.lastIndex = 0;
 
 	let match: RegExpExecArray | null;
 	while (
-		(match = REGISTER_BLOCK_BINDINGS_SOURCE_CALL_PATTERN.exec(maskedSource))
+		(match =
+			REGISTER_BLOCK_BINDINGS_SOURCE_CALL_PATTERN.exec(structureMaskedSource))
 	) {
-		const openIndex = maskedSource.indexOf("(", match.index);
+		const openIndex = structureMaskedSource.indexOf("(", match.index);
 		if (openIndex === -1) {
 			continue;
 		}
 
-		const closeIndex = findClosingParenthesis(maskedSource, openIndex);
+		const closeIndex = findClosingParenthesis(structureMaskedSource, openIndex);
 		if (closeIndex === null) {
 			continue;
 		}
 
-		const callArgumentsSource = maskedSource.slice(openIndex + 1, closeIndex);
+		const maskedCallArgumentsSource = structureMaskedSource.slice(
+			openIndex + 1,
+			closeIndex,
+		);
+		const satisfiesMatch = /\bsatisfies\b/u.exec(maskedCallArgumentsSource);
+		const runtimeArgumentEnd = satisfiesMatch?.index ?? maskedCallArgumentsSource.length;
+		const callArgumentsSource = commentMaskedSource.slice(
+			openIndex + 1,
+			openIndex + 1 + runtimeArgumentEnd,
+		);
 		GET_FIELDS_LIST_PROPERTY_PATTERN.lastIndex = 0;
 		if (GET_FIELDS_LIST_PROPERTY_PATTERN.test(callArgumentsSource)) {
 			return true;
@@ -233,6 +250,18 @@ function hasRegisterBlockBindingsSourceGetFieldsList(source: string): boolean {
 	}
 
 	return false;
+}
+
+function hasSupportedAttributesFilterRegistration(source: string): boolean {
+	return (
+		hasPhpFunctionCallWithStringArgumentPrefix(
+			source,
+			"add_filter",
+			SUPPORTED_ATTRIBUTES_FILTER_PREFIX,
+		) ||
+		(hasPhpFunctionCall(source, "add_filter") &&
+			hasPhpCodeStringLiteralPrefix(source, SUPPORTED_ATTRIBUTES_FILTER_PREFIX))
+	);
 }
 
 function collectBlockMetadataRequirements(
@@ -452,14 +481,7 @@ function collectBindingSourceRequirements(
 			bindingSource.serverFile,
 		);
 		const serverSource = readExistingTextFile(serverFilePath);
-		if (
-			serverSource &&
-			hasPhpFunctionCallWithStringArgumentPrefix(
-				serverSource,
-				"add_filter",
-				SUPPORTED_ATTRIBUTES_FILTER_PREFIX,
-			)
-		) {
+		if (serverSource && hasSupportedAttributesFilterRegistration(serverSource)) {
 			pushBlockApiRequirement(
 				requirements,
 				`Binding source ${bindingSource.slug}`,

--- a/packages/wp-typia-project-tools/src/runtime/doctor/cli-doctor-wordpress-version.ts
+++ b/packages/wp-typia-project-tools/src/runtime/doctor/cli-doctor-wordpress-version.ts
@@ -10,8 +10,7 @@ import {
 } from "./cli-doctor-workspace-shared.js";
 import { readJsonFileSync } from "../shared/json-utils.js";
 import {
-	hasPhpCodeStringLiteralPrefix,
-	hasPhpFunctionCall,
+	hasPhpFunctionCallWithAssignedStringPrefixArgument,
 	hasPhpFunctionCallWithStringArgumentPrefix,
 } from "../shared/php-utils.js";
 import {
@@ -72,14 +71,14 @@ const BLOCK_VARIATION_BLOCK_JSON_KEYS = {
 } as const satisfies Record<BlockVariationBlockJsonFeature, string>;
 
 const CORE_VARIATION_REGISTRY_IMPORT_PATTERN =
-	/^\s*import\s*(?!type[\s{])\{[^}]+\}\s*from\s*["']\.\/[^"']+\/[^"']+\/[^"']+["']\s*;?\s*$/mu;
+	/^\s*import\s*(?!type\b)\{[\s\S]*?\}\s*from\s*["']\.\/[^"']+\/[^"']+\/[^"']+["']\s*;?\s*$/mu;
 const REGISTER_BLOCK_VARIATION_CALL_PATTERN = /\bregisterBlockVariation\s*\(/u;
 const REGISTER_WORKSPACE_CORE_VARIATIONS_CALL_PATTERN =
 	/^\s*registerWorkspaceCoreVariations\s*\(\s*\)\s*;?\s*$/mu;
 const REGISTER_BLOCK_BINDINGS_SOURCE_CALL_PATTERN =
 	/\bregisterBlockBindingsSource\s*\(/gu;
 const GET_FIELDS_LIST_PROPERTY_PATTERN =
-	/(?:async\s+)?\bgetFieldsList\s*\([^)]*\)\s*(?::\s*[^{};,]+)?\s*\{|["']getFieldsList["']\s*\([^)]*\)\s*(?::\s*[^{};,]+)?\s*\{|\bgetFieldsList\s*:|["']getFieldsList["']\s*:|\bgetFieldsList\s*(?=,|\})/gu;
+	/(?:async\s+)?\bgetFieldsList\s*\([^)]*\)\s*(?::\s*[^{};,]+)?\s*\{|(?:async\s+)?["']getFieldsList["']\s*\([^)]*\)\s*(?::\s*[^{};,]+)?\s*\{|\bgetFieldsList\s*:|["']getFieldsList["']\s*:|\bgetFieldsList\s*(?=,|\})/gu;
 const SUPPORTED_ATTRIBUTES_FILTER_PREFIX =
 	"block_bindings_supported_attributes_";
 
@@ -190,10 +189,6 @@ function readExistingTextFile(filePath: string): string | undefined {
 	}
 
 	return fs.readFileSync(filePath, "utf8");
-}
-
-function escapeRegExp(value: string): string {
-	return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
 }
 
 function isTypeScriptIdentifierPart(character: string | undefined): boolean {
@@ -439,22 +434,71 @@ function findObjectInitializerStart(
 	return null;
 }
 
+function isTopLevelTypeScriptPosition(
+	structureMaskedSource: string,
+	index: number,
+): boolean {
+	let braceDepth = 0;
+	let bracketDepth = 0;
+	let parenthesisDepth = 0;
+
+	for (let cursor = 0; cursor < index; cursor += 1) {
+		const character = structureMaskedSource[cursor];
+		if (character === "{") {
+			braceDepth += 1;
+			continue;
+		}
+		if (character === "}") {
+			braceDepth = Math.max(0, braceDepth - 1);
+			continue;
+		}
+		if (character === "[") {
+			bracketDepth += 1;
+			continue;
+		}
+		if (character === "]") {
+			bracketDepth = Math.max(0, bracketDepth - 1);
+			continue;
+		}
+		if (character === "(") {
+			parenthesisDepth += 1;
+			continue;
+		}
+		if (character === ")") {
+			parenthesisDepth = Math.max(0, parenthesisDepth - 1);
+		}
+	}
+
+	return braceDepth === 0 && bracketDepth === 0 && parenthesisDepth === 0;
+}
+
 function variableObjectHasGetFieldsListProperty(
 	identifier: string,
 	commentMaskedSource: string,
 	structureMaskedSource: string,
+	beforeIndex: number,
 ): boolean {
-	const variablePattern = new RegExp(
-		`\\b(?:export\\s+)?(?:const|let|var)\\s+${escapeRegExp(identifier)}\\b`,
-		"gu",
-	);
+	const variablePattern =
+		/\b(?:export\s+)?(?:const|let|var)\s+([A-Za-z_$][\w$]*)\b/gu;
 	let match: RegExpExecArray | null;
+	let nearestObjectSpan: { end: number; start: number } | undefined;
+
 	while ((match = variablePattern.exec(structureMaskedSource))) {
+		if (match.index >= beforeIndex) {
+			break;
+		}
+		if (match[1] !== identifier) {
+			continue;
+		}
+		if (!isTopLevelTypeScriptPosition(structureMaskedSource, match.index)) {
+			continue;
+		}
+
 		const objectStart = findObjectInitializerStart(
 			structureMaskedSource,
 			match.index + match[0].length,
 		);
-		if (objectStart === null) {
+		if (objectStart === null || objectStart >= beforeIndex) {
 			continue;
 		}
 		const objectEnd = findClosingDelimiter(
@@ -467,17 +511,24 @@ function variableObjectHasGetFieldsListProperty(
 			continue;
 		}
 
-		if (
-			objectLiteralHasGetFieldsListProperty(
-				commentMaskedSource.slice(objectStart, objectEnd + 1),
-				structureMaskedSource.slice(objectStart, objectEnd + 1),
-			)
-		) {
-			return true;
-		}
+		nearestObjectSpan = {
+			end: objectEnd + 1,
+			start: objectStart,
+		};
 	}
 
-	return false;
+	return nearestObjectSpan
+		? objectLiteralHasGetFieldsListProperty(
+				commentMaskedSource.slice(
+					nearestObjectSpan.start,
+					nearestObjectSpan.end,
+				),
+				structureMaskedSource.slice(
+					nearestObjectSpan.start,
+					nearestObjectSpan.end,
+				),
+			)
+		: false;
 }
 
 function hasRegisterBlockBindingsSourceGetFieldsList(source: string): boolean {
@@ -538,6 +589,7 @@ function hasRegisterBlockBindingsSourceGetFieldsList(source: string): boolean {
 				runtimeArgumentIdentifier,
 				commentMaskedSource,
 				structureMaskedSource,
+				match.index,
 			)
 		) {
 			return true;
@@ -556,8 +608,11 @@ function hasSupportedAttributesFilterRegistration(source: string): boolean {
 			"add_filter",
 			SUPPORTED_ATTRIBUTES_FILTER_PREFIX,
 		) ||
-		(hasPhpFunctionCall(source, "add_filter") &&
-			hasPhpCodeStringLiteralPrefix(source, SUPPORTED_ATTRIBUTES_FILTER_PREFIX))
+		hasPhpFunctionCallWithAssignedStringPrefixArgument(
+			source,
+			"add_filter",
+			SUPPORTED_ATTRIBUTES_FILTER_PREFIX,
+		)
 	);
 }
 

--- a/packages/wp-typia-project-tools/src/runtime/doctor/cli-doctor-wordpress-version.ts
+++ b/packages/wp-typia-project-tools/src/runtime/doctor/cli-doctor-wordpress-version.ts
@@ -66,11 +66,12 @@ const BLOCK_VARIATION_BLOCK_JSON_KEYS = {
 } as const satisfies Record<BlockVariationBlockJsonFeature, string>;
 
 const CORE_VARIATION_REGISTRY_IMPORT_PATTERN =
-	/^\s*import\s*\{[^}]+\}\s*from\s*["']\.\/[^"']+\/[^"']+\/[^"']+["']\s*;?\s*$/mu;
+	/^\s*import\s*(?!type[\s{])\{[^}]+\}\s*from\s*["']\.\/[^"']+\/[^"']+\/[^"']+["']\s*;?\s*$/mu;
 const REGISTER_BLOCK_VARIATION_CALL_PATTERN = /\bregisterBlockVariation\s*\(/u;
 const REGISTER_WORKSPACE_CORE_VARIATIONS_CALL_PATTERN =
-	/\bregisterWorkspaceCoreVariations\s*\(/u;
-const GET_FIELDS_LIST_REGISTRATION_PATTERN = /\bgetFieldsList\s*(?:\(|:)/u;
+	/^\s*registerWorkspaceCoreVariations\s*\(\s*\)\s*;?\s*$/mu;
+const GET_FIELDS_LIST_REGISTRATION_PATTERN =
+	/\bgetFieldsList\s*(?:\(|:\s*(?:async\s*)?\()/u;
 const SUPPORTED_ATTRIBUTES_FILTER_PREFIX =
 	"block_bindings_supported_attributes_";
 
@@ -280,6 +281,7 @@ function collectBlockMetadataRequirements(
 }
 
 function hasGeneratedCoreVariationRegistry(projectDir: string): boolean {
+	// Convention: generated core variation registries are rooted at this entrypoint.
 	const registryPath = path.join(
 		projectDir,
 		"src",

--- a/packages/wp-typia-project-tools/src/runtime/doctor/cli-doctor-wordpress-version.ts
+++ b/packages/wp-typia-project-tools/src/runtime/doctor/cli-doctor-wordpress-version.ts
@@ -78,7 +78,7 @@ const REGISTER_WORKSPACE_CORE_VARIATIONS_CALL_PATTERN =
 const REGISTER_BLOCK_BINDINGS_SOURCE_CALL_PATTERN =
 	/\bregisterBlockBindingsSource\s*\(/gu;
 const GET_FIELDS_LIST_PROPERTY_PATTERN =
-	/(?:async\s+)?\bgetFieldsList\s*\([^)]*\)\s*(?::\s*[^{};,]+)?\s*\{|(?:async\s+)?["']getFieldsList["']\s*\([^)]*\)\s*(?::\s*[^{};,]+)?\s*\{|\bgetFieldsList\s*:|["']getFieldsList["']\s*:|\bgetFieldsList\s*(?=,|\})/gu;
+	/(?:async\s+)?\bgetFieldsList\s*\([^)]*\)|(?:async\s+)?["']getFieldsList["']\s*\([^)]*\)|\bgetFieldsList\s*:|["']getFieldsList["']\s*:|\bgetFieldsList\s*(?=,|\})/gu;
 const SUPPORTED_ATTRIBUTES_FILTER_PREFIX =
 	"block_bindings_supported_attributes_";
 
@@ -378,7 +378,7 @@ function getSimpleRuntimeArgumentIdentifier(
 	structureMaskedRuntimeArgumentsSource: string,
 ): string | undefined {
 	const trimmed = structureMaskedRuntimeArgumentsSource.trim();
-	const match = /^([A-Za-z_$][\w$]*)$/u.exec(trimmed);
+	const match = /^([A-Za-z_$][\w$]*)(?:\s+as\b[\s\S]*)?$/u.exec(trimmed);
 	return match?.[1];
 }
 

--- a/packages/wp-typia-project-tools/src/runtime/doctor/cli-doctor-wordpress-version.ts
+++ b/packages/wp-typia-project-tools/src/runtime/doctor/cli-doctor-wordpress-version.ts
@@ -71,7 +71,7 @@ const REGISTER_BLOCK_VARIATION_CALL_PATTERN = /\bregisterBlockVariation\s*\(/u;
 const REGISTER_WORKSPACE_CORE_VARIATIONS_CALL_PATTERN =
 	/^\s*registerWorkspaceCoreVariations\s*\(\s*\)\s*;?\s*$/mu;
 const GET_FIELDS_LIST_REGISTRATION_PATTERN =
-	/\bgetFieldsList\s*(?:\([^)]*\)\s*\{|:\s*(?:async\s*)?\([^)]*\)\s*=>\s*\{)/u;
+	/\bgetFieldsList\s*(?:\([^)]*\)\s*\{|:\s*(?:(?:async\s+)?function(?:\s+\w+)?\s*\([^)]*\)|(?:async\s*)?\([^)]*\)\s*=>)\s*\{)/u;
 const SUPPORTED_ATTRIBUTES_FILTER_PREFIX =
 	"block_bindings_supported_attributes_";
 

--- a/packages/wp-typia-project-tools/src/runtime/shared/php-utils.ts
+++ b/packages/wp-typia-project-tools/src/runtime/shared/php-utils.ts
@@ -230,6 +230,57 @@ function matchesPhpFunctionCallAt(
 	return callStart !== null && source[callStart] === "(";
 }
 
+function parsePhpQuotedStringLiteralAt(
+	source: string,
+	index: number,
+): { end: number; value: string } | null {
+	const quote = source[index];
+	if (quote !== "'" && quote !== '"') {
+		return null;
+	}
+
+	let cursor = index + 1;
+	let value = "";
+	while (cursor < source.length) {
+		const character = source[cursor];
+		if (character === "\\") {
+			const escapedCharacter = source[cursor + 1];
+			if (escapedCharacter === undefined) {
+				return null;
+			}
+			value += escapedCharacter;
+			cursor += 2;
+			continue;
+		}
+
+		if (character === quote) {
+			return {
+				end: cursor + 1,
+				value,
+			};
+		}
+
+		value += character;
+		cursor += 1;
+	}
+
+	return null;
+}
+
+function getPhpFunctionCallFirstArgumentStart(
+	source: string,
+	index: number,
+	functionName: string,
+): number | null {
+	const cursor = index + functionName.length;
+	const callStart = skipPhpCallTrivia(source, cursor);
+	if (callStart === null || source[callStart] !== "(") {
+		return null;
+	}
+
+	return skipPhpCallTrivia(source, callStart + 1);
+}
+
 function createPhpScannerState(): PhpScannerState {
 	return {
 		heredocDelimiter: "",
@@ -422,6 +473,55 @@ export function hasPhpFunctionCall(source: string, functionName: string): boolea
 		}
 
 		index += 1;
+	}
+
+	return false;
+}
+
+/**
+ * Detect a PHP function call whose first argument is a literal string value.
+ *
+ * This uses the same code-mode scanner as {@link hasPhpFunctionCall}, so
+ * comments, quoted strings, heredoc, and nowdoc content cannot create matches.
+ */
+export function hasPhpFunctionCallWithStringArgument(
+	source: string,
+	functionName: string,
+	literalArgument: string,
+): boolean {
+	const scanner = createPhpScannerState();
+	let index = 0;
+	while (index < source.length) {
+		const scan = advancePhpScanner(source, index, scanner);
+		if (scan.ambiguous) {
+			return false;
+		}
+		if (!scan.inCode) {
+			index = scan.index;
+			continue;
+		}
+
+		if (!matchesPhpFunctionCallAt(source, index, functionName)) {
+			index += 1;
+			continue;
+		}
+
+		const argumentStart = getPhpFunctionCallFirstArgumentStart(
+			source,
+			index,
+			functionName,
+		);
+		if (argumentStart === null) {
+			index += functionName.length;
+			continue;
+		}
+
+		const argument = parsePhpQuotedStringLiteralAt(source, argumentStart);
+		if (argument?.value === literalArgument) {
+			return true;
+		}
+
+		index += functionName.length;
 	}
 
 	return false;

--- a/packages/wp-typia-project-tools/src/runtime/shared/php-utils.ts
+++ b/packages/wp-typia-project-tools/src/runtime/shared/php-utils.ts
@@ -225,7 +225,10 @@ function matchesPhpFunctionCallAt(
 		previousCursor -= 1;
 	}
 	const previousToken = source[previousCursor];
-	if (previousToken === ">" || previousToken === ":") {
+	if (
+		previousToken === ">" ||
+		(previousToken === ":" && source[previousCursor - 1] === ":")
+	) {
 		return false;
 	}
 

--- a/packages/wp-typia-project-tools/src/runtime/shared/php-utils.ts
+++ b/packages/wp-typia-project-tools/src/runtime/shared/php-utils.ts
@@ -524,6 +524,86 @@ export function hasPhpFunctionCallWithStringArgumentPrefix(
 	);
 }
 
+/**
+ * Detect a code-mode PHP string literal that starts with a literal prefix.
+ *
+ * This is useful for dynamic hook names stored in variables before a later
+ * global function call consumes the variable.
+ */
+export function hasPhpCodeStringLiteralPrefix(
+	source: string,
+	literalPrefix: string,
+): boolean {
+	let index = 0;
+	while (index < source.length) {
+		if (source.startsWith("<?php", index)) {
+			index += 5;
+			continue;
+		}
+
+		if (source.startsWith("<?", index) || source.startsWith("?>", index)) {
+			index += 2;
+			continue;
+		}
+
+		if (source[index] === "/" && source[index + 1] === "*") {
+			const commentEnd = source.indexOf("*/", index + 2);
+			if (commentEnd === -1) {
+				return false;
+			}
+			index = commentEnd + 2;
+			continue;
+		}
+
+		const literal = parsePhpQuotedStringLiteralAt(source, index);
+		if (literal) {
+			if (literal.value.startsWith(literalPrefix)) {
+				return true;
+			}
+			index = literal.end;
+			continue;
+		}
+
+		if (source[index] === "/" && source[index + 1] === "/") {
+			index = findPhpLineBoundary(source, index + 2).nextStart;
+			continue;
+		}
+
+		if (source[index] === "#" && source[index + 1] !== "[") {
+			index = findPhpLineBoundary(source, index + 1).nextStart;
+			continue;
+		}
+
+		const heredoc = parsePhpHeredocStart(source, index);
+		if (heredoc) {
+			let cursor = heredoc.contentStart;
+			let closingEnd: number | null = null;
+			while (cursor < source.length) {
+				closingEnd = findPhpHeredocClosingEnd(
+					source,
+					cursor,
+					heredoc.delimiter,
+				);
+				if (closingEnd !== null) {
+					break;
+				}
+				cursor = findPhpLineBoundary(source, cursor).nextStart;
+			}
+
+			if (closingEnd === null) {
+				return false;
+			}
+
+			index = findPhpLineBoundary(source, closingEnd).nextStart;
+			continue;
+		}
+
+		index += 1;
+	}
+
+	return false;
+}
+
 function hasPhpFunctionCallWithStringArgumentMatching(
 	source: string,
 	functionName: string,

--- a/packages/wp-typia-project-tools/src/runtime/shared/php-utils.ts
+++ b/packages/wp-typia-project-tools/src/runtime/shared/php-utils.ts
@@ -489,6 +489,33 @@ export function hasPhpFunctionCallWithStringArgument(
 	functionName: string,
 	literalArgument: string,
 ): boolean {
+	return hasPhpFunctionCallWithStringArgumentMatching(
+		source,
+		functionName,
+		(value) => value === literalArgument,
+	);
+}
+
+/**
+ * Detect a PHP function call whose first argument is a literal string prefix.
+ */
+export function hasPhpFunctionCallWithStringArgumentPrefix(
+	source: string,
+	functionName: string,
+	literalPrefix: string,
+): boolean {
+	return hasPhpFunctionCallWithStringArgumentMatching(
+		source,
+		functionName,
+		(value) => value.startsWith(literalPrefix),
+	);
+}
+
+function hasPhpFunctionCallWithStringArgumentMatching(
+	source: string,
+	functionName: string,
+	matchesArgument: (value: string) => boolean,
+): boolean {
 	const scanner = createPhpScannerState();
 	let index = 0;
 	while (index < source.length) {
@@ -517,7 +544,7 @@ export function hasPhpFunctionCallWithStringArgument(
 		}
 
 		const argument = parsePhpQuotedStringLiteralAt(source, argumentStart);
-		if (argument?.value === literalArgument) {
+		if (argument && matchesArgument(argument.value)) {
 			return true;
 		}
 

--- a/packages/wp-typia-project-tools/src/runtime/shared/php-utils.ts
+++ b/packages/wp-typia-project-tools/src/runtime/shared/php-utils.ts
@@ -525,6 +525,7 @@ function isPhpAssignmentOperatorAt(source: string, index: number | null): boolea
 		previousToken !== "!" &&
 		previousToken !== "<" &&
 		previousToken !== ">" &&
+		previousToken !== "." &&
 		nextToken !== "=" &&
 		nextToken !== ">"
 	);
@@ -609,6 +610,7 @@ export function hasPhpFunctionCallWithAssignedStringPrefixArgument(
 					index = literal.end;
 					continue;
 				}
+				variablesWithPrefix.delete(variable.name);
 			}
 		}
 

--- a/packages/wp-typia-project-tools/src/runtime/shared/php-utils.ts
+++ b/packages/wp-typia-project-tools/src/runtime/shared/php-utils.ts
@@ -220,6 +220,14 @@ function matchesPhpFunctionCallAt(
 	if (isPhpIdentifierPart(source[index - 1])) {
 		return false;
 	}
+	let previousCursor = index - 1;
+	while (previousCursor >= 0 && /\s/u.test(source[previousCursor] ?? "")) {
+		previousCursor -= 1;
+	}
+	const previousToken = source[previousCursor];
+	if (previousToken === ">" || previousToken === ":") {
+		return false;
+	}
 
 	const cursor = index + functionName.length;
 	if (isPhpIdentifierPart(source[cursor])) {

--- a/packages/wp-typia-project-tools/src/runtime/shared/php-utils.ts
+++ b/packages/wp-typia-project-tools/src/runtime/shared/php-utils.ts
@@ -226,7 +226,7 @@ function matchesPhpFunctionCallAt(
 	}
 	const previousToken = source[previousCursor];
 	if (
-		previousToken === ">" ||
+		(previousToken === ">" && source[previousCursor - 1] === "-") ||
 		(previousToken === ":" && source[previousCursor - 1] === ":")
 	) {
 		return false;
@@ -276,6 +276,30 @@ function parsePhpQuotedStringLiteralAt(
 	}
 
 	return null;
+}
+
+function parsePhpVariableNameAt(
+	source: string,
+	index: number,
+): { end: number; name: string } | null {
+	if (source[index] !== "$") {
+		return null;
+	}
+
+	const nameStart = index + 1;
+	if (!isPhpIdentifierStart(source[nameStart])) {
+		return null;
+	}
+
+	let cursor = nameStart + 1;
+	while (isPhpIdentifierPart(source[cursor])) {
+		cursor += 1;
+	}
+
+	return {
+		end: cursor,
+		name: source.slice(nameStart, cursor),
+	};
 }
 
 function getPhpFunctionCallFirstArgumentStart(
@@ -481,6 +505,128 @@ export function hasPhpFunctionCall(source: string, functionName: string): boolea
 
 		if (matchesPhpFunctionCallAt(source, index, functionName)) {
 			return true;
+		}
+
+		index += 1;
+	}
+
+	return false;
+}
+
+function isPhpAssignmentOperatorAt(source: string, index: number | null): boolean {
+	if (index === null || source[index] !== "=") {
+		return false;
+	}
+
+	const previousToken = source[index - 1];
+	const nextToken = source[index + 1];
+	return (
+		previousToken !== "=" &&
+		previousToken !== "!" &&
+		previousToken !== "<" &&
+		previousToken !== ">" &&
+		nextToken !== "=" &&
+		nextToken !== ">"
+	);
+}
+
+function isSupportedPhpAssignedStringSuffix(
+	source: string,
+	index: number,
+): boolean {
+	const nextTokenIndex = skipPhpCallTrivia(source, index);
+	const nextToken =
+		nextTokenIndex === null ? undefined : source[nextTokenIndex];
+	return nextToken === "." || nextToken === ";" || nextToken === undefined;
+}
+
+function getPhpFunctionCallFirstVariableArgumentName(
+	source: string,
+	index: number,
+	functionName: string,
+): string | undefined {
+	const argumentStart = getPhpFunctionCallFirstArgumentStart(
+		source,
+		index,
+		functionName,
+	);
+	if (argumentStart === null) {
+		return undefined;
+	}
+
+	const variable = parsePhpVariableNameAt(source, argumentStart);
+	if (!variable) {
+		return undefined;
+	}
+
+	const argumentEnd = skipPhpCallTrivia(source, variable.end);
+	const nextToken = argumentEnd === null ? undefined : source[argumentEnd];
+	return nextToken === "," || nextToken === ")" || nextToken === undefined
+		? variable.name
+		: undefined;
+}
+
+/**
+ * Detect a PHP function call whose first argument is a variable previously
+ * assigned from a literal string prefix in executable PHP code.
+ */
+export function hasPhpFunctionCallWithAssignedStringPrefixArgument(
+	source: string,
+	functionName: string,
+	literalPrefix: string,
+): boolean {
+	const variablesWithPrefix = new Set<string>();
+	const scanner = createPhpScannerState();
+	let index = 0;
+	while (index < source.length) {
+		const scan = advancePhpScanner(source, index, scanner);
+		if (scan.ambiguous) {
+			return false;
+		}
+		if (!scan.inCode) {
+			index = scan.index;
+			continue;
+		}
+
+		const variable = parsePhpVariableNameAt(source, index);
+		if (variable) {
+			const assignmentStart = skipPhpCallTrivia(source, variable.end);
+			if (
+				assignmentStart !== null &&
+				isPhpAssignmentOperatorAt(source, assignmentStart)
+			) {
+				const literalStart = skipPhpCallTrivia(source, assignmentStart + 1);
+				const literal =
+					literalStart === null
+						? null
+						: parsePhpQuotedStringLiteralAt(source, literalStart);
+				if (
+					literal &&
+					literal.value.startsWith(literalPrefix) &&
+					isSupportedPhpAssignedStringSuffix(source, literal.end)
+				) {
+					variablesWithPrefix.add(variable.name);
+					index = literal.end;
+					continue;
+				}
+			}
+		}
+
+		if (matchesPhpFunctionCallAt(source, index, functionName)) {
+			const variableArgumentName = getPhpFunctionCallFirstVariableArgumentName(
+				source,
+				index,
+				functionName,
+			);
+			if (
+				variableArgumentName &&
+				variablesWithPrefix.has(variableArgumentName)
+			) {
+				return true;
+			}
+
+			index += functionName.length;
+			continue;
 		}
 
 		index += 1;

--- a/packages/wp-typia-project-tools/src/runtime/shared/php-utils.ts
+++ b/packages/wp-typia-project-tools/src/runtime/shared/php-utils.ts
@@ -493,11 +493,15 @@ export function hasPhpFunctionCallWithStringArgument(
 		source,
 		functionName,
 		(value) => value === literalArgument,
+		{ allowConcatenatedPrefix: false },
 	);
 }
 
 /**
- * Detect a PHP function call whose first argument is a literal string prefix.
+ * Detect a PHP function call whose first argument starts with a literal string prefix.
+ *
+ * Concatenated expressions are accepted here so dynamic WordPress hooks such as
+ * `'block_bindings_supported_attributes_' . $block_type` remain detectable.
  */
 export function hasPhpFunctionCallWithStringArgumentPrefix(
 	source: string,
@@ -508,6 +512,7 @@ export function hasPhpFunctionCallWithStringArgumentPrefix(
 		source,
 		functionName,
 		(value) => value.startsWith(literalPrefix),
+		{ allowConcatenatedPrefix: true },
 	);
 }
 
@@ -515,6 +520,7 @@ function hasPhpFunctionCallWithStringArgumentMatching(
 	source: string,
 	functionName: string,
 	matchesArgument: (value: string) => boolean,
+	options: { allowConcatenatedPrefix: boolean },
 ): boolean {
 	const scanner = createPhpScannerState();
 	let index = 0;
@@ -544,7 +550,26 @@ function hasPhpFunctionCallWithStringArgumentMatching(
 		}
 
 		const argument = parsePhpQuotedStringLiteralAt(source, argumentStart);
-		if (argument && matchesArgument(argument.value)) {
+		if (!argument) {
+			index += functionName.length;
+			continue;
+		}
+
+		const argumentEnd = skipPhpCallTrivia(source, argument.end);
+		const nextToken = argumentEnd === null ? undefined : source[argumentEnd];
+		const isCompleteLiteralArgument =
+			nextToken === "," || nextToken === ")" || nextToken === undefined;
+		const isSupportedPrefixExpression =
+			options.allowConcatenatedPrefix && nextToken === ".";
+		if (
+			!isCompleteLiteralArgument &&
+			!isSupportedPrefixExpression
+		) {
+			index += functionName.length;
+			continue;
+		}
+
+		if (matchesArgument(argument.value)) {
 			return true;
 		}
 

--- a/packages/wp-typia-project-tools/tests/php-utils.test.ts
+++ b/packages/wp-typia-project-tools/tests/php-utils.test.ts
@@ -259,6 +259,18 @@ TEXT;
 			"wp_enqueue_script_module",
 		),
 	).toBe(true);
+	expect(
+		hasPhpFunctionCall(
+			`${source}\n$scripts->wp_enqueue_script_module( 'demo', 'url', array(), null );\n`,
+			"wp_enqueue_script_module",
+		),
+	).toBe(false);
+	expect(
+		hasPhpFunctionCall(
+			`${source}\nScripts::wp_enqueue_script_module( 'demo', 'url', array(), null );\n`,
+			"wp_enqueue_script_module",
+		),
+	).toBe(false);
 });
 
 test("hasPhpFunctionCallWithStringArgument matches only code-mode literal first arguments", () => {
@@ -292,6 +304,20 @@ add_filter(
 	expect(
 		hasPhpFunctionCallWithStringArgument(
 			`<?php\nadd_filter( '${filterName}' . '_suffix', 'ignored' );\n`,
+			"add_filter",
+			filterName,
+		),
+	).toBe(false);
+	expect(
+		hasPhpFunctionCallWithStringArgument(
+			`<?php\n$filters->add_filter( '${filterName}', 'ignored' );\n`,
+			"add_filter",
+			filterName,
+		),
+	).toBe(false);
+	expect(
+		hasPhpFunctionCallWithStringArgument(
+			`<?php\nFilters::add_filter( '${filterName}', 'ignored' );\n`,
 			"add_filter",
 			filterName,
 		),
@@ -344,6 +370,20 @@ add_filter(
 			source,
 			"add_filter",
 			"block_bindings_supported_attributes_missing/",
+		),
+	).toBe(false);
+	expect(
+		hasPhpFunctionCallWithStringArgumentPrefix(
+			`<?php\n$filters->add_filter( 'block_bindings_supported_attributes_core/paragraph', 'ignored' );\n`,
+			"add_filter",
+			prefix,
+		),
+	).toBe(false);
+	expect(
+		hasPhpFunctionCallWithStringArgumentPrefix(
+			`<?php\nFilters::add_filter( 'block_bindings_supported_attributes_core/paragraph', 'ignored' );\n`,
+			"add_filter",
+			prefix,
 		),
 	).toBe(false);
 });

--- a/packages/wp-typia-project-tools/tests/php-utils.test.ts
+++ b/packages/wp-typia-project-tools/tests/php-utils.test.ts
@@ -5,6 +5,7 @@ import {
 	findPhpFunctionRange,
 	hasPhpCodeStringLiteralPrefix,
 	hasPhpFunctionCall,
+	hasPhpFunctionCallWithAssignedStringPrefixArgument,
 	hasPhpFunctionCallWithStringArgument,
 	hasPhpFunctionCallWithStringArgumentPrefix,
 	hasPhpFunctionDefinition,
@@ -395,6 +396,13 @@ add_filter(
 	).toBe(true);
 	expect(
 		hasPhpFunctionCallWithStringArgumentPrefix(
+			`<?php\n$register = fn() => add_filter( 'block_bindings_supported_attributes_core/paragraph', 'cb' );\n`,
+			"add_filter",
+			prefix,
+		),
+	).toBe(true);
+	expect(
+		hasPhpFunctionCallWithStringArgumentPrefix(
 			`<?php\n$filters->add_filter( 'block_bindings_supported_attributes_core/paragraph', 'ignored' );\n`,
 			"add_filter",
 			prefix,
@@ -403,6 +411,52 @@ add_filter(
 	expect(
 		hasPhpFunctionCallWithStringArgumentPrefix(
 			`<?php\nFilters::add_filter( 'block_bindings_supported_attributes_core/paragraph', 'ignored' );\n`,
+			"add_filter",
+			prefix,
+		),
+	).toBe(false);
+});
+
+test("hasPhpFunctionCallWithAssignedStringPrefixArgument matches assigned hook variables", () => {
+	const prefix = "block_bindings_supported_attributes_";
+	const source = `<?php
+$hook = 'block_bindings_supported_attributes_' . $block_type;
+add_filter( $hook, 'demo_space_supported_attributes' );
+`;
+
+	expect(
+		hasPhpFunctionCallWithAssignedStringPrefixArgument(
+			source,
+			"add_filter",
+			prefix,
+		),
+	).toBe(true);
+	expect(
+		hasPhpFunctionCallWithAssignedStringPrefixArgument(
+			`<?php
+$hook = 'block_bindings_supported_attributes_core/paragraph';
+add_filter( 'init', 'demo_space_supported_attributes' );
+`,
+			"add_filter",
+			prefix,
+		),
+	).toBe(false);
+	expect(
+		hasPhpFunctionCallWithAssignedStringPrefixArgument(
+			`<?php
+add_filter( $hook, 'demo_space_supported_attributes' );
+$hook = 'block_bindings_supported_attributes_core/paragraph';
+`,
+			"add_filter",
+			prefix,
+		),
+	).toBe(false);
+	expect(
+		hasPhpFunctionCallWithAssignedStringPrefixArgument(
+			`<?php
+$hook = 'block_bindings_supported_attributes_core/paragraph';
+$filters->add_filter( $hook, 'ignored' );
+`,
 			"add_filter",
 			prefix,
 		),

--- a/packages/wp-typia-project-tools/tests/php-utils.test.ts
+++ b/packages/wp-typia-project-tools/tests/php-utils.test.ts
@@ -262,6 +262,12 @@ TEXT;
 	).toBe(true);
 	expect(
 		hasPhpFunctionCall(
+			`${source}\nif ( $ok ) : wp_enqueue_script_module( 'demo', 'url', array(), null ); endif;\n`,
+			"wp_enqueue_script_module",
+		),
+	).toBe(true);
+	expect(
+		hasPhpFunctionCall(
 			`${source}\n$scripts->wp_enqueue_script_module( 'demo', 'url', array(), null );\n`,
 			"wp_enqueue_script_module",
 		),
@@ -327,6 +333,13 @@ add_filter(
 		hasPhpFunctionCallWithStringArgument(source, "add_filter", "other_filter"),
 	).toBe(true);
 	expect(
+		hasPhpFunctionCallWithStringArgument(
+			`<?php\ncase 'x': add_filter( '${filterName}', 'cb' );\n`,
+			"add_filter",
+			filterName,
+		),
+	).toBe(true);
+	expect(
 		hasPhpFunctionCallWithStringArgument(source, "add_filter", "missing_filter"),
 	).toBe(false);
 });
@@ -373,6 +386,13 @@ add_filter(
 			"block_bindings_supported_attributes_missing/",
 		),
 	).toBe(false);
+	expect(
+		hasPhpFunctionCallWithStringArgumentPrefix(
+			`<?php\nif ( $ok ) : add_filter( 'block_bindings_supported_attributes_core/paragraph', 'cb' ); endif;\n`,
+			"add_filter",
+			prefix,
+		),
+	).toBe(true);
 	expect(
 		hasPhpFunctionCallWithStringArgumentPrefix(
 			`<?php\n$filters->add_filter( 'block_bindings_supported_attributes_core/paragraph', 'ignored' );\n`,

--- a/packages/wp-typia-project-tools/tests/php-utils.test.ts
+++ b/packages/wp-typia-project-tools/tests/php-utils.test.ts
@@ -280,11 +280,22 @@ add_filter(
 \t"${filterName}",
 \t'demo_space_double_quoted_supported_attributes'
 );
+add_filter(
+\t'${filterName}' . '_suffix',
+\t'demo_space_concatenated_supported_attributes'
+);
 `;
 
 	expect(
 		hasPhpFunctionCallWithStringArgument(source, "add_filter", filterName),
 	).toBe(true);
+	expect(
+		hasPhpFunctionCallWithStringArgument(
+			`<?php\nadd_filter( '${filterName}' . '_suffix', 'ignored' );\n`,
+			"add_filter",
+			filterName,
+		),
+	).toBe(false);
 	expect(
 		hasPhpFunctionCallWithStringArgument(source, "add_filter", "other_filter"),
 	).toBe(true);

--- a/packages/wp-typia-project-tools/tests/php-utils.test.ts
+++ b/packages/wp-typia-project-tools/tests/php-utils.test.ts
@@ -454,6 +454,28 @@ $hook = 'block_bindings_supported_attributes_core/paragraph';
 	expect(
 		hasPhpFunctionCallWithAssignedStringPrefixArgument(
 			`<?php
+$hook = 'block_bindings_supported_attributes_' . $block_type;
+$hook = 'init';
+add_filter( $hook, 'demo_space_supported_attributes' );
+`,
+			"add_filter",
+			prefix,
+		),
+	).toBe(false);
+	expect(
+		hasPhpFunctionCallWithAssignedStringPrefixArgument(
+			`<?php
+$hook = 'block_bindings_supported_attributes_' . $block_type;
+$hook = $other_hook;
+add_filter( $hook, 'demo_space_supported_attributes' );
+`,
+			"add_filter",
+			prefix,
+		),
+	).toBe(false);
+	expect(
+		hasPhpFunctionCallWithAssignedStringPrefixArgument(
+			`<?php
 $hook = 'block_bindings_supported_attributes_core/paragraph';
 $filters->add_filter( $hook, 'ignored' );
 `,

--- a/packages/wp-typia-project-tools/tests/php-utils.test.ts
+++ b/packages/wp-typia-project-tools/tests/php-utils.test.ts
@@ -4,6 +4,7 @@ import {
 	escapeRegex,
 	findPhpFunctionRange,
 	hasPhpFunctionCall,
+	hasPhpFunctionCallWithStringArgument,
 	hasPhpFunctionDefinition,
 	quotePhpString,
 	replacePhpFunctionDefinition,
@@ -257,6 +258,51 @@ TEXT;
 			"wp_enqueue_script_module",
 		),
 	).toBe(true);
+});
+
+test("hasPhpFunctionCallWithStringArgument matches only code-mode literal first arguments", () => {
+	const filterName = "block_bindings_supported_attributes_demo-space/card";
+	const source = `<?php
+// add_filter( '${filterName}', 'ignored_comment' );
+$single = "add_filter( '${filterName}', 'ignored_string' )";
+$double = '${filterName}';
+add_filter(
+\t'other_filter',
+\t'demo_space_other'
+);
+add_filter(
+\t/* generated binding floor */
+\t'${filterName}',
+\t'demo_space_supported_attributes'
+);
+`;
+
+	expect(
+		hasPhpFunctionCallWithStringArgument(source, "add_filter", filterName),
+	).toBe(true);
+	expect(
+		hasPhpFunctionCallWithStringArgument(source, "add_filter", "other_filter"),
+	).toBe(true);
+	expect(
+		hasPhpFunctionCallWithStringArgument(source, "add_filter", "missing_filter"),
+	).toBe(false);
+});
+
+test("hasPhpFunctionCallWithStringArgument ignores comments, strings, heredoc, and non-first arguments", () => {
+	const filterName = "block_bindings_supported_attributes_demo-space/card";
+	const source = `<?php
+// add_filter( '${filterName}', 'ignored_comment' );
+$single = 'add_filter( "${filterName}", "ignored_string" )';
+$double = "${filterName}";
+$heredoc = <<<TEXT
+add_filter( '${filterName}', 'ignored_heredoc' )
+TEXT;
+add_filter( 'other_filter', '${filterName}' );
+`;
+
+	expect(
+		hasPhpFunctionCallWithStringArgument(source, "add_filter", filterName),
+	).toBe(false);
 });
 
 test("PHP scanner transitions agree between range and call helpers", () => {

--- a/packages/wp-typia-project-tools/tests/php-utils.test.ts
+++ b/packages/wp-typia-project-tools/tests/php-utils.test.ts
@@ -5,6 +5,7 @@ import {
 	findPhpFunctionRange,
 	hasPhpFunctionCall,
 	hasPhpFunctionCallWithStringArgument,
+	hasPhpFunctionCallWithStringArgumentPrefix,
 	hasPhpFunctionDefinition,
 	quotePhpString,
 	replacePhpFunctionDefinition,
@@ -302,6 +303,29 @@ add_filter( 'other_filter', '${filterName}' );
 
 	expect(
 		hasPhpFunctionCallWithStringArgument(source, "add_filter", filterName),
+	).toBe(false);
+});
+
+test("hasPhpFunctionCallWithStringArgumentPrefix matches code-mode literal first argument prefixes", () => {
+	const prefix = "block_bindings_supported_attributes_";
+	const source = `<?php
+// add_filter( 'block_bindings_supported_attributes_demo/comment', 'ignored_comment' );
+$fake = 'block_bindings_supported_attributes_demo/string';
+add_filter(
+\t'block_bindings_supported_attributes_core/paragraph',
+\t'demo_space_supported_attributes'
+);
+`;
+
+	expect(
+		hasPhpFunctionCallWithStringArgumentPrefix(source, "add_filter", prefix),
+	).toBe(true);
+	expect(
+		hasPhpFunctionCallWithStringArgumentPrefix(
+			source,
+			"add_filter",
+			"block_bindings_supported_attributes_missing/",
+		),
 	).toBe(false);
 });
 

--- a/packages/wp-typia-project-tools/tests/php-utils.test.ts
+++ b/packages/wp-typia-project-tools/tests/php-utils.test.ts
@@ -276,6 +276,10 @@ add_filter(
 \t'${filterName}',
 \t'demo_space_supported_attributes'
 );
+add_filter(
+\t"${filterName}",
+\t'demo_space_double_quoted_supported_attributes'
+);
 `;
 
 	expect(
@@ -314,6 +318,10 @@ $fake = 'block_bindings_supported_attributes_demo/string';
 add_filter(
 \t'block_bindings_supported_attributes_core/paragraph',
 \t'demo_space_supported_attributes'
+);
+add_filter(
+\t"block_bindings_supported_attributes_" . $block_type,
+\t'demo_space_dynamic_supported_attributes'
 );
 `;
 

--- a/packages/wp-typia-project-tools/tests/php-utils.test.ts
+++ b/packages/wp-typia-project-tools/tests/php-utils.test.ts
@@ -3,6 +3,7 @@ import { expect, test } from "bun:test";
 import {
 	escapeRegex,
 	findPhpFunctionRange,
+	hasPhpCodeStringLiteralPrefix,
 	hasPhpFunctionCall,
 	hasPhpFunctionCallWithStringArgument,
 	hasPhpFunctionCallWithStringArgumentPrefix,
@@ -383,6 +384,26 @@ add_filter(
 		hasPhpFunctionCallWithStringArgumentPrefix(
 			`<?php\nFilters::add_filter( 'block_bindings_supported_attributes_core/paragraph', 'ignored' );\n`,
 			"add_filter",
+			prefix,
+		),
+	).toBe(false);
+});
+
+test("hasPhpCodeStringLiteralPrefix matches only code-mode PHP string literals", () => {
+	const prefix = "block_bindings_supported_attributes_";
+	const source = `<?php
+// 'block_bindings_supported_attributes_demo/comment'
+$fake = "ignored";
+$hook = 'block_bindings_supported_attributes_' . $block_type;
+$heredoc = <<<TEXT
+block_bindings_supported_attributes_demo/heredoc
+TEXT;
+`;
+
+	expect(hasPhpCodeStringLiteralPrefix(source, prefix)).toBe(true);
+	expect(
+		hasPhpCodeStringLiteralPrefix(
+			`<?php\n// 'block_bindings_supported_attributes_demo/comment'\n$fake = "ignored";\n`,
 			prefix,
 		),
 	).toBe(false);

--- a/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
@@ -857,13 +857,18 @@ test("doctor WordPress version check covers binding source API floors", async ()
   );
   replaceBootstrapHeader(targetDir, "Requires at least", "6.8");
 
-  for (const replacement of [
-    "getFieldsList: () => {",
-    "getFieldsList: function () {",
+  for (const transformSource of [
+    (source: string) => source.replace("getFieldsList() {", "getFieldsList: () => {"),
+    (source: string) =>
+      source.replace("getFieldsList() {", "getFieldsList: function () {"),
+    (source: string) =>
+      source.replace(
+        /\tgetFieldsList\(\) \{\n[\s\S]*?\n\t\},/u,
+        "\tgetFieldsList: () => [],"
+      ),
   ]) {
-    const rewrittenBindingEditorSource = originalBindingEditorSource.replace(
-      "getFieldsList() {",
-      replacement
+    const rewrittenBindingEditorSource = transformSource(
+      originalBindingEditorSource
     );
     expect(rewrittenBindingEditorSource).not.toBe(originalBindingEditorSource);
     fs.writeFileSync(

--- a/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
@@ -867,20 +867,79 @@ test("doctor WordPress version check covers binding source API floors", async ()
     bindingEditorFilePath,
     "utf8"
   );
+  const getFieldsListMethodBlockPattern =
+    /\tgetFieldsList\(\) \{\n[\s\S]*?\n\t\},\n\tgetValues/u;
   replaceBootstrapHeader(targetDir, "Requires at least", "6.8");
 
-  for (const transformSource of [
-    (source: string) => source.replace("getFieldsList() {", "getFieldsList: () => {"),
-    (source: string) =>
-      source.replace("getFieldsList() {", "getFieldsList: function () {"),
-    (source: string) =>
-      source.replace("getFieldsList() {", "getFieldsList(): BindingField[] {"),
-    (source: string) =>
-      source.replace(
-        /\tgetFieldsList\(\) \{\n[\s\S]*?\n\t\},/u,
-        '\t"getFieldsList": () => [],'
-      ),
-  ]) {
+  for (const [label, transformSource] of [
+    [
+      "arrow property",
+      (source: string) =>
+        source.replace("getFieldsList() {", "getFieldsList: () => {"),
+    ],
+    [
+      "function property",
+      (source: string) =>
+        source.replace("getFieldsList() {", "getFieldsList: function () {"),
+    ],
+    [
+      "typed method",
+      (source: string) =>
+        source.replace("getFieldsList() {", "getFieldsList(): BindingField[] {"),
+    ],
+    [
+      "quoted property",
+      (source: string) =>
+        source.replace(
+          getFieldsListMethodBlockPattern,
+          '\t"getFieldsList": () => [],\n\tgetValues'
+        ),
+    ],
+    [
+      "shorthand property",
+      (source: string) =>
+        source
+          .replace(
+            "function resolveBindingSourceValue",
+            "const getFieldsList = () => [];\n\nfunction resolveBindingSourceValue"
+          )
+          .replace(getFieldsListMethodBlockPattern, "\tgetFieldsList,\n\tgetValues"),
+    ],
+    [
+      "function reference property",
+      (source: string) =>
+        source
+          .replace(
+            "function resolveBindingSourceValue",
+            "const buildFieldsList = () => [];\n\nfunction resolveBindingSourceValue"
+          )
+          .replace(
+            getFieldsListMethodBlockPattern,
+            "\tgetFieldsList: buildFieldsList,\n\tgetValues"
+          ),
+    ],
+    [
+      "variable source object",
+      (source: string) =>
+        source
+          .replace(
+            "registerBlockBindingsSource( {",
+            "const bindingSourceRegistration = {"
+          )
+          .replace(
+            /\n\} \);\s*$/u,
+            "\n};\n\nregisterBlockBindingsSource( bindingSourceRegistration );\n"
+          ),
+    ],
+    [
+      "inner satisfies expression",
+      (source: string) =>
+        source.replace(
+          "registerBlockBindingsSource( {",
+          "const metadata = {};\n\nregisterBlockBindingsSource( {\n\tmeta: metadata satisfies Record<string, unknown>,"
+        ),
+    ],
+  ] satisfies Array<[string, (source: string) => string]>) {
     const rewrittenBindingEditorSource = transformSource(
       originalBindingEditorSource
     );
@@ -913,6 +972,15 @@ test("doctor WordPress version check covers binding source API floors", async ()
     expect(result.status).toBe(1);
     expect(featureMinimumCheck?.status).toBe("fail");
     expect(featureMinimumCheck?.detail).toContain("feature floor 6.9");
+    if (
+      !featureMinimumCheck?.detail.includes(
+        "registerBlockBindingsSource() getFieldsList()"
+      )
+    ) {
+      throw new Error(
+        `${label} did not report getFieldsList(): ${featureMinimumCheck?.detail ?? "<missing check>"}`
+      );
+    }
     expect(featureMinimumCheck?.detail).toContain(
       "registerBlockBindingsSource() getFieldsList()"
     );
@@ -922,8 +990,8 @@ test("doctor WordPress version check covers binding source API floors", async ()
   }
 
   const sourceWithoutRuntimeGetFieldsList = originalBindingEditorSource.replace(
-    /\tgetFieldsList\(\) \{\n[\s\S]*?\n\t\},\n/u,
-    ""
+    getFieldsListMethodBlockPattern,
+    "\tgetValues"
   );
   expect(sourceWithoutRuntimeGetFieldsList).not.toBe(
     originalBindingEditorSource

--- a/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
@@ -851,6 +851,18 @@ test("doctor WordPress version check covers binding source API floors", async ()
     throw new Error("Expected hero-data binding source in workspace inventory");
   }
   const bindingEditorFilePath = path.join(targetDir, bindingSource.editorFile);
+  const bindingServerFilePath = path.join(targetDir, bindingSource.serverFile);
+  const originalBindingServerSource = fs.readFileSync(
+    bindingServerFilePath,
+    "utf8"
+  );
+  const rewrittenBindingServerSource = originalBindingServerSource.replace(
+    /add_filter\(\n\t\t('block_bindings_supported_attributes_[^']+'),/u,
+    "$hook = $1;\n\tadd_filter(\n\t\t$hook,"
+  );
+  expect(rewrittenBindingServerSource).not.toBe(originalBindingServerSource);
+  fs.writeFileSync(bindingServerFilePath, rewrittenBindingServerSource, "utf8");
+
   const originalBindingEditorSource = fs.readFileSync(
     bindingEditorFilePath,
     "utf8"
@@ -862,9 +874,11 @@ test("doctor WordPress version check covers binding source API floors", async ()
     (source: string) =>
       source.replace("getFieldsList() {", "getFieldsList: function () {"),
     (source: string) =>
+      source.replace("getFieldsList() {", "getFieldsList(): BindingField[] {"),
+    (source: string) =>
       source.replace(
         /\tgetFieldsList\(\) \{\n[\s\S]*?\n\t\},/u,
-        "\tgetFieldsList: () => [],"
+        '\t"getFieldsList": () => [],'
       ),
   ]) {
     const rewrittenBindingEditorSource = transformSource(
@@ -906,6 +920,49 @@ test("doctor WordPress version check covers binding source API floors", async ()
       "block_bindings_supported_attributes filters"
     );
   }
+
+  const sourceWithoutRuntimeGetFieldsList = originalBindingEditorSource.replace(
+    /\tgetFieldsList\(\) \{\n[\s\S]*?\n\t\},\n/u,
+    ""
+  );
+  expect(sourceWithoutRuntimeGetFieldsList).not.toBe(
+    originalBindingEditorSource
+  );
+  fs.writeFileSync(
+    bindingEditorFilePath,
+    `${sourceWithoutRuntimeGetFieldsList}
+registerBlockBindingsSource( {} satisfies { getFieldsList: () => string[] } );
+`,
+    "utf8"
+  );
+  const typeOnlyResult = runCapturedCli(
+    "node",
+    [entryPath, "doctor", "--wp-version-check", "--format", "json"],
+    {
+      cwd: targetDir,
+    }
+  );
+  const typeOnlyDoctorChecks = parseJsonObjectFromOutput<{
+    checks: Array<{
+      code?: string;
+      detail: string;
+      label: string;
+      status: string;
+    }>;
+  }>(typeOnlyResult.stdout);
+  const typeOnlyFeatureMinimumCheck = typeOnlyDoctorChecks.checks.find(
+    (check) => check.code === "wp-typia.workspace.wordpress.feature-minimum"
+  );
+
+  expect(typeOnlyResult.status).toBe(1);
+  expect(typeOnlyFeatureMinimumCheck?.status).toBe("fail");
+  expect(typeOnlyFeatureMinimumCheck?.detail).toContain("feature floor 6.9");
+  expect(typeOnlyFeatureMinimumCheck?.detail).not.toContain(
+    "registerBlockBindingsSource() getFieldsList()"
+  );
+  expect(typeOnlyFeatureMinimumCheck?.detail).toContain(
+    "block_bindings_supported_attributes filters"
+  );
 }, 20_000);
 
 test("doctor accepts workspaces that keep binding registries in src/bindings/index.js", async () => {

--- a/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
@@ -851,13 +851,16 @@ test("doctor WordPress version check covers binding source API floors", async ()
     throw new Error("Expected hero-data binding source in workspace inventory");
   }
   const bindingEditorFilePath = path.join(targetDir, bindingSource.editorFile);
-  fs.writeFileSync(
+  const originalBindingEditorSource = fs.readFileSync(
     bindingEditorFilePath,
-    fs
-      .readFileSync(bindingEditorFilePath, "utf8")
-      .replace("getFieldsList() {", "getFieldsList: () => {"),
     "utf8"
   );
+  const rewrittenBindingEditorSource = originalBindingEditorSource.replace(
+    "getFieldsList() {",
+    "getFieldsList: () => {"
+  );
+  expect(rewrittenBindingEditorSource).not.toBe(originalBindingEditorSource);
+  fs.writeFileSync(bindingEditorFilePath, rewrittenBindingEditorSource, "utf8");
   replaceBootstrapHeader(targetDir, "Requires at least", "6.8");
 
   const result = runCapturedCli(

--- a/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
@@ -825,6 +825,21 @@ test("doctor WordPress version check covers binding source API floors", async ()
       cwd: targetDir,
     }
   );
+  const inventory = readWorkspaceInventory(targetDir);
+  const bindingSource = inventory.bindingSources.find(
+    (entry) => entry.slug === "hero-data"
+  );
+  if (!bindingSource) {
+    throw new Error("Expected hero-data binding source in workspace inventory");
+  }
+  const bindingEditorFilePath = path.join(targetDir, bindingSource.editorFile);
+  fs.writeFileSync(
+    bindingEditorFilePath,
+    fs
+      .readFileSync(bindingEditorFilePath, "utf8")
+      .replace("getFieldsList() {", "getFieldsList: () => {"),
+    "utf8"
+  );
   replaceBootstrapHeader(targetDir, "Requires at least", "6.8");
 
   const result = runCapturedCli(

--- a/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
@@ -668,6 +668,21 @@ test("doctor WordPress version check covers generated core variation registratio
       cwd: targetDir,
     }
   );
+  const registryPath = path.join(
+    targetDir,
+    "src",
+    "editor-plugins",
+    "core-variations",
+    "index.ts"
+  );
+  const originalRegistrySource = fs.readFileSync(registryPath, "utf8");
+  const formattedRegistrySource = originalRegistrySource.replace(
+    /^import\s+\{\s*([^}]+?)\s*\}\s+from\s+(['"]\.\/[^'"]+\/[^'"]+\/[^'"]+['"]);?$/mu,
+    (_, imports: string, specifier: string) =>
+      `import {\n\t${imports.trim()},\n} from ${specifier};`
+  );
+  expect(formattedRegistrySource).not.toBe(originalRegistrySource);
+  fs.writeFileSync(registryPath, formattedRegistrySource, "utf8");
   replaceBootstrapHeader(targetDir, "Requires at least", "5.3");
 
   const result = runCapturedCli(
@@ -888,6 +903,11 @@ test("doctor WordPress version check covers binding source API floors", async ()
         source.replace("getFieldsList() {", "getFieldsList(): BindingField[] {"),
     ],
     [
+      "async quoted method",
+      (source: string) =>
+        source.replace("getFieldsList() {", 'async "getFieldsList"() {'),
+    ],
+    [
       "quoted property",
       (source: string) =>
         source.replace(
@@ -1029,6 +1049,53 @@ registerBlockBindingsSource( {} satisfies { getFieldsList: () => string[] } );
     "registerBlockBindingsSource() getFieldsList()"
   );
   expect(typeOnlyFeatureMinimumCheck?.detail).toContain(
+    "block_bindings_supported_attributes filters"
+  );
+
+  fs.writeFileSync(
+    bindingEditorFilePath,
+    `${sourceWithoutRuntimeGetFieldsList}
+if ( true ) {
+\tconst bindingSourceRegistration = {
+\t\tgetFieldsList() {
+\t\t\treturn [];
+\t\t},
+\t};
+}
+
+registerBlockBindingsSource( bindingSourceRegistration );
+`,
+    "utf8"
+  );
+  const shadowedVariableResult = runCapturedCli(
+    "node",
+    [entryPath, "doctor", "--wp-version-check", "--format", "json"],
+    {
+      cwd: targetDir,
+    }
+  );
+  const shadowedVariableDoctorChecks = parseJsonObjectFromOutput<{
+    checks: Array<{
+      code?: string;
+      detail: string;
+      label: string;
+      status: string;
+    }>;
+  }>(shadowedVariableResult.stdout);
+  const shadowedVariableFeatureMinimumCheck =
+    shadowedVariableDoctorChecks.checks.find(
+      (check) => check.code === "wp-typia.workspace.wordpress.feature-minimum"
+    );
+
+  expect(shadowedVariableResult.status).toBe(1);
+  expect(shadowedVariableFeatureMinimumCheck?.status).toBe("fail");
+  expect(shadowedVariableFeatureMinimumCheck?.detail).toContain(
+    "feature floor 6.9"
+  );
+  expect(shadowedVariableFeatureMinimumCheck?.detail).not.toContain(
+    "registerBlockBindingsSource() getFieldsList()"
+  );
+  expect(shadowedVariableFeatureMinimumCheck?.detail).toContain(
     "block_bindings_supported_attributes filters"
   );
 }, 20_000);

--- a/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
@@ -693,6 +693,61 @@ test("doctor WordPress version check covers generated core variation registratio
   );
 }, 30_000);
 
+test("doctor WordPress version check ignores stray core variation TypeScript files", async () => {
+  const targetDir = path.join(
+    tempRoot,
+    "demo-workspace-wp-version-stray-core-variation-file"
+  );
+
+  await scaffoldOfficialWorkspace(targetDir, {
+    description: "Demo workspace WordPress version stray core variation file",
+    slug: "demo-workspace-wp-version-stray-core-variation-file",
+    title: "Demo Workspace WordPress Version Stray Core Variation File",
+  });
+
+  linkWorkspaceNodeModules(targetDir);
+  const strayCoreVariationDir = path.join(
+    targetDir,
+    "src",
+    "editor-plugins",
+    "core-variations",
+    "core",
+    "group"
+  );
+  fs.mkdirSync(strayCoreVariationDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(strayCoreVariationDir, "notes.ts"),
+    [
+      "// This file documents a planned core variation.",
+      "const planned = 'registerBlockVariation(core/group, demo)';",
+      "export default planned;",
+      "",
+    ].join("\n"),
+    "utf8"
+  );
+  replaceBootstrapHeader(targetDir, "Requires at least", "5.3");
+
+  const result = runCapturedCli(
+    "node",
+    [entryPath, "doctor", "--wp-version-check", "--format", "json"],
+    {
+      cwd: targetDir,
+    }
+  );
+  const doctorChecks = parseJsonObjectFromOutput<{
+    checks: Array<{ code?: string; detail: string; label: string; status: string }>;
+  }>(result.stdout);
+  const featureMinimumCheck = doctorChecks.checks.find(
+    (check) => check.code === "wp-typia.workspace.wordpress.feature-minimum"
+  );
+
+  expect(result.status).toBe(0);
+  expect(featureMinimumCheck?.status).toBe("pass");
+  expect(featureMinimumCheck?.detail).not.toContain(
+    "Core variations editor plugin"
+  );
+}, 30_000);
+
 test("doctor WordPress version check reads ability inventory compatibility floors", async () => {
   const targetDir = path.join(
     tempRoot,

--- a/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
@@ -719,8 +719,26 @@ test("doctor WordPress version check ignores stray core variation TypeScript fil
     path.join(strayCoreVariationDir, "notes.ts"),
     [
       "// This file documents a planned core variation.",
-      "const planned = 'registerBlockVariation(core/group, demo)';",
-      "export default planned;",
+      "export const planned = 'registerBlockVariation(core/group, demo)';",
+      "",
+    ].join("\n"),
+    "utf8"
+  );
+  fs.writeFileSync(
+    path.join(
+      targetDir,
+      "src",
+      "editor-plugins",
+      "core-variations",
+      "index.ts"
+    ),
+    [
+      "import { planned } from './core/group/notes';",
+      "import { registerBlockVariation } from '@wordpress/blocks';",
+      "",
+      "export function registerWorkspaceCoreVariations() {",
+      "\tregisterBlockVariation('core/group', planned);",
+      "}",
       "",
     ].join("\n"),
     "utf8"

--- a/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
@@ -855,37 +855,52 @@ test("doctor WordPress version check covers binding source API floors", async ()
     bindingEditorFilePath,
     "utf8"
   );
-  const rewrittenBindingEditorSource = originalBindingEditorSource.replace(
-    "getFieldsList() {",
-    "getFieldsList: () => {"
-  );
-  expect(rewrittenBindingEditorSource).not.toBe(originalBindingEditorSource);
-  fs.writeFileSync(bindingEditorFilePath, rewrittenBindingEditorSource, "utf8");
   replaceBootstrapHeader(targetDir, "Requires at least", "6.8");
 
-  const result = runCapturedCli(
-    "node",
-    [entryPath, "doctor", "--wp-version-check", "--format", "json"],
-    {
-      cwd: targetDir,
-    }
-  );
-  const doctorChecks = parseJsonObjectFromOutput<{
-    checks: Array<{ code?: string; detail: string; label: string; status: string }>;
-  }>(result.stdout);
-  const featureMinimumCheck = doctorChecks.checks.find(
-    (check) => check.code === "wp-typia.workspace.wordpress.feature-minimum"
-  );
+  for (const replacement of [
+    "getFieldsList: () => {",
+    "getFieldsList: function () {",
+  ]) {
+    const rewrittenBindingEditorSource = originalBindingEditorSource.replace(
+      "getFieldsList() {",
+      replacement
+    );
+    expect(rewrittenBindingEditorSource).not.toBe(originalBindingEditorSource);
+    fs.writeFileSync(
+      bindingEditorFilePath,
+      rewrittenBindingEditorSource,
+      "utf8"
+    );
 
-  expect(result.status).toBe(1);
-  expect(featureMinimumCheck?.status).toBe("fail");
-  expect(featureMinimumCheck?.detail).toContain("feature floor 6.9");
-  expect(featureMinimumCheck?.detail).toContain(
-    "registerBlockBindingsSource() getFieldsList()"
-  );
-  expect(featureMinimumCheck?.detail).toContain(
-    "block_bindings_supported_attributes filters"
-  );
+    const result = runCapturedCli(
+      "node",
+      [entryPath, "doctor", "--wp-version-check", "--format", "json"],
+      {
+        cwd: targetDir,
+      }
+    );
+    const doctorChecks = parseJsonObjectFromOutput<{
+      checks: Array<{
+        code?: string;
+        detail: string;
+        label: string;
+        status: string;
+      }>;
+    }>(result.stdout);
+    const featureMinimumCheck = doctorChecks.checks.find(
+      (check) => check.code === "wp-typia.workspace.wordpress.feature-minimum"
+    );
+
+    expect(result.status).toBe(1);
+    expect(featureMinimumCheck?.status).toBe("fail");
+    expect(featureMinimumCheck?.detail).toContain("feature floor 6.9");
+    expect(featureMinimumCheck?.detail).toContain(
+      "registerBlockBindingsSource() getFieldsList()"
+    );
+    expect(featureMinimumCheck?.detail).toContain(
+      "block_bindings_supported_attributes filters"
+    );
+  }
 }, 20_000);
 
 test("doctor accepts workspaces that keep binding registries in src/bindings/index.js", async () => {

--- a/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
@@ -903,6 +903,14 @@ test("doctor WordPress version check covers binding source API floors", async ()
         source.replace("getFieldsList() {", "getFieldsList(): BindingField[] {"),
     ],
     [
+      "object return type method",
+      (source: string) =>
+        source.replace(
+          "getFieldsList() {",
+          "getFieldsList(): Array<{ label: string; type: string }> {"
+        ),
+    ],
+    [
       "async quoted method",
       (source: string) =>
         source.replace("getFieldsList() {", 'async "getFieldsList"() {'),
@@ -949,6 +957,19 @@ test("doctor WordPress version check covers binding source API floors", async ()
           .replace(
             /\n\} \);\s*$/u,
             "\n};\n\nregisterBlockBindingsSource( bindingSourceRegistration );\n"
+          ),
+    ],
+    [
+      "variable source object with type assertion",
+      (source: string) =>
+        source
+          .replace(
+            "registerBlockBindingsSource( {",
+            "const bindingSourceRegistration = {"
+          )
+          .replace(
+            /\n\} \);\s*$/u,
+            "\n};\n\nregisterBlockBindingsSource( bindingSourceRegistration as unknown );\n"
           ),
     ],
     [


### PR DESCRIPTION
## Summary
- tighten `doctor --wp-version-check` core variation detection to require the generated registry entrypoint instead of any stray nested `.ts` file
- detect binding source `getFieldsList()` and supported-attributes filters only from executable TS/PHP registrations
- add PHP scanner coverage, a workspace doctor regression test, and a Sampo patch changeset

## Validation
- `bun test packages/wp-typia-project-tools/tests/php-utils.test.ts`
- `bun test packages/wp-typia-project-tools/tests/workspace-doctor.test.ts --timeout 60000`
- `bun run changesets:validate`
- `bun run --filter @wp-typia/project-tools build`
- `bun run format:check`
- `bun run typecheck`
- `bun run lint:repo`
- `bun run --filter wp-typia build`
- `bun run --filter wp-typia test`
- `bun run --filter @wp-typia/project-tools test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * doctor --wp-version-check now reliably detects required block/core-variation and binding compatibility using source-aware PHP/TypeScript detection, ignoring matches in comments, strings, heredocs, member/static qualified calls, and stray files.

* **Tests**
  * Added and extended tests to cover the improved feature-floor detection, direct-call and assigned-variable detection cases, and other PHP/TypeScript call-pattern scenarios to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->