### PR TITLE
fix(cli): polish template help and doctor diagnostics

### DIFF
--- a/.sampo/changesets/cli-doctor-dx-polish.md
+++ b/.sampo/changesets/cli-doctor-dx-polish.md
@@ -1,0 +1,7 @@
+---
+npm/@wp-typia/project-tools: patch
+npm/wp-typia: patch
+---
+
+Polish CLI help and doctor diagnostics with template defaults, AI-agent JSON
+mode notices, and actionable WordPress version-check guidance.

--- a/packages/wp-typia-project-tools/src/runtime/doctor/cli-doctor-wordpress-version.ts
+++ b/packages/wp-typia-project-tools/src/runtime/doctor/cli-doctor-wordpress-version.ts
@@ -906,6 +906,10 @@ function formatRequirementSummary(
 	return labels.length > 0 ? labels.join(", ") : "generated workspace features";
 }
 
+function formatFeatureMinimumAction(floor: string): string {
+	return `Update the plugin bootstrap \`Requires at least\` header to ${floor} or remove the features that require that floor.`;
+}
+
 function createFeatureMinimumCheck(
 	workspace: WorkspaceProject,
 	inventory: WorkspaceInventory,
@@ -939,7 +943,9 @@ function createFeatureMinimumCheck(
 		return createDoctorCheck(
 			"WordPress feature minimum",
 			"fail",
-			`Plugin bootstrap is missing a Requires at least header but generated features require WordPress ${highestFloor}.`,
+			`Plugin bootstrap is missing a Requires at least header but generated features require WordPress ${highestFloor}. ${formatFeatureMinimumAction(
+				highestFloor,
+			)}`,
 			WORDPRESS_VERSION_CHECK_CODES.featureMinimum,
 		);
 	}
@@ -952,7 +958,7 @@ function createFeatureMinimumCheck(
 				`Requires at least ${headers.requiresAtLeast} is below generated feature floor ${highestFloor} (${formatRequirementSummary(
 					requirements,
 					highestFloor,
-				)}).`,
+				)}). ${formatFeatureMinimumAction(highestFloor)}`,
 				WORDPRESS_VERSION_CHECK_CODES.featureMinimum,
 			);
 		}
@@ -994,7 +1000,7 @@ function createTestedTargetCheck(
 			return createDoctorCheck(
 				"WordPress tested target",
 				"warn",
-				`Tested up to ${headers.testedUpTo} is below the selected WordPress target ${targetVersion}.`,
+				`Tested up to ${headers.testedUpTo} is below the selected WordPress target ${targetVersion}. Update the plugin bootstrap \`Tested up to\` header when the workspace is verified against WordPress ${targetVersion}.`,
 				WORDPRESS_VERSION_CHECK_CODES.testedTarget,
 			);
 		}

--- a/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
+++ b/packages/wp-typia-project-tools/tests/workspace-doctor.test.ts
@@ -314,6 +314,9 @@ test("doctor WordPress version checks stay opt-in and warn on target drift", asy
   expect(testedTargetCheck?.status).toBe("warn");
   expect(testedTargetCheck?.detail).toContain("Tested up to 6.9");
   expect(testedTargetCheck?.detail).toContain("WordPress target 7.0");
+  expect(testedTargetCheck?.detail).toContain(
+    "Update the plugin bootstrap `Tested up to` header"
+  );
 }, 15_000);
 
 test("doctor WordPress version check fails when block feature floors exceed headers", async () => {
@@ -382,6 +385,9 @@ test("doctor WordPress version check fails when block feature floors exceed head
   expect(featureMinimumCheck?.status).toBe("fail");
   expect(featureMinimumCheck?.detail).toContain("Requires at least 6.4");
   expect(featureMinimumCheck?.detail).toContain("feature floor 6.5");
+  expect(featureMinimumCheck?.detail).toContain(
+    "Update the plugin bootstrap `Requires at least` header to 6.5"
+  );
   expect(featureMinimumCheck?.detail).toContain("block metadata.bindings");
   expect(featureMinimumCheck?.detail).toContain("supports.interactivity");
   expect(featureMinimumCheck?.detail).toContain("supports.splitting");

--- a/packages/wp-typia/src/cli-diagnostic-output.ts
+++ b/packages/wp-typia/src/cli-diagnostic-output.ts
@@ -6,6 +6,10 @@ import {
 import { detectAIAgents } from './ai-agent-detection';
 import { resolveEntrypointCliCommand } from './cli-command-resolution';
 import { isSupportedCliOutputFormat } from './cli-output-format';
+import {
+  getStructuredOutputNoticesForArgv,
+  withStructuredOutputNotices,
+} from './structured-output-notices';
 
 type CliStructuredOutputArgs = {
   agent?: unknown;
@@ -107,15 +111,20 @@ export function writeStructuredCliDiagnosticError(
     return false;
   }
 
-  writeStructuredCliJsonToStderr({
-    error: serializeCliDiagnosticError(
-      createCliCommandError({
-        command: resolveEntrypointCliCommand(argv),
-        error,
-      }),
+  writeStructuredCliJsonToStderr(
+    withStructuredOutputNotices(
+      {
+        error: serializeCliDiagnosticError(
+          createCliCommandError({
+            command: resolveEntrypointCliCommand(argv),
+            error,
+          }),
+        ),
+        ok: false,
+      },
+      getStructuredOutputNoticesForArgv(argv),
     ),
-    ok: false,
-  });
+  );
   process.exitCode = 1;
   return true;
 }

--- a/packages/wp-typia/src/command-option-metadata.ts
+++ b/packages/wp-typia/src/command-option-metadata.ts
@@ -103,7 +103,16 @@ export function formatPortableCliOptionHelp(
       const short = option.short
         ? `, -${option.short}${valueLabel}`
         : '';
-      return `- --${name}${valueLabel}${short}: ${option.description}`;
+      const details = [
+        option.description,
+        option.choices && option.choices.length > 0
+          ? `Choices: ${option.choices.join(', ')}.`
+          : undefined,
+        option.defaultValue !== undefined
+          ? `Default: ${option.defaultValue}.`
+          : undefined,
+      ].filter((value): value is string => Boolean(value));
+      return `- --${name}${valueLabel}${short}: ${details.join(' ')}`;
     });
 }
 

--- a/packages/wp-typia/src/command-options/add.ts
+++ b/packages/wp-typia/src/command-options/add.ts
@@ -1,5 +1,12 @@
 import type { CommandOptionMetadataMap } from './types';
 
+const ADD_BLOCK_TEMPLATE_CHOICES = [
+  'basic',
+  'interactivity',
+  'persistence',
+  'compound',
+] as const;
+
 /**
  * Shared `wp-typia add` option metadata used by both runtime entry paths.
  */
@@ -216,8 +223,10 @@ export const ADD_OPTION_METADATA = {
     type: 'string',
   },
   template: {
+    choices: ADD_BLOCK_TEMPLATE_CHOICES,
+    defaultValue: 'basic',
     description:
-      'Built-in block family for add block; one of basic, interactivity, persistence, or compound. Defaults to basic in non-interactive runs; interactive runs prompt when omitted.',
+      'Built-in block family for add block; interactive runs prompt when omitted.',
     short: 't',
     type: 'string',
   },

--- a/packages/wp-typia/src/command-options/create.ts
+++ b/packages/wp-typia/src/command-options/create.ts
@@ -1,5 +1,14 @@
 import type { CommandOptionMetadataMap } from './types';
 
+const CREATE_TEMPLATE_CHOICES = [
+  'basic',
+  'interactivity',
+  'persistence',
+  'compound',
+  'query-loop',
+  'workspace',
+] as const;
+
 /**
  * Shared `wp-typia create` option metadata used by the Gunshi runtime parser
  * and help surface.
@@ -68,7 +77,10 @@ export const CREATE_OPTION_METADATA = {
     type: 'string',
   },
   template: {
-    description: 'Template id or external template package.',
+    choices: CREATE_TEMPLATE_CHOICES,
+    defaultValue: 'basic',
+    description:
+      'Template id, external template package, local path, or GitHub locator.',
     short: 't',
     type: 'string',
   },

--- a/packages/wp-typia/src/command-options/types.ts
+++ b/packages/wp-typia/src/command-options/types.ts
@@ -1,5 +1,7 @@
 export type CommandOptionMetadata = {
   argumentKind?: 'flag';
+  choices?: readonly string[];
+  defaultValue?: string;
   description: string;
   hidden?: boolean;
   repeatable?: boolean;

--- a/packages/wp-typia/src/node-cli.ts
+++ b/packages/wp-typia/src/node-cli.ts
@@ -59,6 +59,10 @@ import type {
   PortableCliGlobalFlags,
 } from './portable-cli/types';
 import { renderPortableCliVersion } from './portable-cli/version';
+import {
+  getStructuredOutputNoticesForArgv,
+  withStructuredOutputNotices,
+} from './structured-output-notices';
 
 const PORTABLE_CLI_OPTION_PARSER = buildCommandOptionParser(
   ALL_COMMAND_OPTION_METADATA,
@@ -209,6 +213,7 @@ async function dispatchPortableCliSkills({
   mergedFlags,
   positionals,
   printLine,
+  structuredNotices,
 }: PortableCliDispatchContext): Promise<void> {
   const subcommand = positionals[1] ?? 'list';
   const structured = mergedFlags.format === 'json';
@@ -216,7 +221,13 @@ async function dispatchPortableCliSkills({
   if (subcommand === 'list') {
     const result = listSkills();
     if (structured) {
-      printLine(JSON.stringify(result, null, 2));
+      printLine(
+        JSON.stringify(
+          withStructuredOutputNotices(result, structuredNotices),
+          null,
+          2,
+        ),
+      );
       return;
     }
     if (result.agents.length === 0) {
@@ -238,7 +249,13 @@ async function dispatchPortableCliSkills({
       global: mergedFlags.local ? false : true,
     });
     if (structured) {
-      printLine(JSON.stringify(result, null, 2));
+      printLine(
+        JSON.stringify(
+          withStructuredOutputNotices(result, structuredNotices),
+          null,
+          2,
+        ),
+      );
       return;
     }
     if (!result.updated) {
@@ -284,6 +301,7 @@ const PORTABLE_CLI_COMMAND_DISPATCHERS = {
     mergedFlags,
     positionals,
     printLine,
+    structuredNotices,
     warnLine,
   }: PortableCliDispatchContext) => {
     const plan = await executeInitCommand(
@@ -304,7 +322,14 @@ const PORTABLE_CLI_COMMAND_DISPATCHERS = {
     );
     if (mergedFlags.format === 'json') {
       printLine(
-        JSON.stringify(buildStructuredInitSuccessPayload(plan), null, 2),
+        JSON.stringify(
+          withStructuredOutputNotices(
+            buildStructuredInitSuccessPayload(plan),
+            structuredNotices,
+          ),
+          null,
+          2,
+        ),
       );
     }
   },
@@ -326,6 +351,7 @@ const PORTABLE_CLI_COMMAND_DISPATCHERS = {
     mergedFlags,
     positionals,
     printLine,
+    structuredNotices,
     warnLine,
   }: PortableCliDispatchContext) => {
     try {
@@ -341,9 +367,7 @@ const PORTABLE_CLI_COMMAND_DISPATCHERS = {
       if (mergedFlags.format === 'json') {
         printLine(
           JSON.stringify(
-            {
-              sync,
-            },
+            withStructuredOutputNotices({ sync }, structuredNotices),
             null,
             2,
           ),
@@ -402,6 +426,9 @@ export async function runNodeCli(argv = process.argv.slice(2)): Promise<void> {
     extractWpTypiaConfigOverride(normalizedArgv);
   validateCliOutputFormatArgv(argvWithoutConfigOverride);
   const outputFormatArgv = normalizeCliOutputFormatArgv(
+    argvWithoutConfigOverride,
+  );
+  const structuredNotices = getStructuredOutputNoticesForArgv(
     argvWithoutConfigOverride,
   );
   const { argv: cliArgv, flags } = parseGlobalFlags(outputFormatArgv);
@@ -486,6 +513,7 @@ export async function runNodeCli(argv = process.argv.slice(2)): Promise<void> {
       mergedFlags,
       positionals,
       printLine,
+      structuredNotices,
       warnLine,
     });
     return;

--- a/packages/wp-typia/src/portable-cli/dispatchers/add.ts
+++ b/packages/wp-typia/src/portable-cli/dispatchers/add.ts
@@ -4,6 +4,7 @@ import {
   buildStructuredCompletionSuccessPayload,
   extractCompletionProjectDir,
 } from '../../runtime-bridge-output';
+import { withStructuredOutputNotices } from '../../structured-output-notices';
 import type { PortableCliDispatchContext } from '../types';
 
 function resolvePortableCliAddName(
@@ -21,6 +22,7 @@ export async function dispatchPortableCliAdd({
   mergedFlags,
   positionals,
   printLine,
+  structuredNotices,
   warnLine,
 }: PortableCliDispatchContext): Promise<void> {
   // Add-specific normalization stays here: map positionals to kind/name and
@@ -51,12 +53,15 @@ export async function dispatchPortableCliAdd({
     }
     printLine(
       JSON.stringify(
-        buildStructuredCompletionSuccessPayload('add', completion, {
-          dryRun: Boolean(mergedFlags['dry-run']),
-          kind,
-          name,
-          projectDir: extractCompletionProjectDir(completion) ?? cwd,
-        }),
+        withStructuredOutputNotices(
+          buildStructuredCompletionSuccessPayload('add', completion, {
+            dryRun: Boolean(mergedFlags['dry-run']),
+            kind,
+            name,
+            projectDir: extractCompletionProjectDir(completion) ?? cwd,
+          }),
+          structuredNotices,
+        ),
         null,
         2,
       ),

--- a/packages/wp-typia/src/portable-cli/dispatchers/create.ts
+++ b/packages/wp-typia/src/portable-cli/dispatchers/create.ts
@@ -8,6 +8,7 @@ import {
   extractCompletionProjectDir,
 } from '../../runtime-bridge-output';
 import { buildMissingCreateProjectDirDetailLines } from '../../cli-error-messages';
+import { withStructuredOutputNotices } from '../../structured-output-notices';
 import type { PortableCliDispatchContext } from '../types';
 
 export async function dispatchPortableCliCreate({
@@ -15,6 +16,7 @@ export async function dispatchPortableCliCreate({
   mergedFlags,
   positionals,
   printLine,
+  structuredNotices,
   warnLine,
 }: PortableCliDispatchContext): Promise<void> {
   const projectDir = positionals[1];
@@ -49,14 +51,17 @@ export async function dispatchPortableCliCreate({
   if (mergedFlags.format === 'json') {
     printLine(
       JSON.stringify(
-        buildStructuredCompletionSuccessPayload('create', completion, {
-          dryRun: Boolean(mergedFlags['dry-run']),
-          projectDir: extractCompletionProjectDir(completion) ?? projectDir,
-          template:
-            typeof mergedFlags.template === 'string'
-              ? mergedFlags.template
-              : undefined,
-        }),
+        withStructuredOutputNotices(
+          buildStructuredCompletionSuccessPayload('create', completion, {
+            dryRun: Boolean(mergedFlags['dry-run']),
+            projectDir: extractCompletionProjectDir(completion) ?? projectDir,
+            template:
+              typeof mergedFlags.template === 'string'
+                ? mergedFlags.template
+                : undefined,
+          }),
+          structuredNotices,
+        ),
         null,
         2,
       ),

--- a/packages/wp-typia/src/portable-cli/doctor.ts
+++ b/packages/wp-typia/src/portable-cli/doctor.ts
@@ -5,6 +5,7 @@ import {
 import type { DoctorExitPolicy } from '@wp-typia/project-tools/cli-doctor';
 import { executeDoctorCommand } from '../runtime-bridge';
 import type { PrintLine } from '../print-line';
+import { withStructuredOutputNotices } from '../structured-output-notices';
 import type { PortableCliDispatchContext } from './types';
 
 async function renderPortableCliDoctorJson(
@@ -12,6 +13,7 @@ async function renderPortableCliDoctorJson(
   exitPolicy: DoctorExitPolicy,
   wordpressVersionCheck: boolean,
   printLine: PrintLine,
+  structuredNotices: readonly string[] | undefined,
 ): Promise<void> {
   const {
     createDoctorRunSummary,
@@ -22,10 +24,7 @@ async function renderPortableCliDoctorJson(
   const summary = createDoctorRunSummary(checks, { exitPolicy });
   printLine(
     JSON.stringify(
-      {
-        checks,
-        summary,
-      },
+      withStructuredOutputNotices({ checks, summary }, structuredNotices),
       null,
       2,
     ),
@@ -44,6 +43,7 @@ export async function dispatchPortableCliDoctor({
   cwd,
   mergedFlags,
   printLine,
+  structuredNotices,
 }: PortableCliDispatchContext): Promise<void> {
   const exitPolicy = mergedFlags['workspace-only'] ? 'workspace-only' : 'strict';
   const wordpressVersionCheck = Boolean(mergedFlags['wp-version-check']);
@@ -53,6 +53,7 @@ export async function dispatchPortableCliDoctor({
       exitPolicy,
       wordpressVersionCheck,
       printLine,
+      structuredNotices,
     );
     return;
   }

--- a/packages/wp-typia/src/portable-cli/errors.ts
+++ b/packages/wp-typia/src/portable-cli/errors.ts
@@ -8,6 +8,10 @@ import {
 import { prefersStructuredCliArgv } from '../cli-diagnostic-output';
 import { resolveCanonicalCommandContext } from '../command-contract';
 import {
+  getStructuredOutputNoticesForArgv,
+  withStructuredOutputNotices,
+} from '../structured-output-notices';
+import {
   PORTABLE_CLI_NO_COMMAND_REASON_LINE,
   STANDALONE_GUIDANCE_LINE,
 } from './help';
@@ -56,10 +60,13 @@ export async function handlePortableCliEntrypointError(
     });
     process.stderr.write(
       `${JSON.stringify(
-        {
-          ok: false,
-          error: serializeCliDiagnosticError(diagnostic),
-        },
+        withStructuredOutputNotices(
+          {
+            ok: false,
+            error: serializeCliDiagnosticError(diagnostic),
+          },
+          getStructuredOutputNoticesForArgv(argv),
+        ),
         null,
         2,
       )}\n`,

--- a/packages/wp-typia/src/portable-cli/templates.ts
+++ b/packages/wp-typia/src/portable-cli/templates.ts
@@ -7,19 +7,24 @@ import {
   listTemplates,
 } from '@wp-typia/project-tools/cli-templates';
 import { executeTemplatesCommand } from '../runtime-bridge';
+import { withStructuredOutputNotices } from '../structured-output-notices';
 import type { PortableCliDispatchContext, PortableCliGlobalFlags } from './types';
 
 function renderPortableCliTemplatesJson(
   printLine: PortableCliDispatchContext['printLine'],
   flags: PortableCliGlobalFlags,
   subcommand: string,
+  structuredNotices: readonly string[] | undefined,
 ) {
   if (subcommand === 'list') {
     printLine(
       JSON.stringify(
-        {
-          templates: listTemplates(),
-        },
+        withStructuredOutputNotices(
+          {
+            templates: listTemplates(),
+          },
+          structuredNotices,
+        ),
         null,
         2,
       ),
@@ -45,9 +50,7 @@ function renderPortableCliTemplatesJson(
   }
   printLine(
     JSON.stringify(
-      {
-        template,
-      },
+      withStructuredOutputNotices({ template }, structuredNotices),
       null,
       2,
     ),
@@ -58,6 +61,7 @@ export async function dispatchPortableCliTemplates({
   mergedFlags,
   positionals,
   printLine,
+  structuredNotices,
 }: PortableCliDispatchContext): Promise<void> {
   const subcommand = positionals[1];
   const templateId =
@@ -82,6 +86,7 @@ export async function dispatchPortableCliTemplates({
         id: templateId,
       },
       resolvedSubcommand,
+      structuredNotices,
     );
     return;
   }

--- a/packages/wp-typia/src/portable-cli/types.ts
+++ b/packages/wp-typia/src/portable-cli/types.ts
@@ -21,6 +21,7 @@ export type PortableCliDispatchContext = {
   mergedFlags: Record<string, unknown>;
   positionals: string[];
   printLine: PrintLine;
+  structuredNotices?: string[];
   warnLine: PrintLine;
 };
 

--- a/packages/wp-typia/src/structured-output-notices.ts
+++ b/packages/wp-typia/src/structured-output-notices.ts
@@ -1,0 +1,66 @@
+import {
+  detectAIAgents,
+  type AIAgentDetectionResult,
+} from './ai-agent-detection';
+
+function getExplicitFormat(argv: readonly string[]): string | undefined {
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg) {
+      continue;
+    }
+    if (arg === '--') {
+      return undefined;
+    }
+    if (arg === '--format') {
+      const next = argv[index + 1];
+      return next && !next.startsWith('-') ? next : undefined;
+    }
+    if (arg.startsWith('--format=')) {
+      return arg.slice('--format='.length) || undefined;
+    }
+  }
+
+  return undefined;
+}
+
+export function createAIAgentStructuredOutputNotice(
+  detection: AIAgentDetectionResult,
+): string | undefined {
+  if (!detection.isAIAgent) {
+    return undefined;
+  }
+
+  const agentLabel =
+    detection.aiAgents.length > 0
+      ? detection.aiAgents.join(', ')
+      : 'AI agent';
+  const envLabel =
+    detection.aiAgentEnvVars.length > 0
+      ? ` via ${detection.aiAgentEnvVars.join(', ')}`
+      : '';
+
+  return `Detected ${agentLabel}${envLabel}; defaulting to --format json. Pass --format text for human-readable output.`;
+}
+
+export function getStructuredOutputNoticesForArgv(
+  argv: readonly string[],
+): string[] {
+  if (getExplicitFormat(argv) !== undefined) {
+    return [];
+  }
+
+  const notice = createAIAgentStructuredOutputNotice(detectAIAgents());
+  return notice ? [notice] : [];
+}
+
+export function withStructuredOutputNotices<
+  TPayload extends Record<string, unknown>,
+>(payload: TPayload, notices: readonly string[] | undefined): TPayload {
+  return notices && notices.length > 0
+    ? {
+        ...payload,
+        notices: [...notices],
+      }
+    : payload;
+}

--- a/packages/wp-typia/tests/cli-diagnostic-output.test.ts
+++ b/packages/wp-typia/tests/cli-diagnostic-output.test.ts
@@ -180,6 +180,41 @@ describe('CLI structured diagnostic output', () => {
     expect(parsed.error?.message).toContain('doctor exploded');
   });
 
+  test('adds AI-agent notices only for implicit structured argv errors', () => {
+    process.env.CODEX_THREAD_ID = 'thread-1';
+
+    const captured = captureStderr(() => {
+      const handled = writeStructuredCliDiagnosticError(
+        ['doctor'],
+        new Error('doctor exploded'),
+      );
+
+      expect(handled).toBe(true);
+    });
+    const parsed = JSON.parse(captured.stderr) as {
+      notices?: string[];
+      ok?: boolean;
+    };
+
+    expect(parsed.ok).toBe(false);
+    expect(parsed.notices?.[0]).toContain(
+      'Detected codex via CODEX_THREAD_ID; defaulting to --format json.',
+    );
+
+    const explicit = captureStderr(() => {
+      const handled = writeStructuredCliDiagnosticError(
+        ['doctor', '--format', 'json'],
+        new Error('doctor exploded'),
+      );
+
+      expect(handled).toBe(true);
+    });
+    const explicitParsed = JSON.parse(explicit.stderr) as {
+      notices?: string[];
+    };
+    expect(explicitParsed.notices).toBeUndefined();
+  });
+
   test('throws human diagnostics and validates unsupported output formats before dispatch', () => {
     expect(() =>
       emitCliDiagnosticFailure(

--- a/packages/wp-typia/tests/cli-package.test.ts
+++ b/packages/wp-typia/tests/cli-package.test.ts
@@ -217,7 +217,10 @@ describe('wp-typia package', () => {
     expect(addHelpOutput).toContain('--external-layer-id');
     expect(addHelpOutput).toContain('--alternate-render-targets');
     expect(addHelpOutput).toContain(
-      'one of basic, interactivity, persistence, or compound. Defaults to basic in non-interactive runs',
+      'Choices: basic, interactivity, persistence, compound. Default: basic.',
+    );
+    expect(createHelpOutput).toContain(
+      'Choices: basic, interactivity, persistence, compound, query-loop, workspace. Default: basic.',
     );
     expect(addHelpOutput).toContain('admin-view');
     expect(addHelpOutput).toContain('ability');

--- a/packages/wp-typia/tests/command-option-metadata.test.ts
+++ b/packages/wp-typia/tests/command-option-metadata.test.ts
@@ -435,7 +435,10 @@ describe('command option metadata helpers', () => {
       '- --secret-preserve-on-empty <value>: Whether blank manual settings secret submissions should preserve the stored secret (true by default).',
     );
     expect(formatPortableCliOptionHelp(ADD_OPTION_METADATA)).toContain(
-      '- --template <value>, -t <value>: Built-in block family for add block; one of basic, interactivity, persistence, or compound. Defaults to basic in non-interactive runs; interactive runs prompt when omitted.',
+      '- --template <value>, -t <value>: Built-in block family for add block; interactive runs prompt when omitted. Choices: basic, interactivity, persistence, compound. Default: basic.',
+    );
+    expect(formatPortableCliOptionHelp(CREATE_OPTION_METADATA)).toContain(
+      '- --template <value>, -t <value>: Template id, external template package, local path, or GitHub locator. Choices: basic, interactivity, persistence, compound, query-loop, workspace. Default: basic.',
     );
     expect(formatPortableCliOptionHelp(ADD_OPTION_METADATA)).toContain(
       '- --dry-run, -d: Preview workspace file updates and completion guidance without writing them.',

--- a/packages/wp-typia/tests/gunshi-dispatch-parity.test.ts
+++ b/packages/wp-typia/tests/gunshi-dispatch-parity.test.ts
@@ -257,6 +257,7 @@ describe('Gunshi dispatch parity boundaries', () => {
       expect(explicitJson.status).toBe(1);
       expect(explicitJson.stdout).toBe('');
       expect(explicitError.ok).toBe(false);
+      expect((explicitError as { notices?: unknown[] }).notices).toBeUndefined();
       expect(explicitError.error?.command).toBe('create');
       expect(explicitError.error?.code).toBe('missing-argument');
 
@@ -272,6 +273,9 @@ describe('Gunshi dispatch parity boundaries', () => {
       expect(aiDefault.status).toBe(1);
       expect(aiDefault.stdout).toBe('');
       expect(aiError.ok).toBe(false);
+      expect((aiError as { notices?: string[] }).notices?.[0]).toContain(
+        'Detected codex via CODEX_THREAD_ID; defaulting to --format json.',
+      );
       expect(aiError.error?.command).toBe('create');
       expect(aiError.error?.code).toBe('missing-argument');
 


### PR DESCRIPTION
## Summary
- add metadata-driven template choices/default rendering for create/add help
- include structured notices when AI-agent detection implicitly defaults CLI output to JSON
- add actionable WordPress version-check guidance to doctor diagnostics

## Validation
- bun run format:check
- bun run typecheck
- bun run lint:repo
- bun run changesets:validate
- bun run --filter @wp-typia/project-tools build
- bun run --filter wp-typia build
- bun test packages/wp-typia/tests/command-option-metadata.test.ts packages/wp-typia/tests/cli-diagnostic-output.test.ts packages/wp-typia/tests/gunshi-dispatch-parity.test.ts
- bun run --filter wp-typia test
- bun run --filter @wp-typia/project-tools test (one unrelated workspace-add integration test timed out at 60s in the full suite)
- bun test packages/wp-typia-project-tools/tests/workspace-add.test.ts --test-name-pattern "canonical CLI can add a compound persistence block to an official workspace template"
- smoke: node packages/wp-typia/bin/wp-typia.js create --help
- smoke: node packages/wp-typia/bin/wp-typia.js add --help
- smoke: CODEX_THREAD_ID=thread-1 node packages/wp-typia/bin/wp-typia.js create
- smoke: node packages/wp-typia/bin/wp-typia.js doctor --help
